### PR TITLE
Check SPIRV-capabilities, early exit parser

### DIFF
--- a/framework/util/spirv_parsing_util.cpp
+++ b/framework/util/spirv_parsing_util.cpp
@@ -192,12 +192,29 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
 
     std::vector<Instruction> instructions;
 
-    // First build up instructions object to make it easier to work with the SPIR-V
+    bool found_buffer_ref = false;
+
+    // build up instructions object to make it easier to work with the SPIR-V
+    // also checks for required capability
     while (spirv_ptr < spirv_end)
     {
         Instruction& insn = instructions.emplace_back(spirv_ptr);
         spirv_ptr += insn.length();
         GFXRECON_ASSERT(insn.length() > 0);
+
+        if (insn.opcode() == spv::OpCapability && insn.word(1) == spv::CapabilityPhysicalStorageBufferAddresses)
+        {
+            found_buffer_ref = true;
+        }
+
+        if (insn.opcode() == spv::OpFunction)
+        {
+            // CapabilityPhysicalStorageBufferAddresses not found
+            if (!found_buffer_ref)
+            {
+                return true;
+            }
+        }
     }
     if (spirv_ptr != spirv_end)
     {

--- a/framework/util/spirv_parsing_util.cpp
+++ b/framework/util/spirv_parsing_util.cpp
@@ -207,6 +207,7 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
             found_buffer_ref = true;
         }
 
+        // arrived at 'OpFunction' -> we have seen all metadata incl. capabilities
         if (insn.opcode() == spv::OpFunction)
         {
             // CapabilityPhysicalStorageBufferAddresses not found


### PR DESCRIPTION
- check for required CapabilityPhysicalStorageBufferAddresses
- bail out early, decrease avg parsing-time

thanks @spencer-lunarg :)