### PR TITLE
Warn when AHardwareBuffer read is skipped

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1846,6 +1846,9 @@ void VulkanCaptureManager::ProcessReferenceToAndroidHardwareBuffer(VkDevice devi
             ahb_info.reference_count     = 0;
 
             WriteCreateHardwareBufferCmd(memory_id, hardware_buffer, plane_info);
+
+            GFXRECON_LOG_WARNING("AHardwareBuffer cannot be read: hardware buffer data will be omitted "
+                                 "from the capture file");
         }
     }
 #else


### PR DESCRIPTION
When AHardwareBuffer does not have usage AHARDWAREBUFFER_USAGE_CPU_READ_MASK, reading from the buffer is skipped and memory is instead filled with 0. All the other paths print a warning, but here it was missing