### PR TITLE
Fix allocator null for trim capture

### DIFF
--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -2413,7 +2413,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateCommandList(ID3D12Devic
     if (IsCaptureModeTrack())
     {
         auto list_wrapper = reinterpret_cast<ID3D12CommandList_Wrapper*>(*ppCommandList);
-        state_tracker_->TrackCommandListCreation(list_wrapper, false, type);
+        state_tracker_->TrackCommandListCreation(list_wrapper, false, type, pCommandAllocator);
     }
 }
 
@@ -2428,7 +2428,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device4_CreateCommandList1(ID3D12Dev
     if (IsCaptureModeTrack())
     {
         auto list_wrapper = reinterpret_cast<ID3D12CommandList_Wrapper*>(*ppCommandList);
-        state_tracker_->TrackCommandListCreation(list_wrapper, true, type);
+        state_tracker_->TrackCommandListCreation(list_wrapper, true, type, nullptr);
     }
 }
 

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -439,6 +439,8 @@ struct ID3D12CommandListInfo : public DxWrapperInfo
     D3D12_COMMAND_LIST_TYPE          command_list_type{};
 
     // Track command list dependencies.
+    format::HandleId                              create_command_allocator_id{ format::kNullHandleId };
+    std::shared_ptr<const ID3D12CommandAllocatorInfo> create_command_allocator_info;
     std::unordered_set<format::HandleId>          command_objects[D3D12GraphicsCommandObjectType::NumObjectTypes];
     std::unordered_set<SIZE_T>                    command_cpu_descriptor_handles;
     std::unordered_set<D3D12_GPU_VIRTUAL_ADDRESS> command_gpu_virtual_addresses;

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -313,11 +313,16 @@ void Dx12StateTracker::TrackResourceGpuVa(ID3D12Resource_Wrapper* resource_wrapp
 
 void Dx12StateTracker::TrackCommandListCreation(ID3D12CommandList_Wrapper* list_wrapper,
                                                 bool                       created_closed,
-                                                D3D12_COMMAND_LIST_TYPE    command_list_type)
+                                                D3D12_COMMAND_LIST_TYPE    command_list_type,
+                                                ID3D12CommandAllocator*    pCommandAllocator)
 {
+    auto cmd_alloc_wrapper       = reinterpret_cast<ID3D12CommandAllocator_Wrapper*>(pCommandAllocator);
+
     auto list_info               = list_wrapper->GetObjectInfo();
     list_info->is_closed         = created_closed;
     list_info->command_list_type = command_list_type;
+    list_info->create_command_allocator_id   = GetDx12WrappedId(pCommandAllocator);
+    list_info->create_command_allocator_info = cmd_alloc_wrapper->GetObjectInfo();
 }
 
 void Dx12StateTracker::TrackDescriptorCreation(ID3D12Device_Wrapper*           create_object_wrapper,

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -153,7 +153,8 @@ class Dx12StateTracker
 
     void TrackCommandListCreation(ID3D12CommandList_Wrapper* list_wrapper,
                                   bool                       created_closed,
-                                  D3D12_COMMAND_LIST_TYPE    command_list_type);
+                                  D3D12_COMMAND_LIST_TYPE    command_list_type,
+                                  ID3D12CommandAllocator*    pCommandAllocator);
 
     void TrackAcquireImage(UINT image_index, IDXGISwapChain_Wrapper* wrapper);
 

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1010,7 +1010,7 @@ void Dx12StateWriter::WriteCommandListState(const Dx12StateTable& state_table)
         {
             if (list_info->is_closed)
             {
-                WriteCommandListCreation(list_wrapper);
+                WriteCommandListCreation(list_wrapper, state_table);
                 WriteCommandListCommands(list_wrapper, state_table);
             }
             else
@@ -1030,7 +1030,7 @@ void Dx12StateWriter::WriteCommandListState(const Dx12StateTable& state_table)
         auto list_info = list_wrapper->GetObjectInfo();
         if (list_info->is_closed)
         {
-            WriteCommandListCreation(list_wrapper);
+            WriteCommandListCreation(list_wrapper, state_table);
             WriteCommandListCommands(list_wrapper, state_table);
         }
         else
@@ -1046,7 +1046,7 @@ void Dx12StateWriter::WriteCommandListState(const Dx12StateTable& state_table)
         auto list_info = list_wrapper->GetObjectInfo();
         if (list_info->was_reset)
         {
-            WriteCommandListCreation(list_wrapper);
+            WriteCommandListCreation(list_wrapper, state_table);
         }
     }
     for (auto list_wrapper : open_command_lists)
@@ -1055,7 +1055,7 @@ void Dx12StateWriter::WriteCommandListState(const Dx12StateTable& state_table)
         auto list_info = list_wrapper->GetObjectInfo();
         if (!list_info->was_reset)
         {
-            WriteCommandListCreation(list_wrapper);
+            WriteCommandListCreation(list_wrapper, state_table);
         }
 
         // Write commands for all open command lists.
@@ -1075,6 +1075,8 @@ void Dx12StateWriter::WriteCommandListCommands(const ID3D12CommandList_Wrapper* 
     size_t         data_size = list_info->command_data.GetDataSize();
     const uint8_t* data      = list_info->command_data.GetData();
 
+    // TODO: Don't write any commands, including the Reset or Close commands, if the command allocator used in the most
+    // recent Reset command no longer exists.
     while (offset < data_size)
     {
         const size_t*            parameter_size = reinterpret_cast<const size_t*>(&data[offset]);
@@ -1128,11 +1130,28 @@ void Dx12StateWriter::WriteCommandListCommands(const ID3D12CommandList_Wrapper* 
     GFXRECON_ASSERT(offset == data_size);
 }
 
-void Dx12StateWriter::WriteCommandListCreation(const ID3D12CommandList_Wrapper* list_wrapper)
+void Dx12StateWriter::WriteCommandListCreation(const ID3D12CommandList_Wrapper* list_wrapper,
+                                               const Dx12StateTable&            state_table)
 {
+    auto list_info = list_wrapper->GetObjectInfo();
+
+    // Create the command allocator if it doesn't exist.
+    bool create_temp_command_allocator =
+        (list_info->create_command_allocator_id != format::kNullHandleId) &&
+        (state_table.GetID3D12CommandAllocator_Wrapper(list_info->create_command_allocator_id) == nullptr);
+    if (create_temp_command_allocator)
+    {
+        GFXRECON_LOG_DEBUG(
+            "Writing the creation for a temporary command allocator %" PRIu64
+            " that was used to create command list %" PRIu64
+            " but has since been released. The command allocator will be freed after the command list creation.",
+            list_info->create_command_allocator_id,
+            list_wrapper->GetCaptureId());
+        StandardCreateWrite(list_info->create_command_allocator_id, *list_info->create_command_allocator_info.get());
+    }
+
     // Write call to create the command list.
     StandardCreateWrite(list_wrapper);
-    auto list_info = list_wrapper->GetObjectInfo();
 
     // If the command list was created open and reset since creation, write a command to close it. This frees up the
     // command allocator used in creation. This list's command_data will contain a reset, possibly with a different
@@ -1141,6 +1160,11 @@ void Dx12StateWriter::WriteCommandListCreation(const ID3D12CommandList_Wrapper* 
     if (list_info->was_reset && created_open)
     {
         WriteCommandListClose(list_wrapper);
+    }
+
+    if (create_temp_command_allocator)
+    {
+        WriteReleaseCommand(list_info->create_command_allocator_id, 0);
     }
 }
 

--- a/framework/encode/dx12_state_writer.h
+++ b/framework/encode/dx12_state_writer.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -148,7 +148,7 @@ class Dx12StateWriter
 
     void WriteCommandListState(const Dx12StateTable& state_table);
 
-    void WriteCommandListCreation(const ID3D12CommandList_Wrapper* list_wrapper);
+    void WriteCommandListCreation(const ID3D12CommandList_Wrapper* list_wrapper, const Dx12StateTable& state_table);
 
     void WriteCommandListCommands(const ID3D12CommandList_Wrapper* list_wrapper, const Dx12StateTable& state_table);
 


### PR DESCRIPTION
**Problem**
During trim capture of some D3D12 apps, some command allocators may be released during state tracking stage, resulting trace replay crash at CreateCommandList() due to null command allocator.

**Solution**
Create temp command allocator for CreateCommandList when it's allocator has been released during state tracking.