### PR TITLE
Clean up Android/Java section of BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -400,14 +400,14 @@ https://developer.apple.com/library/archive/documentation/Security/Conceptual/Co
   - The [Android Platform tools](https://developer.android.com/studio/releases/platform-tools) for your specific platform
   - [Android SDK 33 (13 Tiramisu) or newer](https://guides.codepath.com/android/installing-android-sdk-tools)
   - [Android NDK 21.3.6528147 (r21d)](https://developer.android.com/ndk/guides/)
-- [Java JDK 1.11](https://jdk.java.net/11)
+- [Java JDK 17](https://jdk.java.net/17/)
 
 #### Additional Linux Command-Linux Prerequisites
 
 Additional requirements for building from the Linux command-line:
 - Define `ANDROID_HOME`to be the path to the SDK installed on your system by Android Studio.
   - Refer to Android Studio to find out where the files are installed
-    - **NOTE:** For older Android Stud io's you may also have to set `ANDROID_SDK_ROOT` to the same value
+    - **NOTE:** For older Android Studio's you may also have to set `ANDROID_SDK_ROOT` to the same value
   - For example:
 
 ```bash
@@ -418,11 +418,8 @@ Additional requirements for building from the Linux command-line:
   - For example:
 
 ```bash
-      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11.0.18.0.10-1.fc37.x86_64
+        export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ```
-
-- Make the `gradlew` script executable
-  - `chmod +x android/gradlew`
 
 ### Android Build
 


### PR DESCRIPTION
This bit me when updating to latest dev--just a doc tweak to mention the new Java version required for Gradle #1667 