### PR TITLE
Adjust trimming state snapshot locking

### DIFF
--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -95,23 +95,34 @@ class ApiCaptureManager
 
     void WriteFrameMarker(format::MarkerType marker_type) { common_manager_->WriteFrameMarker(marker_type); }
 
-    void EndFrame() { common_manager_->EndFrame(api_family_); }
+    void EndFrame(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock)
+    {
+        common_manager_->EndFrame(api_family_, current_lock);
+    }
 
     // Pre/PostQueueSubmit to be called immediately before and after work is submitted to the GPU by vkQueueSubmit for
     // Vulkan or by ID3D12CommandQueue::ExecuteCommandLists for DX12.
-    void PreQueueSubmit() { common_manager_->PreQueueSubmit(api_family_); }
-    void PostQueueSubmit() { common_manager_->PostQueueSubmit(api_family_); }
+    void PreQueueSubmit(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock)
+    {
+        common_manager_->PreQueueSubmit(api_family_, current_lock);
+    }
+    void PostQueueSubmit(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock)
+    {
+        common_manager_->PostQueueSubmit(api_family_, current_lock);
+    }
 
     bool ShouldTriggerScreenshot() { return common_manager_->ShouldTriggerScreenshot(); }
 
-    void CheckContinueCaptureForWriteMode(uint32_t current_boundary_count)
+    void CheckContinueCaptureForWriteMode(uint32_t                                               current_boundary_count,
+                                          std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock)
     {
-        common_manager_->CheckContinueCaptureForWriteMode(api_family_, current_boundary_count);
+        common_manager_->CheckContinueCaptureForWriteMode(api_family_, current_boundary_count, current_lock);
     }
 
-    void CheckStartCaptureForTrackMode(uint32_t current_boundary_count)
+    void CheckStartCaptureForTrackMode(uint32_t                                               current_boundary_count,
+                                       std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock)
     {
-        common_manager_->CheckStartCaptureForTrackMode(api_family_, current_boundary_count);
+        common_manager_->CheckStartCaptureForTrackMode(api_family_, current_boundary_count, current_lock);
     }
 
     bool IsTrimHotkeyPressed() { return common_manager_->IsTrimHotkeyPressed(); }

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -682,15 +682,16 @@ bool CommonCaptureManager::RuntimeTriggerDisabled()
     return result;
 }
 
-void CommonCaptureManager::CheckContinueCaptureForWriteMode(format::ApiFamilyId api_family,
-                                                            uint32_t            current_boundary_count)
+void CommonCaptureManager::CheckContinueCaptureForWriteMode(format::ApiFamilyId              api_family,
+                                                            uint32_t                         current_boundary_count,
+                                                            std::shared_lock<ApiCallMutexT>& current_lock)
 {
     if (!trim_ranges_.empty())
     {
         if (current_boundary_count == (trim_ranges_[trim_current_range_].last + 1))
         {
             // Stop recording and close file.
-            DeactivateTrimming();
+            DeactivateTrimming(current_lock);
             GFXRECON_LOG_INFO("Finished recording graphics API capture");
 
             // Advance to next range
@@ -716,7 +717,7 @@ void CommonCaptureManager::CheckContinueCaptureForWriteMode(format::ApiFamilyId 
                 bool        success    = CreateCaptureFile(api_family, CreateTrimFilename(base_filename_, trim_range));
                 if (success)
                 {
-                    ActivateTrimming();
+                    ActivateTrimming(current_lock);
                 }
                 else
                 {
@@ -732,13 +733,14 @@ void CommonCaptureManager::CheckContinueCaptureForWriteMode(format::ApiFamilyId 
              RuntimeTriggerDisabled())
     {
         // Stop recording and close file.
-        DeactivateTrimming();
+        DeactivateTrimming(current_lock);
         GFXRECON_LOG_INFO("Finished recording graphics API capture");
     }
 }
 
-void CommonCaptureManager::CheckStartCaptureForTrackMode(format::ApiFamilyId api_family,
-                                                         uint32_t            current_boundary_count)
+void CommonCaptureManager::CheckStartCaptureForTrackMode(format::ApiFamilyId              api_family,
+                                                         uint32_t                         current_boundary_count,
+                                                         std::shared_lock<ApiCallMutexT>& current_lock)
 {
     if (!trim_ranges_.empty())
     {
@@ -748,7 +750,7 @@ void CommonCaptureManager::CheckStartCaptureForTrackMode(format::ApiFamilyId api
             bool        success    = CreateCaptureFile(api_family, CreateTrimFilename(base_filename_, trim_range));
             if (success)
             {
-                ActivateTrimming();
+                ActivateTrimming(current_lock);
             }
             else
             {
@@ -766,7 +768,7 @@ void CommonCaptureManager::CheckStartCaptureForTrackMode(format::ApiFamilyId api
         {
 
             trim_key_first_frame_ = current_boundary_count;
-            ActivateTrimming();
+            ActivateTrimming(current_lock);
         }
         else
         {
@@ -819,7 +821,7 @@ void CommonCaptureManager::WriteFrameMarker(format::MarkerType marker_type)
     }
 }
 
-void CommonCaptureManager::EndFrame(format::ApiFamilyId api_family)
+void CommonCaptureManager::EndFrame(format::ApiFamilyId api_family, std::shared_lock<ApiCallMutexT>& current_lock)
 {
     // Write an end-of-frame marker to the capture file.
     WriteFrameMarker(format::MarkerType::kEndMarker);
@@ -832,13 +834,13 @@ void CommonCaptureManager::EndFrame(format::ApiFamilyId api_family)
         {
             // Currently capturing a frame range.
             // Check for end of range or hotkey trigger to stop capture.
-            CheckContinueCaptureForWriteMode(api_family, current_frame_);
+            CheckContinueCaptureForWriteMode(api_family, current_frame_, current_lock);
         }
         else if ((capture_mode_ & kModeTrack) == kModeTrack)
         {
             // Capture is not active.
             // Check for start of capture frame range or hotkey trigger to start capture
-            CheckStartCaptureForTrackMode(api_family, current_frame_);
+            CheckStartCaptureForTrackMode(api_family, current_frame_, current_lock);
         }
     }
 
@@ -856,7 +858,7 @@ void CommonCaptureManager::EndFrame(format::ApiFamilyId api_family)
     }
 }
 
-void CommonCaptureManager::PreQueueSubmit(format::ApiFamilyId api_family)
+void CommonCaptureManager::PreQueueSubmit(format::ApiFamilyId api_family, std::shared_lock<ApiCallMutexT>& current_lock)
 {
     ++queue_submit_count_;
 
@@ -865,12 +867,13 @@ void CommonCaptureManager::PreQueueSubmit(format::ApiFamilyId api_family)
         if (((capture_mode_ & kModeWrite) != kModeWrite) && ((capture_mode_ & kModeTrack) == kModeTrack))
         {
             // Capture is not active, check for start of capture frame range.
-            CheckStartCaptureForTrackMode(api_family, queue_submit_count_);
+            CheckStartCaptureForTrackMode(api_family, queue_submit_count_, current_lock);
         }
     }
 }
 
-void CommonCaptureManager::PostQueueSubmit(format::ApiFamilyId api_family)
+void CommonCaptureManager::PostQueueSubmit(format::ApiFamilyId              api_family,
+                                           std::shared_lock<ApiCallMutexT>& current_lock)
 {
     if (trim_enabled_ && (trim_boundary_ == CaptureSettings::TrimBoundary::kQueueSubmits))
     {
@@ -879,7 +882,7 @@ void CommonCaptureManager::PostQueueSubmit(format::ApiFamilyId api_family)
             // Currently capturing a queue submit range, check for end of range.
             // It checks the boundary count with +1. That is for trim frames.
             // It will write one more QueueSubmit for trim QueueSubmits, so +1.
-            CheckContinueCaptureForWriteMode(api_family, queue_submit_count_ + 1);
+            CheckContinueCaptureForWriteMode(api_family, queue_submit_count_ + 1, current_lock);
         }
     }
 }
@@ -1048,26 +1051,56 @@ bool CommonCaptureManager::CreateCaptureFile(format::ApiFamilyId api_family, con
     return success;
 }
 
-void CommonCaptureManager::ActivateTrimming()
+void CommonCaptureManager::ActivateTrimming(std::shared_lock<ApiCallMutexT>& current_lock)
 {
-    capture_mode_ |= kModeWrite;
-
-    auto thread_data = GetThreadData();
-    assert(thread_data != nullptr);
-
-    for (auto& manager : api_capture_managers_)
+    auto has_shared_lock = current_lock.owns_lock();
+    if (has_shared_lock)
     {
-        manager.first->WriteTrackedState(file_stream_.get(), thread_data->thread_id_);
+        current_lock.unlock();
+    }
+
+    {
+        auto state_lock = AcquireExclusiveApiCallLock();
+
+        capture_mode_ |= kModeWrite;
+
+        auto thread_data = GetThreadData();
+        assert(thread_data != nullptr);
+
+        for (auto& manager : api_capture_managers_)
+        {
+            manager.first->WriteTrackedState(file_stream_.get(), thread_data->thread_id_);
+        }
+    }
+
+    if (has_shared_lock)
+    {
+        current_lock.lock();
     }
 }
 
-void CommonCaptureManager::DeactivateTrimming()
+void CommonCaptureManager::DeactivateTrimming(std::shared_lock<ApiCallMutexT>& current_lock)
 {
-    capture_mode_ &= ~kModeWrite;
+    auto has_shared_lock = current_lock.owns_lock();
+    if (has_shared_lock)
+    {
+        current_lock.unlock();
+    }
 
-    assert(file_stream_);
-    file_stream_->Flush();
-    file_stream_ = nullptr;
+    {
+        auto state_lock = AcquireExclusiveApiCallLock();
+
+        capture_mode_ &= ~kModeWrite;
+
+        assert(file_stream_);
+        file_stream_->Flush();
+        file_stream_ = nullptr;
+    }
+
+    if (has_shared_lock)
+    {
+        current_lock.lock();
+    }
 }
 
 void CommonCaptureManager::WriteFileHeader()

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -1060,7 +1060,12 @@ void CommonCaptureManager::ActivateTrimming(std::shared_lock<ApiCallMutexT>& cur
     }
 
     {
-        auto state_lock = AcquireExclusiveApiCallLock();
+        auto exclusive_api_call_lock = std::unique_lock<CommonCaptureManager::ApiCallMutexT>{};
+        if (!GetForceCommandSerialization())
+        {
+            // If command serialization is active, the caller already holds the exclusive lock.
+            exclusive_api_call_lock = AcquireExclusiveApiCallLock();
+        }
 
         capture_mode_ |= kModeWrite;
 
@@ -1088,7 +1093,12 @@ void CommonCaptureManager::DeactivateTrimming(std::shared_lock<ApiCallMutexT>& c
     }
 
     {
-        auto state_lock = AcquireExclusiveApiCallLock();
+        auto exclusive_api_call_lock = std::unique_lock<CommonCaptureManager::ApiCallMutexT>{};
+        if (!GetForceCommandSerialization())
+        {
+            // If command serialization is active, the caller already holds the exclusive lock.
+            exclusive_api_call_lock = AcquireExclusiveApiCallLock();
+        }
 
         capture_mode_ &= ~kModeWrite;
 

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -117,20 +117,24 @@ class CommonCaptureManager
 
     void WriteFrameMarker(format::MarkerType marker_type);
 
-    void EndFrame(format::ApiFamilyId api_family);
+    void EndFrame(format::ApiFamilyId api_family, std::shared_lock<ApiCallMutexT>& current_lock);
 
     // Pre/PostQueueSubmit to be called immediately before and after work is submitted to the GPU by vkQueueSubmit for
     // Vulkan or by ID3D12CommandQueue::ExecuteCommandLists for DX12.
-    void PreQueueSubmit(format::ApiFamilyId api_family);
-    void PostQueueSubmit(format::ApiFamilyId api_family);
+    void PreQueueSubmit(format::ApiFamilyId api_family, std::shared_lock<ApiCallMutexT>& current_lock);
+    void PostQueueSubmit(format::ApiFamilyId api_family, std::shared_lock<ApiCallMutexT>& current_lock);
 
     bool ShouldTriggerScreenshot();
 
     util::ScreenshotFormat GetScreenshotFormat() { return screenshot_format_; }
 
-    void CheckContinueCaptureForWriteMode(format::ApiFamilyId api_family, uint32_t current_boundary_count);
+    void CheckContinueCaptureForWriteMode(format::ApiFamilyId              api_family,
+                                          uint32_t                         current_boundary_count,
+                                          std::shared_lock<ApiCallMutexT>& current_lock);
 
-    void CheckStartCaptureForTrackMode(format::ApiFamilyId api_family, uint32_t current_boundary_count);
+    void CheckStartCaptureForTrackMode(format::ApiFamilyId              api_family,
+                                       uint32_t                         current_boundary_count,
+                                       std::shared_lock<ApiCallMutexT>& current_lock);
 
     bool IsTrimHotkeyPressed();
 
@@ -266,8 +270,8 @@ class CommonCaptureManager
     std::string CreateTrimFilename(const std::string& base_filename, const util::UintRange& trim_range);
     bool        CreateCaptureFile(format::ApiFamilyId api_family, const std::string& base_filename);
     void        WriteCaptureOptions(std::string& operation_annotation);
-    void        ActivateTrimming();
-    void        DeactivateTrimming();
+    void        ActivateTrimming(std::shared_lock<ApiCallMutexT>& current_lock);
+    void        DeactivateTrimming(std::shared_lock<ApiCallMutexT>& current_lock);
 
     void WriteFileHeader();
     void BuildOptionList(const format::EnabledOptions&        enabled_options,

--- a/framework/encode/custom_dx12_wrapper_commands.h
+++ b/framework/encode/custom_dx12_wrapper_commands.h
@@ -86,9 +86,11 @@ template <>
 struct CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_Present>
 {
     template <typename... Args>
-    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    static void Dispatch(D3D12CaptureManager*                                   manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         Args... args)
     {
-        manager->PostProcess_IDXGISwapChain_Present(args...);
+        manager->PostProcess_IDXGISwapChain_Present(current_lock, args...);
     }
 };
 
@@ -96,9 +98,11 @@ template <>
 struct CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_Present1>
 {
     template <typename... Args>
-    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    static void Dispatch(D3D12CaptureManager*                                   manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         Args... args)
     {
-        manager->PostProcess_IDXGISwapChain1_Present1(args...);
+        manager->PostProcess_IDXGISwapChain1_Present1(current_lock, args...);
     }
 };
 
@@ -388,9 +392,11 @@ template <>
 struct CustomWrapperPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_ExecuteCommandLists>
 {
     template <typename... Args>
-    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    static void Dispatch(D3D12CaptureManager*                                   manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         Args... args)
     {
-        manager->PreProcess_ID3D12CommandQueue_ExecuteCommandLists(args...);
+        manager->PreProcess_ID3D12CommandQueue_ExecuteCommandLists(current_lock, args...);
     }
 };
 
@@ -398,9 +404,11 @@ template <>
 struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_ExecuteCommandLists>
 {
     template <typename... Args>
-    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    static void Dispatch(D3D12CaptureManager*                                   manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         Args... args)
     {
-        manager->PostProcess_ID3D12CommandQueue_ExecuteCommandLists(args...);
+        manager->PostProcess_ID3D12CommandQueue_ExecuteCommandLists(current_lock, args...);
     }
 };
 

--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -264,9 +264,12 @@ template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueuePresentKHR>
 {
     template <typename... Args>
-    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    static void Dispatch(VulkanCaptureManager*                                  manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         VkResult                                               result,
+                         Args... args)
     {
-        manager->PostProcess_vkQueuePresentKHR(result, args...);
+        manager->PostProcess_vkQueuePresentKHR(current_lock, result, args...);
     }
 };
 
@@ -274,9 +277,11 @@ template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFrameBoundaryANDROID>
 {
     template <typename... Args>
-    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    static void Dispatch(VulkanCaptureManager*                                  manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         Args... args)
     {
-        manager->PostProcess_vkFrameBoundaryANDROID(args...);
+        manager->PostProcess_vkFrameBoundaryANDROID(current_lock, args...);
     }
 };
 
@@ -674,9 +679,11 @@ template <>
 struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit>
 {
     template <typename... Args>
-    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    static void Dispatch(VulkanCaptureManager*                                  manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         Args... args)
     {
-        manager->PreProcess_vkQueueSubmit(args...);
+        manager->PreProcess_vkQueueSubmit(current_lock, args...);
     }
 };
 
@@ -684,9 +691,12 @@ template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit>
 {
     template <typename... Args>
-    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    static void Dispatch(VulkanCaptureManager*                                  manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         VkResult                                               result,
+                         Args... args)
     {
-        manager->PostProcess_vkQueueSubmit(result, args...);
+        manager->PostProcess_vkQueueSubmit(current_lock, result, args...);
     }
 };
 
@@ -694,9 +704,11 @@ template <>
 struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit2>
 {
     template <typename... Args>
-    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    static void Dispatch(VulkanCaptureManager*                                  manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         Args... args)
     {
-        manager->PreProcess_vkQueueSubmit2(args...);
+        manager->PreProcess_vkQueueSubmit2(current_lock, args...);
     }
 };
 
@@ -704,9 +716,11 @@ template <>
 struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit2KHR>
 {
     template <typename... Args>
-    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    static void Dispatch(VulkanCaptureManager*                                  manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         Args... args)
     {
-        manager->PreProcess_vkQueueSubmit2(args...);
+        manager->PreProcess_vkQueueSubmit2(current_lock, args...);
     }
 };
 
@@ -714,9 +728,12 @@ template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit2>
 {
     template <typename... Args>
-    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    static void Dispatch(VulkanCaptureManager*                                  manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         VkResult                                               result,
+                         Args... args)
     {
-        manager->PostProcess_vkQueueSubmit2(result, args...);
+        manager->PostProcess_vkQueueSubmit2(current_lock, result, args...);
     }
 };
 
@@ -724,9 +741,12 @@ template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit2KHR>
 {
     template <typename... Args>
-    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    static void Dispatch(VulkanCaptureManager*                                  manager,
+                         std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                         VkResult                                               result,
+                         Args... args)
     {
-        manager->PostProcess_vkQueueSubmit2(result, args...);
+        manager->PostProcess_vkQueueSubmit2(current_lock, result, args...);
     }
 };
 

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -607,11 +607,13 @@ void D3D12CaptureManager::PrePresent(IDXGISwapChain_Wrapper* swapchain_wrapper)
     }
 }
 
-void D3D12CaptureManager::PostPresent(IDXGISwapChain_Wrapper* swapchain_wrapper, UINT flags)
+void D3D12CaptureManager::PostPresent(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                      IDXGISwapChain_Wrapper*                                swapchain_wrapper,
+                                      UINT                                                   flags)
 {
     if ((flags & DXGI_PRESENT_TEST) == 0)
     {
-        EndFrame();
+        EndFrame(current_lock);
     }
 }
 
@@ -619,7 +621,6 @@ void D3D12CaptureManager::PreProcess_IDXGISwapChain_Present(IDXGISwapChain_Wrapp
                                                             UINT                    sync_interval,
                                                             UINT                    flags)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(wrapper);
     GFXRECON_UNREFERENCED_PARAMETER(sync_interval);
     GFXRECON_UNREFERENCED_PARAMETER(flags);
 
@@ -631,7 +632,6 @@ void D3D12CaptureManager::PreProcess_IDXGISwapChain1_Present1(IDXGISwapChain_Wra
                                                               UINT                           present_flags,
                                                               const DXGI_PRESENT_PARAMETERS* present_parameters)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(wrapper);
     GFXRECON_UNREFERENCED_PARAMETER(sync_interval);
     GFXRECON_UNREFERENCED_PARAMETER(present_flags);
     GFXRECON_UNREFERENCED_PARAMETER(present_parameters);
@@ -639,32 +639,32 @@ void D3D12CaptureManager::PreProcess_IDXGISwapChain1_Present1(IDXGISwapChain_Wra
     PrePresent(wrapper);
 }
 
-void D3D12CaptureManager::PostProcess_IDXGISwapChain_Present(IDXGISwapChain_Wrapper* wrapper,
-                                                             HRESULT                 result,
-                                                             UINT                    sync_interval,
-                                                             UINT                    flags)
+void D3D12CaptureManager::PostProcess_IDXGISwapChain_Present(
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+    IDXGISwapChain_Wrapper*                                wrapper,
+    HRESULT                                                result,
+    UINT                                                   sync_interval,
+    UINT                                                   flags)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(wrapper);
     GFXRECON_UNREFERENCED_PARAMETER(result);
     GFXRECON_UNREFERENCED_PARAMETER(sync_interval);
-    GFXRECON_UNREFERENCED_PARAMETER(flags);
 
-    PostPresent(wrapper, flags);
+    PostPresent(current_lock, wrapper, flags);
 }
 
-void D3D12CaptureManager::PostProcess_IDXGISwapChain1_Present1(IDXGISwapChain_Wrapper*        wrapper,
-                                                               HRESULT                        result,
-                                                               UINT                           sync_interval,
-                                                               UINT                           present_flags,
-                                                               const DXGI_PRESENT_PARAMETERS* present_parameters)
+void D3D12CaptureManager::PostProcess_IDXGISwapChain1_Present1(
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+    IDXGISwapChain_Wrapper*                                wrapper,
+    HRESULT                                                result,
+    UINT                                                   sync_interval,
+    UINT                                                   present_flags,
+    const DXGI_PRESENT_PARAMETERS*                         present_parameters)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(wrapper);
     GFXRECON_UNREFERENCED_PARAMETER(result);
     GFXRECON_UNREFERENCED_PARAMETER(sync_interval);
-    GFXRECON_UNREFERENCED_PARAMETER(present_flags);
     GFXRECON_UNREFERENCED_PARAMETER(present_parameters);
 
-    PostPresent(wrapper, present_flags);
+    PostPresent(current_lock, wrapper, present_flags);
 }
 
 void D3D12CaptureManager::PostProcess_IDXGISwapChain_ResizeBuffers(IDXGISwapChain_Wrapper* wrapper,
@@ -1717,9 +1717,11 @@ void D3D12CaptureManager::PostProcess_ID3D12Heap_GetDesc(ID3D12Heap_Wrapper* wra
     }
 }
 
-void D3D12CaptureManager::PreProcess_ID3D12CommandQueue_ExecuteCommandLists(ID3D12CommandQueue_Wrapper* wrapper,
-                                                                            UINT                        num_lists,
-                                                                            ID3D12CommandList* const*   lists)
+void D3D12CaptureManager::PreProcess_ID3D12CommandQueue_ExecuteCommandLists(
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+    ID3D12CommandQueue_Wrapper*                            wrapper,
+    UINT                                                   num_lists,
+    ID3D12CommandList* const*                              lists)
 {
     GFXRECON_UNREFERENCED_PARAMETER(wrapper);
     GFXRECON_UNREFERENCED_PARAMETER(num_lists);
@@ -1770,14 +1772,16 @@ void D3D12CaptureManager::PreProcess_ID3D12CommandQueue_ExecuteCommandLists(ID3D
         }
     }
 
-    PreQueueSubmit();
+    PreQueueSubmit(current_lock);
 }
 
-void D3D12CaptureManager::PostProcess_ID3D12CommandQueue_ExecuteCommandLists(ID3D12CommandQueue_Wrapper* wrapper,
-                                                                             UINT                        num_lists,
-                                                                             ID3D12CommandList* const*   lists)
+void D3D12CaptureManager::PostProcess_ID3D12CommandQueue_ExecuteCommandLists(
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+    ID3D12CommandQueue_Wrapper*                            wrapper,
+    UINT                                                   num_lists,
+    ID3D12CommandList* const*                              lists)
 {
-    PostQueueSubmit();
+    PostQueueSubmit(current_lock);
 
     if (IsCaptureModeTrack())
     {

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -251,13 +251,17 @@ class D3D12CaptureManager : public ApiCaptureManager
                                              UINT                           present_flags,
                                              const DXGI_PRESENT_PARAMETERS* present_parameters);
 
-    void
-    PostProcess_IDXGISwapChain_Present(IDXGISwapChain_Wrapper* wrapper, HRESULT result, UINT sync_interval, UINT flags);
+    void PostProcess_IDXGISwapChain_Present(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                            IDXGISwapChain_Wrapper*                                wrapper,
+                                            HRESULT                                                result,
+                                            UINT                                                   sync_interval,
+                                            UINT                                                   flags);
 
-    void PostProcess_IDXGISwapChain1_Present1(IDXGISwapChain_Wrapper*        wrapper,
-                                              HRESULT                        result,
-                                              UINT                           sync_interval,
-                                              UINT                           present_flags,
+    void PostProcess_IDXGISwapChain1_Present1(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                              IDXGISwapChain_Wrapper*                                wrapper,
+                                              HRESULT                                                result,
+                                              UINT                                                   sync_interval,
+                                              UINT                                                   present_flags,
                                               const DXGI_PRESENT_PARAMETERS* present_parameters);
 
     void PreProcess_IDXGISwapChain_ResizeBuffers(IDXGISwapChain_Wrapper* wrapper,
@@ -444,13 +448,17 @@ class D3D12CaptureManager : public ApiCaptureManager
 
     void PostProcess_ID3D12Heap_GetDesc(ID3D12Heap_Wrapper* wrapper, D3D12_HEAP_DESC& desc);
 
-    void PreProcess_ID3D12CommandQueue_ExecuteCommandLists(ID3D12CommandQueue_Wrapper* wrapper,
-                                                           UINT                        num_lists,
-                                                           ID3D12CommandList* const*   lists);
+    void PreProcess_ID3D12CommandQueue_ExecuteCommandLists(
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+        ID3D12CommandQueue_Wrapper*                            wrapper,
+        UINT                                                   num_lists,
+        ID3D12CommandList* const*                              lists);
 
-    void PostProcess_ID3D12CommandQueue_ExecuteCommandLists(ID3D12CommandQueue_Wrapper* wrapper,
-                                                            UINT                        num_lists,
-                                                            ID3D12CommandList* const*   lists);
+    void PostProcess_ID3D12CommandQueue_ExecuteCommandLists(
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+        ID3D12CommandQueue_Wrapper*                            wrapper,
+        UINT                                                   num_lists,
+        ID3D12CommandList* const*                              lists);
 
     void PreProcess_D3D12CreateDevice(IUnknown*         pAdapter,
                                       D3D_FEATURE_LEVEL MinimumFeatureLevel,
@@ -813,7 +821,10 @@ class D3D12CaptureManager : public ApiCaptureManager
     bool                          RvAnnotationActive();
 
     void                              PrePresent(IDXGISwapChain_Wrapper* wrapper);
-    void                              PostPresent(IDXGISwapChain_Wrapper* wrapper, UINT flags);
+    void                              PostPresent(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                                  IDXGISwapChain_Wrapper*                                wrapper,
+                                                  UINT                                                   flags);
+
     static D3D12CaptureManager*       singleton_;
     std::set<ID3D12Resource_Wrapper*> mapped_resources_; ///< Track mapped resources for unassisted tracking mode.
     DxgiDispatchTable  dxgi_dispatch_table_;  ///< DXGI dispatch table for functions retrieved from the DXGI DLL.

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2401,10 +2401,11 @@ void VulkanCaptureManager::PostProcess_vkGetDeviceGroupSurfacePresentModes2EXT(
     }
 }
 
-void VulkanCaptureManager::PreProcess_vkQueueSubmit(VkQueue             queue,
-                                                    uint32_t            submitCount,
-                                                    const VkSubmitInfo* pSubmits,
-                                                    VkFence             fence)
+void VulkanCaptureManager::PreProcess_vkQueueSubmit(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                                    VkQueue                                                queue,
+                                                    uint32_t                                               submitCount,
+                                                    const VkSubmitInfo*                                    pSubmits,
+                                                    VkFence                                                fence)
 {
     GFXRECON_UNREFERENCED_PARAMETER(queue);
     GFXRECON_UNREFERENCED_PARAMETER(submitCount);
@@ -2413,7 +2414,7 @@ void VulkanCaptureManager::PreProcess_vkQueueSubmit(VkQueue             queue,
 
     QueueSubmitWriteFillMemoryCmd();
 
-    PreQueueSubmit();
+    PreQueueSubmit(current_lock);
 
     if (IsCaptureModeTrack())
     {
@@ -2428,10 +2429,12 @@ void VulkanCaptureManager::PreProcess_vkQueueSubmit(VkQueue             queue,
     }
 }
 
-void VulkanCaptureManager::PreProcess_vkQueueSubmit2(VkQueue              queue,
-                                                     uint32_t             submitCount,
-                                                     const VkSubmitInfo2* pSubmits,
-                                                     VkFence              fence)
+void VulkanCaptureManager::PreProcess_vkQueueSubmit2(
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+    VkQueue                                                queue,
+    uint32_t                                               submitCount,
+    const VkSubmitInfo2*                                   pSubmits,
+    VkFence                                                fence)
 {
     GFXRECON_UNREFERENCED_PARAMETER(queue);
     GFXRECON_UNREFERENCED_PARAMETER(submitCount);
@@ -2440,7 +2443,7 @@ void VulkanCaptureManager::PreProcess_vkQueueSubmit2(VkQueue              queue,
 
     QueueSubmitWriteFillMemoryCmd();
 
-    PreQueueSubmit();
+    PreQueueSubmit(current_lock);
 
     if (IsCaptureModeTrack())
     {
@@ -2702,25 +2705,27 @@ bool VulkanCaptureManager::CheckBindAlignment(VkDeviceSize memoryOffset)
 }
 
 bool VulkanCaptureManager::CheckCommandBufferWrapperForFrameBoundary(
-    const vulkan_wrappers::CommandBufferWrapper* command_buffer_wrapper)
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+    const vulkan_wrappers::CommandBufferWrapper*           command_buffer_wrapper)
 {
     GFXRECON_ASSERT(command_buffer_wrapper != nullptr);
     if (command_buffer_wrapper->is_frame_boundary)
     {
         // Do common capture manager end of frame processing.
-        EndFrame();
+        EndFrame(current_lock);
         return true;
     }
     return false;
 }
 
-bool VulkanCaptureManager::CheckPNextChainForFrameBoundary(const VkBaseInStructure* current)
+bool VulkanCaptureManager::CheckPNextChainForFrameBoundary(
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock, const VkBaseInStructure* current)
 {
     if (auto frame_boundary = graphics::vulkan_struct_get_pnext<VkFrameBoundaryEXT>(current))
     {
         if (frame_boundary->flags & VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT)
         {
-            EndFrame();
+            EndFrame(current_lock);
             return true;
         }
     }

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -513,7 +513,10 @@ class VulkanCaptureManager : public ApiCaptureManager
         }
     }
 
-    void PostProcess_vkQueuePresentKHR(VkResult result, VkQueue queue, const VkPresentInfoKHR* pPresentInfo)
+    void PostProcess_vkQueuePresentKHR(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                       VkResult                                               result,
+                                       VkQueue                                                queue,
+                                       const VkPresentInfoKHR*                                pPresentInfo)
     {
         if (IsCaptureModeTrack() && ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR)))
         {
@@ -524,7 +527,7 @@ class VulkanCaptureManager : public ApiCaptureManager
                 pPresentInfo->swapchainCount, pPresentInfo->pSwapchains, pPresentInfo->pImageIndices, queue);
         }
 
-        EndFrame();
+        EndFrame(current_lock);
     }
 
     void PostProcess_vkQueueBindSparse(
@@ -907,10 +910,14 @@ class VulkanCaptureManager : public ApiCaptureManager
         }
     }
 
-    void
-    PostProcess_vkQueueSubmit(VkResult result, VkQueue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence)
+    void PostProcess_vkQueueSubmit(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                   VkResult                                               result,
+                                   VkQueue,
+                                   uint32_t            submitCount,
+                                   const VkSubmitInfo* pSubmits,
+                                   VkFence)
     {
-        PostQueueSubmit();
+        PostQueueSubmit(current_lock);
 
         if (IsCaptureModeTrack() && (result == VK_SUCCESS))
         {
@@ -930,7 +937,7 @@ class VulkanCaptureManager : public ApiCaptureManager
         // Check whether this queue submission contains a command buffer that should be treated as a frame boundary.
         for (uint32_t i = 0; i < submitCount; ++i)
         {
-            if (CheckPNextChainForFrameBoundary(reinterpret_cast<const VkBaseInStructure*>(pSubmits + i)))
+            if (CheckPNextChainForFrameBoundary(current_lock, reinterpret_cast<const VkBaseInStructure*>(pSubmits + i)))
             {
                 break;
             }
@@ -939,7 +946,7 @@ class VulkanCaptureManager : public ApiCaptureManager
             {
                 auto cmd_buffer_wrapper =
                     vulkan_wrappers::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(pSubmits[i].pCommandBuffers[j]);
-                if (CheckCommandBufferWrapperForFrameBoundary(cmd_buffer_wrapper))
+                if (CheckCommandBufferWrapperForFrameBoundary(current_lock, cmd_buffer_wrapper))
                 {
                     break;
                 }
@@ -947,10 +954,14 @@ class VulkanCaptureManager : public ApiCaptureManager
         }
     }
 
-    void PostProcess_vkQueueSubmit2(
-        VkResult result, VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence)
+    void PostProcess_vkQueueSubmit2(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                    VkResult                                               result,
+                                    VkQueue                                                queue,
+                                    uint32_t                                               submitCount,
+                                    const VkSubmitInfo2*                                   pSubmits,
+                                    VkFence                                                fence)
     {
-        PostQueueSubmit();
+        PostQueueSubmit(current_lock);
 
         if (IsCaptureModeTrack() && (result == VK_SUCCESS))
         {
@@ -970,7 +981,7 @@ class VulkanCaptureManager : public ApiCaptureManager
         // Check whether this queue submission contains a command buffer that should be treated as a frame boundary.
         for (uint32_t i = 0; i < submitCount; ++i)
         {
-            if (CheckPNextChainForFrameBoundary(reinterpret_cast<const VkBaseInStructure*>(pSubmits + i)))
+            if (CheckPNextChainForFrameBoundary(current_lock, reinterpret_cast<const VkBaseInStructure*>(pSubmits + i)))
             {
                 break;
             }
@@ -979,7 +990,7 @@ class VulkanCaptureManager : public ApiCaptureManager
             {
                 auto cmd_buffer_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(
                     pSubmits[i].pCommandBufferInfos[j].commandBuffer);
-                if (CheckCommandBufferWrapperForFrameBoundary(cmd_buffer_wrapper))
+                if (CheckCommandBufferWrapperForFrameBoundary(current_lock, cmd_buffer_wrapper))
                 {
                     break;
                 }
@@ -1199,9 +1210,17 @@ class VulkanCaptureManager : public ApiCaptureManager
 
     void PostProcess_vkFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator);
 
-    void PreProcess_vkQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence);
+    void PreProcess_vkQueueSubmit(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                  VkQueue                                                queue,
+                                  uint32_t                                               submitCount,
+                                  const VkSubmitInfo*                                    pSubmits,
+                                  VkFence                                                fence);
 
-    void PreProcess_vkQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence);
+    void PreProcess_vkQueueSubmit2(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                   VkQueue                                                queue,
+                                   uint32_t                                               submitCount,
+                                   const VkSubmitInfo2*                                   pSubmits,
+                                   VkFence                                                fence);
 
     void PreProcess_vkCreateDescriptorUpdateTemplate(VkResult                                    result,
                                                      VkDevice                                    device,
@@ -1256,9 +1275,12 @@ class VulkanCaptureManager : public ApiCaptureManager
     void PostProcess_vkCmdDebugMarkerInsertEXT(VkCommandBuffer                   commandBuffer,
                                                const VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
 
-    void PostProcess_vkFrameBoundaryANDROID(VkDevice device, VkSemaphore semaphore, VkImage image)
+    void PostProcess_vkFrameBoundaryANDROID(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                            VkDevice                                               device,
+                                            VkSemaphore                                            semaphore,
+                                            VkImage                                                image)
     {
-        EndFrame();
+        EndFrame(current_lock);
     }
 
     void PostProcess_vkCmdInsertDebugUtilsLabelEXT(VkCommandBuffer             commandBuffer,
@@ -1338,9 +1360,11 @@ class VulkanCaptureManager : public ApiCaptureManager
     void ReleaseAndroidHardwareBuffer(AHardwareBuffer* hardware_buffer);
     bool CheckBindAlignment(VkDeviceSize memoryOffset);
 
-    bool CheckCommandBufferWrapperForFrameBoundary(const vulkan_wrappers::CommandBufferWrapper* command_buffer_wrapper);
+    bool CheckCommandBufferWrapperForFrameBoundary(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                                   const vulkan_wrappers::CommandBufferWrapper* command_buffer_wrapper);
 
-    bool CheckPNextChainForFrameBoundary(const VkBaseInStructure* current);
+    bool CheckPNextChainForFrameBoundary(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                                         const VkBaseInStructure*                               current);
 
   private:
     void QueueSubmitWriteFillMemoryCmd();

--- a/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
@@ -57,6 +57,18 @@ class Dx12WrapperBodyGenerator(Dx12BaseGenerator):
     # will be replaced by the override value.
     CAPTURE_OVERRIDES = {}
 
+    # Functions that can activate trimming from a pre call command.
+    PRECALL_TRIM_TRIGGERS = {
+        'ID3D12CommandQueue': ['ExecuteCommandLists'],
+    }
+
+    # Functions that can activate trimming from a post call command.
+    POSTCALL_TRIM_TRIGGERS = {
+        'ID3D12CommandQueue': ['ExecuteCommandLists'],
+        'IDXGISwapChain': ['Present'],
+        'IDXGISwapChain1': ['Present1']
+    }
+
     def __init__(
         self,
         source_dict,
@@ -372,6 +384,10 @@ class Dx12WrapperBodyGenerator(Dx12BaseGenerator):
 
         indent = self.increment_indent(indent)
         expr += indent + 'manager,\n'
+
+        if (class_name in self.PRECALL_TRIM_TRIGGERS) and (method_name in self.PRECALL_TRIM_TRIGGERS[class_name]):
+            expr += indent + 'shared_api_call_lock,\n'
+
         expr += indent + 'this'
         if wrapped_args:
             expr += ',\n'
@@ -438,6 +454,10 @@ class Dx12WrapperBodyGenerator(Dx12BaseGenerator):
 
         indent = self.increment_indent(indent)
         expr += indent + 'manager,\n'
+
+        if (class_name in self.POSTCALL_TRIM_TRIGGERS) and (method_name in self.POSTCALL_TRIM_TRIGGERS[class_name]):
+            expr += indent + 'shared_api_call_lock,\n'
+
         expr += indent + 'this'
         if return_type != 'void':
             expr += ',\n'
@@ -685,21 +705,17 @@ class Dx12WrapperBodyGenerator(Dx12BaseGenerator):
             expr += indent + '{\n'
             indent = self.increment_indent(indent)
 
-            if class_name.startswith("IDXGISwapChain"
-                                     ) and method_name.startswith("Present"):
-                expr += indent + 'auto api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();\n'
-            else:
-                expr += indent + 'auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();\n'
-                expr += indent + 'std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;\n'
-                expr += indent + 'std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;\n'
-                expr += indent + 'if (force_command_serialization)\n'
-                expr += indent + '{\n'
-                expr += indent + '    exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();\n'
-                expr += indent + '}\n'
-                expr += indent + 'else\n'
-                expr += indent + '{\n'
-                expr += indent + '    shared_api_call_lock = D3D12CaptureManager::AcquireSharedApiCallLock();\n'
-                expr += indent + '}\n'
+            expr += indent + 'auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();\n'
+            expr += indent + 'std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;\n'
+            expr += indent + 'std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;\n'
+            expr += indent + 'if (force_command_serialization)\n'
+            expr += indent + '{\n'
+            expr += indent + '    exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();\n'
+            expr += indent + '}\n'
+            expr += indent + 'else\n'
+            expr += indent + '{\n'
+            expr += indent + '    shared_api_call_lock = D3D12CaptureManager::AcquireSharedApiCallLock();\n'
+            expr += indent + '}\n'
 
             expr += '\n'
 

--- a/framework/generated/generated_dx12_wrappers.cpp
+++ b/framework/generated/generated_dx12_wrappers.cpp
@@ -2155,7 +2155,17 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::Present(
 
     if (call_scope == 1)
     {
-        auto api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
+        auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        if (force_command_serialization)
+        {
+            exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
+        }
+        else
+        {
+            shared_api_call_lock = D3D12CaptureManager::AcquireSharedApiCallLock();
+        }
 
         CustomWrapperPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_Present>::Dispatch(
             manager,
@@ -2175,6 +2185,7 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::Present(
 
         CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_Present>::Dispatch(
             manager,
+            shared_api_call_lock,
             this,
             result,
             SyncInterval,
@@ -4881,7 +4892,17 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::Present1(
 
     if (call_scope == 1)
     {
-        auto api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
+        auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        if (force_command_serialization)
+        {
+            exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
+        }
+        else
+        {
+            shared_api_call_lock = D3D12CaptureManager::AcquireSharedApiCallLock();
+        }
 
         CustomWrapperPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_Present1>::Dispatch(
             manager,
@@ -4904,6 +4925,7 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::Present1(
 
         CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_Present1>::Dispatch(
             manager,
+            shared_api_call_lock,
             this,
             result,
             SyncInterval,
@@ -15360,6 +15382,7 @@ void STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::ExecuteCommandLists(
 
         CustomWrapperPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_ExecuteCommandLists>::Dispatch(
             manager,
+            shared_api_call_lock,
             this,
             NumCommandLists,
             ppCommandLists);
@@ -15377,6 +15400,7 @@ void STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::ExecuteCommandLists(
 
         CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_ExecuteCommandLists>::Dispatch(
             manager,
+            shared_api_call_lock,
             this,
             NumCommandLists,
             ppCommandLists);

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -532,7 +532,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(
         shared_api_call_lock = VulkanCaptureManager::AcquireSharedApiCallLock();
     }
 
-    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit>::Dispatch(manager, queue, submitCount, pSubmits, fence);
+    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit>::Dispatch(manager, shared_api_call_lock, queue, submitCount, pSubmits, fence);
 
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSubmitInfo* pSubmits_unwrapped = vulkan_wrappers::UnwrapStructArrayHandles(pSubmits, submitCount, handle_unwrap_memory);
@@ -550,7 +550,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(
         manager->EndApiCallCapture();
     }
 
-    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit>::Dispatch(manager, result, queue, submitCount, pSubmits, fence);
+    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit>::Dispatch(manager, shared_api_call_lock, result, queue, submitCount, pSubmits, fence);
 
     return result;
 }
@@ -7246,7 +7246,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2(
         shared_api_call_lock = VulkanCaptureManager::AcquireSharedApiCallLock();
     }
 
-    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit2>::Dispatch(manager, queue, submitCount, pSubmits, fence);
+    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit2>::Dispatch(manager, shared_api_call_lock, queue, submitCount, pSubmits, fence);
 
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSubmitInfo2* pSubmits_unwrapped = vulkan_wrappers::UnwrapStructArrayHandles(pSubmits, submitCount, handle_unwrap_memory);
@@ -7264,7 +7264,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2(
         manager->EndApiCallCapture();
     }
 
-    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit2>::Dispatch(manager, result, queue, submitCount, pSubmits, fence);
+    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit2>::Dispatch(manager, shared_api_call_lock, result, queue, submitCount, pSubmits, fence);
 
     return result;
 }
@@ -8601,7 +8601,17 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(
 {
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
-    auto api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
+    auto force_command_serialization = manager->GetForceCommandSerialization();
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    if (force_command_serialization)
+    {
+        exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
+    }
+    else
+    {
+        shared_api_call_lock = VulkanCaptureManager::AcquireSharedApiCallLock();
+    }
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueuePresentKHR>::Dispatch(manager, queue, pPresentInfo);
 
@@ -8619,7 +8629,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(
         manager->EndApiCallCapture();
     }
 
-    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueuePresentKHR>::Dispatch(manager, result, queue, pPresentInfo);
+    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueuePresentKHR>::Dispatch(manager, shared_api_call_lock, result, queue, pPresentInfo);
 
     return result;
 }
@@ -13681,7 +13691,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(
         shared_api_call_lock = VulkanCaptureManager::AcquireSharedApiCallLock();
     }
 
-    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit2KHR>::Dispatch(manager, queue, submitCount, pSubmits, fence);
+    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit2KHR>::Dispatch(manager, shared_api_call_lock, queue, submitCount, pSubmits, fence);
 
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSubmitInfo2* pSubmits_unwrapped = vulkan_wrappers::UnwrapStructArrayHandles(pSubmits, submitCount, handle_unwrap_memory);
@@ -13699,7 +13709,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(
         manager->EndApiCallCapture();
     }
 
-    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit2KHR>::Dispatch(manager, result, queue, submitCount, pSubmits, fence);
+    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit2KHR>::Dispatch(manager, shared_api_call_lock, result, queue, submitCount, pSubmits, fence);
 
     return result;
 }
@@ -14672,7 +14682,7 @@ VKAPI_ATTR void VKAPI_CALL FrameBoundaryANDROID(
 
     vulkan_wrappers::GetDeviceTable(device)->FrameBoundaryANDROID(device, semaphore, image);
 
-    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFrameBoundaryANDROID>::Dispatch(manager, device, semaphore, image);
+    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFrameBoundaryANDROID>::Dispatch(manager, shared_api_call_lock, device, semaphore, image);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -66,6 +66,12 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
     # will be replaced by the override value.
     CAPTURE_OVERRIDES = {}
 
+    # Functions that can activate trimming from a pre call command.
+    PRECALL_TRIM_TRIGGERS = ['vkQueueSubmit', 'vkQueueSubmit2', 'vkQueueSubmit2KHR']
+
+    # Functions that can activate trimming from a post call command.
+    POSTCALL_TRIM_TRIGGERS = ['vkQueueSubmit', 'vkQueueSubmit2', 'vkQueueSubmit2KHR', 'vkQueuePresentKHR', 'vkFrameBoundaryANDROID']
+
     def __init__(
         self, err_file=sys.stderr, warn_file=sys.stderr, diag_file=sys.stdout
     ):
@@ -237,7 +243,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
         if name != "vkCreateInstance":
             body += indent + 'VulkanCaptureManager* manager = VulkanCaptureManager::Get();\n'
             body += indent + 'GFXRECON_ASSERT(manager != nullptr);\n'
-        if name == "vkCreateInstance" or name == "vkQueuePresentKHR":
+        if name == "vkCreateInstance":
             body += indent + 'auto api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();\n'
         else:
             body += indent + 'auto force_command_serialization = manager->GetForceCommandSerialization();\n'
@@ -262,9 +268,14 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
             body += indent + 'bool omit_output_data = false;\n'
             body += '\n'
 
-        body += indent + 'CustomEncoderPreCall<format::ApiCallId::ApiCall_{}>::Dispatch({}, {});\n'.format(
-            name, capture_manager, arg_list
-        )
+        if name in self.PRECALL_TRIM_TRIGGERS:
+            body += indent + 'CustomEncoderPreCall<format::ApiCallId::ApiCall_{}>::Dispatch({}, shared_api_call_lock, {});\n'.format(
+                name, capture_manager, arg_list
+            )
+        else:
+            body += indent + 'CustomEncoderPreCall<format::ApiCallId::ApiCall_{}>::Dispatch({}, {});\n'.format(
+                name, capture_manager, arg_list
+            )
 
         if not encode_after:
             body += self.make_parameter_encoding(
@@ -348,13 +359,23 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
 
         body += '\n'
         if return_type and return_type != 'void':
-            body += '    CustomEncoderPostCall<format::ApiCallId::ApiCall_{}>::Dispatch({}, result, {});\n'.format(
-                name, capture_manager, arg_list
-            )
+            if name in self.POSTCALL_TRIM_TRIGGERS:
+                body += '    CustomEncoderPostCall<format::ApiCallId::ApiCall_{}>::Dispatch({}, shared_api_call_lock, result, {});\n'.format(
+                    name, capture_manager, arg_list
+                )
+            else:
+                body += '    CustomEncoderPostCall<format::ApiCallId::ApiCall_{}>::Dispatch({}, result, {});\n'.format(
+                    name, capture_manager, arg_list
+                )
         else:
-            body += '    CustomEncoderPostCall<format::ApiCallId::ApiCall_{}>::Dispatch({}, {});\n'.format(
-                name, capture_manager, arg_list
-            )
+            if name in self.POSTCALL_TRIM_TRIGGERS:
+                body += '    CustomEncoderPostCall<format::ApiCallId::ApiCall_{}>::Dispatch({}, shared_api_call_lock, {});\n'.format(
+                    name, capture_manager, arg_list
+                )
+            else:
+                body += '    CustomEncoderPostCall<format::ApiCallId::ApiCall_{}>::Dispatch({}, {});\n'.format(
+                    name, capture_manager, arg_list
+                )
 
         cleanup_expr = self.make_handle_cleanup(name, values, indent)
         if cleanup_expr:


### PR DESCRIPTION
The exclusive lock that was intended to be acquired when writing the trimming state snapshot was only acquired when trimming was activated by a present call, where the exclusive lock was always acquired, which also had a negative impact on capture performance. This change makes the following adjustments:
- Acquire the shared lock at present, instead of the exclusive lock.
- Release the shared lock and acquire the exclusive lock when activating trimming.
- Acquire the exclusive lock when trimming is activated by API calls other than present.