### PR TITLE
Enable Exclusive Capture Lock to Specific Functions

### DIFF
--- a/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
@@ -685,8 +685,9 @@ class Dx12WrapperBodyGenerator(Dx12BaseGenerator):
             expr += indent + '{\n'
             indent = self.increment_indent(indent)
 
-            if class_name.startswith("IDXGISwapChain"
-                                     ) and method_name.startswith("Present"):
+            if (class_name.startswith("IDXGISwapChain") and method_name.startswith("Present")) or (
+                class_name == "ID3D12GraphicsCommandList4" and method_name == "BuildRaytracingAccelerationStructure") or (
+                    class_name == "ID3D12GraphicsCommandList4" and method_name == "CopyRaytracingAccelerationStructure"):
                 expr += indent + 'auto api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();\n'
             else:
                 expr += indent + 'auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();\n'

--- a/framework/generated/generated_dx12_wrappers.cpp
+++ b/framework/generated/generated_dx12_wrappers.cpp
@@ -22961,17 +22961,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::BuildRaytracingAccele
 
     if (call_scope == 1)
     {
-        auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
-        if (force_command_serialization)
-        {
-            exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
-        }
-        else
-        {
-            shared_api_call_lock = D3D12CaptureManager::AcquireSharedApiCallLock();
-        }
+        auto api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
 
         std::unique_ptr<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC> pDesc_unannotated = nullptr;
         std::unique_ptr<D3D12_RAYTRACING_GEOMETRY_DESC[]> pDesc_dependency = nullptr;
@@ -23106,17 +23096,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::CopyRaytracingAcceler
 
     if (call_scope == 1)
     {
-        auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
-        if (force_command_serialization)
-        {
-            exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
-        }
-        else
-        {
-            shared_api_call_lock = D3D12CaptureManager::AcquireSharedApiCallLock();
-        }
+        auto api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
 
         RvAnnotationUtil::RemoveRvAnnotation(DestAccelerationStructureData);
 


### PR DESCRIPTION
Enable exclusive capture lock to ID3D12GraphicsCommandList4::BuildRaytracingAccelerationStructure()
and ID3D12GraphicsCommandList4::CopyRaytracingAccelerationStructure().
Make the PostProcessXXX() to add metablock data block attach to the API calls block.