### PR TITLE
Fix Capture Crash Caused by Error in Parsing Shader Code

### DIFF
--- a/framework/util/spirv_parsing_util.cpp
+++ b/framework/util/spirv_parsing_util.cpp
@@ -300,8 +300,12 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
                                                                    buffer_reference_info.binding,
                                                                    buffer_reference_info.set,
                                                                    &spv_result);
-                                td        = spv_descriptor_binding->type_description;
-                                root_name = spv_descriptor_binding->name;
+                                td = spv_descriptor_binding->type_description;
+
+                                // spirv_reflect sets the name by tracking SPIR-V instructions like OpName. Some
+                                // optimizations may remove these instructions, resulting in a nullptr name. Actually we
+                                // can find some title removes all such names.
+                                root_name = spv_descriptor_binding->name ? spv_descriptor_binding->name : "";
                             }
 
                             if (root_name.empty())


### PR DESCRIPTION
**The problem**
   
Certain optimizations may remove SPIR-V instructions such as OpName (actually some title may remove all such instructions with shader optimization tool), which can lead to a nullptr name in the spirv_reflect SpvReflectDescriptorBinding struct. This occurs because spirv_reflect sets the name by keeping track of these SPIR-V instructions. The error causes an access violation issue when parsing the shader code.

**The solution**

The commit addresses the issue by setting the root_name to empty in handling this scenario when parsing the shader code.

**Result**
Tested the target title with the build of the pull request, it fixed this issue.
