### PR TITLE
Fix features no longer checked at device creation

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2662,16 +2662,13 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult            original_resu
     graphics::VulkanDevicePropertyFeatureInfo property_feature_info = device_util.EnableRequiredPhysicalDeviceFeatures(
         physical_device_info->parent_api_version, instance_table, physical_device, &modified_create_info);
 
-    // Remove unsupported features
-    if (options_.remove_unsupported_features)
-    {
-        feature_util::CheckUnsupportedFeatures(physical_device,
-                                               instance_table->GetPhysicalDeviceFeatures,
-                                               instance_table->GetPhysicalDeviceFeatures2,
-                                               modified_create_info.pNext,
-                                               modified_create_info.pEnabledFeatures,
-                                               options_.remove_unsupported_features);
-    }
+    // Abort on/Remove unsupported features
+    feature_util::CheckUnsupportedFeatures(physical_device,
+                                           instance_table->GetPhysicalDeviceFeatures,
+                                           instance_table->GetPhysicalDeviceFeatures2,
+                                           modified_create_info.pNext,
+                                           modified_create_info.pEnabledFeatures,
+                                           options_.remove_unsupported_features);
 
     // Forward device creation to next layer/driver
     result =


### PR DESCRIPTION
Hello !

Because of an error I made in #1478 features supported by the replaying device were not compared anymore to features requested by the capture when `--remove-unsupported` was not present.
This commit simply fixes it.