### PR TITLE
vulkan: Split OverrideCreateInstance

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1407,6 +1407,20 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     VulkanBufferTracker& GetBufferTracker(VkDevice device);
 
+    struct CreateInstanceInfoState
+    {
+        std::vector<const char*> modified_layers;
+        std::vector<const char*> modified_extensions;
+        VkInstanceCreateInfo     modified_create_info;
+    };
+    CreateInstanceInfoState
+    ModifyCreateInstanceInfo(const StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo,
+                             HandlePointerDecoder<VkInstance>*                         pInstance);
+
+    void PostCreateInstanceUpdateConsumerData(const VkInstance*                 replay_instance,
+                                              const VkInstanceCreateInfo&       modified_create_info,
+                                              HandlePointerDecoder<VkInstance>* pInstance);
+
   private:
     struct HardwareBufferInfo
     {


### PR DESCRIPTION
into reusable pieces. The before and after dispatch processing will be needed by OpenXr calls that create vulkan instances.

To trigger CI on the change, and subject to review not necessarily, for commit.
