### PR TITLE
Two bugfixes to enable OpenXR-SDK-Source HelloXr support --api Vulkan

### DIFF
--- a/framework/decode/struct_pointer_decoder.h
+++ b/framework/decode/struct_pointer_decoder.h
@@ -372,8 +372,11 @@ class StructPointerDecoder<T*> : public PointerDecoderBase
 
                     typename T::struct_type* inner_struct_memory = reinterpret_cast<typename T::struct_type*>(
                         DecodeAllocator::Allocate<typename T::union_size_type>(inner_len));
+                    // TODO: We initialize == true because the next field isn't always cleared on kIsNull in the lower
+                    //       level decoders.  If this is a performance bottleneck, can clean up the lower decoders to
+                    //       initialize all fields.
                     T* inner_decoded_structs =
-                        T::AllocateAppropriate((buffer + bytes_read), (buffer_size - bytes_read), len);
+                        T::AllocateAppropriate((buffer + bytes_read), (buffer_size - bytes_read), len, true);
 
                     for (size_t j = 0; j < inner_len; ++j)
                     {


### PR DESCRIPTION

1) Ensure decoded base header children have defined state

    The lower level decoders are always setting values, so force a good
    state at initialization (zeros)

2) Make view local viewing 1.0 compatible

    Convert xrLocateSpaces calls (which are 1.1 only) to xrLocateSpace -- which is available on XR 1.0