### PR TITLE
Fix warnings

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -408,10 +408,8 @@ struct ShaderModuleInfo : public VulkanObjectInfo<VkShaderModule>
             type(type), readonly(readonly), accessed(accessed), count(count), is_array(is_array)
         {}
 
-        ShaderDescriptorInfo(const ShaderDescriptorInfo& other) :
-            type(other.type), readonly(other.readonly), accessed(other.accessed), count(other.count),
-            is_array(other.is_array)
-        {}
+        ShaderDescriptorInfo(const ShaderDescriptorInfo& other) = default;
+        ShaderDescriptorInfo& operator =(const ShaderDescriptorInfo& other) = default;
 
         VkDescriptorType type;
         bool             readonly;
@@ -428,6 +426,7 @@ struct ShaderModuleInfo : public VulkanObjectInfo<VkShaderModule>
         capture_id            = other.capture_id;
         used_descriptors_info = other.used_descriptors_info;
     }
+    ShaderModuleInfo& operator =(const ShaderModuleInfo& other) = default;
 
     // One entry per descriptor binding
     using ShaderDescriptorSetInfo = std::map<uint32_t, ShaderDescriptorInfo>;

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -408,8 +408,8 @@ struct ShaderModuleInfo : public VulkanObjectInfo<VkShaderModule>
             type(type), readonly(readonly), accessed(accessed), count(count), is_array(is_array)
         {}
 
-        ShaderDescriptorInfo(const ShaderDescriptorInfo& other) = default;
-        ShaderDescriptorInfo& operator =(const ShaderDescriptorInfo& other) = default;
+        ShaderDescriptorInfo(const ShaderDescriptorInfo& other)            = default;
+        ShaderDescriptorInfo& operator=(const ShaderDescriptorInfo& other) = default;
 
         VkDescriptorType type;
         bool             readonly;
@@ -426,7 +426,7 @@ struct ShaderModuleInfo : public VulkanObjectInfo<VkShaderModule>
         capture_id            = other.capture_id;
         used_descriptors_info = other.used_descriptors_info;
     }
-    ShaderModuleInfo& operator =(const ShaderModuleInfo& other) = default;
+    ShaderModuleInfo& operator=(const ShaderModuleInfo& other) = default;
 
     // One entry per descriptor binding
     using ShaderDescriptorSetInfo = std::map<uint32_t, ShaderDescriptorInfo>;

--- a/framework/graphics/vulkan_device_util.h
+++ b/framework/graphics/vulkan_device_util.h
@@ -31,7 +31,7 @@
 namespace gfxrecon::decode
 {
 //! forward declaration to avoid cyclic include
-class ReplayDeviceInfo;
+struct ReplayDeviceInfo;
 } // namespace gfxrecon::decode
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)


### PR DESCRIPTION
Minor changes to reduce warnings seen when using gfxreconstruct, no (intentional) functional changes.

Using struct as in the definition for forward declaration of the ReplayDeviceInfo tag (clang -Wmismatched-tags)

Explicitly define assignment operators for clang
 -Wdeprecated-copy-with-user-provided-copy warning.
  clang output:
> definition of implicit copy assignment operator for 'ShaderDescriptorInfo'
> is deprecated because it has a user-provided copy constructor