### PR TITLE
Check SPIRV/Buffer-References inlined in pNext

### DIFF
--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(gfxrecon_graphics
                PRIVATE
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/fps_info.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/fps_info.cpp
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_check_buffer_references.h
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_check_buffer_references.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_resources_util.h

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -9267,21 +9267,26 @@ void VulkanReplayConsumerBase::OverrideDestroyPipeline(
     PipelineInfo*                                              pipeline_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice   in_device = device_info->handle;
-    VkPipeline in_pipeline =
-        MapHandle<PipelineInfo>(pipeline_info->capture_id, &VulkanObjectInfoTable::GetPipelineInfo);
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
+    GFXRECON_ASSERT(device_info != nullptr);
+    VkDevice in_device = device_info->handle;
 
-    if (!IsUsedByAsyncTask(pipeline_info->capture_id))
+    if (pipeline_info != nullptr)
     {
-        func(in_device, in_pipeline, in_pAllocator);
-    }
-    else
-    {
-        // schedule deletion
-        DestroyAsyncHandle(pipeline_info->capture_id, [func, in_device, in_pipeline, in_pAllocator]() {
+        VkPipeline in_pipeline =
+            MapHandle<PipelineInfo>(pipeline_info->capture_id, &VulkanObjectInfoTable::GetPipelineInfo);
+        const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
+
+        if (!IsUsedByAsyncTask(pipeline_info->capture_id))
+        {
             func(in_device, in_pipeline, in_pAllocator);
-        });
+        }
+        else
+        {
+            // schedule deletion
+            DestroyAsyncHandle(pipeline_info->capture_id, [func, in_device, in_pipeline, in_pAllocator]() {
+                func(in_device, in_pipeline, in_pAllocator);
+            });
+        }
     }
 }
 

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -41,6 +41,8 @@ target_sources(gfxrecon_graphics
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_image_renderer.cpp>
                     ${CMAKE_CURRENT_LIST_DIR}/fps_info.h
                     ${CMAKE_CURRENT_LIST_DIR}/fps_info.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_check_buffer_references.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_check_buffer_references.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_resources_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_resources_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_util.h

--- a/framework/graphics/vulkan_check_buffer_references.cpp
+++ b/framework/graphics/vulkan_check_buffer_references.cpp
@@ -1,0 +1,70 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "vulkan_check_buffer_references.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+void vulkan_check_buffer_references(const VkGraphicsPipelineCreateInfo* create_infos, uint32_t create_info_count)
+{
+    for (uint32_t i = 0; i < create_info_count; ++i)
+    {
+        for (uint32_t j = 0; j < create_infos[i].stageCount; ++j)
+        {
+            const void* pNext = create_infos[i].pStages[j].pNext;
+            while (pNext != nullptr)
+            {
+                auto base = reinterpret_cast<const VkBaseInStructure*>(pNext);
+
+                if (base->sType == VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
+                {
+                    auto module_create_info = reinterpret_cast<const VkShaderModuleCreateInfo*>(base);
+                    graphics::vulkan_check_buffer_references(module_create_info->pCode, module_create_info->codeSize);
+                }
+                pNext = base->pNext;
+            }
+        }
+    }
+}
+
+void vulkan_check_buffer_references(const VkComputePipelineCreateInfo* create_infos, uint32_t create_info_count)
+{
+    for (uint32_t i = 0; i < create_info_count; ++i)
+    {
+        const void* pNext = create_infos[i].stage.pNext;
+        while (pNext != nullptr)
+        {
+            auto base = reinterpret_cast<const VkBaseInStructure*>(pNext);
+
+            if (base->sType == VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
+            {
+                auto module_create_info = reinterpret_cast<const VkShaderModuleCreateInfo*>(base);
+                graphics::vulkan_check_buffer_references(module_create_info->pCode, module_create_info->codeSize);
+            }
+            pNext = base->pNext;
+        }
+    }
+}
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/vulkan_check_buffer_references.cpp
+++ b/framework/graphics/vulkan_check_buffer_references.cpp
@@ -25,6 +25,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
+template <>
 void vulkan_check_buffer_references(const VkGraphicsPipelineCreateInfo* create_infos, uint32_t create_info_count)
 {
     for (uint32_t i = 0; i < create_info_count; ++i)
@@ -47,6 +48,7 @@ void vulkan_check_buffer_references(const VkGraphicsPipelineCreateInfo* create_i
     }
 }
 
+template <>
 void vulkan_check_buffer_references(const VkComputePipelineCreateInfo* create_infos, uint32_t create_info_count)
 {
     for (uint32_t i = 0; i < create_info_count; ++i)

--- a/framework/graphics/vulkan_check_buffer_references.h
+++ b/framework/graphics/vulkan_check_buffer_references.h
@@ -47,6 +47,47 @@ static void vulkan_check_buffer_references(const uint32_t* const spirv_code, uin
     }
 }
 
+static void vulkan_check_buffer_references(const VkGraphicsPipelineCreateInfo* create_infos, uint32_t create_info_count)
+{
+    for (uint32_t i = 0; i < create_info_count; ++i)
+    {
+        for (uint32_t j = 0; j < create_infos[i].stageCount; ++j)
+        {
+            const void* pNext = create_infos[i].pStages[j].pNext;
+            while (pNext != nullptr)
+            {
+                auto base = reinterpret_cast<const VkBaseInStructure*>(pNext);
+
+                if (base->sType == VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
+                {
+                    auto module_create_info = reinterpret_cast<const VkShaderModuleCreateInfo*>(base);
+                    graphics::vulkan_check_buffer_references(module_create_info->pCode, module_create_info->codeSize);
+                }
+                pNext = base->pNext;
+            }
+        }
+    }
+}
+
+static void vulkan_check_buffer_references(const VkComputePipelineCreateInfo* create_infos, uint32_t create_info_count)
+{
+    for (uint32_t i = 0; i < create_info_count; ++i)
+    {
+        const void* pNext = create_infos[i].stage.pNext;
+        while (pNext != nullptr)
+        {
+            auto base = reinterpret_cast<const VkBaseInStructure*>(pNext);
+
+            if (base->sType == VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
+            {
+                auto module_create_info = reinterpret_cast<const VkShaderModuleCreateInfo*>(base);
+                graphics::vulkan_check_buffer_references(module_create_info->pCode, module_create_info->codeSize);
+            }
+            pNext = base->pNext;
+        }
+    }
+}
+
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/graphics/vulkan_check_buffer_references.h
+++ b/framework/graphics/vulkan_check_buffer_references.h
@@ -62,12 +62,19 @@ static void vulkan_check_buffer_references(const uint32_t* const spirv_code, uin
  * Inlined SPIRV: VkPipelineShaderStageCreateInfo 'can' provide a VkShaderModuleCreateInfo
  * This function will iterate all contained 'VkPipelineShaderStageCreateInfo' and descend their pNext-chains.
  * If any 'VkShaderModuleCreateInfo' are contained in the pNext-chains, the contained spirv-code will be checked using:
- * vulkan_check_buffer_references(spirv, spirv_bytes).
+ * vulkan_check_buffer_references(spirv_code, num_bytes).
  *
+ * @tparam  T                   structure-type
  * @param   create_infos        an array of pipeline/shader create-info structures.
  * @param   create_info_count   create-infos' array-count
  */
+template <typename T>
+void vulkan_check_buffer_references(const T* create_infos, uint32_t create_info_count) = delete;
+
+template <>
 void vulkan_check_buffer_references(const VkGraphicsPipelineCreateInfo* create_infos, uint32_t create_info_count);
+
+template <>
 void vulkan_check_buffer_references(const VkComputePipelineCreateInfo* create_infos, uint32_t create_info_count);
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/framework/graphics/vulkan_struct_extract_handles.cpp
+++ b/framework/graphics/vulkan_struct_extract_handles.cpp
@@ -28,6 +28,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
+template <>
 std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
     const decode::StructPointerDecoder<decode::Decoded_VkGraphicsPipelineCreateInfo>* create_infos)
 {
@@ -67,6 +68,7 @@ std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
     return handle_deps;
 }
 
+template <>
 std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
     const decode::StructPointerDecoder<decode::Decoded_VkComputePipelineCreateInfo>* create_infos)
 {
@@ -103,6 +105,8 @@ std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
     }
     return handle_deps;
 }
+
+template <>
 std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
     const decode::StructPointerDecoder<decode::Decoded_VkShaderCreateInfoEXT>* create_infos)
 {

--- a/framework/graphics/vulkan_struct_extract_handles.h
+++ b/framework/graphics/vulkan_struct_extract_handles.h
@@ -38,24 +38,19 @@ GFXRECON_BEGIN_NAMESPACE(graphics)
  * @param   create_infos    a decoder-object, wrapping create-infos structs.
  * @return  a set containing all referenced handles
  */
+template <typename T>
+std::unordered_set<format::HandleId>
+vulkan_struct_extract_handle_ids(const typename decode::StructPointerDecoder<T>* create_infos) = delete;
+
+template <>
 std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
     const decode::StructPointerDecoder<decode::Decoded_VkGraphicsPipelineCreateInfo>* create_infos);
 
-/**
- * @brief   vulkan_struct_extract_handle_ids can be used to extract the handle-ids for all referenced handles.
- *
- * @param   create_infos    a decoder-object, wrapping create-infos structs.
- * @return  a set containing all referenced handles
- */
+template <>
 std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
     const decode::StructPointerDecoder<decode::Decoded_VkComputePipelineCreateInfo>* create_infos);
 
-/**
- * @brief   vulkan_struct_extract_handle_ids can be used to extract the handle-ids for all referenced handles.
- *
- * @param   create_infos    a decoder-object, wrapping create-infos structs.
- * @return  a set containing all referenced handles
- */
+template <>
 std::unordered_set<format::HandleId> vulkan_struct_extract_handle_ids(
     const decode::StructPointerDecoder<decode::Decoded_VkShaderCreateInfoEXT>* create_infos);
 


### PR DESCRIPTION
- `VkPipelineShaderStageCreateInfo` 'can' provide a `VkShaderModuleCreateInfo` in pNext
- Add helper-routines to check for that case
- Add a nullptr-check required in certain cases, in presence of asynchronous pipeline-creation (`--pcj X` option)
- Refactoring and doc of `vulkan_struct_extract_handle_ids`