### PR TITLE
Track Buffer-Device-Addresses

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -44,6 +44,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/value_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/metadata_consumer_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/marker_consumer_base.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_buffer_tracker.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_buffer_tracker.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_consumer_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_decoder_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_decoder_base.cpp

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -141,6 +141,8 @@ target_sources(gfxrecon_decode
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_browse_consumer.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_dump_resources.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_dump_resources.cpp>
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_buffer_tracker.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_buffer_tracker.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_decoder_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_decoder_base.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_default_allocator.h

--- a/framework/decode/vulkan_buffer_tracker.cpp
+++ b/framework/decode/vulkan_buffer_tracker.cpp
@@ -38,11 +38,6 @@ void decode::VulkanBufferTracker::TrackBuffer(const decode::BufferInfo* buffer_i
         {
             _capture_addresses[buffer_info->capture_address] = buffer_info->capture_id;
         }
-
-        if (buffer_info->replay_address != 0)
-        {
-            _replay_addresses[buffer_info->replay_address] = buffer_info->capture_id;
-        }
     }
 }
 
@@ -51,14 +46,7 @@ void VulkanBufferTracker::RemoveBuffer(const BufferInfo* buffer_info)
     if (buffer_info != nullptr)
     {
         _capture_addresses.erase(buffer_info->capture_address);
-        _replay_addresses.erase(buffer_info->replay_address);
     }
-}
-
-const decode::BufferInfo*
-decode::VulkanBufferTracker::GetBufferByReplayDeviceAddress(VkDeviceAddress replay_address) const
-{
-    return GetBufferInfo(replay_address, _replay_addresses);
 }
 
 const decode::BufferInfo*

--- a/framework/decode/vulkan_buffer_tracker.cpp
+++ b/framework/decode/vulkan_buffer_tracker.cpp
@@ -73,7 +73,7 @@ const BufferInfo* VulkanBufferTracker::GetBufferInfo(VkDeviceAddress            
     if (!address_map.empty())
     {
         // find first address equal or greater
-        auto address_it = address_map.upper_bound(device_address);
+        auto address_it = address_map.lower_bound(device_address);
 
         if (address_it == address_map.end() || address_it->first > device_address)
         {

--- a/framework/decode/vulkan_buffer_tracker.cpp
+++ b/framework/decode/vulkan_buffer_tracker.cpp
@@ -30,7 +30,7 @@ VulkanBufferTracker::VulkanBufferTracker(const VulkanObjectInfoTable& object_inf
     _object_info_table(object_info_table)
 {}
 
-void decode::VulkanBufferTracker::TrackBuffer(decode::BufferInfo* buffer_info)
+void decode::VulkanBufferTracker::TrackBuffer(const decode::BufferInfo* buffer_info)
 {
     if (buffer_info != nullptr)
     {
@@ -77,6 +77,7 @@ const BufferInfo* VulkanBufferTracker::GetBufferInfo(VkDeviceAddress            
             // decrement iterator, now pointing to the first VkDeviceAddress that is lower than device_address
             address_it--;
         }
+        // found_address is lower or equal to device_address
         const auto& [found_address, buffer_handle] = *address_it;
         const BufferInfo* found_buffer             = _object_info_table.GetBufferInfo(buffer_handle);
 

--- a/framework/decode/vulkan_buffer_tracker.cpp
+++ b/framework/decode/vulkan_buffer_tracker.cpp
@@ -1,0 +1,95 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "decode/vulkan_buffer_tracker.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+VulkanBufferTracker::VulkanBufferTracker(const VulkanObjectInfoTable& object_info_table) :
+    _object_info_table(object_info_table)
+{}
+
+void decode::VulkanBufferTracker::TrackBuffer(decode::BufferInfo* buffer_info)
+{
+    if (buffer_info != nullptr)
+    {
+        if (buffer_info->capture_address != 0)
+        {
+            _capture_addresses[buffer_info->capture_address] = buffer_info->capture_id;
+        }
+
+        if (buffer_info->replay_address != 0)
+        {
+            _replay_addresses[buffer_info->replay_address] = buffer_info->capture_id;
+        }
+    }
+}
+
+const decode::BufferInfo*
+decode::VulkanBufferTracker::GetBufferByReplayDeviceAddress(VkDeviceAddress replay_address) const
+{
+    return GetBufferInfo(replay_address, _replay_addresses);
+}
+
+const decode::BufferInfo*
+decode::VulkanBufferTracker::GetBufferByCaptureDeviceAddress(VkDeviceAddress capture_address) const
+{
+    return GetBufferInfo(capture_address, _capture_addresses);
+}
+
+const BufferInfo* VulkanBufferTracker::GetBufferInfo(VkDeviceAddress                                  device_address,
+                                                     const VulkanBufferTracker::device_address_map_t& address_map) const
+{
+    if (!address_map.empty())
+    {
+        // find first address equal or greater
+        auto address_it = address_map.upper_bound(device_address);
+
+        if (address_it == address_map.end() || address_it->first > device_address)
+        {
+            // not found
+            if (address_it == address_map.begin())
+            {
+                return nullptr;
+            }
+
+            // decrement iterator, now pointing to the first VkDeviceAddress that is lower than device_address
+            address_it--;
+        }
+        const auto& [found_address, buffer_handle] = *address_it;
+        const BufferInfo* found_buffer             = _object_info_table.GetBufferInfo(buffer_handle);
+
+        if (found_buffer != nullptr)
+        {
+            if (device_address < found_address + found_buffer->size)
+            {
+                return found_buffer;
+            }
+        }
+    }
+    return nullptr;
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_buffer_tracker.cpp
+++ b/framework/decode/vulkan_buffer_tracker.cpp
@@ -46,6 +46,15 @@ void decode::VulkanBufferTracker::TrackBuffer(const decode::BufferInfo* buffer_i
     }
 }
 
+void VulkanBufferTracker::RemoveBuffer(const BufferInfo* buffer_info)
+{
+    if (buffer_info != nullptr)
+    {
+        _capture_addresses.erase(buffer_info->capture_address);
+        _replay_addresses.erase(buffer_info->replay_address);
+    }
+}
+
 const decode::BufferInfo*
 decode::VulkanBufferTracker::GetBufferByReplayDeviceAddress(VkDeviceAddress replay_address) const
 {

--- a/framework/decode/vulkan_buffer_tracker.h
+++ b/framework/decode/vulkan_buffer_tracker.h
@@ -45,7 +45,7 @@ class VulkanBufferTracker
     ~VulkanBufferTracker() = default;
 
     /**
-     * @brief   Track an existing buffer by its capture- and replay-time VkDeviceAddress.
+     * @brief   Track an existing buffer by its capture-time VkDeviceAddress.
      *
      * @param   buffer_info a provided buffer_info containing a buffer-handle and associated device-addresses.
      */

--- a/framework/decode/vulkan_buffer_tracker.h
+++ b/framework/decode/vulkan_buffer_tracker.h
@@ -36,12 +36,35 @@ class VulkanBufferTracker
   public:
     explicit VulkanBufferTracker(const VulkanObjectInfoTable& object_info_table);
 
+    //! prevent copying
+    VulkanBufferTracker(const VulkanBufferTracker&) = delete;
+
+    //! allow moving
+    VulkanBufferTracker(VulkanBufferTracker&&) = default;
+
     ~VulkanBufferTracker() = default;
 
-    void TrackBuffer(BufferInfo* buffer_info);
+    /**
+     * @brief   Track an existing buffer by its capture- and replay-time VkDeviceAddress.
+     *
+     * @param   buffer_info a provided buffer_info containing a buffer-handle and associated device-addresses.
+     */
+    void TrackBuffer(const BufferInfo* buffer_info);
 
+    /**
+     * @brief   Retrieve a buffer by providing a replay-time VkDeviceAddress within its range.
+     *
+     * @param   replay_address  a replay-time VkDeviceAddress pointing inside a buffer.
+     * @return  a const-pointer to a found BufferInfo or nullptr.
+     */
     [[nodiscard]] const BufferInfo* GetBufferByReplayDeviceAddress(VkDeviceAddress replay_address) const;
 
+    /**
+     * @brief   Retrieve a buffer by providing a capture-time VkDeviceAddress within its range.
+     *
+     * @param   replay_address  a capture-time VkDeviceAddress pointing inside a buffer.
+     * @return  a const-pointer to a found BufferInfo or nullptr.
+     */
     [[nodiscard]] const BufferInfo* GetBufferByCaptureDeviceAddress(VkDeviceAddress capture_address) const;
 
   private:

--- a/framework/decode/vulkan_buffer_tracker.h
+++ b/framework/decode/vulkan_buffer_tracker.h
@@ -1,0 +1,61 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_VULKAN_BUFFER_TRACKER_H
+#define GFXRECON_DECODE_VULKAN_BUFFER_TRACKER_H
+
+#include "decode/vulkan_object_info.h"
+#include "vulkan_object_info_table.h"
+#include <map>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class VulkanBufferTracker
+{
+  public:
+    explicit VulkanBufferTracker(const VulkanObjectInfoTable& object_info_table);
+
+    ~VulkanBufferTracker() = default;
+
+    void TrackBuffer(BufferInfo* buffer_info);
+
+    [[nodiscard]] const BufferInfo* GetBufferByReplayDeviceAddress(VkDeviceAddress replay_address) const;
+
+    [[nodiscard]] const BufferInfo* GetBufferByCaptureDeviceAddress(VkDeviceAddress capture_address) const;
+
+  private:
+    //! use a sorted (BST-based) map
+    using device_address_map_t = std::map<VkDeviceAddress, format::HandleId>;
+
+    [[nodiscard]] const BufferInfo* GetBufferInfo(VkDeviceAddress             device_address,
+                                                  const device_address_map_t& address_map) const;
+
+    const VulkanObjectInfoTable& _object_info_table;
+    device_address_map_t         _capture_addresses, _replay_addresses;
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_VULKAN_BUFFER_TRACKER_H

--- a/framework/decode/vulkan_buffer_tracker.h
+++ b/framework/decode/vulkan_buffer_tracker.h
@@ -52,6 +52,13 @@ class VulkanBufferTracker
     void TrackBuffer(const BufferInfo* buffer_info);
 
     /**
+     * @brief   RemoveBuffer will stop tracking of a currently tracked buffer.
+     *
+     * @param   buffer_info a provided buffer_info.
+     */
+    void RemoveBuffer(const BufferInfo* buffer_info);
+
+    /**
      * @brief   Retrieve a buffer by providing a replay-time VkDeviceAddress within its range.
      *
      * @param   replay_address  a replay-time VkDeviceAddress pointing inside a buffer.

--- a/framework/decode/vulkan_buffer_tracker.h
+++ b/framework/decode/vulkan_buffer_tracker.h
@@ -59,14 +59,6 @@ class VulkanBufferTracker
     void RemoveBuffer(const BufferInfo* buffer_info);
 
     /**
-     * @brief   Retrieve a buffer by providing a replay-time VkDeviceAddress within its range.
-     *
-     * @param   replay_address  a replay-time VkDeviceAddress pointing inside a buffer.
-     * @return  a const-pointer to a found BufferInfo or nullptr.
-     */
-    [[nodiscard]] const BufferInfo* GetBufferByReplayDeviceAddress(VkDeviceAddress replay_address) const;
-
-    /**
      * @brief   Retrieve a buffer by providing a capture-time VkDeviceAddress within its range.
      *
      * @param   replay_address  a capture-time VkDeviceAddress pointing inside a buffer.
@@ -82,7 +74,7 @@ class VulkanBufferTracker
                                                   const device_address_map_t& address_map) const;
 
     const VulkanObjectInfoTable& _object_info_table;
-    device_address_map_t         _capture_addresses, _replay_addresses;
+    device_address_map_t         _capture_addresses;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -337,6 +337,8 @@ struct BufferInfo : public VulkanObjectInfo<VkBuffer>
 {
     // The following values are only used for memory portability.
     VulkanResourceAllocator::ResourceData allocator_data{ 0 };
+    VkDeviceAddress                       capture_address{ 0 };
+    VkDeviceAddress                       replay_address{ 0 };
 
     // This is only used when loading the initial state for trimmed files.
     VkMemoryPropertyFlags memory_property_flags{ 0 };

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4483,8 +4483,8 @@ VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory(PFN_vkBindBufferMemo
         auto entry = device_info->opaque_addresses.find(memory_info->capture_id);
         if (entry != device_info->opaque_addresses.end())
         {
-            uint64_t                      memory_device_address   = entry->second;
-            uint64_t                      original_buffer_address = memory_device_address + memoryOffset;
+            uint64_t                  memory_device_address   = entry->second;
+            uint64_t                  original_buffer_address = memory_device_address + memoryOffset;
             VkBufferDeviceAddressInfo info                    = {};
             info.sType                                        = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
             info.pNext                                        = nullptr;
@@ -7835,7 +7835,6 @@ VkDeviceAddress VulkanReplayConsumerBase::OverrideGetBufferDeviceAddress(
 
     // track device-addresses
     GetBufferTracker(device).TrackBuffer(buffer_info);
-    
     return replay_device_address;
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -7816,7 +7816,8 @@ VkDeviceAddress VulkanReplayConsumerBase::OverrideGetBufferDeviceAddress(
 
     if (!device_info->allocator->SupportsOpaqueDeviceAddresses())
     {
-        // TODO: make this warning obsolete by re-mapping addresses (and a whole lot more ...)
+        // TODO: make this warning obsolete by re-mapping addresses (and fix addresses stored in buffers)
+        // TODO: remove TODO/warning when issue #1526 is solved
         GFXRECON_LOG_WARNING_ONCE(
             "The captured application used vkGetBufferDeviceAddress. The specified replay option '-m rebind' may not "
             "support the replay of captured device addresses, so replay may fail.");
@@ -8217,6 +8218,7 @@ void VulkanReplayConsumerBase::OverrideCmdTraceRaysKHR(
                 physical_device_info->shaderGroupBaseAlignment != replay_props.shaderGroupBaseAlignment)
             {
                 // TODO: move forward with address-remapping and re-assembly of a binding-table
+                // TODO: remove TODO/warning when issue #1526 is solved
                 GFXRECON_LOG_WARNING_ONCE("capture/replay have mismatching shader-binding-table size or alignments");
             }
         }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -7798,7 +7798,7 @@ VkDeviceAddress VulkanReplayConsumerBase::OverrideGetBufferDeviceAddress(
     }
     else
     {
-        // opaque device-addresses should match
+        // opaque device-addresses are expected to match
         GFXRECON_ASSERT(original_result == replay_device_address);
     }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -7835,17 +7835,7 @@ VkDeviceAddress VulkanReplayConsumerBase::OverrideGetBufferDeviceAddress(
 
     // track device-addresses
     GetBufferTracker(device).TrackBuffer(buffer_info);
-
-    // Fabian tmp
-    // request 'some' address anywhere in buffer, assert we get back correct buffers
-    const auto& buffer_tracker = GetBufferTracker(device);
-    auto found_capture_info =
-        buffer_tracker.GetBufferByCaptureDeviceAddress(buffer_info->capture_address + buffer_info->size / 2);
-    auto found_replay_info =
-        buffer_tracker.GetBufferByReplayDeviceAddress(buffer_info->replay_address + buffer_info->size / 2);
-    GFXRECON_ASSERT(found_capture_info && found_replay_info)
-    GFXRECON_ASSERT(found_capture_info == found_replay_info)
-
+    
     return replay_device_address;
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1081,11 +1081,13 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     VkDeviceAddress
     OverrideGetBufferDeviceAddress(PFN_vkGetBufferDeviceAddress                                   func,
+                                   VkDeviceAddress                                                original_result,
                                    const DeviceInfo*                                              device_info,
                                    const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo);
 
     void OverrideGetAccelerationStructureDeviceAddressKHR(
         PFN_vkGetAccelerationStructureDeviceAddressKHR                                   func,
+        VkDeviceAddress                                                                  original_result,
         const DeviceInfo*                                                                device_info,
         const StructPointerDecoder<Decoded_VkAccelerationStructureDeviceAddressInfoKHR>* pInfo);
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1163,6 +1163,17 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                     VkSubpassContents                                    contents);
 
     void
+    OverrideCmdTraceRaysKHR(PFN_vkCmdTraceRaysKHR                                          func,
+                            CommandBufferInfo*                                             command_buffer_info,
+                            StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
+                            StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
+                            StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pHitShaderBindingTable,
+                            StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pCallableShaderBindingTable,
+                            uint32_t                                                       width,
+                            uint32_t                                                       height,
+                            uint32_t                                                       depth);
+
+    void
     OverrideCmdBeginRenderPass2(PFN_vkCmdBeginRenderPass2                            func,
                                 CommandBufferInfo*                                   command_buffer_info,
                                 StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -29,6 +29,7 @@
 #include "decode/pointer_decoder.h"
 #include "decode/screenshot_handler.h"
 #include "decode/swapchain_image_tracker.h"
+#include "decode/vulkan_buffer_tracker.h"
 #include "decode/vulkan_handle_mapping_util.h"
 #include "decode/vulkan_object_info.h"
 #include "decode/vulkan_object_info_table.h"
@@ -1393,6 +1394,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                              const DescriptorUpdateTemplateInfo*    template_info,
                                              const DescriptorUpdateTemplateDecoder* decoder) const;
 
+    VulkanBufferTracker& GetBufferTracker(VkDevice device);
+
   private:
     struct HardwareBufferInfo
     {
@@ -1439,6 +1442,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unique_ptr<VulkanSwapchain>                                           swapchain_;
     std::string                                                                screenshot_file_prefix_;
     graphics::FpsInfo*                                                         fps_info_;
+
+    std::unordered_map<VkDevice, decode::VulkanBufferTracker> _buffer_trackers;
 
     util::ThreadPool main_thread_queue_;
     util::ThreadPool background_queue_;

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -10475,17 +10475,13 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysKHR(
     uint32_t                                    height,
     uint32_t                                    depth)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
-    const VkStridedDeviceAddressRegionKHR* in_pRaygenShaderBindingTable = pRaygenShaderBindingTable->GetPointer();
-    const VkStridedDeviceAddressRegionKHR* in_pMissShaderBindingTable = pMissShaderBindingTable->GetPointer();
-    const VkStridedDeviceAddressRegionKHR* in_pHitShaderBindingTable = pHitShaderBindingTable->GetPointer();
-    const VkStridedDeviceAddressRegionKHR* in_pCallableShaderBindingTable = pCallableShaderBindingTable->GetPointer();
+    auto in_commandBuffer = GetObjectInfoTable().GetCommandBufferInfo(commandBuffer);
 
-    GetDeviceTable(in_commandBuffer)->CmdTraceRaysKHR(in_commandBuffer, in_pRaygenShaderBindingTable, in_pMissShaderBindingTable, in_pHitShaderBindingTable, in_pCallableShaderBindingTable, width, height, depth);
+    OverrideCmdTraceRaysKHR(GetDeviceTable(in_commandBuffer->handle)->CmdTraceRaysKHR, in_commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdTraceRaysKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysKHR, in_commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
+        resource_dumper.Process_vkCmdTraceRaysKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdTraceRaysKHR, in_commandBuffer->handle, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
     }
 }
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -2873,7 +2873,7 @@ void VulkanReplayConsumer::Process_vkGetBufferDeviceAddress(
 
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
-    OverrideGetBufferDeviceAddress(GetDeviceTable(in_device->handle)->GetBufferDeviceAddress, in_device, pInfo);
+    OverrideGetBufferDeviceAddress(GetDeviceTable(in_device->handle)->GetBufferDeviceAddress, returnValue, in_device, pInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferOpaqueCaptureAddress(
@@ -5397,7 +5397,7 @@ void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressKHR(
 
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
-    OverrideGetBufferDeviceAddress(GetDeviceTable(in_device->handle)->GetBufferDeviceAddressKHR, in_device, pInfo);
+    OverrideGetBufferDeviceAddress(GetDeviceTable(in_device->handle)->GetBufferDeviceAddressKHR, returnValue, in_device, pInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
@@ -10409,7 +10409,7 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
 
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
-    OverrideGetAccelerationStructureDeviceAddressKHR(GetDeviceTable(in_device->handle)->GetAccelerationStructureDeviceAddressKHR, in_device, pInfo);
+    OverrideGetAccelerationStructureDeviceAddressKHR(GetDeviceTable(in_device->handle)->GetAccelerationStructureDeviceAddressKHR, returnValue, in_device, pInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR(

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -121,6 +121,7 @@
     "vkCreateVideoSessionKHR": "OverrideCreateVideoSessionKHR",
     "vkDestroyVideoSessionKHR": "OverrideDestroyVideoSessionKHR",
     "vkBindVideoSessionMemoryKHR": "OverrideBindVideoSessionMemoryKHR",
-    "vkCreateShadersEXT": "OverrideCreateShadersEXT"
+    "vkCreateShadersEXT": "OverrideCreateShadersEXT",
+    "vkCmdTraceRaysKHR": "OverrideCmdTraceRaysKHR"
   }
 }

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -314,7 +314,7 @@ class VulkanReplayConsumerBodyGenerator(
                 call_expr = '{}(returnValue, {})'.format(
                     self.REPLAY_OVERRIDES[name], arglist
                 )
-            elif return_type == 'VkResult':
+            elif return_type in ['VkResult', 'VkDeviceAddress']:
                 # Override functions receive the decoded return value in addition to parameters.
                 if name not in ['vkQueueSubmit', 'vkBeginCommandBuffer']:
                     call_expr = '{}({}, returnValue, {})'.format(


### PR DESCRIPTION
- Add `VulkanBufferTracker` class -> map device-addresses (ranges) to BufferInfo*, O(log n)
- Add `OverrideGetBufferDeviceAddress`, track capture/replay buffer-addresses during replay
- Add `OverrideCmdTraceRaysKHR`, sprinkle asserts using buffer-tracker queries
- Augment `OverrideBindBufferMemory` with tracking logic

Building up necessary foundation as demonstrated by @bartosz-muszarski-arm's  [portable-raytracing branch](https://github.com/LunarG/gfxreconstruct/pull/1533)