### PR TITLE
Expose 2 symbols from android_main

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -28,6 +28,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/handle_pointer_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/json_writer.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/json_writer.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/mark_injected_commands.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/mark_injected_commands.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/pointer_decoder_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/pointer_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/portability.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -74,6 +74,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/json_writer.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/decode_json_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/decode_json_util.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/mark_injected_commands.h
+                    ${CMAKE_CURRENT_LIST_DIR}/mark_injected_commands.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/pointer_decoder_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/pointer_decoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/portability.h

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -47,7 +47,7 @@ const uint32_t kFirstFrame = 0;
 FileProcessor::FileProcessor() :
     current_frame_number_(kFirstFrame), error_state_(kErrorInvalidFileDescriptor), bytes_read_(0),
     annotation_handler_(nullptr), compressor_(nullptr), block_index_(0), api_call_index_(0), block_limit_(0),
-    capture_uses_frame_markers_(false), first_frame_(kFirstFrame + 1)
+    capture_uses_frame_markers_(false), first_frame_(kFirstFrame + 1), loading_trimmed_capture_state_(false)
 {}
 
 FileProcessor::FileProcessor(uint64_t block_limit) : FileProcessor()
@@ -2167,11 +2167,13 @@ bool FileProcessor::ProcessStateMarker(const format::BlockHeader& block_header, 
         if (marker_type == format::kBeginMarker)
         {
             GFXRECON_LOG_INFO("Loading state for captured frame %" PRId64, frame_number);
+            loading_trimmed_capture_state_ = true;
         }
         else if (marker_type == format::kEndMarker)
         {
             GFXRECON_LOG_INFO("Finished loading state for captured frame %" PRId64, frame_number);
-            first_frame_ = frame_number;
+            first_frame_                   = frame_number;
+            loading_trimmed_capture_state_ = false;
         }
 
         for (auto decoder : decoders_)

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -276,7 +276,6 @@ class FileProcessor
 
         return file_stack_.back();
     }
-
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -98,6 +98,10 @@ class FileProcessor
 
     uint32_t GetCurrentFrameNumber() const { return current_frame_number_; }
 
+    uint64_t GetCurrentBlockIndex() const { return block_index_; }
+
+    bool GetLoadingTrimmedState() const { return loading_trimmed_capture_state_; }
+
     uint64_t GetNumBytesRead() const { return bytes_read_; }
 
     Error GetErrorState() const { return error_state_; }
@@ -238,6 +242,7 @@ class FileProcessor
     bool                                enable_print_block_info_{ false };
     int64_t                             block_index_from_{ 0 };
     int64_t                             block_index_to_{ 0 };
+    bool                                loading_trimmed_capture_state_;
 
     struct ActiveFiles
     {
@@ -271,6 +276,7 @@ class FileProcessor
 
         return file_stack_.back();
     }
+
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/mark_injected_commands.cpp
+++ b/framework/decode/mark_injected_commands.cpp
@@ -1,0 +1,75 @@
+/*
+** Copyright (c) 2024 Valve Corporation
+** Copyright (c) 2024 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "util/defines.h"
+#include "util/logging.h"
+#include "mark_injected_commands.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+static void BeginEndInjectedCommandsNoop(void* data)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(data);
+}
+
+#ifdef GFXRECON_DEBUG_BUILD
+static bool injecting_api_calls_g = false;
+#endif
+
+static PFN_BeginInjectedCommands BeginInjectCommands_fp = BeginEndInjectedCommandsNoop;
+static PFN_EndInjectedCommands   EndInjectCommands_fp   = BeginEndInjectedCommandsNoop;
+static void*                     InjectCommandsData_ptr = nullptr;
+
+extern "C" void
+SetInjectedCommandCallbacks(PFN_BeginInjectedCommands begin_fp, PFN_EndInjectedCommands end_fp, void* data)
+{
+    BeginInjectCommands_fp = begin_fp != nullptr ? begin_fp : BeginEndInjectedCommandsNoop;
+    EndInjectCommands_fp   = end_fp != nullptr ? end_fp : BeginEndInjectedCommandsNoop;
+    InjectCommandsData_ptr = data;
+}
+
+void BeginInjectedCommands()
+{
+#ifdef GFXRECON_DEBUG_BUILD
+    // Nested BeginInjectedCommands/EndInjectedCommands
+    GFXRECON_ASSERT(!injecting_api_calls_g);
+    injecting_api_calls_g = true;
+#endif
+
+    BeginInjectCommands_fp(InjectCommandsData_ptr);
+}
+
+void EndInjectedCommands()
+{
+#ifdef GFXRECON_DEBUG_BUILD
+    // Nested BeginInjectedCommands/EndInjectedCommands
+    GFXRECON_ASSERT(injecting_api_calls_g);
+    injecting_api_calls_g = false;
+#endif
+
+    EndInjectCommands_fp(InjectCommandsData_ptr);
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/mark_injected_commands.h
+++ b/framework/decode/mark_injected_commands.h
@@ -1,0 +1,47 @@
+/*
+** Copyright (c) 2024 Valve Corporation
+** Copyright (c) 2024 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "util/defines.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+using PFN_BeginInjectedCommands = void (*)(void*);
+using PFN_EndInjectedCommands   = void (*)(void*);
+
+// Interface for registering callbacks so that GFXReconstruct can notify an external library about
+// generated API calls that are not included in the capture file.
+// Intended usage: GFXR will call PFN_BeginInjectedCommands once before it starts issuing synthesized
+// API calls, and PFN_EndInjectedCommands once it is finished.
+// A void * pointer allows passing optional data that will be forwared into both callbacks.
+//
+// SetInjectedCommandCallbacks can be discovered through dlsym/GetProcAddress.
+extern "C" void
+SetInjectedCommandCallbacks(PFN_BeginInjectedCommands begin_fp, PFN_EndInjectedCommands end_fp, void* data);
+
+void BeginInjectedCommands();
+
+void EndInjectedCommands();
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/mark_injected_commands.h
+++ b/framework/decode/mark_injected_commands.h
@@ -26,8 +26,9 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-using PFN_BeginInjectedCommands = void (*)(void*);
-using PFN_EndInjectedCommands   = void (*)(void*);
+using PFN_BeginInjectedCommands       = void (*)(void*);
+using PFN_EndInjectedCommands         = void (*)(void*);
+using PFN_SetInjectedCommandCallbacks = void (*)(PFN_BeginInjectedCommands, PFN_EndInjectedCommands, void*);
 
 // Interface for registering callbacks so that GFXReconstruct can notify an external library about
 // generated API calls that are not included in the capture file.

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1366,8 +1366,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                      const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     std::function<handle_create_result_t<VkPipeline>()>
-    AsyncCreateGraphicsPipelines(const ApiCallInfo&                                          call_info,
+    AsyncCreateGraphicsPipelines(PFN_vkCreateGraphicsPipelines                               func,
                                  VkResult                                                    returnValue,
+                                 const ApiCallInfo&                                          call_info,
                                  const VulkanDeviceInfo*                                     device_info,
                                  const VulkanPipelineCacheInfo*                              pipeline_cache_info,
                                  uint32_t                                                    createInfoCount,
@@ -1376,8 +1377,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                  HandlePointerDecoder<VkPipeline>*                           pPipelines);
 
     std::function<handle_create_result_t<VkPipeline>()>
-    AsyncCreateComputePipelines(const ApiCallInfo&                                         call_info,
+    AsyncCreateComputePipelines(PFN_vkCreateComputePipelines                               func,
                                 VkResult                                                   returnValue,
+                                const ApiCallInfo&                                         call_info,
                                 const VulkanDeviceInfo*                                    device_info,
                                 const VulkanPipelineCacheInfo*                             pipeline_cache_info,
                                 uint32_t                                                   createInfoCount,
@@ -1386,8 +1388,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                 HandlePointerDecoder<VkPipeline>*                          pPipelines);
 
     std::function<handle_create_result_t<VkShaderEXT>()>
-    AsyncCreateShadersEXT(const ApiCallInfo&                                   call_info,
+    AsyncCreateShadersEXT(PFN_vkCreateShadersEXT                               func,
                           VkResult                                             returnValue,
+                          const ApiCallInfo&                                   call_info,
                           const VulkanDeviceInfo*                              device_info,
                           uint32_t                                             createInfoCount,
                           StructPointerDecoder<Decoded_VkShaderCreateInfoEXT>* pCreateInfos,

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -636,12 +636,10 @@ VkResult VulkanVirtualSwapchain::GetSwapchainImagesKHR(VkResult                 
         // Notify any layers by calling the provided pointer to their ReportReplayGeneratedVulkanCommands
         decode::BeginInjectedCommands();
 
-        VkResult res = CreateSwapchainResourceData(
+        result = CreateSwapchainResourceData(
             device_info, swapchain_info, capture_image_count, replay_image_count, images, false);
 
         decode::EndInjectedCommands();
-
-        return res;
     }
 
     return result;
@@ -983,7 +981,6 @@ VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                       
     VkPresentInfoKHR modified_present_info   = *present_info;
     modified_present_info.waitSemaphoreCount = static_cast<uint32_t>(present_wait_semaphores.size());
     modified_present_info.pWaitSemaphores    = present_wait_semaphores.data();
-
     return func(queue, &modified_present_info);
 }
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -987,7 +987,7 @@ void VulkanReplayConsumer::Process_vkCreateGraphicsPipelines(
 
     if (UseAsyncOperations())
     {
-        auto task = AsyncCreateGraphicsPipelines(call_info, returnValue, in_device, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+        auto task = AsyncCreateGraphicsPipelines(GetDeviceTable(in_device->handle)->CreateGraphicsPipelines, returnValue, call_info, in_device, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
         if(task)
         {
            AddHandlesAsync<VulkanPipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), std::move(handle_info), &VulkanObjectInfoTable::AddVkPipelineInfo, std::move(task));
@@ -1021,7 +1021,7 @@ void VulkanReplayConsumer::Process_vkCreateComputePipelines(
 
     if (UseAsyncOperations())
     {
-        auto task = AsyncCreateComputePipelines(call_info, returnValue, in_device, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+        auto task = AsyncCreateComputePipelines(GetDeviceTable(in_device->handle)->CreateComputePipelines, returnValue, call_info, in_device, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
         if(task)
         {
            AddHandlesAsync<VulkanPipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), std::move(handle_info), &VulkanObjectInfoTable::AddVkPipelineInfo, std::move(task));
@@ -10116,7 +10116,7 @@ void VulkanReplayConsumer::Process_vkCreateShadersEXT(
 
     if (UseAsyncOperations())
     {
-        auto task = AsyncCreateShadersEXT(call_info, returnValue, in_device, createInfoCount, pCreateInfos, pAllocator, pShaders);
+        auto task = AsyncCreateShadersEXT(GetDeviceTable(in_device->handle)->CreateShadersEXT, returnValue, call_info, in_device, createInfoCount, pCreateInfos, pAllocator, pShaders);
         if(task)
         {
            AddHandlesAsync<VulkanShaderEXTInfo>(device, pShaders->GetPointer(), pShaders->GetLength(), std::move(handle_info), &VulkanObjectInfoTable::AddVkShaderEXTInfo, std::move(task));

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -341,7 +341,7 @@ class VulkanReplayConsumerBodyGenerator(
             if is_async:
                 body += '    if (UseAsyncOperations())\n'
                 body += '    {\n'
-                body += '        auto task = {}(call_info, returnValue, {});\n'.format(self.REPLAY_ASYNC_OVERRIDES[name], arglist)
+                body += '        auto task = {}({}, returnValue, call_info, {});\n'.format(self.REPLAY_ASYNC_OVERRIDES[name], dispatchfunc, arglist)
                 body += '        if(task)\n'
                 body += '        {\n'
                 body += '           {}\n'.format(postexpr[0])

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(gfxrecon-replay
                           $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>
                           $<$<BOOL:${DXC_FOUND}>:${DXC_LIBRARY_PATH}>)
 
-target_link_options(gfxrecon-replay PUBLIC "-export-dynamic")
+target_link_options(gfxrecon-replay PUBLIC "-rdynamic")
 
 if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -51,6 +51,8 @@ target_link_libraries(gfxrecon-replay
                           $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>
                           $<$<BOOL:${DXC_FOUND}>:${DXC_LIBRARY_PATH}>)
 
+target_link_options(gfxrecon-replay PUBLIC "-export-dynamic")
+
 if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -59,6 +59,21 @@ void        ProcessAppCmd(struct android_app* app, int32_t cmd);
 int32_t     ProcessInputEvent(struct android_app* app, AInputEvent* event);
 void        DestroyActivity(struct android_app* app);
 
+static std::unique_ptr<gfxrecon::decode::FileProcessor> file_processor;
+
+extern "C"
+{
+    uint64_t MainGetCurrentBlockIndex()
+    {
+        return file_processor->GetCurrentBlockIndex();
+    }
+
+    bool MainGetLoadingTrimmedState()
+    {
+        return file_processor->GetLoadingTrimmedState();
+    }
+}
+
 void android_main(struct android_app* app)
 {
     gfxrecon::util::Log::Init();
@@ -102,10 +117,9 @@ void android_main(struct android_app* app)
 
         try
         {
-            std::unique_ptr<gfxrecon::decode::FileProcessor> file_processor =
-                arg_parser.IsOptionSet(kPreloadMeasurementRangeOption)
-                    ? std::make_unique<gfxrecon::decode::PreloadFileProcessor>()
-                    : std::make_unique<gfxrecon::decode::FileProcessor>();
+            file_processor = arg_parser.IsOptionSet(kPreloadMeasurementRangeOption)
+                                 ? std::make_unique<gfxrecon::decode::PreloadFileProcessor>()
+                                 : std::make_unique<gfxrecon::decode::FileProcessor>();
 
             if (!file_processor->Initialize(filename))
             {


### PR DESCRIPTION
MainGetCurrentBlockIndex and MainGetLoadingTrimmedState whould de discoveralbe through dlopen + dlsym from the android replay native .so:

- MainGetCurrentBlockIndex(): Returns the current block index as calculated from the file processor

- MainGetLoadingTrimmedState(): Returns wheter file processor is between a FrameStateBegin/FrameStateEnd markers pair