### PR TITLE
build: Apply /bigobj for encode & decode targets

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -262,16 +262,8 @@ target_sources(gfxrecon_decode
 endif()
 
 if (MSVC)
-    # These files may fail to compile with VS2017 and older, requiring the default section limit of 2^16 to be increased.
-    set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_decode_pnext_struct.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-    set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_dx12_json_consumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/test/main.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-    if (MSVC_VERSION LESS 1920)
-        set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_decode_pnext_struct.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-        set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-        set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-        set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/vulkan_replay_consumer_base.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-    endif()
+    # gfxrecon_decode exceeds the default number of sections during compilation, use this flag to increase the limit
+    target_compile_options(gfxrecon_decode PRIVATE /bigobj)
 endif()
 
 if (TARGET ZLIB::ZLIB)

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -133,10 +133,8 @@ target_sources(gfxrecon_encode
 )
 
 if (MSVC)
-    # Increase object size limit to handle large numbers of template function instantiations.
-    set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_dx12_api_call_encoders.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-    set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_dx12_wrappers.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-    set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_api_call_encoders.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+    # gfxrecon_encode exceeds the default number of sections during compilation, use this flag to increase the limit
+    target_compile_options(gfxrecon_encode PRIVATE /bigobj)
 endif()
 
 target_include_directories(gfxrecon_encode


### PR DESCRIPTION
Rather than adding the /bigobj flag to individual files, apply it to the entire static library on MSVC