### PR TITLE
Extend Async Support: vkCreateComputePipelines, vkCreateShadersEXT

### DIFF
--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -12,7 +12,7 @@ target_sources(gfxrecon_graphics
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_deep_copy.h
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy.cpp
-                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy_pnext.cpp
+                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_extract_handles.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_extract_handles.cpp
               )

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -566,7 +566,7 @@ struct VideoSessionKHRInfo : VulkanObjectInfo<VkVideoSessionKHR>
     uint32_t queue_family_index{ 0 };
 };
 
-struct ShaderEXTInfo : VulkanObjectInfo<VkShaderEXT>
+struct ShaderEXTInfo : VulkanObjectInfoAsync<VkShaderEXT>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
 };

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -9279,29 +9279,6 @@ void VulkanReplayConsumerBase::OverrideDestroyPipeline(
     }
 }
 
-void VulkanReplayConsumerBase::OverrideDestroyShaderEXT(
-    PFN_vkDestroyShaderEXT                                     func,
-    const DeviceInfo*                                          device_info,
-    ShaderEXTInfo*                                             shader_info,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
-{
-    VkDevice    in_device = device_info->handle;
-    VkShaderEXT in_shader = MapHandle<ShaderEXTInfo>(shader_info->capture_id, &VulkanObjectInfoTable::GetShaderEXTInfo);
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
-
-    if (!IsUsedByAsyncTask(shader_info->capture_id))
-    {
-        func(in_device, in_shader, in_pAllocator);
-    }
-    else
-    {
-        // schedule deletion
-        DestroyAsyncHandle(shader_info->capture_id, [func, in_device, in_shader, in_pAllocator]() {
-            func(in_device, in_shader, in_pAllocator);
-        });
-    }
-}
-
 void VulkanReplayConsumerBase::OverrideDestroyRenderPass(
     PFN_vkDestroyRenderPass                                    func,
     const DeviceInfo*                                          device_info,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -9230,8 +9230,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShadersEXT(
     HandlePointerDecoder<VkShaderEXT>*                         pShaders)
 {
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
-    assert((device_info != nullptr) && (pCreateInfos != nullptr) && (pAllocator != nullptr) && (pShaders != nullptr) &&
-           !pShaders->IsNull() && (pShaders->GetHandlePointer() != nullptr));
+    GFXRECON_ASSERT((device_info != nullptr) && (pCreateInfos != nullptr) && (pAllocator != nullptr) &&
+                    (pShaders != nullptr) && !pShaders->IsNull() && (pShaders->GetHandlePointer() != nullptr));
 
     VkDevice                     in_device                 = device_info->handle;
     const VkShaderCreateInfoEXT* in_p_create_infos         = pCreateInfos->GetPointer();

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -38,6 +38,7 @@
 #include "generated/generated_vulkan_struct_decoders.h"
 #include "generated/generated_vulkan_struct_handle_mappers.h"
 #include "generated/generated_vulkan_constant_maps.h"
+#include "graphics/vulkan_check_buffer_references.h"
 #include "graphics/vulkan_device_util.h"
 #include "graphics/vulkan_util.h"
 #include "graphics/vulkan_struct_deep_copy.h"
@@ -46,7 +47,6 @@
 #include "util/hash.h"
 #include "util/platform.h"
 #include "util/logging.h"
-#include "util/spirv_parsing_util.h"
 
 #include "spirv_reflect.h"
 
@@ -5601,19 +5601,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
         if (vk_res == VK_SUCCESS)
         {
             // check for buffer-references, issue warning
-            gfxrecon::util::SpirVParsingUtil spirv_util;
-
-            if (spirv_util.ParseBufferReferences(original_info->pCode, original_info->codeSize))
-            {
-                auto buffer_reference_infos = spirv_util.GetBufferReferenceInfos();
-
-                if (!buffer_reference_infos.empty())
-                {
-                    GFXRECON_LOG_WARNING_ONCE("A Shader is using the 'SPV_KHR_physical_storage_buffer' feature. "
-                                              "Resource tracking for buffers accessed via references is currently "
-                                              "unsupported, so replay may fail.");
-                }
-            }
+            graphics::vulkan_check_buffer_references(original_info->pCode, original_info->codeSize);
 
             if (options_.dumping_resources)
             {
@@ -5664,19 +5652,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
     if (vk_res == VK_SUCCESS)
     {
         // check for buffer-references, issue warning
-        gfxrecon::util::SpirVParsingUtil spirv_util;
-
-        if (spirv_util.ParseBufferReferences(original_info->pCode, original_info->codeSize))
-        {
-            auto buffer_reference_infos = spirv_util.GetBufferReferenceInfos();
-
-            if (!buffer_reference_infos.empty())
-            {
-                GFXRECON_LOG_WARNING_ONCE("A Shader is using the 'SPV_KHR_physical_storage_buffer' feature. "
-                                          "Resource tracking for buffers accessed via references is currently "
-                                          "unsupported, so replay may fail.");
-            }
-        }
+        graphics::vulkan_check_buffer_references(original_info->pCode, original_info->codeSize);
 
         if (vk_res == VK_SUCCESS && options_.dumping_resources)
         {
@@ -9244,14 +9220,50 @@ VkResult VulkanReplayConsumerBase::OverrideCreateComputePipelines(
     return replay_result;
 }
 
+VkResult VulkanReplayConsumerBase::OverrideCreateShadersEXT(
+    PFN_vkCreateShadersEXT                                     func,
+    VkResult                                                   original_result,
+    const DeviceInfo*                                          device_info,
+    uint32_t                                                   create_info_count,
+    const StructPointerDecoder<Decoded_VkShaderCreateInfoEXT>* pCreateInfos,
+    const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+    HandlePointerDecoder<VkShaderEXT>*                         pShaders)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(original_result);
+    assert((device_info != nullptr) && (pCreateInfos != nullptr) && (pAllocator != nullptr) && (pShaders != nullptr) &&
+           !pShaders->IsNull() && (pShaders->GetHandlePointer() != nullptr));
+
+    VkDevice                     in_device                 = device_info->handle;
+    const VkShaderCreateInfoEXT* in_p_create_infos         = pCreateInfos->GetPointer();
+    const VkAllocationCallbacks* in_p_allocation_callbacks = GetAllocationCallbacks(pAllocator);
+    VkShaderEXT*                 out_shaders               = pShaders->GetHandlePointer();
+
+    VkResult replay_result =
+        func(in_device, create_info_count, in_p_create_infos, in_p_allocation_callbacks, out_shaders);
+
+    if (replay_result == VK_SUCCESS)
+    {
+        for (uint32_t i = 0; i < create_info_count; ++i)
+        {
+            if (in_p_create_infos[i].codeType == VK_SHADER_CODE_TYPE_SPIRV_EXT)
+            {
+                graphics::vulkan_check_buffer_references(reinterpret_cast<const uint32_t*>(in_p_create_infos[i].pCode),
+                                                         in_p_create_infos[i].codeSize);
+            }
+        }
+    }
+    return replay_result;
+}
+
 void VulkanReplayConsumerBase::OverrideDestroyPipeline(
     PFN_vkDestroyPipeline                                      func,
     const DeviceInfo*                                          device_info,
     PipelineInfo*                                              pipeline_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice                     in_device     = device_info->handle;
-    VkPipeline                   in_pipeline   = pipeline_info->handle;
+    VkDevice   in_device = device_info->handle;
+    VkPipeline in_pipeline =
+        MapHandle<PipelineInfo>(pipeline_info->capture_id, &VulkanObjectInfoTable::GetPipelineInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     if (!IsUsedByAsyncTask(pipeline_info->capture_id))
@@ -9263,6 +9275,29 @@ void VulkanReplayConsumerBase::OverrideDestroyPipeline(
         // schedule deletion
         DestroyAsyncHandle(pipeline_info->capture_id, [func, in_device, in_pipeline, in_pAllocator]() {
             func(in_device, in_pipeline, in_pAllocator);
+        });
+    }
+}
+
+void VulkanReplayConsumerBase::OverrideDestroyShaderEXT(
+    PFN_vkDestroyShaderEXT                                     func,
+    const DeviceInfo*                                          device_info,
+    ShaderEXTInfo*                                             shader_info,
+    const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+{
+    VkDevice    in_device = device_info->handle;
+    VkShaderEXT in_shader = MapHandle<ShaderEXTInfo>(shader_info->capture_id, &VulkanObjectInfoTable::GetShaderEXTInfo);
+    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
+
+    if (!IsUsedByAsyncTask(shader_info->capture_id))
+    {
+        func(in_device, in_shader, in_pAllocator);
+    }
+    else
+    {
+        // schedule deletion
+        DestroyAsyncHandle(shader_info->capture_id, [func, in_device, in_shader, in_pAllocator]() {
+            func(in_device, in_shader, in_pAllocator);
         });
     }
 }
@@ -9341,7 +9376,7 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
     graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, create_info_data.data());
 
     // extract handle-dependencies and track those
-    auto handle_deps = graphics::vulkan_struct_extract_handle_ids(pCreateInfos, createInfoCount);
+    auto handle_deps = graphics::vulkan_struct_extract_handle_ids(pCreateInfos);
     TrackAsyncHandles(handle_deps);
 
     // define pipeline-creation task, assert object-lifetimes by copying/moving into closure
@@ -9364,6 +9399,112 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
         // schedule dependency-clear on main-thread
         MainThreadQueue().post([this, handle_deps = std::move(handle_deps)] { ClearAsyncHandles(handle_deps); });
         return { replay_result, std::move(out_pipelines) };
+    };
+    return task;
+}
+
+std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::AsyncCreateComputePipelines(
+    const ApiCallInfo&                                         call_info,
+    VkResult                                                   returnValue,
+    const DeviceInfo*                                          device_info,
+    const PipelineCacheInfo*                                   pipeline_cache_info,
+    uint32_t                                                   createInfoCount,
+    StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfos,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
+    HandlePointerDecoder<VkPipeline>*                          pPipelines)
+{
+    const VkComputePipelineCreateInfo* in_pCreateInfos = pCreateInfos->GetPointer();
+    const VkAllocationCallbacks*       in_pAllocator   = GetAllocationCallbacks(pAllocator);
+    VkDevice                           device_handle   = device_info->handle;
+    VkPipelineCache                    pipeline_cache_handle =
+        (pipeline_cache_info != nullptr) ? pipeline_cache_info->handle : VK_NULL_HANDLE;
+
+    // replace with deep-copy of create-info array
+    uint32_t             num_bytes = graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, nullptr);
+    std::vector<uint8_t> create_info_data(num_bytes);
+    graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, create_info_data.data());
+
+    // extract handle-dependencies and track those
+    auto handle_deps = graphics::vulkan_struct_extract_handle_ids(pCreateInfos);
+    TrackAsyncHandles(handle_deps);
+
+    // define pipeline-creation task, assert object-lifetimes by copying/moving into closure
+    auto task = [this,
+                 device_handle,
+                 pipeline_cache_handle,
+                 returnValue,
+                 call_info,
+                 in_pAllocator,
+                 createInfoCount,
+                 create_info_data = std::move(create_info_data),
+                 handle_deps      = std::move(handle_deps)]() mutable -> handle_create_result_t<VkPipeline> {
+        std::vector<VkPipeline> out_pipelines(createInfoCount);
+        auto     create_infos  = reinterpret_cast<const VkComputePipelineCreateInfo*>(create_info_data.data());
+        auto     device_table  = GetDeviceTable(device_handle);
+        VkResult replay_result = device_table->CreateComputePipelines(
+            device_handle, pipeline_cache_handle, createInfoCount, create_infos, in_pAllocator, out_pipelines.data());
+        CheckResult("vkCreateComputePipelines", returnValue, replay_result, call_info);
+
+        // schedule dependency-clear on main-thread
+        MainThreadQueue().post([this, handle_deps = std::move(handle_deps)] { ClearAsyncHandles(handle_deps); });
+        return { replay_result, std::move(out_pipelines) };
+    };
+    return task;
+}
+
+std::function<handle_create_result_t<VkShaderEXT>()>
+VulkanReplayConsumerBase::AsyncCreateShadersEXT(const ApiCallInfo&                                   call_info,
+                                                VkResult                                             returnValue,
+                                                const DeviceInfo*                                    device_info,
+                                                uint32_t                                             createInfoCount,
+                                                StructPointerDecoder<Decoded_VkShaderCreateInfoEXT>* pCreateInfos,
+                                                StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                                                HandlePointerDecoder<VkShaderEXT>*                   pShaders)
+{
+    const VkShaderCreateInfoEXT* in_pCreateInfos = pCreateInfos->GetPointer();
+    const VkAllocationCallbacks* in_pAllocator   = GetAllocationCallbacks(pAllocator);
+    VkDevice                     device_handle   = device_info->handle;
+
+    // replace with deep-copy of create-info array
+    uint32_t             num_bytes = graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, nullptr);
+    std::vector<uint8_t> create_info_data(num_bytes);
+    graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, create_info_data.data());
+
+    // extract handle-dependencies and track those
+    auto handle_deps = graphics::vulkan_struct_extract_handle_ids(pCreateInfos);
+    TrackAsyncHandles(handle_deps);
+
+    // define pipeline-creation task, assert object-lifetimes by copying/moving into closure
+    auto task = [this,
+                 device_handle,
+                 returnValue,
+                 call_info,
+                 in_pAllocator,
+                 createInfoCount,
+                 create_info_data = std::move(create_info_data),
+                 handle_deps      = std::move(handle_deps)]() mutable -> handle_create_result_t<VkShaderEXT> {
+        std::vector<VkShaderEXT> out_shaders(createInfoCount);
+        auto                     create_infos = reinterpret_cast<const VkShaderCreateInfoEXT*>(create_info_data.data());
+        auto                     device_table = GetDeviceTable(device_handle);
+        VkResult                 replay_result = device_table->CreateShadersEXT(
+            device_handle, createInfoCount, create_infos, in_pAllocator, out_shaders.data());
+        CheckResult("vkCreateShadersEXT", returnValue, replay_result, call_info);
+
+        if (replay_result == VK_SUCCESS)
+        {
+            for (uint32_t i = 0; i < createInfoCount; ++i)
+            {
+                if (create_infos[i].codeType == VK_SHADER_CODE_TYPE_SPIRV_EXT)
+                {
+                    graphics::vulkan_check_buffer_references(reinterpret_cast<const uint32_t*>(create_infos[i].pCode),
+                                                             create_infos[i].codeSize);
+                }
+            }
+        }
+
+        // schedule dependency-clear on main-thread
+        MainThreadQueue().post([this, handle_deps = std::move(handle_deps)] { ClearAsyncHandles(handle_deps); });
+        return { replay_result, std::move(out_shaders) };
     };
     return task;
 }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1243,10 +1243,23 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
                                    HandlePointerDecoder<VkPipeline>*                                pPipelines);
 
+    VkResult OverrideCreateShadersEXT(PFN_vkCreateShadersEXT                                     func,
+                                      VkResult                                                   original_result,
+                                      const DeviceInfo*                                          device_info,
+                                      uint32_t                                                   create_info_count,
+                                      const StructPointerDecoder<Decoded_VkShaderCreateInfoEXT>* pCreateInfos,
+                                      const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                                      HandlePointerDecoder<VkShaderEXT>*                         pShaders);
+
     void OverrideDestroyPipeline(PFN_vkDestroyPipeline                                      func,
                                  const DeviceInfo*                                          device_info,
                                  PipelineInfo*                                              pipeline_info,
                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
+
+    void OverrideDestroyShaderEXT(PFN_vkDestroyShaderEXT                                     func,
+                                  const DeviceInfo*                                          device_info,
+                                  ShaderEXTInfo*                                             shader_info,
+                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     void OverrideDestroyRenderPass(PFN_vkDestroyRenderPass                                    func,
                                    const DeviceInfo*                                          device_info,
@@ -1267,6 +1280,25 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                  StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
                                  StructPointerDecoder<Decoded_VkAllocationCallbacks>*        pAllocator,
                                  HandlePointerDecoder<VkPipeline>*                           pPipelines);
+
+    std::function<handle_create_result_t<VkPipeline>()>
+    AsyncCreateComputePipelines(const ApiCallInfo&                                         call_info,
+                                VkResult                                                   returnValue,
+                                const DeviceInfo*                                          device_info,
+                                const PipelineCacheInfo*                                   pipeline_cache_info,
+                                uint32_t                                                   createInfoCount,
+                                StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfos,
+                                StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
+                                HandlePointerDecoder<VkPipeline>*                          pPipelines);
+
+    std::function<handle_create_result_t<VkShaderEXT>()>
+    AsyncCreateShadersEXT(const ApiCallInfo&                                   call_info,
+                          VkResult                                             returnValue,
+                          const DeviceInfo*                                    device_info,
+                          uint32_t                                             createInfoCount,
+                          StructPointerDecoder<Decoded_VkShaderCreateInfoEXT>* pCreateInfos,
+                          StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                          HandlePointerDecoder<VkShaderEXT>*                   pShaders);
 
     const VulkanReplayOptions options_;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1256,11 +1256,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                  PipelineInfo*                                              pipeline_info,
                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
-    void OverrideDestroyShaderEXT(PFN_vkDestroyShaderEXT                                     func,
-                                  const DeviceInfo*                                          device_info,
-                                  ShaderEXTInfo*                                             shader_info,
-                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
-
     void OverrideDestroyRenderPass(PFN_vkDestroyRenderPass                                    func,
                                    const DeviceInfo*                                          device_info,
                                    RenderPassInfo*                                            renderpass_info,

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -31,13 +31,13 @@
 #include "encode/vulkan_state_writer.h"
 #include "format/format_util.h"
 #include "generated/generated_vulkan_struct_handle_wrappers.h"
+#include "graphics/vulkan_check_buffer_references.h"
 #include "graphics/vulkan_device_util.h"
 #include "graphics/vulkan_util.h"
 #include "util/compressor.h"
 #include "util/logging.h"
 #include "util/page_guard_manager.h"
 #include "util/platform.h"
-#include "util/spirv_parsing_util.h"
 
 #include <cassert>
 #include <unordered_set>
@@ -2850,20 +2850,7 @@ void VulkanCaptureManager::PostProcess_vkCreateShaderModule(VkResult            
 
     if (result == VK_SUCCESS)
     {
-        // spirv-parsing for buffer-references
-        gfxrecon::util::SpirVParsingUtil spirv_util;
-
-        if (spirv_util.ParseBufferReferences(pCreateInfo->pCode, pCreateInfo->codeSize))
-        {
-            auto buffer_reference_infos = spirv_util.GetBufferReferenceInfos();
-
-            if (!buffer_reference_infos.empty())
-            {
-                GFXRECON_LOG_WARNING_ONCE(
-                    "Shader is using the 'SPV_KHR_physical_storage_buffer' feature. "
-                    "Resource tracking for buffers accessed via references is currently unsupported");
-            }
-        }
+        graphics::vulkan_check_buffer_references(pCreateInfo->pCode, pCreateInfo->codeSize);
     }
 }
 

--- a/framework/encode/vulkan_track_struct.h
+++ b/framework/encode/vulkan_track_struct.h
@@ -37,9 +37,9 @@ GFXRECON_BEGIN_NAMESPACE(vulkan_trackers)
  */
 inline void* TrackStruct(const void* value, std::unique_ptr<uint8_t[]>& out_data)
 {
-    size_t num_bytes = graphics::vulkan_struct_deep_copy_pnext(value, nullptr);
+    size_t num_bytes = graphics::vulkan_struct_deep_copy_stype(value, nullptr);
     out_data         = std::make_unique<uint8_t[]>(num_bytes);
-    graphics::vulkan_struct_deep_copy_pnext(value, out_data.get());
+    graphics::vulkan_struct_deep_copy_stype(value, out_data.get());
     return out_data.get();
 }
 
@@ -49,7 +49,7 @@ inline void* TrackStruct(const void* value, std::unique_ptr<uint8_t[]>& out_data
  * @tparam  T           structure-type
  * @param   structs     an array of vulkan-structures
  * @param   count       element count in structs-array
- * @param   out_data    reference to an output-array or nullptr
+ * @param   out_data    reference to an output std::unique_pointer
  * @return  a typed pointer to the beginning of the tracked struct-memory.
  */
 template <typename T>

--- a/framework/generated/generate_vulkan.py
+++ b/framework/generated/generate_vulkan.py
@@ -48,7 +48,7 @@ generate_targets = [
     'generated_vulkan_struct_handle_wrappers.h',
     'generated_vulkan_struct_handle_wrappers.cpp',
     'generated_vulkan_struct_deep_copy.cpp',
-    'generated_vulkan_struct_deep_copy_pnext.cpp',
+    'generated_vulkan_struct_deep_copy_stype.cpp',
     'generated_vulkan_api_call_encoders.h',
     'generated_vulkan_api_call_encoders.cpp',
     'generated_vulkan_command_buffer_util.h',

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -10019,10 +10019,11 @@ void VulkanReplayConsumer::Process_vkDestroyShaderEXT(
     format::HandleId                            shader,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
-    auto in_shader = GetObjectInfoTable().GetShaderEXTInfo(shader);
+    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
+    VkShaderEXT in_shader = MapHandle<ShaderEXTInfo>(shader, &VulkanObjectInfoTable::GetShaderEXTInfo);
+    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
-    OverrideDestroyShaderEXT(GetDeviceTable(in_device->handle)->DestroyShaderEXT, in_device, in_shader, pAllocator);
+    GetDeviceTable(in_device)->DestroyShaderEXT(in_device, in_shader, in_pAllocator);
     RemoveHandle(shader, &VulkanObjectInfoTable::RemoveShaderEXTInfo);
 }
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -1016,6 +1016,12 @@ void VulkanReplayConsumer::Process_vkCreateComputePipelines(
     std::vector<PipelineInfo> handle_info(createInfoCount);
     for (size_t i = 0; i < createInfoCount; ++i) { pPipelines->SetConsumerData(i, &handle_info[i]); }
 
+    if (UseAsyncOperations())
+    {
+        auto task = AsyncCreateComputePipelines(call_info, returnValue, in_device, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+        AddHandlesAsync<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), std::move(handle_info), &VulkanObjectInfoTable::AddPipelineInfo, std::move(task));
+        return;
+    }
     VkResult replay_result = OverrideCreateComputePipelines(GetDeviceTable(in_device->handle)->CreateComputePipelines, returnValue, in_device, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
     CheckResult("vkCreateComputePipelines", returnValue, replay_result, call_info);
 
@@ -9988,17 +9994,23 @@ void VulkanReplayConsumer::Process_vkCreateShadersEXT(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkShaderEXT>*          pShaders)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    const VkShaderCreateInfoEXT* in_pCreateInfos = pCreateInfos->GetPointer();
-    MapStructArrayHandles(pCreateInfos->GetMetaStructPointer(), pCreateInfos->GetLength(), GetObjectInfoTable());
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
-    if (!pShaders->IsNull()) { pShaders->SetHandleLength(createInfoCount); }
-    VkShaderEXT* out_pShaders = pShaders->GetHandlePointer();
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
 
-    VkResult replay_result = GetDeviceTable(in_device)->CreateShadersEXT(in_device, createInfoCount, in_pCreateInfos, in_pAllocator, out_pShaders);
+    MapStructArrayHandles(pCreateInfos->GetMetaStructPointer(), pCreateInfos->GetLength(), GetObjectInfoTable());
+    if (!pShaders->IsNull()) { pShaders->SetHandleLength(createInfoCount); }
+    std::vector<ShaderEXTInfo> handle_info(createInfoCount);
+    for (size_t i = 0; i < createInfoCount; ++i) { pShaders->SetConsumerData(i, &handle_info[i]); }
+
+    if (UseAsyncOperations())
+    {
+        auto task = AsyncCreateShadersEXT(call_info, returnValue, in_device, createInfoCount, pCreateInfos, pAllocator, pShaders);
+        AddHandlesAsync<ShaderEXTInfo>(device, pShaders->GetPointer(), pShaders->GetLength(), std::move(handle_info), &VulkanObjectInfoTable::AddShaderEXTInfo, std::move(task));
+        return;
+    }
+    VkResult replay_result = OverrideCreateShadersEXT(GetDeviceTable(in_device->handle)->CreateShadersEXT, returnValue, in_device, createInfoCount, pCreateInfos, pAllocator, pShaders);
     CheckResult("vkCreateShadersEXT", returnValue, replay_result, call_info);
 
-    AddHandles<ShaderEXTInfo>(device, pShaders->GetPointer(), pShaders->GetLength(), out_pShaders, createInfoCount, &VulkanObjectInfoTable::AddShaderEXTInfo);
+    AddHandles<ShaderEXTInfo>(device, pShaders->GetPointer(), pShaders->GetLength(), pShaders->GetHandlePointer(), createInfoCount, std::move(handle_info), &VulkanObjectInfoTable::AddShaderEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyShaderEXT(
@@ -10007,11 +10019,10 @@ void VulkanReplayConsumer::Process_vkDestroyShaderEXT(
     format::HandleId                            shader,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkShaderEXT in_shader = MapHandle<ShaderEXTInfo>(shader, &VulkanObjectInfoTable::GetShaderEXTInfo);
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_shader = GetObjectInfoTable().GetShaderEXTInfo(shader);
 
-    GetDeviceTable(in_device)->DestroyShaderEXT(in_device, in_shader, in_pAllocator);
+    OverrideDestroyShaderEXT(GetDeviceTable(in_device->handle)->DestroyShaderEXT, in_device, in_shader, pAllocator);
     RemoveHandle(shader, &VulkanObjectInfoTable::RemoveShaderEXTInfo);
 }
 

--- a/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
+++ b/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
@@ -39,7 +39,7 @@ inline uint8_t* offset_ptr(uint8_t* ptr, uint32_t offset)
     return ptr != nullptr ? ptr + offset : nullptr;
 }
 
-size_t vulkan_struct_deep_copy_pnext(const void* pNext, uint8_t* out_data)
+size_t vulkan_struct_deep_copy_stype(const void* pNext, uint8_t* out_data)
 {
     uint64_t offset = 0;
     auto     base    = reinterpret_cast<const VkBaseInStructure*>(pNext);
@@ -47,7 +47,7 @@ size_t vulkan_struct_deep_copy_pnext(const void* pNext, uint8_t* out_data)
     switch (base->sType)
     {
         default:
-            GFXRECON_LOG_WARNING("vulkan_struct_deep_copy_pnext: unknown struct-type: %d", base->sType);
+            GFXRECON_LOG_WARNING("vulkan_struct_deep_copy_stype: unknown struct-type: %d", base->sType);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER:
             offset += vulkan_struct_deep_copy(

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -87,7 +87,7 @@ from encode_pnext_struct_generator import EncodePNextStructGenerator, EncodePNex
 from vulkan_struct_handle_wrappers_header_generator import VulkanStructHandleWrappersHeaderGenerator, VulkanStructHandleWrappersHeaderGeneratorOptions
 from vulkan_struct_handle_wrappers_body_generator import VulkanStructHandleWrappersBodyGenerator, VulkanStructHandleWrappersBodyGeneratorOptions
 from vulkan_struct_deep_copy_body_generator import VulkanStructDeepCopyBodyGenerator, VulkanStructDeepCopyBodyGeneratorOptions
-from vulkan_struct_deep_copy_pnext_body_generator import VulkanStructDeepCopyPNextBodyGenerator, VulkanStructDeepCopyPNextBodyGeneratorOptions
+from vulkan_struct_deep_copy_stype_body_generator import VulkanStructDeepCopySTypeBodyGenerator, VulkanStructDeepCopySTypeBodyGeneratorOptions
 
 # To String
 from vulkan_enum_to_string_body_generator import VulkanEnumToStringBodyGenerator, VulkanEnumToStringBodyGeneratorOptions
@@ -907,10 +907,10 @@ def make_gen_opts(args):
         )
     ]
 
-    gen_opts['generated_vulkan_struct_deep_copy_pnext.cpp'] = [
-        VulkanStructDeepCopyPNextBodyGenerator,
-        VulkanStructDeepCopyPNextBodyGeneratorOptions(
-            filename='generated_vulkan_struct_deep_copy_pnext.cpp',
+    gen_opts['generated_vulkan_struct_deep_copy_stype.cpp'] = [
+        VulkanStructDeepCopySTypeBodyGenerator,
+        VulkanStructDeepCopySTypeBodyGeneratorOptions(
+            filename='generated_vulkan_struct_deep_copy_stype.cpp',
             directory=directory,
             blacklists=blacklists,
             platform_types=platform_types,

--- a/framework/generated/vulkan_generators/replay_async_overrides.json
+++ b/framework/generated/vulkan_generators/replay_async_overrides.json
@@ -1,5 +1,7 @@
 {
   "functions": {
-    "vkCreateGraphicsPipelines": "AsyncCreateGraphicsPipelines"
+    "vkCreateGraphicsPipelines": "AsyncCreateGraphicsPipelines",
+    "vkCreateComputePipelines": "AsyncCreateComputePipelines",
+    "vkCreateShadersEXT": "AsyncCreateShadersEXT"
   }
 }

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -120,6 +120,8 @@
     "vkDestroyRenderPass": "OverrideDestroyRenderPass",
     "vkCreateVideoSessionKHR": "OverrideCreateVideoSessionKHR",
     "vkDestroyVideoSessionKHR": "OverrideDestroyVideoSessionKHR",
-    "vkBindVideoSessionMemoryKHR": "OverrideBindVideoSessionMemoryKHR"
+    "vkBindVideoSessionMemoryKHR": "OverrideBindVideoSessionMemoryKHR",
+    "vkCreateShadersEXT": "OverrideCreateShadersEXT",
+    "vkDestroyShaderEXT": "OverrideDestroyShaderEXT"
   }
 }

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -121,7 +121,6 @@
     "vkCreateVideoSessionKHR": "OverrideCreateVideoSessionKHR",
     "vkDestroyVideoSessionKHR": "OverrideDestroyVideoSessionKHR",
     "vkBindVideoSessionMemoryKHR": "OverrideBindVideoSessionMemoryKHR",
-    "vkCreateShadersEXT": "OverrideCreateShadersEXT",
-    "vkDestroyShaderEXT": "OverrideDestroyShaderEXT"
+    "vkCreateShadersEXT": "OverrideCreateShadersEXT"
   }
 }

--- a/framework/generated/vulkan_generators/vulkan_struct_deep_copy_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_deep_copy_body_generator.py
@@ -121,12 +121,29 @@ void handle_pnext(const T& base_struct, uint32_t out_index, uint64_t& offset, ui
     if (base_struct.pNext != nullptr)
     {
         uint8_t* out_address = offset_ptr(out_data, offset);
-        offset += vulkan_struct_deep_copy_pnext(base_struct.pNext, out_address);
+        offset += vulkan_struct_deep_copy_stype(base_struct.pNext, out_address);
         if (out_address != nullptr)
         {
             void** out_pNext = reinterpret_cast<void**>(out_data + out_index * sizeof(T) + offsetof(T, pNext));
             *out_pNext       = out_address;
         }
+    }
+}
+
+template <typename T, typename U>
+void handle_struct_member(
+    const T& base_struct, const U& struct_member, uint32_t out_index, uint64_t& offset, uint8_t* out_data)
+{
+    uint32_t member_offset =
+        reinterpret_cast<const uint8_t*>(&struct_member) - reinterpret_cast<const uint8_t*>(&base_struct);
+
+    auto out_address = offset_ptr(out_data, offset);
+    offset += vulkan_struct_deep_copy_stype(&struct_member, out_address);
+
+    if (out_data != nullptr)
+    {
+        auto& out_struct_member = *reinterpret_cast<U*>(out_data + out_index * sizeof(T) + member_offset);
+        out_struct_member       = *reinterpret_cast<U*>(out_address);
     }
 }
 '''
@@ -280,6 +297,8 @@ class VulkanStructDeepCopyBodyGenerator(BaseGenerator):
                     write('                handle_pointer_member(base_struct.{0}[j], 1);'.format(value.name), file=self.outFile)
                     write('            }', file=self.outFile)
                     write('        }', file=self.outFile)
+            elif value.base_type in ["VkPipelineShaderStageCreateInfo", "VkAccelerationStructureGeometryDataKHR"]:
+                write('        handle_struct_member(base_struct, base_struct.{0}, i, offset, out_data);'.format(value.name), file=self.outFile)
         write('    }', file=self.outFile)
         write('    return offset;', file=self.outFile)
         write('}', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_deep_copy_stype_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_deep_copy_stype_body_generator.py
@@ -25,7 +25,7 @@ import sys
 from base_generator import BaseGenerator, BaseGeneratorOptions, write
 
 
-class VulkanStructDeepCopyPNextBodyGeneratorOptions(BaseGeneratorOptions):
+class VulkanStructDeepCopySTypeBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating function definitions to track (deepcopy) Vulkan structs at API capture for trimming."""
 
     def __init__(
@@ -52,7 +52,7 @@ class VulkanStructDeepCopyPNextBodyGeneratorOptions(BaseGeneratorOptions):
         )
 
 
-class VulkanStructDeepCopyPNextBodyGenerator(BaseGenerator):
+class VulkanStructDeepCopySTypeBodyGenerator(BaseGenerator):
     """VulkanStructTrackersHeaderGenerator - subclass of BaseGenerator.
     Generates C++ function definitions to track (deepcopy) Vulkan structs
     at API capture for trimming.
@@ -93,7 +93,7 @@ class VulkanStructDeepCopyPNextBodyGenerator(BaseGenerator):
         write('    return ptr != nullptr ? ptr + offset : nullptr;', file=self.outFile)
         write('}', file=self.outFile)
         self.newline()
-        write('size_t vulkan_struct_deep_copy_pnext(const void* pNext, uint8_t* out_data)', file=self.outFile)
+        write('size_t vulkan_struct_deep_copy_stype(const void* pNext, uint8_t* out_data)', file=self.outFile)
         write('{', file=self.outFile)
         write('    uint64_t offset = 0;', file=self.outFile)
         write('    auto     base    = reinterpret_cast<const VkBaseInStructure*>(pNext);', file=self.outFile)
@@ -101,7 +101,7 @@ class VulkanStructDeepCopyPNextBodyGenerator(BaseGenerator):
         write('    switch (base->sType)', file=self.outFile)
         write('    {', file=self.outFile)
         write('        default:', file=self.outFile)
-        write('            GFXRECON_LOG_WARNING("vulkan_struct_deep_copy_pnext: unknown struct-type: %d", base->sType);', file=self.outFile)
+        write('            GFXRECON_LOG_WARNING("vulkan_struct_deep_copy_stype: unknown struct-type: %d", base->sType);', file=self.outFile)
         write('            break;', file=self.outFile)
 
     def endFile(self):

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -49,7 +49,7 @@ target_sources(gfxrecon_graphics
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_deep_copy.h
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy.cpp
-                    ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy_pnext.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy_stype.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_extract_handles.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_extract_handles.cpp
               )

--- a/framework/graphics/vulkan_check_buffer_references.h
+++ b/framework/graphics/vulkan_check_buffer_references.h
@@ -1,0 +1,35 @@
+//
+// Created by crocdialer on 31.07.24.
+//
+
+#ifndef GFXRECON_GRAPHICS_CHECK_BUFFER_REFERENCES_H
+#define GFXRECON_GRAPHICS_CHECK_BUFFER_REFERENCES_H
+
+#include "util/spirv_parsing_util.h"
+#include "util/logging.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+static void vulkan_check_buffer_references(const uint32_t* const spirv_code, uint32_t num_bytes)
+{
+    // check for buffer-references, issue warning
+    gfxrecon::util::SpirVParsingUtil spirv_util;
+
+    if (spirv_util.ParseBufferReferences(spirv_code, num_bytes))
+    {
+        auto buffer_reference_infos = spirv_util.GetBufferReferenceInfos();
+
+        if (!buffer_reference_infos.empty())
+        {
+            GFXRECON_LOG_WARNING_ONCE("A Shader is using the 'SPV_KHR_physical_storage_buffer' feature. "
+                                      "Resource tracking for buffers accessed via references is currently "
+                                      "unsupported, so replay may fail.");
+        }
+    }
+}
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_GRAPHICS_CHECK_BUFFER_REFERENCES_H

--- a/framework/graphics/vulkan_struct_deep_copy.h
+++ b/framework/graphics/vulkan_struct_deep_copy.h
@@ -48,14 +48,14 @@ template <typename T>
 size_t vulkan_struct_deep_copy(const T* structs, uint32_t count, uint8_t* out_data);
 
 /**
- * @brief   vulkan_struct_deep_copy_pnext is similar to 'vulkan_struct_deep_copy',
+ * @brief   vulkan_struct_deep_copy_stype is similar to 'vulkan_struct_deep_copy',
  *          with additional type-resolution based on sType-member.
  *
  * @param   pNext       a pointer to a pNext-chain
  * @param   out_data    pointer to an output-array or nullptr
  * @return  number of bytes required for deep-copy
  */
-size_t vulkan_struct_deep_copy_pnext(const void* pNext, uint8_t* out_data);
+size_t vulkan_struct_deep_copy_stype(const void* pNext, uint8_t* out_data);
 
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/vulkan_struct_extract_handles.h
+++ b/framework/graphics/vulkan_struct_extract_handles.h
@@ -32,8 +32,32 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
+/**
+ * @brief   vulkan_struct_extract_handle_ids can be used to extract the handle-ids for all referenced handles.
+ *
+ * @param   create_infos    a decoder-object, wrapping create-infos structs.
+ * @return  a set containing all referenced handles
+ */
 std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
-    const decode::StructPointerDecoder<decode::Decoded_VkGraphicsPipelineCreateInfo>* create_infos, uint32_t count);
+    const decode::StructPointerDecoder<decode::Decoded_VkGraphicsPipelineCreateInfo>* create_infos);
+
+/**
+ * @brief   vulkan_struct_extract_handle_ids can be used to extract the handle-ids for all referenced handles.
+ *
+ * @param   create_infos    a decoder-object, wrapping create-infos structs.
+ * @return  a set containing all referenced handles
+ */
+std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
+    const decode::StructPointerDecoder<decode::Decoded_VkComputePipelineCreateInfo>* create_infos);
+
+/**
+ * @brief   vulkan_struct_extract_handle_ids can be used to extract the handle-ids for all referenced handles.
+ *
+ * @param   create_infos    a decoder-object, wrapping create-infos structs.
+ * @return  a set containing all referenced handles
+ */
+std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
+    const decode::StructPointerDecoder<decode::Decoded_VkShaderCreateInfoEXT>* create_infos);
 
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -325,10 +325,11 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tDump immutable shader resources.");
     GFXRECON_WRITE_CONSOLE("  --dump-resources-dump-all-image-subresources");
     GFXRECON_WRITE_CONSOLE("          \t\tDump all available mip levels and layers when dumping images.");
-    GFXRECON_WRITE_CONSOLE("  --pcj\t\t\tSpecify the number of pipeline-creation-jobs or background-threads.");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tDefault is 0.");
-    GFXRECON_WRITE_CONSOLE("       \t\t\t(same as --pipeline-creation-jobs");
-
+    GFXRECON_WRITE_CONSOLE("  --pipeline-creation-jobs <num_jobs>");
+    GFXRECON_WRITE_CONSOLE("          \t\tSpecify the number of asynchronous pipeline-creation jobs as integer.");
+    GFXRECON_WRITE_CONSOLE("          \t\tIf <num_jobs> is negative it will be added to the number of cpu-cores");
+    GFXRECON_WRITE_CONSOLE("          \t\tDefault: 0 (do not use asynchronous operations).");
+    GFXRECON_WRITE_CONSOLE("          \t\tSame as --pcj <num_jobs>");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("D3D12 only:")


### PR DESCRIPTION
- Extends support for asynchronous pipeline/shader-compilation to `vkCreateComputePipelines`, `vkCreateShadersEXT`
- Add missing sync before destroying `VkPipeline`, same for `VkShaderEXT`
- minor improvement for `vulkan_struct_deep_copy` routine, cover some edge-cases
- minor cleanup/refactoring