### PR TITLE
Rework vulkan optimizer

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -211,6 +211,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_offscreen_swapchain.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_offscreen_swapchain.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/window.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_referenced_resource_consumer_base.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_example_modifier.h
                     $<$<BOOL:${GFXRECON_TOCPP_SUPPORT}>:${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_cpp_consumer.h>
                     $<$<BOOL:${GFXRECON_TOCPP_SUPPORT}>:${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_cpp_consumer.cpp>
                     $<$<BOOL:${GFXRECON_TOCPP_SUPPORT}>:${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_cpp_structs.h>

--- a/framework/decode/vulkan_example_modifier.h
+++ b/framework/decode/vulkan_example_modifier.h
@@ -1,22 +1,190 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
 #ifndef GFXRECON_DECODE_VULKAN_EXAMPLE_MODIFIER_H
 #define GFXRECON_DECODE_VULKAN_EXAMPLE_MODIFIER_H
 
-#include "decode/referenced_resource_table.h"
-#include "generated/generated_vulkan_consumer.h"
 #include "util/defines.h"
 #include "util/vulkan_modifier_base.h"
-
+#include "encode/struct_pointer_encoder.h"
 #include "vulkan/vulkan.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+// Example usage of VulkanModifier to add, modify and remove calls from trace.
+// This is just for demonstration purposes.
+// This modifier will use vkSetDebugUtilsObjectNameEXT call to name all compacted copies of
+// other acceleration structures. Performs several operaions:
+// 1. Adds vkSetDebugUtilsObjectNameEXT calls after relevant vkCreateAccelerationStructureKHR
+// 2. Removes existing vkSetDebugUtilsObjectNameEXT calls for objects marked in step 1.
+// 3. Modifies VkCreateInstance call to include VK_EXT_debug_utils in enabled extension list
+// To test this example you need any trace that performs an acceleration structure copy with
+// VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR mode, for example:
+// https://github.com/ARM-software/tracetooltests/blob/main/src/vulkan_as_3.cpp
 class VulkanExampleModifier : public util::VulkanModifierBase
 {
   public:
     VulkanExampleModifier(){};
 
-    virtual bool CanOptimize() override { return true; }
+    virtual bool CanOptimize() override { return compacted_copies_.empty(); }
+
+    // Example call modification
+    // Add debug utils to list of extensions
+    void Process_vkCreateInstance(const ApiCallInfo&                                   call_info,
+                                  VkResult                                             returnValue,
+                                  StructPointerDecoder<Decoded_VkInstanceCreateInfo>*  pCreateInfo,
+                                  StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                                  HandlePointerDecoder<VkInstance>*                    pInstance)
+    {
+        // Just modification pass, nothing to analyze
+        if (parameter_buffer_)
+        {
+            auto create_info     = pCreateInfo->GetMetaStructPointer()->decoded_value;
+            auto extension_count = create_info->enabledExtensionCount;
+            if (extension_count)
+            {
+                bool debug_utils_enabled = false;
+                for (uint32_t i = 0; i < extension_count; i++)
+                {
+                    std::string extension_name = create_info->ppEnabledExtensionNames[i];
+                    if (extension_name == VK_EXT_DEBUG_UTILS_EXTENSION_NAME)
+                    {
+                        debug_utils_enabled = true;
+                        break;
+                    }
+                }
+                if (!debug_utils_enabled)
+                {
+                    auto                     new_extension_count = extension_count + 1;
+                    std::vector<const char*> new_extensions(new_extension_count);
+                    new_extensions.assign(create_info->ppEnabledExtensionNames,
+                                          create_info->ppEnabledExtensionNames + extension_count);
+                    new_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+                    create_info->enabledExtensionCount   = new_extension_count;
+                    create_info->ppEnabledExtensionNames = new_extensions.data();
+
+                    parameter_buffer_->Clear();
+                    gfxrecon::encode::ParameterEncoder encoder(parameter_buffer_);
+                    EncodeStructPtr(&encoder, pCreateInfo->GetPointer());
+                    EncodeStructPtr(&encoder, pAllocator->GetPointer());
+                    encoder.EncodeHandleIdPtr(pInstance->GetPointer());
+                    encoder.EncodeEnumValue(returnValue);
+                }
+            }
+        }
+    }
+
+    // Example call deletion
+    // Remove other SetName calls targeting the object we want to name
+    virtual void
+    Process_vkSetDebugUtilsObjectNameEXT(const ApiCallInfo&                                           call_info,
+                                         VkResult                                                     returnValue,
+                                         format::HandleId                                             device,
+                                         StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo)
+    {
+        if (parameter_buffer_)
+        {
+            const auto compacted_copy = compacted_copies_.find(pNameInfo->GetPointer()->objectHandle);
+            if (compacted_copy != compacted_copies_.end())
+            {
+                delete_current_call = true;
+            }
+        }
+    }
+
+    // Example call tracking
+    // This override does not modify anything, just stores data required for later modifications.
+    // In this case, handles of acceleration structures used for compaction purposes are stored in a map
+    // along with the handle of the original non-compacted AS.
+    virtual void
+    Process_vkCmdCopyAccelerationStructureKHR(const ApiCallInfo& call_info,
+                                              format::HandleId   commandBuffer,
+                                              StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo)
+    {
+        // Keep track of compacted acceleration structures
+        if (!parameter_buffer_)
+        {
+            const auto* info = pInfo->GetMetaStructPointer();
+
+            if (info->decoded_value->mode == VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR)
+            {
+                compacted_copies_[info->dst] = info->src;
+            }
+        }
+    }
+
+    // Example of adding new call
+    // When vkCreateAccelerationStructureKHR call is processed in the modification pass
+    // and there's a record of the created acceleration structure being used later as compacted
+    // copy destination, add vkSetDebugUtilsObjectNameEXT after this call.
+    virtual void Process_vkCreateAccelerationStructureKHR(
+        const ApiCallInfo&                                                  call_info,
+        VkResult                                                            returnValue,
+        format::HandleId                                                    device,
+        StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>*                pAllocator,
+        HandlePointerDecoder<VkAccelerationStructureKHR>*                   pAccelerationStructure)
+    {
+        // In modification pass, add SetObjectName command after AS creation
+        if (parameter_buffer_)
+        {
+            const auto compaction_info = compacted_copies_.find(*pAccelerationStructure->GetPointer());
+
+            if (compaction_info != compacted_copies_.end())
+            {
+                // Initialize new call data
+                auto new_call        = CreatePostCall();
+                new_call->call_id    = gfxrecon::format::ApiCallId::ApiCall_vkSetDebugUtilsObjectNameEXT;
+                new_call->thread_id  = call_info.thread_id;
+                std::string new_name = "Compacted copy of " + std::to_string(compaction_info->second);
+
+                VkDebugUtilsObjectNameInfoEXT object_name_info;
+                object_name_info.sType        = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+                object_name_info.objectType   = VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR;
+                object_name_info.pObjectName  = new_name.c_str();
+                object_name_info.objectHandle = *pAccelerationStructure->GetPointer();
+                object_name_info.pNext        = NULL;
+                assert(object_name_info.pNext == nullptr);
+
+                // Encode new call
+                gfxrecon::encode::ParameterEncoder encoder(&new_call->parameter_buffer);
+                encoder.EncodeHandleIdValue(device);
+                encoder.EncodeStructPtrPreamble(&object_name_info, false, false);
+                encoder.EncodeEnumValue(object_name_info.sType);
+                EncodePNextStruct(&encoder, object_name_info.pNext);
+                encoder.EncodeEnumValue(object_name_info.objectType);
+                encoder.EncodeUInt64Value(object_name_info.objectHandle);
+                encoder.EncodeString(object_name_info.pObjectName);
+                encoder.EncodeEnumValue(VK_SUCCESS);
+            }
+        }
+    }
+
+  private:
+    // Contains handles of a compacted copy (fist) and the original non-compacted acceleration structure (second)
+    std::unordered_map<format::HandleId, format::HandleId> compacted_copies_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_example_modifier.h
+++ b/framework/decode/vulkan_example_modifier.h
@@ -1,0 +1,25 @@
+#ifndef GFXRECON_DECODE_VULKAN_EXAMPLE_MODIFIER_H
+#define GFXRECON_DECODE_VULKAN_EXAMPLE_MODIFIER_H
+
+#include "decode/referenced_resource_table.h"
+#include "generated/generated_vulkan_consumer.h"
+#include "util/defines.h"
+#include "util/vulkan_modifier_base.h"
+
+#include "vulkan/vulkan.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class VulkanExampleModifier : public util::VulkanModifierBase
+{
+  public:
+    VulkanExampleModifier(){};
+
+    virtual bool CanOptimize() override { return true; }
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_VULKAN_EXAMPLE_MODIFIER_H

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -256,7 +256,7 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
 
     bool IsComplete(uint64_t current_block_index) override { return not_optimizable_; }
 
-    bool WasNotOptimizable() { return not_optimizable_; }
+    bool WasOptimizable() { return !not_optimizable_; }
 
   protected:
     bool IsStateLoading() const { return loading_state_; }

--- a/framework/format/format_util.h
+++ b/framework/format/format_util.h
@@ -27,6 +27,7 @@
 #include "format/format.h"
 #include "util/compressor.h"
 #include "util/defines.h"
+#include "util/memory_output_stream.h"
 
 #include <string>
 
@@ -94,6 +95,32 @@ bool ValidateFileHeader(const FileHeader& header);
 util::Compressor* CreateCompressor(CompressionType type);
 
 std::string GetCompressionTypeName(CompressionType type);
+
+//! groups memory regions for header & data of an optionally compressed function-block
+struct function_call_block_t
+{
+    char        header[std::max(sizeof(format::FunctionCallHeader), sizeof(format::CompressedFunctionCallHeader))]{};
+    size_t      header_size = 0;
+    const void* data        = nullptr;
+    size_t      data_size   = 0;
+};
+
+/**
+ * @brief   CreateFunctionCallBlock can be used to create an optionally compressed function-call block
+ *          and return pointers to the created header- and data-segments.
+ *
+ * @param   call_id                     provided ApiCallId
+ * @param   thread_id                   provided ThreadId
+ * @param   parameter_buffer            a MemoryOutputStream containing parameters
+ * @param   compressor                  optional compressor, can be nullptr
+ * @param   compressor_scratch_space    optional scratch-space to be used during compression, can be nullptr
+ * @return  a struct grouping pointers for header- and data-segments
+ */
+format::function_call_block_t CreateFunctionCallBlock(format::ApiCallId               call_id,
+                                                      format::ThreadId                thread_id,
+                                                      const util::MemoryOutputStream* parameter_buffer,
+                                                      util::Compressor*               compressor,
+                                                      std::vector<uint8_t>*           compressor_scratch_space);
 
 GFXRECON_END_NAMESPACE(format)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -78,6 +78,8 @@ target_sources(gfxrecon_util
                     ${CMAKE_CURRENT_LIST_DIR}/spirv_helper.h
                     ${CMAKE_CURRENT_LIST_DIR}/spirv_parsing_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/spirv_parsing_util.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_modifier_base.h
+                    ${CMAKE_CURRENT_LIST_DIR}/call_modifier_base.h
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/interception/hooking_detours.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/interception/hooking_detours.cpp>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/interception/interception_util.h>

--- a/framework/util/call_modifier_base.h
+++ b/framework/util/call_modifier_base.h
@@ -1,0 +1,88 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_UTIL_CALL_MODIFIER_BASE_H
+#define GFXRECON_UTIL_CALL_MODIFIER_BASE_H
+
+#include "util/defines.h"
+#include "format/format.h"
+#include "encode/parameter_buffer.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+// Facilitates communication between file optimizer and modificators
+// Provides access to buffers and information on types of modification
+class CallModifierBase
+{
+  public:
+    struct NewCallData
+    {
+        format::ApiCallId        call_id;
+        format::ThreadId         thread_id;
+        util::MemoryOutputStream parameter_buffer;
+    };
+
+    virtual void SetParameterBuffer(encode::ParameterBuffer* buffer) { parameter_buffer_ = buffer; }
+
+    // Move new call data to the end of input vector
+    // The source data becomes invalid and its container is cleared
+    virtual void AppendPreCalls(std::vector<std::unique_ptr<NewCallData>>& pre_calls)
+    {
+        pre_calls.insert(pre_calls.end(),
+                         std::make_move_iterator(new_pre_calls_.begin()),
+                         std::make_move_iterator(new_pre_calls_.end()));
+        new_pre_calls_.clear();
+    }
+
+    virtual bool GetDeleteCurrentCall()
+    {
+        bool result = delete_current_call;
+        // reset the delete flag
+        delete_current_call = false;
+        return result;
+    }
+
+    virtual bool CanOptimize() = 0;
+
+  protected:
+    NewCallData* CreatePreCall()
+    {
+        new_pre_calls_.push_back(std::make_unique<NewCallData>());
+        return new_pre_calls_.back().get();
+    }
+
+    // Points to parameter buffer that can be modified
+    encode::ParameterBuffer* parameter_buffer_ = nullptr;
+
+    // Set if current call is meant to be removed from the trace
+    bool delete_current_call = false;
+
+    // Vector of new calls to add before currently processed call
+    std::vector<std::unique_ptr<NewCallData>> new_pre_calls_;
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_CALL_MODIFIER_BASE_H

--- a/framework/util/call_modifier_base.h
+++ b/framework/util/call_modifier_base.h
@@ -55,6 +55,16 @@ class CallModifierBase
         new_pre_calls_.clear();
     }
 
+    // Move new call data to the end of input vector
+    // The source data becomes invalid and its container is cleared
+    virtual void AppendPostCalls(std::vector<std::unique_ptr<NewCallData>>& post_calls)
+    {
+        post_calls.insert(post_calls.end(),
+                          std::make_move_iterator(new_post_calls_.begin()),
+                          std::make_move_iterator(new_post_calls_.end()));
+        new_post_calls_.clear();
+    }
+
     virtual bool GetDeleteCurrentCall()
     {
         bool result = delete_current_call;
@@ -72,6 +82,12 @@ class CallModifierBase
         return new_pre_calls_.back().get();
     }
 
+    NewCallData* CreatePostCall()
+    {
+        new_post_calls_.push_back(std::make_unique<NewCallData>());
+        return new_post_calls_.back().get();
+    }
+
     // Points to parameter buffer that can be modified
     encode::ParameterBuffer* parameter_buffer_ = nullptr;
 
@@ -80,6 +96,9 @@ class CallModifierBase
 
     // Vector of new calls to add before currently processed call
     std::vector<std::unique_ptr<NewCallData>> new_pre_calls_;
+
+    // Vector of new calls to add before currently processed call
+    std::vector<std::unique_ptr<NewCallData>> new_post_calls_;
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/vulkan_modifier_base.h
+++ b/framework/util/vulkan_modifier_base.h
@@ -1,0 +1,42 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+#ifndef GFXRECON_UTIL_VULKAN_MODIFIER_BASE_H
+#define GFXRECON_UTIL_VULKAN_MODIFIER_BASE_H
+#include "generated/generated_vulkan_consumer.h"
+#include "util/call_modifier_base.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+// Allows implementation of overrides for vulkan calls that can apply modifications
+// to the processed trace
+class VulkanModifierBase : public decode::VulkanConsumer, public util::CallModifierBase
+{
+  public:
+    virtual ~VulkanModifierBase() override {}
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_VULKAN_MODIFIER_BASE_H

--- a/tools/optimize/CMakeLists.txt
+++ b/tools/optimize/CMakeLists.txt
@@ -33,6 +33,8 @@ target_sources(gfxrecon-optimize
                    ${CMAKE_CURRENT_LIST_DIR}/main.cpp
                    ${CMAKE_CURRENT_LIST_DIR}/file_optimizer.h
                    ${CMAKE_CURRENT_LIST_DIR}/file_optimizer.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/vulkan_file_optimizer.h
+                   ${CMAKE_CURRENT_LIST_DIR}/vulkan_file_optimizer.cpp
                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_file_optimizer.h>
                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_file_optimizer.cpp>
                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_optimize_util.h>
@@ -60,6 +62,7 @@ target_include_directories(gfxrecon-optimize PUBLIC ${CMAKE_BINARY_DIR})
 target_link_libraries(gfxrecon-optimize
                           gfxrecon_application
                           gfxrecon_decode
+                          gfxrecon_encode
                           gfxrecon_graphics
                           gfxrecon_format
                           gfxrecon_util

--- a/tools/optimize/file_optimizer.h
+++ b/tools/optimize/file_optimizer.h
@@ -57,7 +57,7 @@ class FileOptimizer : public decode::FileTransformer
 
     bool FilterMethodCall(const format::BlockHeader& block_header, format::ApiCallId api_call_id, uint64_t block_index);
 
-  private:
+  protected:
     std::unordered_set<format::HandleId> unreferenced_ids_;
     std::unordered_set<uint64_t>         unreferenced_blocks_;
 };

--- a/tools/optimize/vulkan_file_optimizer.cpp
+++ b/tools/optimize/vulkan_file_optimizer.cpp
@@ -1,0 +1,191 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "tools/optimize/vulkan_file_optimizer.h"
+#include "framework/format/format_util.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+
+bool VulkanFileOptimizer::ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id)
+{
+    // Regular funciton call processing/compression handling - duplicated in multiple places, TODO: extract, reuse
+    size_t              parameter_buffer_size = static_cast<size_t>(block_header.size) - sizeof(call_id);
+    uint64_t            uncompressed_size     = 0;
+    decode::ApiCallInfo call_info{ GetCurrentBlockIndex() };
+    bool                success = ReadBytes(&call_info.thread_id, sizeof(call_info.thread_id));
+
+    parameter_buffer_size -= sizeof(call_info.thread_id);
+
+    if (format::IsBlockCompressed(block_header.type))
+    {
+        parameter_buffer_size -= sizeof(uncompressed_size);
+        success = ReadBytes(&uncompressed_size, sizeof(uncompressed_size));
+
+        if (success)
+        {
+            GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, uncompressed_size);
+
+            size_t actual_size = 0;
+            success            = ReadCompressedParameterBuffer(
+                parameter_buffer_size, static_cast<size_t>(uncompressed_size), &actual_size);
+
+            if (success)
+            {
+                assert(actual_size == uncompressed_size);
+                parameter_buffer_size = static_cast<size_t>(uncompressed_size);
+            }
+            else
+            {
+                HandleBlockReadError(kErrorReadingCompressedBlockData,
+                                     "Failed to read compressed function call block data");
+            }
+        }
+        else
+        {
+            HandleBlockReadError(kErrorReadingCompressedBlockHeader,
+                                 "Failed to read compressed function call block header");
+        }
+    }
+    else
+    {
+        success = ReadParameterBuffer(parameter_buffer_size);
+
+        if (!success)
+        {
+            HandleBlockReadError(kErrorReadingBlockData, "Failed to read function call block data");
+        }
+    }
+
+    // Separate buffer that holds call parameters to modify
+    encode::ParameterBuffer buffer;
+
+    // Initialize our modifiable parameter buffer with the initial data from trace
+    // Each modifier will get access to parameter buffer to read and modify
+    // The same parameter buffer will be passed to next modifier in chain
+    buffer.Write(GetParameterBuffer().data(), parameter_buffer_size);
+
+    // Each modifier can request the call to be removed from the trace
+    // This does not affect processing of the current call by other modifiers
+    bool delete_current_call = false;
+
+    // This vector owns new call data to be inserted before currently processed call
+    std::vector<std::unique_ptr<util::CallModifierBase::NewCallData>> new_pre_calls;
+
+    for (auto& modifier : optimization_data_->modifiers)
+    {
+        modifier->SetParameterBuffer(&buffer);
+        decoder.AddConsumer(modifier.get());
+        decode::DecodeAllocator::Begin();
+        decoder.DecodeFunctionCall(call_id, call_info, buffer.GetData(), buffer.GetDataSize());
+        decode::DecodeAllocator::End();
+        decoder.RemoveConsumer(modifier.get());
+        delete_current_call |= modifier->GetDeleteCurrentCall();
+        modifier->AppendPreCalls(new_pre_calls);
+    }
+
+    for (auto& new_call : new_pre_calls)
+    {
+        WriteFunctionCall(new_call->call_id, new_call->thread_id, &(new_call->parameter_buffer));
+    }
+
+    if (!delete_current_call)
+    {
+        WriteFunctionCall(call_id, call_info.thread_id, &buffer);
+    }
+
+    // TODO: Write buffer with calls to add post current call
+
+    return success;
+}
+
+// TODO: This is the same code used by CaptureManager to write function call data. It could be moved to a format
+// utility.
+void VulkanFileOptimizer::WriteFunctionCall(format::ApiCallId               call_id,
+                                            format::ThreadId                thread_id,
+                                            const util::MemoryOutputStream* parameter_buffer)
+{
+    assert(parameter_buffer != nullptr);
+
+    bool                                 not_compressed      = true;
+    format::CompressedFunctionCallHeader compressed_header   = {};
+    format::FunctionCallHeader           uncompressed_header = {};
+    size_t                               uncompressed_size   = parameter_buffer->GetDataSize();
+    size_t                               header_size         = 0;
+    const void*                          header_pointer      = nullptr;
+    size_t                               data_size           = 0;
+    const void*                          data_pointer        = nullptr;
+
+    auto compressor                  = GetCompressor();
+    auto compressed_parameter_buffer = GetCompressedParameterBuffer();
+
+    if (compressor != nullptr)
+    {
+        size_t packet_size = 0;
+        size_t compressed_size =
+            compressor->Compress(uncompressed_size, parameter_buffer->GetData(), &compressed_parameter_buffer, 0);
+
+        if ((0 < compressed_size) && (compressed_size < uncompressed_size))
+        {
+            data_pointer   = reinterpret_cast<const void*>(compressed_parameter_buffer.data());
+            data_size      = compressed_size;
+            header_pointer = reinterpret_cast<const void*>(&compressed_header);
+            header_size    = sizeof(format::CompressedFunctionCallHeader);
+
+            compressed_header.block_header.type = format::BlockType::kCompressedFunctionCallBlock;
+            compressed_header.api_call_id       = call_id;
+            compressed_header.thread_id         = thread_id;
+            compressed_header.uncompressed_size = uncompressed_size;
+
+            packet_size += sizeof(compressed_header.api_call_id) + sizeof(compressed_header.uncompressed_size) +
+                           sizeof(compressed_header.thread_id) + compressed_size;
+
+            compressed_header.block_header.size = packet_size;
+            not_compressed                      = false;
+        }
+    }
+
+    if (not_compressed)
+    {
+        size_t packet_size = 0;
+        data_pointer       = reinterpret_cast<const void*>(parameter_buffer->GetData());
+        data_size          = uncompressed_size;
+        header_pointer     = reinterpret_cast<const void*>(&uncompressed_header);
+        header_size        = sizeof(format::FunctionCallHeader);
+
+        uncompressed_header.block_header.type = format::BlockType::kFunctionCallBlock;
+        uncompressed_header.api_call_id       = call_id;
+        uncompressed_header.thread_id         = thread_id;
+
+        packet_size += sizeof(uncompressed_header.api_call_id) + sizeof(uncompressed_header.thread_id) + data_size;
+
+        uncompressed_header.block_header.size = packet_size;
+    }
+
+    // Write appropriate function call block header.
+    WriteBytes(header_pointer, header_size);
+
+    // Write parameter data.
+    WriteBytes(data_pointer, data_size);
+}
+
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/tools/optimize/vulkan_file_optimizer.h
+++ b/tools/optimize/vulkan_file_optimizer.h
@@ -1,0 +1,60 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_VULKAN_FILE_OPTIMIZER_H
+#define GFXRECON_VULKAN_FILE_OPTIMIZER_H
+
+#include "file_optimizer.h"
+#include "util/defines.h"
+#include "generated/generated_vulkan_decoder.h"
+#include "util/vulkan_modifier_base.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+
+class VulkanFileOptimizer : public FileOptimizer
+{
+  public:
+    struct VulkanOptimizationData
+    {
+        std::unordered_set<gfxrecon::format::HandleId>         unreferenced_ids;
+        std::vector<std::unique_ptr<util::VulkanModifierBase>> modifiers;
+    };
+
+    VulkanFileOptimizer(VulkanOptimizationData* optimization_data) :
+        FileOptimizer(optimization_data->unreferenced_ids), optimization_data_(optimization_data)
+    {}
+
+  private:
+    virtual bool ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id) override;
+
+    void WriteFunctionCall(format::ApiCallId               call_id,
+                           format::ThreadId                thread_id,
+                           const util::MemoryOutputStream* parameter_buffer);
+
+    VulkanOptimizationData* optimization_data_;
+    decode::VulkanDecoder   decoder;
+};
+
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_FILE_OPTIMIZER_H

--- a/tools/optimize/vulkan_file_optimizer.h
+++ b/tools/optimize/vulkan_file_optimizer.h
@@ -40,12 +40,12 @@ class VulkanFileOptimizer : public FileOptimizer
         std::vector<std::unique_ptr<util::VulkanModifierBase>> modifiers;
     };
 
-    VulkanFileOptimizer(VulkanOptimizationData* optimization_data) :
+    explicit VulkanFileOptimizer(VulkanOptimizationData* optimization_data) :
         FileOptimizer(optimization_data->unreferenced_ids), optimization_data_(optimization_data)
     {}
 
   private:
-    virtual bool ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id) override;
+    bool ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id) override;
 
     void WriteFunctionCall(format::ApiCallId               call_id,
                            format::ThreadId                thread_id,


### PR DESCRIPTION
Current implementation does not allow to implement different kind of optimizations in a modular and scalable way.
This commit established base infrastructure allowing implementation of modules that can process vulkan calls and apply modifications to them.
Gfxrecon-optimize for vulkan uses 2 pass approach:
* first pass to generate optimization data 
* second pass to generate modified trace
Modifications are performed in predefined order for each call separately.
Each modifier is given a pointer to same modifiable parameter buffer, a method to insert new calls before current call and a flag to request removal of current call from trace.
