### PR TITLE
Fix vulkan_struct_deep_copy edge-cases

### DIFF
--- a/framework/generated/generated_vulkan_struct_deep_copy.cpp
+++ b/framework/generated/generated_vulkan_struct_deep_copy.cpp
@@ -227,32 +227,6 @@ size_t vulkan_struct_deep_copy(const VkMemoryBarrier* structs, uint32_t count, u
 }
 
 template <>
-size_t vulkan_struct_deep_copy(const VkAllocationCallbacks* structs, uint32_t count, uint8_t* out_data)
-{
-    using struct_type              = std::decay_t<decltype(*structs)>;
-    constexpr uint32_t struct_size = sizeof(struct_type);
-
-    if (structs == nullptr || count == 0)
-    {
-        return 0;
-    }
-    uint64_t offset = struct_size * count;
-
-    for (uint32_t i = 0; i < count; ++i)
-    {
-        const auto& base_struct = structs[i];
-        if (out_data != nullptr)
-        {
-            auto out_structures = reinterpret_cast<struct_type*>(out_data);
-            out_structures[i]   = base_struct;
-        }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pUserData, 1);
-    }
-    return offset;
-}
-
-template <>
 size_t vulkan_struct_deep_copy(const VkApplicationInfo* structs, uint32_t count, uint8_t* out_data)
 {
     using struct_type              = std::decay_t<decltype(*structs)>;
@@ -6214,10 +6188,7 @@ size_t vulkan_struct_deep_copy(const VkWin32SurfaceCreateInfoKHR* structs, uint3
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.hinstance, 1);
-        handle_pointer_member(base_struct.hwnd, 1);
     }
     return offset;
 }
@@ -7743,7 +7714,6 @@ size_t vulkan_struct_deep_copy(const VkImportMemoryWin32HandleInfoKHR* structs, 
         }
         auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.handle, 1);
         handle_pointer_member(base_struct.name, 1);
     }
     return offset;
@@ -7955,7 +7925,6 @@ size_t vulkan_struct_deep_copy(const VkImportSemaphoreWin32HandleInfoKHR* struct
         }
         auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.handle, 1);
         handle_pointer_member(base_struct.name, 1);
     }
     return offset;
@@ -8217,7 +8186,6 @@ size_t vulkan_struct_deep_copy(const VkImportFenceWin32HandleInfoKHR* structs, u
         }
         auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.handle, 1);
         handle_pointer_member(base_struct.name, 1);
     }
     return offset;
@@ -9905,9 +9873,7 @@ size_t vulkan_struct_deep_copy(const VkCheckpointData2NV* structs, uint32_t coun
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pCheckpointMarker, 1);
     }
     return offset;
 }
@@ -10987,33 +10953,6 @@ size_t vulkan_struct_deep_copy(const VkPushDescriptorSetInfoKHR* structs, uint32
 }
 
 template <>
-size_t vulkan_struct_deep_copy(const VkPushDescriptorSetWithTemplateInfoKHR* structs, uint32_t count, uint8_t* out_data)
-{
-    using struct_type              = std::decay_t<decltype(*structs)>;
-    constexpr uint32_t struct_size = sizeof(struct_type);
-
-    if (structs == nullptr || count == 0)
-    {
-        return 0;
-    }
-    uint64_t offset = struct_size * count;
-
-    for (uint32_t i = 0; i < count; ++i)
-    {
-        const auto& base_struct = structs[i];
-        if (out_data != nullptr)
-        {
-            auto out_structures = reinterpret_cast<struct_type*>(out_data);
-            out_structures[i]   = base_struct;
-        }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
-        handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pData, 1);
-    }
-    return offset;
-}
-
-template <>
 size_t vulkan_struct_deep_copy(const VkSetDescriptorBufferOffsetsInfoEXT* structs, uint32_t count, uint8_t* out_data)
 {
     using struct_type              = std::decay_t<decltype(*structs)>;
@@ -11238,9 +11177,7 @@ size_t vulkan_struct_deep_copy(const VkDebugReportCallbackCreateInfoEXT* structs
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pUserData, 1);
     }
     return offset;
 }
@@ -11696,9 +11633,7 @@ size_t vulkan_struct_deep_copy(const VkImportMemoryWin32HandleInfoNV* structs, u
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.handle, 1);
     }
     return offset;
 }
@@ -11808,9 +11743,7 @@ size_t vulkan_struct_deep_copy(const VkViSurfaceCreateInfoNN* structs, uint32_t 
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.window, 1);
     }
     return offset;
 }
@@ -12468,9 +12401,7 @@ size_t vulkan_struct_deep_copy(const VkIOSSurfaceCreateInfoMVK* structs, uint32_
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pView, 1);
     }
     return offset;
 }
@@ -12495,9 +12426,7 @@ size_t vulkan_struct_deep_copy(const VkMacOSSurfaceCreateInfoMVK* structs, uint3
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pView, 1);
     }
     return offset;
 }
@@ -12607,9 +12536,7 @@ size_t vulkan_struct_deep_copy(const VkDebugUtilsMessengerCreateInfoEXT* structs
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pUserData, 1);
     }
     return offset;
 }
@@ -13870,9 +13797,7 @@ size_t vulkan_struct_deep_copy(const VkImportMemoryHostPointerInfoEXT* structs, 
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pHostPointer, 1);
     }
     return offset;
 }
@@ -14249,9 +14174,7 @@ size_t vulkan_struct_deep_copy(const VkCheckpointDataNV* structs, uint32_t count
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pCheckpointMarker, 1);
     }
     return offset;
 }
@@ -14301,9 +14224,7 @@ size_t vulkan_struct_deep_copy(const VkInitializePerformanceApiInfoINTEL* struct
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pUserData, 1);
     }
     return offset;
 }
@@ -15206,9 +15127,7 @@ size_t vulkan_struct_deep_copy(const VkSurfaceFullScreenExclusiveWin32InfoEXT* s
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.hmonitor, 1);
     }
     return offset;
 }
@@ -15361,9 +15280,7 @@ size_t vulkan_struct_deep_copy(const VkMemoryToImageCopyEXT* structs, uint32_t c
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pHostPointer, 1);
     }
     return offset;
 }
@@ -15388,9 +15305,7 @@ size_t vulkan_struct_deep_copy(const VkImageToMemoryCopyEXT* structs, uint32_t c
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pHostPointer, 1);
     }
     return offset;
 }
@@ -15621,9 +15536,7 @@ size_t vulkan_struct_deep_copy(const VkMemoryMapPlacedInfoEXT* structs, uint32_t
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pPlacedAddress, 1);
     }
     return offset;
 }
@@ -16375,9 +16288,7 @@ size_t vulkan_struct_deep_copy(const VkDeviceDeviceMemoryReportCreateInfoEXT* st
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pUserData, 1);
     }
     return offset;
 }
@@ -16652,9 +16563,7 @@ size_t vulkan_struct_deep_copy(const VkQueryLowLatencySupportNV* structs, uint32
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pQueriedLowLatencyData, 1);
     }
     return offset;
 }
@@ -17210,7 +17119,6 @@ size_t vulkan_struct_deep_copy(const VkDeviceFaultInfoEXT* structs, uint32_t cou
         handle_pnext(base_struct, i, offset, out_data);
         handle_pointer_member(base_struct.pAddressInfos, 1);
         handle_pointer_member(base_struct.pVendorInfos, 1);
-        handle_pointer_member(base_struct.pVendorBinaryData, 1);
     }
     return offset;
 }
@@ -19887,9 +19795,7 @@ size_t vulkan_struct_deep_copy(const VkOpticalFlowSessionCreatePrivateDataInfoNV
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pPrivateData, 1);
     }
     return offset;
 }
@@ -21747,9 +21653,7 @@ size_t vulkan_struct_deep_copy(const VkRayTracingShaderGroupCreateInfoKHR* struc
             auto out_structures = reinterpret_cast<struct_type*>(out_data);
             out_structures[i]   = base_struct;
         }
-        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.pShaderGroupCaptureReplayHandle, 1);
     }
     return offset;
 }

--- a/framework/generated/generated_vulkan_struct_deep_copy.cpp
+++ b/framework/generated/generated_vulkan_struct_deep_copy.cpp
@@ -160,7 +160,7 @@ void handle_array_of_pointers(const T&  base_struct,
                               uint8_t*  out_data)
 {
     using pointer_type = std::decay_t<decltype(*struct_pointer_array)>;
-    static_assert(std::is_pointer_v<pointer_type>);
+    static_assert(std::is_pointer_v<U> && std::is_pointer_v<pointer_type>);
 
     if (struct_pointer_array == nullptr || struct_pointer_array_count == 0)
     {

--- a/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
+++ b/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
@@ -1689,10 +1689,6 @@ size_t vulkan_struct_deep_copy_stype(const void* pNext, uint8_t* out_data)
             offset += vulkan_struct_deep_copy(
                 reinterpret_cast<const VkPushDescriptorSetInfoKHR*>(pNext), 1, out_ptr);
             break;
-        case VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_WITH_TEMPLATE_INFO_KHR:
-            offset += vulkan_struct_deep_copy(
-                reinterpret_cast<const VkPushDescriptorSetWithTemplateInfoKHR*>(pNext), 1, out_ptr);
-            break;
         case VK_STRUCTURE_TYPE_SET_DESCRIPTOR_BUFFER_OFFSETS_INFO_EXT:
             offset += vulkan_struct_deep_copy(
                 reinterpret_cast<const VkSetDescriptorBufferOffsetsInfoEXT*>(pNext), 1, out_ptr);

--- a/framework/generated/vulkan_generators/vulkan_struct_deep_copy_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_deep_copy_body_generator.py
@@ -157,7 +157,7 @@ void handle_array_of_pointers(const T&  base_struct,
                               uint8_t*  out_data)
 {
     using pointer_type = std::decay_t<decltype(*struct_pointer_array)>;
-    static_assert(std::is_pointer_v<pointer_type>);
+    static_assert(std::is_pointer_v<U> && std::is_pointer_v<pointer_type>);
 
     if (struct_pointer_array == nullptr || struct_pointer_array_count == 0)
     {

--- a/framework/generated/vulkan_generators/vulkan_struct_deep_copy_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_deep_copy_body_generator.py
@@ -85,35 +85,36 @@ size_t vulkan_struct_deep_copy(const void* structs, uint32_t count, uint8_t* out
     return count;
 }
 
-//! create a helper-lambda to handle pointer-type struct-members
-template <typename T>
-auto create_pointer_helper_function(const T& base_struct, uint32_t out_index, uint64_t& offset, uint8_t* out_data)
+template <typename T, typename U>
+void handle_pointer(const T&  base_struct,
+                    const U&  pointer_member,
+                    uint32_t  count,
+                    uint32_t  out_index,
+                    uint64_t& offset,
+                    uint8_t*  out_data)
 {
-    auto handle_pointer_fn = [out_data, out_index, &offset, &base_struct](const auto& pointer_member, uint32_t count) {
-        if (pointer_member == nullptr || count == 0)
-        {
-            return;
-        }
+    static_assert(std::is_pointer_v<U>);
+    
+    if (pointer_member == nullptr || count == 0)
+    {
+        return;
+    }
 
-        // member-offset within struct in bytes
-        uint32_t member_offset =
-            reinterpret_cast<const uint8_t*>(&pointer_member) - reinterpret_cast<const uint8_t*>(&base_struct);
+    // member-offset within struct in bytes
+    uint32_t member_offset =
+        reinterpret_cast<const uint8_t*>(&pointer_member) - reinterpret_cast<const uint8_t*>(&base_struct);
 
-        // copy pointer-chain recursively
-        uint32_t copy_size = vulkan_struct_deep_copy(pointer_member, count, offset_ptr(out_data, offset));
+    // copy pointer-chain recursively
+    uint32_t copy_size = vulkan_struct_deep_copy(pointer_member, count, offset_ptr(out_data, offset));
 
-        // re-direct pointers to point at copy
-        if (out_data != nullptr)
-        {
-            using pointer_type = std::decay_t<decltype(pointer_member)>;
-            auto* out_ptr      = reinterpret_cast<pointer_type*>(out_data + out_index * sizeof(T) + member_offset);
-            *out_ptr           = reinterpret_cast<pointer_type>(offset_ptr(out_data, offset));
-        }
-        offset += copy_size;
-    };
-    return handle_pointer_fn;
-
-};
+    // re-direct pointers to point at copy
+    if (out_data != nullptr)
+    {
+        auto* out_ptr = reinterpret_cast<U*>(out_data + out_index * sizeof(T) + member_offset);
+        *out_ptr      = reinterpret_cast<U>(offset_ptr(out_data, offset));
+    }
+    offset += copy_size;
+}
 
 template <typename T>
 void handle_pnext(const T& base_struct, uint32_t out_index, uint64_t& offset, uint8_t* out_data)
@@ -145,6 +146,50 @@ void handle_struct_member(
         auto& out_struct_member = *reinterpret_cast<U*>(out_data + out_index * sizeof(T) + member_offset);
         out_struct_member       = *reinterpret_cast<U*>(out_address);
     }
+}
+
+template <typename T, typename U>
+void handle_array_of_pointers(const T&  base_struct,
+                              const U&  struct_pointer_array,
+                              uint32_t  struct_pointer_array_count,
+                              uint32_t  out_index,
+                              uint64_t& offset,
+                              uint8_t*  out_data)
+{
+    using pointer_type = std::decay_t<decltype(*struct_pointer_array)>;
+    static_assert(std::is_pointer_v<pointer_type>);
+
+    if (struct_pointer_array == nullptr || struct_pointer_array_count == 0)
+    {
+        return;
+    }
+    uint32_t copy_size = struct_pointer_array_count * sizeof(pointer_type);
+
+    // member-offset within struct in bytes
+    uint32_t member_offset =
+        reinterpret_cast<const uint8_t*>(&struct_pointer_array) - reinterpret_cast<const uint8_t*>(&base_struct);
+
+    for (uint32_t i = 0; i < struct_pointer_array_count; ++i)
+    {
+        uint32_t out_offset = offset + copy_size;
+
+        // copy pointers in array recursively
+        copy_size += vulkan_struct_deep_copy(struct_pointer_array[i], 1, offset_ptr(out_data, out_offset));
+
+        // re-direct pointers to point at copy
+        if (out_data != nullptr)
+        {
+            auto* out_ptr = reinterpret_cast<pointer_type*>(out_data + offset + i * sizeof(pointer_type));
+            *out_ptr      = reinterpret_cast<pointer_type>(offset_ptr(out_data, out_offset));
+        }
+    }
+    // re-direct array-pointer to point at copy
+    if (out_data != nullptr)
+    {
+        auto* out_ptr = reinterpret_cast<U*>(out_data + out_index * sizeof(T) + member_offset);
+        *out_ptr      = reinterpret_cast<U>(offset_ptr(out_data, offset));
+    }
+    offset += copy_size;
 }
 '''
 class VulkanStructDeepCopyBodyGeneratorOptions(BaseGeneratorOptions):
@@ -284,24 +329,15 @@ class VulkanStructDeepCopyBodyGenerator(BaseGenerator):
         write('            out_structures[i]   = base_struct;', file=self.outFile)
         write('        }', file=self.outFile)
 
-        if has_pointer_members:
-            write('        auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);', file=self.outFile)
-
         for value in self.feature_struct_members[typename]:
             if value.name == 'pNext':
                 write('        handle_pnext(base_struct, i, offset, out_data);', file=self.outFile)
             elif value.is_pointer and not self.isExternalObject(value):
                 count_exp = self.getPointerCountExpression(typename, value)
                 if value.pointer_count == 1:
-                    write('        handle_pointer_member(base_struct.{0}, {1});'.format(value.name, count_exp), file=self.outFile)
+                    write('        handle_pointer(base_struct, base_struct.{0}, {1}, i, offset, out_data);'.format(value.name, count_exp), file=self.outFile)
                 elif value.pointer_count == 2:
-                    write('        if(base_struct.{0} != nullptr)'.format(value.name), file=self.outFile)
-                    write('        {', file=self.outFile)
-                    write('            for(uint32_t j = 0; j < {}; ++j)'.format(count_exp), file=self.outFile)
-                    write('            {', file=self.outFile)
-                    write('                handle_pointer_member(base_struct.{0}[j], 1);'.format(value.name), file=self.outFile)
-                    write('            }', file=self.outFile)
-                    write('        }', file=self.outFile)
+                    write('        handle_array_of_pointers(base_struct, base_struct.{0}, {1}, i, offset, out_data);'.format(value.name, count_exp), file=self.outFile)
             elif value.base_type in ["VkPipelineShaderStageCreateInfo", "VkAccelerationStructureGeometryDataKHR"]:
                 write('        handle_struct_member(base_struct, base_struct.{0}, i, offset, out_data);'.format(value.name), file=self.outFile)
         write('    }', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_deep_copy_stype_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_deep_copy_stype_body_generator.py
@@ -127,6 +127,7 @@ class VulkanStructDeepCopySTypeBodyGenerator(BaseGenerator):
                         'VkMetalSurfaceCreateInfoEXT',
                         'VkDirectFBSurfaceCreateInfoEXT',
                         'VkScreenSurfaceCreateInfoQNX',
+                        'VkPushDescriptorSetWithTemplateInfoKHR'
                         ]:
             return False
         return True


### PR DESCRIPTION
part 1:
- do not copy 'external'-object-handles, e.g. in `VkSurfaceFullScreenExclusiveWin32InfoEXT`
- do not generate overload for `VkPushDescriptorSetWithTemplateInfoKHR`

When making deep copies of structures, avoid attempting to copy the values referenced by opaque handles and opaque pointers. These are generally pointers to a single value with the void* type, which cannot be safely copied because the size of the referenced value is unknown. For most cases, the referenced value is unneeded because capture treats the address stored in these handles/pointers as external object IDs that are encoded as 64-bit integer values.

Additionally omits `VkPushDescriptorSetWithTemplateInfoKHR` from code-gen, as it requires knowledge about the template's layout, which is not available in the routine's scope.

many thanks @dgraves for reporting and [already providing this fix](https://github.com/LunarG/gfxreconstruct/commit/fb10c2bbc4b88969885389aa0aa58e17bea73049)! 

part 2:
- correct handling of arrays-of-pointers (generally members starting with `pp`), only 6 cases total, e.g. in `VkInstanceCreateInfo`, `VkDeviceCreateInfo`, `VkMicromapBuildInfoEXT` 
- minor refactor, add static_asserts