### PR TITLE
Remove hanging back-quote

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -411,7 +411,7 @@ Additional requirements for building from the Linux command-line:
   - For example:
 
 ```bash
-        export ANDROID_HOME=$HOME/Android/Sdk`
+        export ANDROID_HOME=$HOME/Android/Sdk
 ```
 
 - Define JAVA_HOME to the path to the directory of the JDK.


### PR DESCRIPTION
Under the "Additional Linux Command-Linux Prerequisites", there was a hanging back-quote in the android home sdk path. This removes the quote.