### PR TITLE
Add log message on app gain/loss of focus and when unpausing application

### DIFF
--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -181,16 +181,20 @@ void Application::Run()
 
 void Application::SetPaused(bool paused)
 {
-    paused_ = paused;
-
-    if (paused_ && (file_processor_ != nullptr))
+    if (file_processor_ != nullptr && paused_ != paused)
     {
         uint32_t current_frame = file_processor_->GetCurrentFrameNumber();
-        if (current_frame > 0)
+        if (paused)
         {
-            GFXRECON_LOG_INFO("Paused at frame %u", file_processor_->GetCurrentFrameNumber());
+            GFXRECON_LOG_INFO("Paused at frame %u", current_frame);
+        }
+        else
+        {
+            GFXRECON_LOG_INFO("Resumed from frame %u", current_frame);
         }
     }
+
+    paused_ = paused;
 }
 
 bool Application::PlaySingleFrame()

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -293,11 +293,13 @@ void ProcessAppCmd(struct android_app* app, int32_t cmd)
             }
             case APP_CMD_GAINED_FOCUS:
             {
+                GFXRECON_LOG_INFO("Application gained focus.")
                 application->SetPaused(false);
                 break;
             }
             case APP_CMD_LOST_FOCUS:
             {
+                GFXRECON_LOG_INFO("Application lost focus.")
                 application->SetPaused(true);
                 break;
             }


### PR DESCRIPTION
It makes more sense to have messages for both when the application is paused and unpaused than only when paused.
In addition, in the context of an automated process, it is useful to be able to differentiate, only with the logs, an application that was paused because of a manual input to an application paused because of a lose of focus.

This commit adds these log messages