### PR TITLE
Add View Relative data to capture/replay

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -196,6 +196,7 @@ class ApiDecoder
 
     virtual void DispatchSetTlasToBlasDependencyCommand(format::HandleId                     tlas,
                                                         const std::vector<format::HandleId>& blases){};
+    virtual void DispatchViewRelativeLocation(format::ThreadId thread_id, format::ViewRelativeLocation& location){};
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -1815,6 +1815,36 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                                  "Failed to read parent to child dependency meta-data block header");
         }
     }
+    else if (meta_data_type == format::MetaDataType::kViewRelativeLocation)
+    {
+        // This command does not support compression.
+        assert(block_header.type != format::BlockType::kCompressedMetaDataBlock);
+
+        format::ViewRelativeLocation Location;
+        format::ThreadId             thread_id;
+        success = ReadBytes(&thread_id, sizeof(thread_id));
+
+        format::ViewRelativeLocation location;
+        if (success)
+        {
+            success = ReadBytes(&location, sizeof(location));
+        }
+
+        if (success)
+        {
+            for (auto decoder : decoders_)
+            {
+                if (decoder->SupportsMetaDataId(meta_data_id))
+                {
+                    decoder->DispatchViewRelativeLocation(thread_id, location);
+                }
+            }
+        }
+        else
+        {
+            HandleBlockReadError(kErrorReadingBlockHeader, "Failed to ViewRelativeLocation meta-data block");
+        }
+    }
     else
     {
         if ((meta_data_type == format::MetaDataType::kReserved23) ||

--- a/framework/decode/metadata_consumer_base.h
+++ b/framework/decode/metadata_consumer_base.h
@@ -106,6 +106,7 @@ class MetadataConsumerBase
     {}
 
     virtual void SetCurrentBlockIndex(uint64_t block_index) {}
+    virtual void ProcessViewRelativeLocation(format::ThreadId thread_id, format::ViewRelativeLocation& location){};
 
   protected:
     uint64_t block_index_;

--- a/framework/decode/openxr_decoder_base.cpp
+++ b/framework/decode/openxr_decoder_base.cpp
@@ -82,6 +82,14 @@ void OpenXrDecoderBase::SetCurrentBlockIndex(uint64_t block_index)
     }
 }
 
+void OpenXrDecoderBase::DispatchViewRelativeLocation(format::ThreadId thread_id, format::ViewRelativeLocation& location)
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessViewRelativeLocation(thread_id, location);
+    }
+}
+
 size_t OpenXrDecoderBase::Decode_xrEnumerateSwapchainImages(const ApiCallInfo& call_info,
                                                             const uint8_t*     parameter_buffer,
                                                             size_t             buffer_size)

--- a/framework/decode/openxr_decoder_base.h
+++ b/framework/decode/openxr_decoder_base.h
@@ -86,6 +86,9 @@ class OpenXrDecoderBase : public ApiDecoder
 
     virtual void SetCurrentBlockIndex(uint64_t block_index) override;
 
+    virtual void DispatchViewRelativeLocation(format::ThreadId              thread_id,
+                                              format::ViewRelativeLocation& location) override;
+
     // Unused stubs
     virtual void DecodeFunctionCall(format::ApiCallId  call_id,
                                     const ApiCallInfo& call_options,

--- a/framework/decode/openxr_json_consumer_base.cpp
+++ b/framework/decode/openxr_json_consumer_base.cpp
@@ -324,6 +324,30 @@ void OpenXrExportJsonConsumerBase::Process_xrPollEvent(const ApiCallInfo&       
     WriteBlockEnd();
 }
 
+void OpenXrExportJsonConsumerBase::ProcessViewRelativeLocation(format::ThreadId              thread_id,
+                                                               format::ViewRelativeLocation& location)
+{
+    const util::JsonOptions& json_options = writer_->GetOptions();
+    // TODO: Fold this into a override for WriteMetaCommandStart if we add many more meta data blocks
+    writer_->SetCurrentBlockIndex(this->block_index_);
+    auto& jdata = writer_->WriteMetaCommandStart("ViewRelativeLocation");
+
+    FieldToJson(jdata["session"], location.session_id, json_options);
+    FieldToJson(jdata["space"], location.space_id, json_options);
+    FieldToJson(jdata["flags"], location.flags, json_options);
+
+    FieldToJson(jdata["qx"], location.qx, json_options);
+    FieldToJson(jdata["qy"], location.qy, json_options);
+    FieldToJson(jdata["qz"], location.qz, json_options);
+    FieldToJson(jdata["qw"], location.qw, json_options);
+
+    FieldToJson(jdata["x"], location.x, json_options);
+    FieldToJson(jdata["y"], location.y, json_options);
+    FieldToJson(jdata["z"], location.z, json_options);
+
+    writer_->WriteBlockEnd();
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/decode/openxr_json_consumer_base.h
+++ b/framework/decode/openxr_json_consumer_base.h
@@ -128,6 +128,7 @@ class OpenXrExportJsonConsumerBase : public OpenXrConsumer
                              XrResult                                         returnValue,
                              format::HandleId                                 instance,
                              StructPointerDecoder<Decoded_XrEventDataBuffer>* eventData) override;
+    void ProcessViewRelativeLocation(format::ThreadId thread_id, format::ViewRelativeLocation& location) override;
 
     uint32_t submit_index_{ 0 }; // index of submissions across the trace
 

--- a/framework/encode/custom_openxr_encoder_commands.h
+++ b/framework/encode/custom_openxr_encoder_commands.h
@@ -92,6 +92,32 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_xrDestroyInstance>
     }
 };
 
+// CustomEncoderPostCall<format::ApiCallId::ApiCall_xrCreateSession>::Dispatch(manager, result, instance, createInfo,
+// session); Dispatch custom command to finalize capture at instance destruction.
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_xrCreateSession>
+{
+    template <typename... Args>
+    static void Dispatch(OpenXrCaptureManager* manager, Args... args)
+    {
+        manager->CreateSessionPostDispatch(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_xrEndFrame>
+{
+    template <typename... Args>
+    static void PreLockReentrant(OpenXrCaptureManager* manager, Args...)
+    {}
+
+    template <typename... Args>
+    static void Dispatch(OpenXrCaptureManager* manager, Args... args)
+    {
+        manager->EndFramePreDispatch(args...);
+    }
+};
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/openxr_capture_manager.h
+++ b/framework/encode/openxr_capture_manager.h
@@ -47,6 +47,7 @@
 #include <mutex>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -182,6 +183,15 @@ class OpenXrCaptureManager : public ApiCaptureManager
                                                    const XrApiLayerCreateInfo* apiLayerInfo,
                                                    XrInstance*                 instance);
 
+    void CreateSessionPostDispatch(XrResult                   result,
+                                   XrInstance                 instance,
+                                   const XrSessionCreateInfo* createInfo,
+                                   XrSession*                 session);
+
+    void EndFramePreDispatch(XrSession session, const XrFrameEndInfo* frameEndInfo);
+
+    using SpaceSet = std::unordered_set<XrSpace>;
+
   protected:
     OpenXrCaptureManager() : ApiCaptureManager(format::ApiFamilyId::ApiFamily_OpenXR) {}
 
@@ -197,6 +207,17 @@ class OpenXrCaptureManager : public ApiCaptureManager
     static OpenXrCaptureManager*        singleton_;
     static OpenXrLayerTable             layer_table_;
     std::unique_ptr<OpenXrStateTracker> state_tracker_;
+
+    void WriteViewRelativeLocationMetadata(XrSession session, const XrFrameEndInfo& frameEndInfo);
+
+    struct SessionCaptureData
+    {
+        XrSpace view_ref_space = XR_NULL_HANDLE;
+    };
+    using SessionDataMap = std::map<XrSession, SessionCaptureData>;
+
+    SessionCaptureData& GetSessionCaptureData(XrSession session);
+    SessionDataMap      session_capture_data_;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -154,6 +154,7 @@ enum class MetaDataType : uint16_t
     kReserved29                             = 29,
     kReserved30                             = 30,
     kReserved31                             = 31,
+    kViewRelativeLocation                   = 32,
 };
 
 // MetaDataId is stored in the capture file and its type must be uint32_t to avoid breaking capture file compatibility.
@@ -647,6 +648,34 @@ struct ParentToChildDependencyHeader
     ParentToChildDependencyType dependency_type;
     format::HandleId            parent_id;
     uint32_t                    child_count;
+};
+
+struct ViewRelativeLocation
+{
+    format::HandleId session_id;
+    format::HandleId space_id;
+
+    // Locate status
+    uint64_t flags;
+
+    // Orientation
+    float qx;
+    float qy;
+    float qz;
+    float qw;
+
+    // Position
+    float x;
+    float y;
+    float z;
+};
+
+struct ViewRelativeLocationCmd
+{
+    MetaDataHeader   meta_header;
+    format::ThreadId thread_id;
+
+    ViewRelativeLocation location;
 };
 
 // Restore size_t to normal behavior.


### PR DESCRIPTION
Capture the view relative location of the `XrCompositionLayer...` at record time, and at replay time create view relative spaces to use for the `XrFrameEndInfo` submitted as proxies for the spaces specified.

View relative information also in JSON output.

Fixes #1720 
