### PR TITLE
Fix capture deadlock when `vkQueuePresentKHR` unlocks a CPU wait

### DIFF
--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -8601,7 +8601,17 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(
 {
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
-    auto api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
+    auto force_command_serialization = manager->GetForceCommandSerialization();
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    if (force_command_serialization)
+    {
+        exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
+    }
+    else
+    {
+        shared_api_call_lock = VulkanCaptureManager::AcquireSharedApiCallLock();
+    }
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueuePresentKHR>::Dispatch(manager, queue, pPresentInfo);
 

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -237,7 +237,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
         if name != "vkCreateInstance":
             body += indent + 'VulkanCaptureManager* manager = VulkanCaptureManager::Get();\n'
             body += indent + 'GFXRECON_ASSERT(manager != nullptr);\n'
-        if name == "vkCreateInstance" or name == "vkQueuePresentKHR":
+        if name == "vkCreateInstance":
             body += indent + 'auto api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();\n'
         else:
             body += indent + 'auto force_command_serialization = manager->GetForceCommandSerialization();\n'


### PR DESCRIPTION
This bug can be observed when capturing the Khronos Vulkan-Sample "timeline_semaphore"

In a situation where you have two threads:
- one waiting on a synchronization primitive (`VkSemaphore`, `VkFence`....)
- another on which a call to `vkQueuePresentKHR` is necessary to signal that primitive

Then if the "CPU waiting call" (`vkWaitForFences`, `vkWaitSemaphores`...) is reached by thread 1 before `vkQueuePresentKHR` is reached by thread 2, the `api_call_mutex_` of the `CaptureManager` is locked by the CPU waiting call which makes it impossible to lock by the call to `vkQueuePresentKHR` (which is always an exclusive lock) and we end up in a deadlock situation.

I don't see why the lock inside `vkQueuePresentKHR` should be exclusive, so I propose to solve this issue by simply using the same system of shared lock as for all the other calls.