### PR TITLE
Refactor pNext-util, enforce usage

### DIFF
--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(gfxrecon_graphics
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_deep_copy.h
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_get_pnext.h
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_extract_handles.h

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -41,6 +41,7 @@
 #include "graphics/vulkan_check_buffer_references.h"
 #include "graphics/vulkan_device_util.h"
 #include "graphics/vulkan_util.h"
+#include "graphics/vulkan_struct_get_pnext.h"
 #include "graphics/vulkan_struct_deep_copy.h"
 #include "graphics/vulkan_struct_extract_handles.h"
 #include "util/file_path.h"
@@ -1297,33 +1298,16 @@ void VulkanReplayConsumerBase::SetPhysicalDeviceProperties(PhysicalDeviceInfo*  
 {
     SetPhysicalDeviceProperties(physical_device_info, &capture_properties->properties, &replay_properties->properties);
 
-    auto get_ray_properties =
-        [](const VkPhysicalDeviceProperties2* device_props) -> const VkPhysicalDeviceRayTracingPipelinePropertiesKHR* {
-        if (device_props != nullptr)
-        {
-            const void* pNext = device_props->pNext;
-
-            while (pNext != nullptr)
-            {
-                auto base = reinterpret_cast<const VkBaseInStructure*>(pNext);
-                if (base->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR)
-                {
-                    return reinterpret_cast<const VkPhysicalDeviceRayTracingPipelinePropertiesKHR*>(base);
-                }
-                pNext = base->pNext;
-            }
-        }
-        return nullptr;
-    };
-
-    if (auto ray_capture_props = get_ray_properties(capture_properties))
+    if (auto ray_capture_props =
+            graphics::vulkan_struct_get_pnext<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>(capture_properties))
     {
         physical_device_info->shaderGroupBaseAlignment   = ray_capture_props->shaderGroupBaseAlignment;
         physical_device_info->shaderGroupHandleAlignment = ray_capture_props->shaderGroupHandleAlignment;
         physical_device_info->shaderGroupHandleSize      = ray_capture_props->shaderGroupHandleSize;
     }
 
-    if (auto ray_replay_props = get_ray_properties(replay_properties))
+    if (auto ray_replay_props =
+            graphics::vulkan_struct_get_pnext<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>(replay_properties))
     {
         physical_device_info->replay_device_info->raytracing_properties        = *ray_replay_props;
         physical_device_info->replay_device_info->raytracing_properties->pNext = nullptr;
@@ -1949,25 +1933,16 @@ void VulkanReplayConsumerBase::ProcessCreateInstanceDebugCallbackInfo(const Deco
 {
     assert(instance_info != nullptr);
 
-    if (instance_info->pNext != nullptr)
+    if (auto debug_report_info =
+            graphics::vulkan_struct_get_pnext<VkDebugReportCallbackCreateInfoEXT>(instance_info->decoded_value))
     {
-        // 'Out' struct for non-const pNext pointers.
-        auto pnext = reinterpret_cast<VkBaseOutStructure*>(instance_info->pNext->GetPointer());
-        while (pnext != nullptr)
-        {
-            if (pnext->sType == VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT)
-            {
-                auto debug_report_info         = reinterpret_cast<VkDebugReportCallbackCreateInfoEXT*>(pnext);
-                debug_report_info->pfnCallback = DebugReportCallback;
-            }
-            else if (pnext->sType == VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
-            {
-                auto debug_utils_info             = reinterpret_cast<VkDebugUtilsMessengerCreateInfoEXT*>(pnext);
-                debug_utils_info->pfnUserCallback = DebugUtilsCallback;
-            }
+        debug_report_info->pfnCallback = DebugReportCallback;
+    }
 
-            pnext = pnext->pNext;
-        }
+    if (auto debug_utils_info =
+            graphics::vulkan_struct_get_pnext<VkDebugUtilsMessengerCreateInfoEXT>(instance_info->decoded_value))
+    {
+        debug_utils_info->pfnUserCallback = DebugUtilsCallback;
     }
 }
 
@@ -1975,50 +1950,39 @@ void VulkanReplayConsumerBase::ProcessSwapchainFullScreenExclusiveInfo(
     const Decoded_VkSwapchainCreateInfoKHR* swapchain_info)
 {
     assert(swapchain_info != nullptr);
+    auto pnext = reinterpret_cast<VkBaseOutStructure*>(swapchain_info->pNext->GetPointer());
 
-    if (swapchain_info->pNext != nullptr)
+    if (auto full_screen_info = graphics::vulkan_struct_get_pnext<VkSurfaceFullScreenExclusiveWin32InfoEXT>(pnext))
     {
-        // 'Out' struct for non-const pNext pointers.
-        auto pnext = reinterpret_cast<VkBaseOutStructure*>(swapchain_info->pNext->GetPointer());
-        while (pnext != nullptr)
-        {
-            if (pnext->sType == VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT)
-            {
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-                // Get the surface info from the Decoded_VkSwapchainCreateInfoKHR handle id.
-                HMONITOR   hmonitor     = nullptr;
-                const auto surface_info = object_info_table_.GetSurfaceKHRInfo(swapchain_info->surface);
+        // Get the surface info from the Decoded_VkSwapchainCreateInfoKHR handle id.
+        HMONITOR   hmonitor     = nullptr;
+        const auto surface_info = object_info_table_.GetSurfaceKHRInfo(swapchain_info->surface);
 
-                if ((surface_info != nullptr) && (surface_info->window != nullptr))
-                {
-                    // Try to retrieve an HWND value from the window.
-                    HWND hwnd = nullptr;
-                    if (surface_info->window->GetNativeHandle(Window::kWin32HWnd, reinterpret_cast<void**>(&hwnd)))
-                    {
-                        hmonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-                    }
-                }
-
-                if (hmonitor != nullptr)
-                {
-                    auto full_screen_info      = reinterpret_cast<VkSurfaceFullScreenExclusiveWin32InfoEXT*>(pnext);
-                    full_screen_info->hmonitor = hmonitor;
-                }
-                else
-                {
-                    GFXRECON_LOG_WARNING(
-                        "Failed to obtain a valid HMONITOR handle for the VkSurfaceFullScreenExclusiveWin32InfoEXT "
-                        "extension structure provided to vkCreateSwapchainKHR")
-                }
-#else
-                GFXRECON_LOG_WARNING("vkCreateSwapchainKHR called with the VkSurfaceFullScreenExclusiveWin32InfoEXT "
-                                     "extension structure, which is not supported by this platform")
-#endif
-                break;
+        if ((surface_info != nullptr) && (surface_info->window != nullptr))
+        {
+            // Try to retrieve an HWND value from the window.
+            HWND hwnd = nullptr;
+            if (surface_info->window->GetNativeHandle(Window::kWin32HWnd, reinterpret_cast<void**>(&hwnd)))
+            {
+                hmonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
             }
-
-            pnext = pnext->pNext;
         }
+
+        if (hmonitor != nullptr)
+        {
+            full_screen_info->hmonitor = hmonitor;
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING(
+                "Failed to obtain a valid HMONITOR handle for the VkSurfaceFullScreenExclusiveWin32InfoEXT "
+                "extension structure provided to vkCreateSwapchainKHR")
+        }
+#else
+        GFXRECON_LOG_WARNING("vkCreateSwapchainKHR called with the VkSurfaceFullScreenExclusiveWin32InfoEXT "
+                             "extension structure, which is not supported by this platform")
+#endif
     }
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1950,9 +1950,9 @@ void VulkanReplayConsumerBase::ProcessSwapchainFullScreenExclusiveInfo(
     const Decoded_VkSwapchainCreateInfoKHR* swapchain_info)
 {
     assert(swapchain_info != nullptr);
-    auto pnext = reinterpret_cast<VkBaseOutStructure*>(swapchain_info->pNext->GetPointer());
 
-    if (auto full_screen_info = graphics::vulkan_struct_get_pnext<VkSurfaceFullScreenExclusiveWin32InfoEXT>(pnext))
+    if (auto full_screen_info =
+            graphics::vulkan_struct_get_pnext<VkSurfaceFullScreenExclusiveWin32InfoEXT>(swapchain_info->decoded_value))
     {
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
         // Get the surface info from the Decoded_VkSwapchainCreateInfoKHR handle id.

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1118,7 +1118,7 @@ VkResult VulkanCaptureManager::OverrideAllocateMemory(VkDevice                  
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
         if (auto import_ahb_info =
-                graphics::vulkan_struct_get_pnext<VkImportAndroidHardwareBufferInfoANDROID>(*pAllocateInfo_unwrapped))
+                graphics::vulkan_struct_get_pnext<VkImportAndroidHardwareBufferInfoANDROID>(pAllocateInfo_unwrapped))
         {
             if (import_ahb_info->buffer != nullptr)
             {

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -33,6 +33,7 @@
 #include "generated/generated_vulkan_struct_handle_wrappers.h"
 #include "graphics/vulkan_check_buffer_references.h"
 #include "graphics/vulkan_device_util.h"
+#include "graphics/vulkan_struct_get_pnext.h"
 #include "graphics/vulkan_util.h"
 #include "util/compressor.h"
 #include "util/logging.h"
@@ -1001,33 +1002,22 @@ VkResult VulkanCaptureManager::OverrideAllocateMemory(VkDevice                  
     VkMemoryAllocateInfo* pAllocateInfo_unwrapped =
         const_cast<VkMemoryAllocateInfo*>(vulkan_wrappers::UnwrapStructPtrHandles(pAllocateInfo, handle_unwrap_memory));
 
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-    const VkImportAndroidHardwareBufferInfoANDROID* import_ahb_info =
-        FindAllocateMemoryExtensions(pAllocateInfo_unwrapped);
-#endif
-
     bool                   uses_address         = false;
     VkMemoryAllocateFlags* modified_alloc_flags = nullptr;
     VkMemoryAllocateFlags  incoming_alloc_flags;
     if (device_wrapper->property_feature_info.feature_bufferDeviceAddressCaptureReplay)
     {
-        VkBaseOutStructure* current_struct = reinterpret_cast<VkBaseOutStructure*>(pAllocateInfo_unwrapped)->pNext;
-        while (current_struct != nullptr)
+        if (auto alloc_flags_info =
+                graphics::vulkan_struct_get_pnext<VkMemoryAllocateFlagsInfo>(pAllocateInfo_unwrapped))
         {
-            if (current_struct->sType == VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO)
+            if ((alloc_flags_info->flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT) ==
+                VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT)
             {
-                auto alloc_flags_info = reinterpret_cast<VkMemoryAllocateFlagsInfo*>(current_struct);
-                if ((alloc_flags_info->flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT) ==
-                    VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT)
-                {
-                    uses_address         = true;
-                    incoming_alloc_flags = alloc_flags_info->flags;
-                    alloc_flags_info->flags |= VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT;
-                    modified_alloc_flags = &(alloc_flags_info->flags);
-                }
-                break;
+                uses_address         = true;
+                incoming_alloc_flags = alloc_flags_info->flags;
+                alloc_flags_info->flags |= VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT;
+                modified_alloc_flags = &(alloc_flags_info->flags);
             }
-            current_struct = current_struct->pNext;
         }
     }
 
@@ -1127,9 +1117,13 @@ VkResult VulkanCaptureManager::OverrideAllocateMemory(VkDevice                  
         }
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-        if ((import_ahb_info != nullptr) && (import_ahb_info->buffer != nullptr))
+        if (auto import_ahb_info =
+                graphics::vulkan_struct_get_pnext<VkImportAndroidHardwareBufferInfoANDROID>(*pAllocateInfo_unwrapped))
         {
-            ProcessImportAndroidHardwareBuffer(device, *pMemory, import_ahb_info->buffer);
+            if (import_ahb_info->buffer != nullptr)
+            {
+                ProcessImportAndroidHardwareBuffer(device, *pMemory, import_ahb_info->buffer);
+            }
         }
 #endif
     }
@@ -1669,32 +1663,6 @@ VkMemoryPropertyFlags VulkanCaptureManager::GetMemoryProperties(vulkan_wrappers:
     assert(memory_type_index < memory_properties->memoryTypeCount);
 
     return memory_properties->memoryTypes[memory_type_index].propertyFlags;
-}
-
-const VkImportAndroidHardwareBufferInfoANDROID*
-VulkanCaptureManager::FindAllocateMemoryExtensions(const VkMemoryAllocateInfo* allocate_info)
-{
-    const VkImportAndroidHardwareBufferInfoANDROID* import_ahb_info = nullptr;
-
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-    assert(allocate_info != nullptr);
-
-    const VkBaseInStructure* pnext = reinterpret_cast<const VkBaseInStructure*>(allocate_info->pNext);
-    while (pnext != nullptr)
-    {
-        if (pnext->sType == VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID)
-        {
-            import_ahb_info = reinterpret_cast<const VkImportAndroidHardwareBufferInfoANDROID*>(pnext);
-            break;
-        }
-
-        pnext = pnext->pNext;
-    }
-#else
-    GFXRECON_UNREFERENCED_PARAMETER(allocate_info);
-#endif
-
-    return import_ahb_info;
 }
 
 void VulkanCaptureManager::ProcessReferenceToAndroidHardwareBuffer(VkDevice device, AHardwareBuffer* hardware_buffer)
@@ -2745,27 +2713,14 @@ bool VulkanCaptureManager::CheckCommandBufferWrapperForFrameBoundary(
 
 bool VulkanCaptureManager::CheckPNextChainForFrameBoundary(const VkBaseInStructure* current)
 {
-    if (current == nullptr)
+    if (auto frame_boundary = graphics::vulkan_struct_get_pnext<VkFrameBoundaryEXT>(current))
     {
-        return false;
-    }
-
-    while (current->sType != VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT && current->pNext != nullptr)
-    {
-        current = current->pNext;
-    }
-
-    if (current->sType == VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT)
-    {
-        const VkFrameBoundaryEXT* frame_boundary = reinterpret_cast<const VkFrameBoundaryEXT*>(current);
-
         if (frame_boundary->flags & VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT)
         {
             EndFrame();
             return true;
         }
     }
-
     return false;
 }
 

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1333,9 +1333,6 @@ class VulkanCaptureManager : public ApiCaptureManager
     VkMemoryPropertyFlags GetMemoryProperties(vulkan_wrappers::DeviceWrapper* device_wrapper,
                                               uint32_t                        memory_type_index);
 
-    const VkImportAndroidHardwareBufferInfoANDROID*
-    FindAllocateMemoryExtensions(const VkMemoryAllocateInfo* allocate_info);
-
     void ProcessReferenceToAndroidHardwareBuffer(VkDevice device, AHardwareBuffer* hardware_buffer);
     void ProcessImportAndroidHardwareBuffer(VkDevice device, VkDeviceMemory memory, AHardwareBuffer* hardware_buffer);
     void ReleaseAndroidHardwareBuffer(AHardwareBuffer* hardware_buffer);

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -32,6 +32,7 @@
 #include "util/defines.h"
 #include "util/logging.h"
 #include "util/memory_output_stream.h"
+#include "graphics/vulkan_struct_get_pnext.h"
 
 #include "vulkan/vulkan.h"
 
@@ -272,15 +273,9 @@ inline void InitializeState<VkDevice, vulkan_wrappers::SemaphoreWrapper, VkSemap
 
     wrapper->device = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
 
-    auto next = reinterpret_cast<const VkBaseInStructure*>(create_info->pNext);
-    while (next)
+    if (auto semaphore_type = graphics::vulkan_struct_get_pnext<VkSemaphoreTypeCreateInfo>(create_info))
     {
-        if (next->sType == VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO)
-        {
-            auto semaphore_type = reinterpret_cast<const VkSemaphoreTypeCreateInfo*>(next);
-            wrapper->type       = semaphore_type->semaphoreType;
-        }
-        next = next->pNext;
+        wrapper->type = semaphore_type->semaphoreType;
     }
 }
 

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(gfxrecon_graphics
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_deep_copy.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_get_pnext.h
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy_stype.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_extract_handles.h

--- a/framework/graphics/vulkan_check_buffer_references.cpp
+++ b/framework/graphics/vulkan_check_buffer_references.cpp
@@ -20,6 +20,7 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
+#include "graphics/vulkan_struct_get_pnext.h"
 #include "vulkan_check_buffer_references.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -32,17 +33,10 @@ void vulkan_check_buffer_references(const VkGraphicsPipelineCreateInfo* create_i
     {
         for (uint32_t j = 0; j < create_infos[i].stageCount; ++j)
         {
-            const void* pNext = create_infos[i].pStages[j].pNext;
-            while (pNext != nullptr)
+            if (auto module_create_info =
+                    vulkan_struct_get_pnext<VkShaderModuleCreateInfo>(create_infos[i].pStages + j))
             {
-                auto base = reinterpret_cast<const VkBaseInStructure*>(pNext);
-
-                if (base->sType == VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
-                {
-                    auto module_create_info = reinterpret_cast<const VkShaderModuleCreateInfo*>(base);
-                    graphics::vulkan_check_buffer_references(module_create_info->pCode, module_create_info->codeSize);
-                }
-                pNext = base->pNext;
+                graphics::vulkan_check_buffer_references(module_create_info->pCode, module_create_info->codeSize);
             }
         }
     }
@@ -53,17 +47,9 @@ void vulkan_check_buffer_references(const VkComputePipelineCreateInfo* create_in
 {
     for (uint32_t i = 0; i < create_info_count; ++i)
     {
-        const void* pNext = create_infos[i].stage.pNext;
-        while (pNext != nullptr)
+        if (auto module_create_info = vulkan_struct_get_pnext<VkShaderModuleCreateInfo>(&create_infos[i].stage))
         {
-            auto base = reinterpret_cast<const VkBaseInStructure*>(pNext);
-
-            if (base->sType == VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
-            {
-                auto module_create_info = reinterpret_cast<const VkShaderModuleCreateInfo*>(base);
-                graphics::vulkan_check_buffer_references(module_create_info->pCode, module_create_info->codeSize);
-            }
-            pNext = base->pNext;
+            graphics::vulkan_check_buffer_references(module_create_info->pCode, module_create_info->codeSize);
         }
     }
 }

--- a/framework/graphics/vulkan_struct_get_pnext.h
+++ b/framework/graphics/vulkan_struct_get_pnext.h
@@ -56,7 +56,7 @@ inline constexpr bool is_vulkan_struct_v = is_vulkan_struct<T>::value;
 template <typename T, typename Parent_T>
 static const T* vulkan_struct_get_pnext(const Parent_T* parent)
 {
-    static_assert(is_vulkan_struct<T>() && is_vulkan_struct<Parent_T>());
+    static_assert(is_vulkan_struct_v<T> && is_vulkan_struct_v<Parent_T>);
 
     if (parent != nullptr)
     {
@@ -89,7 +89,7 @@ static const T* vulkan_struct_get_pnext(const Parent_T* parent)
 template <typename T, typename Parent_T>
 static T* vulkan_struct_get_pnext(Parent_T* parent)
 {
-    static_assert(is_vulkan_struct<T>() && is_vulkan_struct<Parent_T>());
+    static_assert(is_vulkan_struct_v<T> && is_vulkan_struct_v<Parent_T>);
 
     if (parent != nullptr)
     {

--- a/framework/graphics/vulkan_struct_get_pnext.h
+++ b/framework/graphics/vulkan_struct_get_pnext.h
@@ -1,0 +1,94 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_GRAPHICS_VULKAN_STRUCT_GET_PNEXT_H
+#define GFXRECON_GRAPHICS_VULKAN_STRUCT_GET_PNEXT_H
+
+#include "util/defines.h"
+#include "format/platform_types.h"
+#include "generated/generated_vulkan_stype_util.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+/**
+ * @brief   vulkan_struct_get_pnext can be used to retrieve elements of a
+ *          provided structure's pNext-chain by their type.
+ *
+ * Searches through the parent's pNext-chain for the first struct with the requested struct_type.
+ * \p T and \p Parent_T must be Vulkan structure-types. Returns nullptr if no matching struct could be found.
+
+ * @tparam  T           the structure-type to retrieve from pNext-chain
+ * @tparam  Parent_T    implicit type of provided structure
+ * @param   parent      a provided vulkan-structure containing a pNext-chain.
+ * @return  a typed pointer to a structure found in the pNext-chain or nullptr.
+ */
+template <typename T, typename Parent_T>
+static const T* vulkan_struct_get_pnext(const Parent_T* parent)
+{
+    if (parent != nullptr)
+    {
+        auto current_struct = reinterpret_cast<const VkBaseInStructure*>(parent)->pNext;
+
+        while (current_struct != nullptr)
+        {
+            if (current_struct->sType == gfxrecon::util::GetSType<T>())
+            {
+                return reinterpret_cast<const T*>(current_struct);
+            }
+            current_struct = current_struct->pNext;
+        }
+    }
+    return nullptr;
+}
+
+/**
+ * @brief   vulkan_struct_get_pnext non-const flavor
+ *
+ * @tparam  T           the structure-type to retrieve from pNext-chain
+ * @tparam  Parent_T    implicit type of provided structure
+ * @param   parent      a provided vulkan-structure containing a pNext-chain.
+ * @return  a typed pointer to a structure found in the pNext-chain or nullptr.
+ */
+template <typename T, typename Parent_T>
+static T* vulkan_struct_get_pnext(Parent_T* parent)
+{
+    if (parent != nullptr)
+    {
+        auto current_struct = reinterpret_cast<VkBaseOutStructure*>(parent)->pNext;
+
+        while (current_struct != nullptr)
+        {
+            if (current_struct->sType == gfxrecon::util::GetSType<T>())
+            {
+                return reinterpret_cast<T*>(current_struct);
+            }
+            current_struct = current_struct->pNext;
+        }
+    }
+    return nullptr;
+}
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_GRAPHICS_VULKAN_STRUCT_GET_PNEXT_H

--- a/framework/graphics/vulkan_struct_get_pnext.h
+++ b/framework/graphics/vulkan_struct_get_pnext.h
@@ -35,8 +35,7 @@ struct is_vulkan_struct : std::false_type
 {};
 
 template <typename T>
-struct is_vulkan_struct<T, decltype((void)T::sType, 0)>
-    : std::is_same<decltype(T::sType), VkStructureType>
+struct is_vulkan_struct<T, decltype((void)T::sType, 0)> : std::is_same<decltype(T::sType), VkStructureType>
 {};
 
 template <typename T>

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -46,24 +46,6 @@ util::platform::LibraryHandle InitializeLoader();
 
 void ReleaseLoader(util::platform::LibraryHandle loader_handle);
 
-// Search through the parent's pNext chain for the first struct with the requested struct_type. parent's struct type is
-// not checked and parent won't be returned as a result. T and Parent_T must be Vulkan struct pointer types. Return
-// nullptr if no matching struct found.
-template <typename T, typename Parent_T>
-static T* GetPNextStruct(const Parent_T* parent, VkStructureType struct_type)
-{
-    VkBaseOutStructure* current_struct = reinterpret_cast<const VkBaseOutStructure*>(parent)->pNext;
-    while (current_struct != nullptr)
-    {
-        if (current_struct->sType == struct_type)
-        {
-            return reinterpret_cast<T*>(current_struct);
-        }
-        current_struct = current_struct->pNext;
-    }
-    return nullptr;
-}
-
 static const char* kVulkanVrFrameDelimiterString = "vr-marker,frame_end,type,application";
 
 GFXRECON_END_NAMESPACE(graphics)


### PR DESCRIPTION
- pNext-chains: replace a commonly repeated loop-pattern with an existing utility-function
- resolve sType with existing GetSType-util
- rename, doc and move to dedicated header
- applied in locations matching grep-pattern '== VK_STRUCTURE_TYPE'