### PR TITLE
Raytracing: Shader-group-handle mapping

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -32,7 +32,6 @@
 #include "graphics/vulkan_device_util.h"
 #include "graphics/vulkan_shader_group_handle.h"
 #include "util/defines.h"
-#include "util/hash.h"
 
 #include "vulkan/vulkan.h"
 

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -42,6 +42,7 @@
 #include <unordered_set>
 #include <vector>
 #include <future>
+#include <optional>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -158,8 +159,11 @@ enum ValidationCacheEXTArrayIndices : uint32_t
 
 struct ReplayDeviceInfo
 {
-    std::unique_ptr<VkPhysicalDeviceProperties>       properties;
-    std::unique_ptr<VkPhysicalDeviceMemoryProperties> memory_properties;
+    std::optional<VkPhysicalDeviceProperties>       properties;
+    std::optional<VkPhysicalDeviceMemoryProperties> memory_properties;
+
+    // extensions
+    std::optional<VkPhysicalDeviceRayTracingPipelinePropertiesKHR> raytracing_properties;
 };
 
 template <typename T>
@@ -258,6 +262,12 @@ struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
     uint8_t                          capture_pipeline_cache_uuid[format::kUuidSize]{};
     std::string                      capture_device_name;
     VkPhysicalDeviceMemoryProperties capture_memory_properties{};
+
+    // capture raytracing shader-binding-table properties
+    // extracted from VkPhysicalDeviceRayTracingPipelinePropertiesKHR
+    uint32_t shaderGroupHandleSize = 0;
+    uint32_t shaderGroupBaseAlignment = 0;
+    uint32_t shaderGroupHandleAlignment = 0;
 
     // Closest matching replay device.
     ReplayDeviceInfo* replay_device_info{ nullptr };

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -30,7 +30,9 @@
 #include "format/format.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "graphics/vulkan_device_util.h"
+#include "graphics/vulkan_shader_group_handle.h"
 #include "util/defines.h"
+#include "util/hash.h"
 
 #include "vulkan/vulkan.h"
 
@@ -265,8 +267,8 @@ struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 
     // capture raytracing shader-binding-table properties
     // extracted from VkPhysicalDeviceRayTracingPipelinePropertiesKHR
-    uint32_t shaderGroupHandleSize = 0;
-    uint32_t shaderGroupBaseAlignment = 0;
+    uint32_t shaderGroupHandleSize      = 0;
+    uint32_t shaderGroupBaseAlignment   = 0;
     uint32_t shaderGroupHandleAlignment = 0;
 
     // Closest matching replay device.
@@ -471,6 +473,9 @@ struct PipelineInfo : public VulkanObjectInfoAsync<VkPipeline>
 
     // Is VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT enabled
     bool dynamic_vertex_binding_stride{ false };
+
+    // map capture- to replay-time shader-group-handles
+    std::unordered_map<graphics::shader_group_handle_t, graphics::shader_group_handle_t> shader_group_handle_map;
 };
 
 struct DescriptorPoolInfo : public VulkanPoolInfo<VkDescriptorPool>

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1610,11 +1610,10 @@ void VulkanReplayConsumerBase::GetMatchingDevice(InstanceInfo* instance_info, Ph
             {
                 if (replay_info.properties == std::nullopt)
                 {
-                    graphics::VulkanDeviceUtil::GetReplayDeviceProperties(
-                        physical_device_info->parent_api_version,
-                        GetInstanceTable(physical_device_info->handle),
-                        physical_device_info->handle,
-                        &replay_info);
+                    graphics::VulkanDeviceUtil::GetReplayDeviceProperties(physical_device_info->parent_api_version,
+                                                                          GetInstanceTable(physical_device),
+                                                                          physical_device,
+                                                                          &replay_info);
                 }
 
                 if ((physical_device_info->capture_vendor_id == replay_info.properties->vendorID) ||

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1288,10 +1288,45 @@ void VulkanReplayConsumerBase::SetPhysicalDeviceProperties(PhysicalDeviceInfo*  
     CheckReplayDeviceInfo(physical_device_info);
     auto replay_device_info = physical_device_info->replay_device_info;
     assert(replay_device_info != nullptr);
+    replay_device_info->properties = *replay_properties;
+}
 
-    if (replay_device_info->properties == nullptr)
+void VulkanReplayConsumerBase::SetPhysicalDeviceProperties(PhysicalDeviceInfo*                physical_device_info,
+                                                           const VkPhysicalDeviceProperties2* capture_properties,
+                                                           const VkPhysicalDeviceProperties2* replay_properties)
+{
+    SetPhysicalDeviceProperties(physical_device_info, &capture_properties->properties, &replay_properties->properties);
+
+    auto get_ray_properties =
+        [](const VkPhysicalDeviceProperties2* device_props) -> const VkPhysicalDeviceRayTracingPipelinePropertiesKHR* {
+        if (device_props != nullptr)
+        {
+            const void* pNext = device_props->pNext;
+
+            while (pNext != nullptr)
+            {
+                auto base = reinterpret_cast<const VkBaseInStructure*>(pNext);
+                if (base->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR)
+                {
+                    return reinterpret_cast<const VkPhysicalDeviceRayTracingPipelinePropertiesKHR*>(base);
+                }
+                pNext = base->pNext;
+            }
+        }
+        return nullptr;
+    };
+
+    if (auto ray_capture_props = get_ray_properties(capture_properties))
     {
-        replay_device_info->properties = std::make_unique<VkPhysicalDeviceProperties>(*replay_properties);
+        physical_device_info->shaderGroupBaseAlignment   = ray_capture_props->shaderGroupBaseAlignment;
+        physical_device_info->shaderGroupHandleAlignment = ray_capture_props->shaderGroupHandleAlignment;
+        physical_device_info->shaderGroupHandleSize      = ray_capture_props->shaderGroupHandleSize;
+    }
+
+    if (auto ray_replay_props = get_ray_properties(replay_properties))
+    {
+        physical_device_info->replay_device_info->raytracing_properties        = *ray_replay_props;
+        physical_device_info->replay_device_info->raytracing_properties->pNext = nullptr;
     }
 }
 
@@ -1310,11 +1345,7 @@ void VulkanReplayConsumerBase::SetPhysicalDeviceMemoryProperties(
     CheckReplayDeviceInfo(physical_device_info);
     auto replay_device_info = physical_device_info->replay_device_info;
     assert(replay_device_info != nullptr);
-
-    if (replay_device_info->memory_properties == nullptr)
-    {
-        replay_device_info->memory_properties = std::make_unique<VkPhysicalDeviceMemoryProperties>(*replay_properties);
-    }
+    replay_device_info->memory_properties = *replay_properties;
 }
 
 void VulkanReplayConsumerBase::SelectPhysicalDevice(PhysicalDeviceInfo* physical_device_info)
@@ -1420,13 +1451,12 @@ bool VulkanReplayConsumerBase::GetOverrideDevice(InstanceInfo* instance_info, Ph
         VkPhysicalDevice replay_device      = replay_devices[i];
         auto             replay_device_info = &instance_info->replay_device_info[replay_device];
 
-        if (replay_device_info->properties == nullptr)
+        if (replay_device_info->properties == std::nullopt)
         {
             auto table = GetInstanceTable(physical_device_info->handle);
             assert(table != nullptr);
-
-            replay_device_info->properties = std::make_unique<VkPhysicalDeviceProperties>();
-            table->GetPhysicalDeviceProperties(physical_device_info->handle, replay_device_info->properties.get());
+            replay_device_info->properties = VkPhysicalDeviceProperties();
+            table->GetPhysicalDeviceProperties(physical_device_info->handle, &replay_device_info->properties.value());
         }
 
         std::string replay_device_name = replay_device_info->properties->deviceName;
@@ -1507,13 +1537,14 @@ bool VulkanReplayConsumerBase::GetOverrideDeviceGroup(InstanceInfo*             
             auto replay_device      = replay_group_prop.physicalDevices[j];
             auto replay_device_info = &instance_info->replay_device_info[replay_device];
 
-            if (replay_device_info->properties == nullptr)
+            if (replay_device_info->properties == std::nullopt)
             {
                 auto table = GetInstanceTable(physical_device_info->handle);
                 assert(table != nullptr);
 
-                replay_device_info->properties = std::make_unique<VkPhysicalDeviceProperties>();
-                table->GetPhysicalDeviceProperties(physical_device_info->handle, replay_device_info->properties.get());
+                replay_device_info->properties = VkPhysicalDeviceProperties();
+                table->GetPhysicalDeviceProperties(physical_device_info->handle,
+                                                   &replay_device_info->properties.value());
             }
 
             std::string replay_device_name = replay_device_info->properties->deviceName;
@@ -1555,16 +1586,14 @@ void VulkanReplayConsumerBase::GetMatchingDevice(InstanceInfo* instance_info, Ph
     auto replay_device_info = physical_device_info->replay_device_info;
     assert(replay_device_info != nullptr);
 
-    if (replay_device_info->properties == nullptr)
+    if (replay_device_info->properties == std::nullopt)
     {
-        replay_device_info->properties = std::make_unique<VkPhysicalDeviceProperties>();
-        table->GetPhysicalDeviceProperties(physical_device_info->handle, replay_device_info->properties.get());
+        replay_device_info->properties = VkPhysicalDeviceProperties();
+        table->GetPhysicalDeviceProperties(physical_device_info->handle, &replay_device_info->properties.value());
     }
 
-    auto replay_properties = replay_device_info->properties.get();
-
-    if ((physical_device_info->capture_vendor_id != replay_properties->vendorID) ||
-        (physical_device_info->capture_device_id != replay_properties->deviceID))
+    if ((physical_device_info->capture_vendor_id != replay_device_info->properties->vendorID) ||
+        (physical_device_info->capture_device_id != replay_device_info->properties->deviceID))
     {
         VkPhysicalDevice current_device = physical_device_info->handle;
 
@@ -1574,25 +1603,25 @@ void VulkanReplayConsumerBase::GetMatchingDevice(InstanceInfo* instance_info, Ph
         // intercept calls to vkEnumeratePhysicalDevices before the list of physical devices is modified, while
         // replay receives the modified list.  So, we check for a match before logical device creation to ensure
         // capture and replay use the same physical device when both are performed on the same system.
-        for (auto& entry : instance_info->replay_device_info)
+        for (auto& [physical_device, info] : instance_info->replay_device_info)
         {
             // Skip the current physical device, which we already know is not a match.
-            if (entry.first != current_device)
+            if (physical_device != current_device)
             {
-                if (entry.second.properties == nullptr)
+                if (info.properties == std::nullopt)
                 {
-                    entry.second.properties = std::make_unique<VkPhysicalDeviceProperties>();
-                    table->GetPhysicalDeviceProperties(entry.first, entry.second.properties.get());
+                    info.properties = VkPhysicalDeviceProperties();
+                    table->GetPhysicalDeviceProperties(physical_device, &info.properties.value());
                 }
 
-                replay_properties = entry.second.properties.get();
+//                replay_properties = entry.second.properties.get();
 
-                if ((physical_device_info->capture_vendor_id == replay_properties->vendorID) ||
-                    (physical_device_info->capture_device_id == replay_properties->deviceID))
+                if ((physical_device_info->capture_vendor_id == info.properties->vendorID) ||
+                    (physical_device_info->capture_device_id == info.properties->deviceID))
                 {
                     // A match has been found.
-                    physical_device_info->handle             = entry.first;
-                    physical_device_info->replay_device_info = &entry.second;
+                    physical_device_info->handle             = physical_device;
+                    physical_device_info->replay_device_info = &info;
                     break;
                 }
             }
@@ -1679,7 +1708,7 @@ void VulkanReplayConsumerBase::CheckPhysicalDeviceCompatibility(PhysicalDeviceIn
     auto replay_device_info = physical_device_info->replay_device_info;
     assert(replay_device_info != nullptr);
 
-    auto replay_properties = replay_device_info->properties.get();
+    const auto &replay_properties = replay_device_info->properties;
 
     // Warn about potential incompatibilities when replay device type does not match capture device type.
     if ((physical_device_info->capture_vendor_id != 0) && (physical_device_info->capture_device_id != 0) &&
@@ -1719,8 +1748,8 @@ void VulkanReplayConsumerBase::CheckPhysicalDeviceGroupCompatibility(
             auto capture_info = GetObjectInfoTable().GetPhysicalDeviceInfo(capture_device_group[i]);
             if (i < replay_size)
             {
-                auto* replay_device_info = &instance_info->replay_device_info[replay_device_group[i]];
-                auto  replay_properties  = replay_device_info->properties.get();
+                auto*       replay_device_info = &instance_info->replay_device_info[replay_device_group[i]];
+                const auto& replay_properties  = replay_device_info->properties;
 
                 if ((capture_info->capture_vendor_id != 0) && (capture_info->capture_device_id != 0) &&
                     ((capture_info->capture_vendor_id != replay_properties->vendorID) ||
@@ -1755,12 +1784,11 @@ void VulkanReplayConsumerBase::CheckPhysicalDeviceGroupCompatibility(
         for (size_t i = 0; i < replay_size; ++i)
         {
             auto* replay_device_info = &instance_info->replay_device_info[replay_device_group[i]];
-            auto  replay_properties  = replay_device_info->properties.get();
 
             std::ostringstream string_stream;
-            string_stream << "[vendorID = " << replay_properties->vendorID
-                          << ", deviceId = " << replay_properties->deviceID
-                          << ", deviceName = " << replay_properties->deviceName << "]";
+            string_stream << "[vendorID = " << replay_device_info->properties->vendorID
+                          << ", deviceId = " << replay_device_info->properties->deviceID
+                          << ", deviceName = " << replay_device_info->properties->deviceName << "]";
 
             GFXRECON_LOG_WARNING("\t%s", string_stream.str().c_str());
         }
@@ -1896,7 +1924,7 @@ void VulkanReplayConsumerBase::InitializeResourceAllocator(const PhysicalDeviceI
     }
 
     auto replay_device_info = physical_device_info->replay_device_info;
-    assert(replay_device_info->memory_properties != nullptr);
+    assert(replay_device_info->memory_properties);
 
     VkResult result = allocator->Initialize(std::min(physical_device_info->parent_api_version,
                                                      physical_device_info->replay_device_info->properties->apiVersion),
@@ -2703,14 +2731,14 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult            original_resu
     auto replay_device_info = physical_device_info->replay_device_info;
     assert(replay_device_info != nullptr);
 
-    if (replay_device_info->memory_properties == nullptr)
+    if (replay_device_info->memory_properties == std::nullopt)
     {
         // Memory properties weren't queried before device creation, so retrieve them now.
         auto table = GetInstanceTable(physical_device);
         assert(table != nullptr);
 
-        replay_device_info->memory_properties = std::make_unique<VkPhysicalDeviceMemoryProperties>();
-        table->GetPhysicalDeviceMemoryProperties(physical_device, replay_device_info->memory_properties.get());
+        replay_device_info->memory_properties = VkPhysicalDeviceMemoryProperties();
+        table->GetPhysicalDeviceMemoryProperties(physical_device, &replay_device_info->memory_properties.value());
     }
 
     auto allocator = options_.create_resource_allocator();
@@ -3057,7 +3085,7 @@ void VulkanReplayConsumerBase::OverrideGetPhysicalDeviceProperties2(
 
     // This can be set by ProcessSetDevicePropertiesCommand, but older files will not contain that data.
     auto capture_properties = pProperties->GetPointer();
-    SetPhysicalDeviceProperties(physical_device_info, &capture_properties->properties, &replay_properties->properties);
+    SetPhysicalDeviceProperties(physical_device_info, capture_properties, replay_properties);
 }
 
 void VulkanReplayConsumerBase::OverrideGetPhysicalDeviceMemoryProperties(

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1296,6 +1296,10 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                      const VkPhysicalDeviceProperties* capture_properties,
                                      const VkPhysicalDeviceProperties* replay_properties);
 
+    void SetPhysicalDeviceProperties(PhysicalDeviceInfo*                physical_device_info,
+                                     const VkPhysicalDeviceProperties2* capture_properties,
+                                     const VkPhysicalDeviceProperties2* replay_properties);
+
     void SetPhysicalDeviceMemoryProperties(PhysicalDeviceInfo*                     physical_device_info,
                                            const VkPhysicalDeviceMemoryProperties* capture_properties,
                                            const VkPhysicalDeviceMemoryProperties* replay_properties);

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -152,8 +152,8 @@ VkResult DispatchTraceRaysDumpingContext::CloneCommandBuffer(CommandBufferInfo* 
     parent_device = device_info->handle;
 
     assert(phys_dev_info->replay_device_info);
-    assert(phys_dev_info->replay_device_info->memory_properties.get());
-    replay_device_phys_mem_props = phys_dev_info->replay_device_info->memory_properties.get();
+    assert(phys_dev_info->replay_device_info->memory_properties);
+    replay_device_phys_mem_props = &phys_dev_info->replay_device_info->memory_properties.value();
 
     return VK_SUCCESS;
 }

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -2492,8 +2492,8 @@ VkResult DrawCallsDumpingContext::CloneCommandBuffer(CommandBufferInfo*         
     assert(phys_dev_info);
 
     assert(phys_dev_info->replay_device_info);
-    assert(phys_dev_info->replay_device_info->memory_properties.get());
-    replay_device_phys_mem_props = phys_dev_info->replay_device_info->memory_properties.get();
+    assert(phys_dev_info->replay_device_info->memory_properties);
+    replay_device_phys_mem_props = &phys_dev_info->replay_device_info->memory_properties.value();
 
     // Allocate auxiliary command buffer
     VkResult res = device_table->AllocateCommandBuffers(dev_info->handle, &ai, &aux_command_buffer);

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -251,11 +251,7 @@ void VulkanDeviceUtil::GetReplayDeviceProperties(uint32_t                       
     VkPhysicalDeviceProperties2 device_properties2;
     device_properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
 
-    auto get_props2_fn = instance_api_version >= VK_MAKE_VERSION(1, 1, 0)
-                             ? instance_table->GetPhysicalDeviceProperties2
-                             : instance_table->GetPhysicalDeviceProperties2KHR;
-
-    if (get_props2_fn != nullptr)
+    if (instance_api_version >= VK_MAKE_VERSION(1, 1, 0))
     {
         // pNext-chaining
         VkPhysicalDeviceRayTracingPipelinePropertiesKHR raytracing_properties;
@@ -263,7 +259,7 @@ void VulkanDeviceUtil::GetReplayDeviceProperties(uint32_t                       
         raytracing_properties.pNext = nullptr;
         device_properties2.pNext    = &raytracing_properties;
 
-        get_props2_fn(physical_device, &device_properties2);
+        instance_table->GetPhysicalDeviceProperties2(physical_device, &device_properties2);
         replay_device_info->raytracing_properties = raytracing_properties;
     }
     else

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -21,6 +21,7 @@
 */
 
 #include "graphics/vulkan_device_util.h"
+#include "decode/vulkan_object_info.h"
 
 #include "util/logging.h"
 
@@ -237,6 +238,39 @@ void VulkanDeviceUtil::RestoreModifiedPhysicalDeviceFeatures()
             rayTracingPipelineShaderGroupHandleCaptureReplay_original;
         rayTracingPipelineShaderGroupHandleCaptureReplay_ptr = nullptr;
     }
+}
+
+void VulkanDeviceUtil::GetReplayDeviceProperties(uint32_t                           instance_api_version,
+                                                 const encode::VulkanInstanceTable* instance_table,
+                                                 VkPhysicalDevice                   physical_device,
+                                                 decode::ReplayDeviceInfo*          replay_device_info)
+{
+    GFXRECON_ASSERT(instance_table != nullptr);
+    GFXRECON_ASSERT(replay_device_info != nullptr);
+
+    VkPhysicalDeviceProperties2 device_properties2;
+    device_properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+
+    auto get_props2_fn = instance_api_version >= VK_MAKE_VERSION(1, 1, 0)
+                             ? instance_table->GetPhysicalDeviceProperties2
+                             : instance_table->GetPhysicalDeviceProperties2KHR;
+
+    if (get_props2_fn != nullptr)
+    {
+        // pNext-chaining
+        VkPhysicalDeviceRayTracingPipelinePropertiesKHR raytracing_properties;
+        raytracing_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
+        raytracing_properties.pNext = nullptr;
+        device_properties2.pNext    = &raytracing_properties;
+
+        get_props2_fn(physical_device, &device_properties2);
+        replay_device_info->raytracing_properties = raytracing_properties;
+    }
+    else
+    {
+        instance_table->GetPhysicalDeviceProperties(physical_device, &device_properties2.properties);
+    }
+    replay_device_info->properties = device_properties2.properties;
 }
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/framework/graphics/vulkan_device_util.h
+++ b/framework/graphics/vulkan_device_util.h
@@ -32,7 +32,7 @@ namespace gfxrecon::decode
 {
 //! forward declaration to avoid cyclic include
 class ReplayDeviceInfo;
-}
+} // namespace gfxrecon::decode
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)

--- a/framework/graphics/vulkan_device_util.h
+++ b/framework/graphics/vulkan_device_util.h
@@ -28,6 +28,12 @@
 
 #include "vulkan/vulkan.h"
 
+namespace gfxrecon::decode
+{
+//! forward declaration to avoid cyclic include
+class ReplayDeviceInfo;
+}
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
@@ -55,6 +61,12 @@ class VulkanDeviceUtil
 
     // Restore any incoming values that were modified in EnableRequiredPhysicalDeviceFeatures
     void RestoreModifiedPhysicalDeviceFeatures();
+
+    // Populates various property-structs in the provided replay_device_info
+    static void GetReplayDeviceProperties(uint32_t                           instance_api_version,
+                                          const encode::VulkanInstanceTable* instance_table,
+                                          VkPhysicalDevice                   physical_device,
+                                          decode::ReplayDeviceInfo*          replay_device_info);
 
   private:
     template <typename T>

--- a/framework/graphics/vulkan_shader_group_handle.h
+++ b/framework/graphics/vulkan_shader_group_handle.h
@@ -1,0 +1,71 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_GRAPHICS_VULKAN_SHADER_GROUP_HANDLE_H
+#define GFXRECON_GRAPHICS_VULKAN_SHADER_GROUP_HANDLE_H
+
+#include "util/defines.h"
+#include "util/logging.h"
+#include "util/hash.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+struct shader_group_handle_t
+{
+    static constexpr uint32_t MAX_HANDLE_SIZE       = 32;
+    uint8_t                   data[MAX_HANDLE_SIZE] = {};
+    uint32_t                  size                  = 0;
+
+    shader_group_handle_t() = default;
+
+    shader_group_handle_t(const uint8_t* in_data, uint32_t in_size)
+    {
+        GFXRECON_ASSERT(in_size <= MAX_HANDLE_SIZE);
+        memcpy(data, in_data, std::min(in_size, MAX_HANDLE_SIZE));
+        size = in_size;
+    }
+
+    inline bool operator==(const shader_group_handle_t& other) const
+    {
+        return size == other.size && memcmp(data, other.data, size) == 0;
+    }
+};
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+//! std::hash overload
+namespace std
+{
+template <>
+struct hash<gfxrecon::graphics::shader_group_handle_t>
+{
+    inline size_t operator()(const gfxrecon::graphics::shader_group_handle_t& handle) const
+    {
+        return gfxrecon::util::hash::hash_range(handle.data, handle.data + handle.size);
+    }
+};
+
+} // namespace std
+
+#endif // GFXRECON_GRAPHICS_VULKAN_SHADER_GROUP_HANDLE_H

--- a/framework/util/hash.h
+++ b/framework/util/hash.h
@@ -62,7 +62,9 @@ Type GenerateCheckSum(const uint8_t* code, size_t code_size)
 }
 
 /**
- * @brief       hash_combine can be used to combine two hashes.
+ * @brief       hash_combine can be used to create a hash-value and combine with an existing hash-value.
+ *
+ * Called repeatedly to incrementally create a hash value from several variables.
  *
  * @tparam  T       value template-type
  * @param   seed    a provided reference to a seed. will be combined with the newly created value-hash.
@@ -77,7 +79,8 @@ inline void hash_combine(std::size_t& seed, const T& v)
 
 /**
  * @brief       hash_range can be used to create hash-values for arbitrary ranges.
- *              requires an existing std::hash overload for the range's element-type.
+ *
+ * Requires an existing std::hash overload for the range's element-type.
  *
  * @tparam It   iterator template-type
  * @param first iterator to the beginning of a range

--- a/framework/util/hash.h
+++ b/framework/util/hash.h
@@ -61,6 +61,40 @@ Type GenerateCheckSum(const uint8_t* code, size_t code_size)
     return current_sum;
 }
 
+/**
+ * @brief       hash_combine can be used to combine two hashes.
+ *
+ * @tparam  T       value template-type
+ * @param   seed    a provided reference to a seed. will be combined with the newly created value-hash.
+ * @param   v       a provided value
+ */
+template <class T>
+inline void hash_combine(std::size_t& seed, const T& v)
+{
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6U) + (seed >> 2U);
+}
+
+/**
+ * @brief       hash_range can be used to create hash-values for arbitrary ranges.
+ *              requires an existing std::hash overload for the range's element-type.
+ *
+ * @tparam It   iterator template-type
+ * @param first iterator to the beginning of a range
+ * @param last  iterator to the end of the same range
+ * @return      a newly created hash-value for the entire range.
+ */
+template <typename It>
+std::size_t hash_range(It first, It last)
+{
+    std::size_t seed = 0;
+    for (; first != last; ++first)
+    {
+        hash_combine(seed, *first);
+    }
+    return seed;
+}
+
 GFXRECON_END_NAMESPACE(hash)
 GFXRECON_END_NAMESPACE(util)
 GFXRECON_END_NAMESPACE(gfxrecon)


### PR DESCRIPTION
- extract+provide required raytracing device-properties for capture- and replay-time (handle-sizes & alignments)
- add required vanilla hash-utils (hash_combine, hash_range -> matching boost's utils)
- create an efficient wrapper-type (`shader_group_handle_t`) that can be compared and hashed (-> can be used as key in std::unordered_map)
- provide a LUT inside `decode::PipelineInfo` to map from capture- to replay-time handles.

this matches @bradgrantham-lunarg's [proof-of-concept](https://github.com/LunarG/gfxreconstruct/compare/dev...bradgrantham-lunarg:gfxreconstruct:brad-hack-shader-group-handles), fleshing out some details, but please note:
no re-mapping is actually added/performed (that part of the proof-of-concept was still too hacky). 
so this PR is only a necessary stepping-stone and should not change GFXR's behavior in any way.