### PR TITLE
Add print block info option on android

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -708,7 +708,9 @@ usage: gfxrecon.py replay [-h] [--push-file LOCAL_FILE] [--version] [--pause-fra
                           [--dump-resources-dump-vertex-index-buffers]
                           [--dump-resources-json-output-per-command]
                           [--dump-resources-dump-immutable-resources]
-                          [--dump-resources-dump-all-image-subresources] [file]
+                          [--dump-resources-dump-all-image-subresources]
+                          [--pbi-all] [--pbis <index1,index2>]
+                          [file]
 
 Launch the replay tool.
 
@@ -899,6 +901,10 @@ optional arguments:
               Enables dumping of resources that are used as inputs in the commands requested for dumping
   --dump-resources-dump-all-image-subresources
               Enables dumping of all image sub resources (mip map levels and array layers)
+  --pbi-all
+              Print all block information.
+  --pbis <index1,index2>
+              Print block information between block index1 and block index2.
 ```
 
 The command will force-stop an active replay process before starting the replay

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -121,6 +121,10 @@ void android_main(struct android_app* app)
                 gfxrecon::decode::VulkanReplayOptions          replay_options =
                     GetVulkanReplayOptions(arg_parser, filename, &tracked_object_info_table);
 
+                file_processor->SetPrintBlockInfoFlag(replay_options.enable_print_block_info,
+                                                      replay_options.block_index_from,
+                                                      replay_options.block_index_to);
+
                 // Process --dump-resources arg. We do it here so that other gfxr tools that use
                 // the VulkanReplayOptions class won't have to link in the json library.
                 if (!gfxrecon::parse_dump_resources::parse_dump_resources_arg(replay_options))


### PR DESCRIPTION
Currently --pbi-all --pbis options are not available on android.
This change adds the android support.
