### PR TITLE
Track external android format

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -358,6 +358,8 @@ struct ImageInfo : public VulkanObjectInfo<VkImage>
     VkImageUsageFlags     usage{ 0 };
     VkImageType           type{};
     VkFormat              format{};
+    // VkExternalFormatANDROID
+    uint64_t              external_format{ 0 };
     VkExtent3D            extent{ 0, 0, 0 };
     VkImageTiling         tiling{};
     VkSampleCountFlagBits sample_count{};

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4921,6 +4921,13 @@ VulkanReplayConsumerBase::OverrideCreateImage(PFN_vkCreateImage                 
         {
             image_info->queue_family_index = 0;
         }
+
+        auto external_format_android = graphics::GetPNextStruct<VkExternalFormatANDROID, VkImageCreateInfo>(
+            replay_create_info, VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID);
+        if (external_format_android)
+        {
+            image_info->external_format = external_format_android->externalFormat;
+        }
     }
 
     return result;

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -490,6 +490,7 @@ VkResult DumpImageToFile(const ImageInfo*                   image_info,
         VkResult res = resource_util.ReadFromImageResourceStaging(
             image_info->handle,
             image_info->format,
+            image_info->external_format,
             image_info->type,
             extent,
             image_info->level_count,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -211,6 +211,8 @@ struct ImageWrapper : public HandleWrapper<VkImage>
     uint32_t                 queue_family_index{ 0 };
     VkImageType              image_type{ VK_IMAGE_TYPE_2D };
     VkFormat                 format{ VK_FORMAT_UNDEFINED };
+    // VkExternalFormatANDROID
+    uint64_t                 external_format{ 0 };
     VkExtent3D               extent{ 0, 0, 0 };
     uint32_t                 mip_levels{ 0 };
     uint32_t                 array_layers{ 0 };

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -648,6 +648,17 @@ inline void InitializeState<VkDevice, vulkan_wrappers::ImageWrapper, VkImageCrea
     {
         wrapper->queue_family_index = create_info->pQueueFamilyIndices[0];
     }
+
+    auto next = reinterpret_cast<const VkBaseInStructure*>(create_info->pNext);
+    while (next)
+    {
+        if (next->sType == VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID)
+        {
+            auto external_format_android = reinterpret_cast<const VkExternalFormatANDROID*>(next);
+            wrapper->external_format     = external_format_android->externalFormat;
+        }
+        next = next->pNext;
+    }
 }
 
 template <>

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1415,6 +1415,7 @@ void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper*
 
             VkResult result = resource_util.ReadFromImageResourceStaging(image_wrapper->handle,
                                                                          image_wrapper->format,
+                                                                         image_wrapper->external_format,
                                                                          image_wrapper->image_type,
                                                                          image_wrapper->extent,
                                                                          image_wrapper->mip_levels,
@@ -1731,6 +1732,7 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
 
                     snapshot_info.resource_size = resource_util.GetImageResourceSizesOptimal(wrapper->handle,
                                                                                              wrapper->format,
+                                                                                             wrapper->external_format,
                                                                                              wrapper->image_type,
                                                                                              wrapper->extent,
                                                                                              wrapper->mip_levels,

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -297,6 +297,7 @@ bool FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properti
 
 uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkImage                image,
                                                            VkFormat               format,
+                                                           uint64_t               external_format,
                                                            VkImageType            type,
                                                            const VkExtent3D&      extent,
                                                            uint32_t               mip_levels,
@@ -321,8 +322,12 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkImage              
 
     uint64_t resource_size = 0;
 
+    VkExternalFormatANDROID external_format_android = { VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID };
+    external_format_android.pNext                   = nullptr;
+    external_format_android.externalFormat          = external_format;
+
     VkImageCreateInfo create_info     = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
-    create_info.pNext                 = nullptr;
+    create_info.pNext                 = (external_format != 0) ? &external_format_android : nullptr;
     create_info.flags                 = 0;
     create_info.imageType             = type;
     create_info.format                = GetImageAspectFormat(format, aspect);
@@ -1137,6 +1142,7 @@ VkResult VulkanResourcesUtil::ResolveImage(VkImage           image,
 
 VkResult VulkanResourcesUtil::ReadFromImageResourceStaging(VkImage                image,
                                                            VkFormat               format,
+                                                           uint64_t               external_format,
                                                            VkImageType            type,
                                                            const VkExtent3D&      extent,
                                                            uint32_t               mip_levels,
@@ -1176,6 +1182,7 @@ VkResult VulkanResourcesUtil::ReadFromImageResourceStaging(VkImage              
 
     resource_size = GetImageResourceSizesOptimal(image,
                                                  format,
+                                                 external_format,
                                                  type,
                                                  scaled_extent,
                                                  mip_levels,

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -83,6 +83,7 @@ class VulkanResourcesUtil
     // Return value is the total size of the image.
     uint64_t GetImageResourceSizesOptimal(VkImage                image,
                                           VkFormat               format,
+                                          uint64_t               external_format,
                                           VkImageType            type,
                                           const VkExtent3D&      extent,
                                           uint32_t               mip_levels,
@@ -100,6 +101,7 @@ class VulkanResourcesUtil
     // GetImageResourceSizesOptimal()
     VkResult ReadFromImageResourceStaging(VkImage                image,
                                           VkFormat               format,
+                                          uint64_t               external_format,
                                           VkImageType            type,
                                           const VkExtent3D&      extent,
                                           uint32_t               mip_levels,


### PR DESCRIPTION
The external format from android must be tracked, because in GetImageResourceSizesOptimal we create temporary images from the same format to calculate the resource size

If format is VK_FORMAT_UNDEFINED and the external android format is not provided it will crash on android