### PR TITLE
Fix Capture Crash Caused by Error in Handling VkSurfaceFullScreenExclusiveWin32InfoEXT

### DIFF
--- a/framework/generated/generated_vulkan_struct_deep_copy.cpp
+++ b/framework/generated/generated_vulkan_struct_deep_copy.cpp
@@ -15208,7 +15208,6 @@ size_t vulkan_struct_deep_copy(const VkSurfaceFullScreenExclusiveWin32InfoEXT* s
         }
         auto handle_pointer_member = create_pointer_helper_function(base_struct, i, offset, out_data);
         handle_pnext(base_struct, i, offset, out_data);
-        handle_pointer_member(base_struct.hmonitor, 1);
     }
     return offset;
 }

--- a/framework/generated/vulkan_generators/vulkan_struct_deep_copy_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_deep_copy_body_generator.py
@@ -285,6 +285,12 @@ class VulkanStructDeepCopyBodyGenerator(BaseGenerator):
         for value in self.feature_struct_members[typename]:
             if value.name == 'pNext':
                 write('        handle_pnext(base_struct, i, offset, out_data);', file=self.outFile)
+            elif value.name == 'hmonitor' and value.base_type == 'void':
+                # For VkSurfaceFullScreenExclusiveWin32InfoEXT, the member "hmonitor" should be considered a non-pointer member,
+                # as it is an opaque pointer defined by the Windows platform. A valid hmonitor is guaranteed not to be a null
+                # pointer, but it may not access the pointed memory. Therefore, we treat "hmonitor" as a non-pointer member and
+                # do not generate any source code to copy its pointed data.
+                continue
             elif value.is_pointer:
                 count_exp = self.getPointerCountExpression(typename, value)
                 if value.pointer_count == 1:


### PR DESCRIPTION
**The problem**
   
When generating deep copy source code for VkSurfaceFullScreenExclusiveWin32InfoEXT, the member "hmonitor" should be
treated as a non-pointer member because it is an opaque pointer defined by the Windows platform. For a valid hmonitor, it is guaranteed that it is not a null pointer, but it may not access the pointed memory. When capturing a specific title, the capturing crashed due to accessing memory through the pointer, causing an access violation.


**The solution**

The commit changed the related source generator to use the member "hmonitor" of VkSurfaceFullScreenExclusiveWin32InfoEXT as a non-pointer member. It does not generate any source code to copy its pointed data.

**Result**

Tested the target title with the pull request build and found that it resolved the access violation.

