### PR TITLE
Add support for xrCreateVulkan(Instance|Device)

### DIFF
--- a/framework/decode/custom_openxr_struct_decoders.cpp
+++ b/framework/decode/custom_openxr_struct_decoders.cpp
@@ -53,7 +53,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_XrVulkanI
     bytes_read +=
         ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->systemId));
     bytes_read +=
-        ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->createFlags));
+        ValueDecoder::DecodeFlags64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->createFlags));
     bytes_read += ValueDecoder::DecodeAddress(
         (buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pfnGetInstanceProcAddr));
     value->pfnGetInstanceProcAddr = nullptr;
@@ -80,7 +80,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_XrVulkanD
     bytes_read +=
         ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->systemId));
     bytes_read +=
-        ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->createFlags));
+        ValueDecoder::DecodeFlags64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->createFlags));
     bytes_read += ValueDecoder::DecodeAddress(
         (buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pfnGetInstanceProcAddr));
     value->pfnGetInstanceProcAddr = nullptr;

--- a/framework/decode/openxr_replay_consumer_base.cpp
+++ b/framework/decode/openxr_replay_consumer_base.cpp
@@ -703,7 +703,7 @@ void OpenXrReplayConsumerBase::Process_xrPollEvent(const ApiCallInfo&           
     XrResult replay_result;
 
     // WIP: Put this constant somewhere interesting
-    const uint32_t kRetryLimit      = 10000;
+    const uint32_t kRetryLimit      = 10;
     const int64_t  kMaxSleepLimitNs = 500000000; // 500ms
     uint32_t       retry_count      = 0;
 

--- a/framework/decode/openxr_replay_consumer_base.cpp
+++ b/framework/decode/openxr_replay_consumer_base.cpp
@@ -579,6 +579,130 @@ void OpenXrReplayConsumerBase::Process_xrCreateApiLayerInstance(
                                   &CommonObjectInfoTable::AddXrInstanceInfo);
 }
 
+void OpenXrReplayConsumerBase::Process_xrCreateVulkanInstanceKHR(
+    const ApiCallInfo&                                           call_info,
+    XrResult                                                     returnValue,
+    format::HandleId                                             instance,
+    StructPointerDecoder<Decoded_XrVulkanInstanceCreateInfoKHR>* createInfo,
+    HandlePointerDecoder<VkInstance>*                            vulkanInstance,
+    PointerDecoder<VkResult>*                                    vulkanResult)
+{
+    XrInstance in_instance = MapHandle<OpenXrInstanceInfo>(instance, &CommonObjectInfoTable::GetXrInstanceInfo);
+    const XrVulkanInstanceCreateInfoKHR* in_createInfo = createInfo->GetPointer();
+    MapStructHandles(createInfo->GetMetaStructPointer(), GetObjectInfoTable());
+    StructPointerDecoder<Decoded_VkInstanceCreateInfo>* vulkanCreateInfo =
+        createInfo->GetMetaStructPointer()->vulkanCreateInfo;
+
+    if (!vulkanInstance->IsNull())
+    {
+        vulkanInstance->SetHandleLength(1);
+    }
+    VkInstance*        out_vulkanInstance = vulkanInstance->GetHandlePointer();
+    VulkanInstanceInfo vulkan_handle_info;
+    vulkanInstance->SetConsumerData(
+        0, &vulkan_handle_info); // To match what the shared routines from vkCreateInstance expect
+
+    // Customize the Vulkan instance the way Vulkan Replay does.
+    VulkanReplayConsumerBase::CreateInstanceInfoState create_state =
+        vulkan_replay_consumer_->ModifyCreateInstanceInfo(vulkanCreateInfo);
+
+    // Make a shallow copy and touch-up
+    XrVulkanInstanceCreateInfoKHR replay_info = *in_createInfo;
+    replay_info.vulkanCreateInfo              = &create_state.modified_create_info;
+    replay_info.pfnGetInstanceProcAddr        = vulkan_replay_consumer_->GetGetInstanceProcAddr();
+
+    VkResult replay_vulkan_result = VK_RESULT_MAX_ENUM; // An invalid value
+    XrResult replay_result =
+        GetInstanceTable(in_instance)
+            ->CreateVulkanInstanceKHR(in_instance, &replay_info, out_vulkanInstance, &replay_vulkan_result);
+    CheckResult("xrCreateVulkanInstanceKHR", returnValue, replay_result, call_info);
+
+    // We also need to check the Vulkan Result
+    VkResult* in_vulkan_result = vulkanResult->GetPointer();
+    assert(in_vulkan_result);
+    vulkan_replay_consumer_->CheckResult(
+        "xrCreateVulkanInstanceKHR", *in_vulkan_result, replay_vulkan_result, call_info);
+
+    if (replay_vulkan_result == VK_SUCCESS)
+    {
+        vulkan_replay_consumer_->PostCreateInstanceUpdateState(
+            *out_vulkanInstance, create_state.modified_create_info, vulkan_handle_info);
+    }
+
+    AddHandle<VulkanInstanceInfo>(instance,
+                                  vulkanInstance->GetPointer(),
+                                  out_vulkanInstance,
+                                  std::move(vulkan_handle_info),
+                                  &CommonObjectInfoTable::AddVkInstanceInfo);
+}
+
+void OpenXrReplayConsumerBase::Process_xrCreateVulkanDeviceKHR(
+    const ApiCallInfo&                                         call_info,
+    XrResult                                                   returnValue,
+    format::HandleId                                           instance,
+    StructPointerDecoder<Decoded_XrVulkanDeviceCreateInfoKHR>* createInfo,
+    HandlePointerDecoder<VkDevice>*                            vulkanDevice,
+    PointerDecoder<VkResult>*                                  vulkanResult)
+{
+    XrInstance in_instance = MapHandle<OpenXrInstanceInfo>(instance, &CommonObjectInfoTable::GetXrInstanceInfo);
+    const XrVulkanDeviceCreateInfoKHR* in_createInfo = createInfo->GetPointer();
+    MapStructHandles(createInfo->GetMetaStructPointer(), GetObjectInfoTable());
+
+    Decoded_XrVulkanDeviceCreateInfoKHR* xr_create_info_wrapper = createInfo->GetMetaStructPointer();
+    assert(xr_create_info_wrapper);
+
+    VulkanPhysicalDeviceInfo* physical_device_info =
+        GetObjectInfoTable().GetVkPhysicalDeviceInfo(xr_create_info_wrapper->vulkanPhysicalDevice);
+    assert(
+        physical_device_info); // The Vulkan replay consumer doesn't test the result or LOG this so just assert for now
+
+    // NOTE: The "GetMatchingDevice" process has side effects that are needed, though it's unclear whether
+    //       the matching process is valid for Xr
+    vulkan_replay_consumer_->GetMatchingDevice(physical_device_info);
+
+    VulkanReplayConsumerBase::CreateDeviceInfoState create_state =
+        vulkan_replay_consumer_->ModifyCreateDeviceInfo(physical_device_info, xr_create_info_wrapper->vulkanCreateInfo);
+    XrVulkanDeviceCreateInfoKHR replay_info = *in_createInfo;
+    replay_info.vulkanCreateInfo            = &create_state.modified_create_info;
+    replay_info.pfnGetInstanceProcAddr      = vulkan_replay_consumer_->GetGetInstanceProcAddr();
+
+    if (!vulkanDevice->IsNull())
+    {
+        vulkanDevice->SetHandleLength(1);
+    }
+    VkDevice* out_vulkanDevice = vulkanDevice->GetHandlePointer();
+    assert(out_vulkanDevice);
+
+    VkResult replay_vulkan_result = VK_RESULT_MAX_ENUM;
+
+    XrResult replay_result =
+        GetInstanceTable(in_instance)
+            ->CreateVulkanDeviceKHR(in_instance, &replay_info, out_vulkanDevice, &replay_vulkan_result);
+    CheckResult("xrCreateVulkanDeviceKHR", returnValue, replay_result, call_info);
+
+    // There's a bit more Vulkan to call to finish device creation
+    VulkanDeviceInfo device_info;
+    if (replay_vulkan_result == VK_SUCCESS)
+    {
+        replay_vulkan_result = vulkan_replay_consumer_->PostCreateDeviceUpdateState(
+            physical_device_info, *out_vulkanDevice, create_state, &device_info);
+    }
+
+    // We also need to check the Vulkan Result
+    VkResult* in_vulkan_result = vulkanResult->GetPointer();
+    assert(in_vulkan_result);
+    vulkan_replay_consumer_->CheckResult(
+        "xrCreateVulkanInstanceKHR", *in_vulkan_result, replay_vulkan_result, call_info);
+
+    // Note: we use the physical device *alias* (if present) instead of the parameter
+    //       s.t. the HandleId is consistent across the call and in later use
+    AddHandle<VulkanDeviceInfo>(physical_device_info->capture_id,
+                                vulkanDevice->GetPointer(),
+                                out_vulkanDevice,
+                                std::move(device_info),
+                                &CommonObjectInfoTable::AddVkDeviceInfo);
+}
+
 void OpenXrReplayConsumerBase::UpdateState_xrCreateSession(
     const ApiCallInfo&                                 call_info,
     XrResult                                           returnValue,
@@ -1183,6 +1307,46 @@ void OpenXrReplayConsumerBase::Process_xrLocateBodyJointsFB(
     CheckResult("xrLocateBodyJointsFB", returnValue, replay_result, call_info);
     CustomProcess<format::ApiCallId::ApiCall_xrLocateBodyJointsFB>::UpdateState(
         this, call_info, returnValue, bodyTracker, locateInfo, locations, replay_result);
+}
+
+void OpenXrReplayConsumerBase::UpdateState_xrGetVulkanGraphicsDeviceKHR(
+    const ApiCallInfo&                      call_info,
+    XrResult                                returnValue,
+    format::HandleId                        instance,
+    format::HandleId                        systemId,
+    format::HandleId                        vulkan_instance,
+    HandlePointerDecoder<VkPhysicalDevice>* vkPhysicalDevice,
+    XrResult                                replay_result)
+{
+    if (XR_SUCCEEDED(replay_result))
+    {
+        VulkanPhysicalDeviceInfo* vulkan_physical_device_info =
+            GetObjectInfoTable().GetVkPhysicalDeviceInfo(*vkPhysicalDevice->GetPointer());
+        assert(vulkan_physical_device_info); // We call this just after we insert it
+        vulkan_replay_consumer_->SetPhysicalDeviceAlias(vulkan_instance, *vulkan_physical_device_info);
+    }
+}
+
+void OpenXrReplayConsumerBase::UpdateState_xrGetVulkanGraphicsDevice2KHR(
+    const ApiCallInfo&                                              call_info,
+    XrResult                                                        returnValue,
+    format::HandleId                                                instance,
+    StructPointerDecoder<Decoded_XrVulkanGraphicsDeviceGetInfoKHR>* getInfo,
+    HandlePointerDecoder<VkPhysicalDevice>*                         vulkanPhysicalDevice,
+    XrResult                                                        replay_result)
+{
+    if (XR_SUCCEEDED(replay_result))
+    {
+        const Decoded_XrVulkanGraphicsDeviceGetInfoKHR* decoded_info = getInfo->GetMetaStructPointer();
+        assert(decoded_info);
+        const format::HandleId vulkan_instance = decoded_info->vulkanInstance;
+
+        VulkanPhysicalDeviceInfo* vulkan_physical_device_info =
+            GetObjectInfoTable().GetVkPhysicalDeviceInfo(*vulkanPhysicalDevice->GetPointer());
+        assert(vulkan_physical_device_info); // We call this just after we insert it
+
+        vulkan_replay_consumer_->SetPhysicalDeviceAlias(vulkan_instance, *vulkan_physical_device_info);
+    }
 }
 
 void OpenXrReplayConsumerBase::CheckResult(const char*                func_name,
@@ -1886,12 +2050,11 @@ OpenXrReplayConsumerBase::VulkanGraphicsBinding::VulkanGraphicsBinding(
     VulkanReplayConsumerBase& vulkan_consumer, const Decoded_XrGraphicsBindingVulkanKHR& xr_binding) :
     XrGraphicsBindingVulkanKHR(*xr_binding.decoded_value),
     vulkan_consumer(&vulkan_consumer), instance_table(vulkan_consumer.GetInstanceTable(physicalDevice)),
-    device_table(vulkan_consumer.GetDeviceTable(device)), instance_id(xr_binding.instance),
-    physicalDevice_id(xr_binding.physicalDevice), device_id(xr_binding.device)
+    device_table(vulkan_consumer.GetDeviceTable(device)), instance_id(xr_binding.instance), device_id(xr_binding.device)
 {
     next = nullptr; // We don't have a safe (deep) copy of the original so stub out the copies downchain pointer
 
-    //
+    // Touch up the queue
     device_table->GetDeviceQueue(device, queueFamilyIndex, queueIndex, &queue);
 }
 

--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -91,6 +91,21 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
                                                   StructPointerDecoder<Decoded_XrApiLayerCreateInfo>* apiLayerInfo,
                                                   HandlePointerDecoder<XrInstance>*) override;
 
+    virtual void
+    Process_xrCreateVulkanInstanceKHR(const ApiCallInfo&                                           call_info,
+                                      XrResult                                                     returnValue,
+                                      format::HandleId                                             instance,
+                                      StructPointerDecoder<Decoded_XrVulkanInstanceCreateInfoKHR>* createInfo,
+                                      HandlePointerDecoder<VkInstance>*                            vulkanInstance,
+                                      PointerDecoder<VkResult>* vulkanResult) override;
+
+    virtual void Process_xrCreateVulkanDeviceKHR(const ApiCallInfo&                                         call_info,
+                                                 XrResult                                                   returnValue,
+                                                 format::HandleId                                           instance,
+                                                 StructPointerDecoder<Decoded_XrVulkanDeviceCreateInfoKHR>* createInfo,
+                                                 HandlePointerDecoder<VkDevice>* vulkanDevice,
+                                                 PointerDecoder<VkResult>*       vulkanResult) override;
+
     virtual void Process_xrPollEvent(const ApiCallInfo&                               call_info,
                                      XrResult                                         returnValue,
                                      format::HandleId                                 instance,
@@ -138,6 +153,22 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
                                               format::HandleId                                        bodyTracker,
                                               StructPointerDecoder<Decoded_XrBodyJointsLocateInfoFB>* locateInfo,
                                               StructPointerDecoder<Decoded_XrBodyJointLocationsFB>* locations) override;
+
+    void UpdateState_xrGetVulkanGraphicsDeviceKHR(const ApiCallInfo&                      call_info,
+                                                  XrResult                                returnValue,
+                                                  format::HandleId                        instance,
+                                                  format::HandleId                        systemId,
+                                                  format::HandleId                        vkInstance,
+                                                  HandlePointerDecoder<VkPhysicalDevice>* vkPhysicalDevice,
+                                                  XrResult                                replay_result);
+
+    void
+    UpdateState_xrGetVulkanGraphicsDevice2KHR(const ApiCallInfo& call_info,
+                                              XrResult           returnValue,
+                                              format::HandleId   instance,
+                                              StructPointerDecoder<Decoded_XrVulkanGraphicsDeviceGetInfoKHR>* getInfo,
+                                              HandlePointerDecoder<VkPhysicalDevice>* vulkanPhysicalDevice,
+                                              XrResult                                replay_result);
 
     void UpdateState_xrCreateSession(const ApiCallInfo&                                 call_info,
                                      XrResult                                           returnValue,
@@ -475,7 +506,6 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
         const encode::VulkanInstanceTable* instance_table{ nullptr };
         const encode::VulkanDeviceTable*   device_table{ nullptr };
         format::HandleId                   instance_id{ format::kNullHandleId };
-        format::HandleId                   physicalDevice_id{ format::kNullHandleId };
         format::HandleId                   device_id{ format::kNullHandleId };
         VkQueue                            queue = VK_NULL_HANDLE;
 
@@ -619,6 +649,26 @@ struct CustomProcess
     template <typename... Args>
     static void UpdateState(OpenXrReplayConsumerBase*, Args...)
     {}
+};
+
+template <>
+struct CustomProcess<format::ApiCallId::ApiCall_xrGetVulkanGraphicsDeviceKHR>
+{
+    template <typename... Args>
+    static void UpdateState(OpenXrReplayConsumerBase* consumer, Args... args)
+    {
+        consumer->UpdateState_xrGetVulkanGraphicsDeviceKHR(args...);
+    }
+};
+
+template <>
+struct CustomProcess<format::ApiCallId::ApiCall_xrGetVulkanGraphicsDevice2KHR>
+{
+    template <typename... Args>
+    static void UpdateState(OpenXrReplayConsumerBase* consumer, Args... args)
+    {
+        consumer->UpdateState_xrGetVulkanGraphicsDevice2KHR(args...);
+    }
 };
 
 template <>

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -245,6 +245,14 @@ struct VulkanPhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 
     // Closest matching replay device.
     VulkanReplayDeviceInfo* replay_device_info{ nullptr };
+
+    // Because Vulkan captures unwrapped handles, and OpenXR captures wrapped handles,
+    // during replay two HandleId will reference the same VkPhysical device.
+    // The vulkan_alias is the handleId as known by the vulkan_consumer, which
+    // will be created/updated, etc, by all Vulkan replay calls.
+
+    // When Non-null, the GetVkObject will recur on the alias Id
+    format::HandleId vulkan_alias{ format::kNullHandleId };
 };
 
 struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2300,29 +2300,23 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDevic
     return true;
 }
 
-VkResult
-VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
-                                                 const StructPointerDecoder<Decoded_VkInstanceCreateInfo>*  pCreateInfo,
-                                                 const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
-                                                 HandlePointerDecoder<VkInstance>*                          pInstance)
+VulkanReplayConsumerBase::CreateInstanceInfoState VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
+    const StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(original_result);
-
-    assert((pInstance != nullptr) && !pInstance->IsNull() && (pInstance->GetHandlePointer() != nullptr) &&
-           (pCreateInfo != nullptr) && (pCreateInfo->GetPointer() != nullptr) &&
-           (pInstance->GetHandlePointer() != nullptr));
 
     const VkInstanceCreateInfo* replay_create_info = pCreateInfo->GetPointer();
-    VkInstance*                 replay_instance    = pInstance->GetHandlePointer();
 
     if (loader_handle_ == nullptr)
     {
         InitializeLoader();
     }
 
-    std::vector<const char*> modified_layers;
-    std::vector<const char*> modified_extensions;
-    VkInstanceCreateInfo     modified_create_info = (*replay_create_info);
+    // Shorthand to reduce clutter, and diff noise
+    CreateInstanceInfoState   create_state;
+    std::vector<const char*>& modified_layers      = create_state.modified_layers;
+    std::vector<const char*>& modified_extensions  = create_state.modified_extensions;
+    VkInstanceCreateInfo&     modified_create_info = create_state.modified_create_info;
+    modified_create_info                           = *replay_create_info;
 
     // If VkDebugUtilsMessengerCreateInfoEXT or VkDebugReportCallbackCreateInfoEXT are in the pNext chain, update the
     // callback pointers.
@@ -2500,61 +2494,72 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
         modified_create_info.enabledLayerCount   = static_cast<uint32_t>(modified_layers.size());
         modified_create_info.ppEnabledLayerNames = modified_layers.data();
     }
+    return create_state;
+}
 
-    VkResult result = create_instance_proc_(&modified_create_info, GetAllocationCallbacks(pAllocator), replay_instance);
+void VulkanReplayConsumerBase::PostCreateInstanceUpdateState(const VkInstance            replay_instance,
+                                                             const VkInstanceCreateInfo& modified_create_info,
+                                                             VulkanInstanceInfo&         instance_info)
+{
+    AddInstanceTable(replay_instance);
 
-    if ((replay_instance != nullptr) && (result == VK_SUCCESS))
+    if (modified_create_info.pApplicationInfo != nullptr)
     {
-        AddInstanceTable(*replay_instance);
+        instance_info.api_version = modified_create_info.pApplicationInfo->apiVersion;
+        instance_info.enabled_extensions.assign(modified_create_info.ppEnabledExtensionNames,
+                                                modified_create_info.ppEnabledExtensionNames +
+                                                    modified_create_info.enabledExtensionCount);
+    }
+}
 
-        if (modified_create_info.pApplicationInfo != nullptr)
-        {
-            auto instance_info = reinterpret_cast<VulkanInstanceInfo*>(pInstance->GetConsumerData(0));
-            assert(instance_info != nullptr);
+VkResult
+VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
+                                                 const StructPointerDecoder<Decoded_VkInstanceCreateInfo>*  pCreateInfo,
+                                                 const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                                                 HandlePointerDecoder<VkInstance>*                          pInstance)
+{
+    assert((pInstance != nullptr) && !pInstance->IsNull() && (pInstance->GetHandlePointer() != nullptr) &&
+           (pCreateInfo != nullptr) && (pCreateInfo->GetPointer() != nullptr));
 
-            instance_info->api_version = modified_create_info.pApplicationInfo->apiVersion;
-            instance_info->enabled_extensions.assign(modified_create_info.ppEnabledExtensionNames,
-                                                     modified_create_info.ppEnabledExtensionNames +
-                                                         modified_create_info.enabledExtensionCount);
-        }
+    CreateInstanceInfoState create_state = ModifyCreateInstanceInfo(pCreateInfo);
+
+    VkInstance* replay_instance = pInstance->GetHandlePointer();
+    assert(replay_instance);
+    *replay_instance = VK_NULL_HANDLE;
+
+    VkResult    result =
+        create_instance_proc_(&create_state.modified_create_info, GetAllocationCallbacks(pAllocator), replay_instance);
+
+    if ((*replay_instance != VK_NULL_HANDLE) && (result == VK_SUCCESS))
+    {
+        auto instance_info = reinterpret_cast<VulkanInstanceInfo*>(pInstance->GetConsumerData(0));
+        assert(instance_info);
+        PostCreateInstanceUpdateState(*replay_instance, create_state.modified_create_info, *instance_info);
     }
 
     return result;
 }
 
-VkResult
-VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  original_result,
-                                               VulkanPhysicalDeviceInfo* physical_device_info,
-                                               const StructPointerDecoder<Decoded_VkDeviceCreateInfo>*    pCreateInfo,
-                                               const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
-                                               HandlePointerDecoder<VkDevice>*                            pDevice)
+VulkanReplayConsumerBase::CreateDeviceInfoState
+VulkanReplayConsumerBase::ModifyCreateDeviceInfo(VulkanPhysicalDeviceInfo* physical_device_info,
+                                                 const StructPointerDecoder<Decoded_VkDeviceCreateInfo>* pCreateInfo)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(original_result);
 
-    assert((physical_device_info != nullptr) && (pDevice != nullptr) && !pDevice->IsNull() &&
-           (pDevice->GetHandlePointer() != nullptr) && (pCreateInfo != nullptr));
+    const VkPhysicalDevice physical_device = physical_device_info->handle;
 
-    SelectPhysicalDevice(physical_device_info);
-
-    VkPhysicalDevice        physical_device      = physical_device_info->handle;
-    PFN_vkGetDeviceProcAddr get_device_proc_addr = GetDeviceAddrProc(physical_device);
-    PFN_vkCreateDevice      create_device_proc   = GetCreateDeviceProc(physical_device);
-
-    if ((get_device_proc_addr == nullptr) || (create_device_proc == nullptr))
-    {
-        return VK_ERROR_INITIALIZATION_FAILED;
-    }
-
-    VkResult result         = VK_ERROR_INITIALIZATION_FAILED;
     auto     instance_table = GetInstanceTable(physical_device);
     assert(instance_table != nullptr);
 
     auto replay_create_info = pCreateInfo->GetPointer();
-    auto replay_device      = pDevice->GetHandlePointer();
     assert(replay_create_info != nullptr);
 
-    VkDeviceCreateInfo       modified_create_info = (*replay_create_info);
-    std::vector<const char*> modified_extensions;
+    CreateDeviceInfoState          state;
+    VkDeviceCreateInfo&            modified_create_info              = state.modified_create_info;
+    std::vector<const char*>&      modified_extensions               = state.modified_extensions;
+    std::vector<VkPhysicalDevice>& replay_device_group               = state.replay_device_group;
+    VkDeviceGroupDeviceCreateInfo& modified_device_group_create_info = state.modified_device_group_create_info;
+
+    modified_create_info = (*replay_create_info);
 
     // Attempt to recreate capture device group with replay device group
 
@@ -2571,8 +2576,6 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
         std::copy(handle_ids, handle_ids + len, std::back_inserter(capture_device_group));
     }
 
-    VkDeviceGroupDeviceCreateInfo modified_device_group_create_info = {};
-    std::vector<VkPhysicalDevice> replay_device_group;
     const VkBaseInStructure* replay_previous_next = reinterpret_cast<const VkBaseInStructure*>(&modified_create_info);
     const VkBaseInStructure* replay_next = reinterpret_cast<const VkBaseInStructure*>(modified_create_info.pNext);
 
@@ -2609,7 +2612,7 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
     }
 
     // Enable extensions used for loading resources during initial state setup for trimmed files.
-    std::vector<std::string> trim_extensions;
+    std::vector<std::string>& trim_extensions = state.trim_extensions;
     if (loading_trim_state_ && CheckTrimDeviceExtensions(physical_device, &trim_extensions))
     {
         for (const auto& extension : trim_extensions)
@@ -2671,8 +2674,7 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
     modified_create_info.ppEnabledExtensionNames = modified_extensions.data();
 
     // Enable necessary features
-    graphics::VulkanDeviceUtil                device_util;
-    graphics::VulkanDevicePropertyFeatureInfo property_feature_info = device_util.EnableRequiredPhysicalDeviceFeatures(
+    state.property_feature_info = state.device_util.EnableRequiredPhysicalDeviceFeatures(
         physical_device_info->parent_api_version, instance_table, physical_device, &modified_create_info);
 
     // Remove unsupported features
@@ -2686,22 +2688,26 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
                                                options_.remove_unsupported_features);
     }
 
-    // Forward device creation to next layer/driver
-    result =
-        create_device_proc(physical_device, &modified_create_info, GetAllocationCallbacks(pAllocator), replay_device);
+    return state;
+}
 
-    if ((replay_device == nullptr) || (result != VK_SUCCESS))
+VkResult VulkanReplayConsumerBase::PostCreateDeviceUpdateState(VulkanPhysicalDeviceInfo* physical_device_info,
+                                                               const VkDevice            replay_device,
+                                                               CreateDeviceInfoState&    create_state,
+                                                               VulkanDeviceInfo*         device_info)
+{
+    VkPhysicalDevice        physical_device      = physical_device_info->handle;
+    PFN_vkGetDeviceProcAddr get_device_proc_addr = GetDeviceAddrProc(physical_device);
+    if (get_device_proc_addr == nullptr)
     {
-        return result;
+        return VK_ERROR_INITIALIZATION_FAILED;
     }
+    AddDeviceTable(replay_device, get_device_proc_addr);
 
-    AddDeviceTable(*replay_device, get_device_proc_addr);
-
-    auto device_info = reinterpret_cast<VulkanDeviceInfo*>(pDevice->GetConsumerData(0));
     assert(device_info != nullptr);
 
-    device_info->replay_device_group = std::move(replay_device_group);
-    device_info->extensions          = std::move(trim_extensions);
+    device_info->replay_device_group = std::move(create_state.replay_device_group);
+    device_info->extensions          = std::move(create_state.trim_extensions);
     device_info->parent              = physical_device;
 
     // Create the memory allocator for the selected physical device.
@@ -2720,32 +2726,32 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
 
     auto allocator = options_.create_resource_allocator();
 
-    std::vector<std::string> enabled_extensions(modified_create_info.ppEnabledExtensionNames,
-                                                modified_create_info.ppEnabledExtensionNames +
-                                                    modified_create_info.enabledExtensionCount);
-    InitializeResourceAllocator(physical_device_info, *replay_device, enabled_extensions, allocator);
+    std::vector<std::string> enabled_extensions(create_state.modified_create_info.ppEnabledExtensionNames,
+                                                create_state.modified_create_info.ppEnabledExtensionNames +
+                                                    create_state.modified_create_info.enabledExtensionCount);
+    InitializeResourceAllocator(physical_device_info, replay_device, enabled_extensions, allocator);
 
     device_info->allocator = std::unique_ptr<VulkanResourceAllocator>(allocator);
 
     // Track state of physical device properties and features at device creation
-    device_info->property_feature_info = property_feature_info;
+    device_info->property_feature_info = create_state.property_feature_info;
 
     // Keep track of what queue families this device is planning on using.  This information is
     // very important if we end up using the VulkanVirtualSwapchain path.
     auto max = [](uint32_t current_max, const VkDeviceQueueCreateInfo& dqci) {
         return std::max(current_max, dqci.queueFamilyIndex);
     };
-    uint32_t max_queue_family =
-        std::accumulate(modified_create_info.pQueueCreateInfos,
-                        modified_create_info.pQueueCreateInfos + modified_create_info.queueCreateInfoCount,
-                        0,
-                        max);
+    uint32_t max_queue_family = std::accumulate(create_state.modified_create_info.pQueueCreateInfos,
+                                                create_state.modified_create_info.pQueueCreateInfos +
+                                                    create_state.modified_create_info.queueCreateInfoCount,
+                                                0,
+                                                max);
     device_info->queue_family_index_enabled.clear();
     device_info->queue_family_index_enabled.resize(max_queue_family + 1, false);
 
-    for (uint32_t q = 0; q < modified_create_info.queueCreateInfoCount; ++q)
+    for (uint32_t q = 0; q < create_state.modified_create_info.queueCreateInfoCount; ++q)
     {
-        const VkDeviceQueueCreateInfo* queue_create_info = &modified_create_info.pQueueCreateInfos[q];
+        const VkDeviceQueueCreateInfo* queue_create_info = &create_state.modified_create_info.pQueueCreateInfos[q];
         assert(device_info->queue_family_creation_flags.find(queue_create_info->queueFamilyIndex) ==
                device_info->queue_family_creation_flags.end());
         device_info->queue_family_creation_flags[queue_create_info->queueFamilyIndex] = queue_create_info->flags;
@@ -2753,8 +2759,53 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
     }
 
     // Restore modified property/feature create info values to the original application values
-    device_util.RestoreModifiedPhysicalDeviceFeatures();
+    create_state.device_util.RestoreModifiedPhysicalDeviceFeatures();
 
+    return VK_SUCCESS;
+}
+
+VkResult
+VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  original_result,
+                                               VulkanPhysicalDeviceInfo* physical_device_info,
+                                               const StructPointerDecoder<Decoded_VkDeviceCreateInfo>*    pCreateInfo,
+                                               const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                                               HandlePointerDecoder<VkDevice>*                            pDevice)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(original_result);
+
+    assert((physical_device_info != nullptr) && (pDevice != nullptr) && !pDevice->IsNull() &&
+           (pDevice->GetHandlePointer() != nullptr) && (pCreateInfo != nullptr));
+
+    // NOTE: This must be first as it *sets* the physical_device_info->handle to point to the replay physical device
+    SelectPhysicalDevice(physical_device_info);
+
+    VkPhysicalDevice physical_device = physical_device_info->handle;
+
+    PFN_vkCreateDevice create_device_proc = GetCreateDeviceProc(physical_device);
+
+    if (create_device_proc == nullptr)
+    {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    // Update the create info to reflect the expectations/limitations of the replaying system (and of GFXR)
+    CreateDeviceInfoState create_state = ModifyCreateDeviceInfo(physical_device_info, pCreateInfo);
+
+    auto replay_device = pDevice->GetHandlePointer();
+    assert(replay_device);
+
+    // Forward device creation to next layer/driver
+    VkResult result = create_device_proc(
+        physical_device, &create_state.modified_create_info, GetAllocationCallbacks(pAllocator), replay_device);
+
+    if ((*replay_device == VK_NULL_HANDLE) || (result != VK_SUCCESS))
+    {
+        return result;
+    }
+
+    VulkanDeviceInfo* device_info = reinterpret_cast<VulkanDeviceInfo*>(pDevice->GetConsumerData(0));
+    assert(device_info);
+    result = PostCreateDeviceUpdateState(physical_device_info, *replay_device, create_state, device_info);
     return result;
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -270,6 +270,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         return get_instance_proc_addr_;
     }
 
+    void SetPhysicalDeviceAlias(format::HandleId instance, VulkanPhysicalDeviceInfo& replay_physical_device);
+
+    // Need the side effects from this when creating vulkan devices from OpenXr
+    void GetMatchingDevice(VulkanPhysicalDeviceInfo* physical_device_info);
+
   protected:
     const CommonObjectInfoTable& GetObjectInfoTable() const { return *object_info_table_; }
 

--- a/framework/encode/custom_openxr_encoder_commands.h
+++ b/framework/encode/custom_openxr_encoder_commands.h
@@ -58,6 +58,18 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_xrGetVulkanGraphicsDevice
                                  VkPhysicalDevice*     vkPhysicalDevice);
 };
 
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_xrGetVulkanGraphicsDevice2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(OpenXrCaptureManager*, Args...)
+    {}
+    static void PreLockReentrant(OpenXrCaptureManager*                   manager,
+                                 XrInstance                              instance,
+                                 const XrVulkanGraphicsDeviceGetInfoKHR* getInfo,
+                                 VkPhysicalDevice*                       vulkanPhysicalDevice);
+};
+
 template <format::ApiCallId Id>
 struct CustomEncoderPostCall
 {

--- a/framework/encode/custom_openxr_struct_encoders.cpp
+++ b/framework/encode/custom_openxr_struct_encoders.cpp
@@ -39,7 +39,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVulkanInstanceCreateInfoKHR
 {
     encoder->EncodeEnumValue(value.type);
     EncodeNextStruct(encoder, value.next);
-    encoder->EncodeUInt64Value(value.systemId);
+    encoder->EncodeOpenXrAtomValue<openxr_wrappers::SystemIdWrapper>(value.systemId);
     encoder->EncodeFlags64Value(value.createFlags);
     encoder->EncodeFunctionPtr(value.pfnGetInstanceProcAddr);
     EncodeStructPtr(encoder, value.vulkanCreateInfo);
@@ -50,7 +50,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVulkanDeviceCreateInfoKHR& 
 {
     encoder->EncodeEnumValue(value.type);
     EncodeNextStruct(encoder, value.next);
-    encoder->EncodeUInt64Value(value.systemId);
+    encoder->EncodeOpenXrAtomValue<openxr_wrappers::SystemIdWrapper>(value.systemId);
     encoder->EncodeFlags64Value(value.createFlags);
     encoder->EncodeFunctionPtr(value.pfnGetInstanceProcAddr);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(value.vulkanPhysicalDevice);

--- a/framework/generated/generated_openxr_replay_consumer.cpp
+++ b/framework/generated/generated_openxr_replay_consumer.cpp
@@ -1123,50 +1123,6 @@ void OpenXrReplayConsumer::Process_xrConvertTimeToTimespecTimeKHR(
 }
 
 
-void OpenXrReplayConsumer::Process_xrCreateVulkanInstanceKHR(
-    const ApiCallInfo&                          call_info,
-    XrResult                                    returnValue,
-    format::HandleId                            instance,
-    StructPointerDecoder<Decoded_XrVulkanInstanceCreateInfoKHR>* createInfo,
-    HandlePointerDecoder<VkInstance>*           vulkanInstance,
-    PointerDecoder<VkResult>*                   vulkanResult)
-{
-    XrInstance in_instance = MapHandle<OpenXrInstanceInfo>(instance, &CommonObjectInfoTable::GetXrInstanceInfo);
-    const XrVulkanInstanceCreateInfoKHR* in_createInfo = createInfo->GetPointer();
-    MapStructHandles(createInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    if (!vulkanInstance->IsNull()) { vulkanInstance->SetHandleLength(1); }
-    VkInstance* out_vulkanInstance = vulkanInstance->GetHandlePointer();
-    VkResult* out_vulkanResult = vulkanResult->IsNull() ? nullptr : vulkanResult->AllocateOutputData(1, static_cast<VkResult>(0));
-
-    XrResult replay_result = GetInstanceTable(in_instance)->CreateVulkanInstanceKHR(in_instance, in_createInfo, out_vulkanInstance, out_vulkanResult);
-    CheckResult("xrCreateVulkanInstanceKHR", returnValue, replay_result, call_info);
-
-    AddHandle<VulkanInstanceInfo>(instance, vulkanInstance->GetPointer(), out_vulkanInstance, &CommonObjectInfoTable::AddVkInstanceInfo);
-    CustomProcess<format::ApiCallId::ApiCall_xrCreateVulkanInstanceKHR>::UpdateState(this, call_info, returnValue, instance, createInfo, vulkanInstance, vulkanResult, replay_result);
-}
-
-void OpenXrReplayConsumer::Process_xrCreateVulkanDeviceKHR(
-    const ApiCallInfo&                          call_info,
-    XrResult                                    returnValue,
-    format::HandleId                            instance,
-    StructPointerDecoder<Decoded_XrVulkanDeviceCreateInfoKHR>* createInfo,
-    HandlePointerDecoder<VkDevice>*             vulkanDevice,
-    PointerDecoder<VkResult>*                   vulkanResult)
-{
-    XrInstance in_instance = MapHandle<OpenXrInstanceInfo>(instance, &CommonObjectInfoTable::GetXrInstanceInfo);
-    const XrVulkanDeviceCreateInfoKHR* in_createInfo = createInfo->GetPointer();
-    MapStructHandles(createInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    if (!vulkanDevice->IsNull()) { vulkanDevice->SetHandleLength(1); }
-    VkDevice* out_vulkanDevice = vulkanDevice->GetHandlePointer();
-    VkResult* out_vulkanResult = vulkanResult->IsNull() ? nullptr : vulkanResult->AllocateOutputData(1, static_cast<VkResult>(0));
-
-    XrResult replay_result = GetInstanceTable(in_instance)->CreateVulkanDeviceKHR(in_instance, in_createInfo, out_vulkanDevice, out_vulkanResult);
-    CheckResult("xrCreateVulkanDeviceKHR", returnValue, replay_result, call_info);
-
-    AddHandle<VulkanDeviceInfo>(instance, vulkanDevice->GetPointer(), out_vulkanDevice, &CommonObjectInfoTable::AddVkDeviceInfo);
-    CustomProcess<format::ApiCallId::ApiCall_xrCreateVulkanDeviceKHR>::UpdateState(this, call_info, returnValue, instance, createInfo, vulkanDevice, vulkanResult, replay_result);
-}
-
 void OpenXrReplayConsumer::Process_xrGetVulkanGraphicsDevice2KHR(
     const ApiCallInfo&                          call_info,
     XrResult                                    returnValue,

--- a/framework/generated/generated_openxr_replay_consumer.h
+++ b/framework/generated/generated_openxr_replay_consumer.h
@@ -495,22 +495,6 @@ class OpenXrReplayConsumer : public OpenXrReplayConsumerBase
         XrTime                                      time,
         StructPointerDecoder<Decoded_timespec>*     timespecTime) override;
 
-    virtual void Process_xrCreateVulkanInstanceKHR(
-        const ApiCallInfo&                          call_info,
-        XrResult                                    returnValue,
-        format::HandleId                            instance,
-        StructPointerDecoder<Decoded_XrVulkanInstanceCreateInfoKHR>* createInfo,
-        HandlePointerDecoder<VkInstance>*           vulkanInstance,
-        PointerDecoder<VkResult>*                   vulkanResult) override;
-
-    virtual void Process_xrCreateVulkanDeviceKHR(
-        const ApiCallInfo&                          call_info,
-        XrResult                                    returnValue,
-        format::HandleId                            instance,
-        StructPointerDecoder<Decoded_XrVulkanDeviceCreateInfoKHR>* createInfo,
-        HandlePointerDecoder<VkDevice>*             vulkanDevice,
-        PointerDecoder<VkResult>*                   vulkanResult) override;
-
     virtual void Process_xrGetVulkanGraphicsDevice2KHR(
         const ApiCallInfo&                          call_info,
         XrResult                                    returnValue,

--- a/framework/generated/openxr_generators/gencode.py
+++ b/framework/generated/openxr_generators/gencode.py
@@ -699,6 +699,8 @@ def make_gen_opts(args):
                 'xrLocateHandJointsEXT',
                 'xrGetHandMeshFB',
                 'xrLocateBodyJointsFB',
+                'xrCreateVulkanInstanceKHR',
+                'xrCreateVulkanDeviceKHR',
             ]
         )
     ]

--- a/framework/generated/openxr_generators/openxr_replay_consumer_body_generator.py
+++ b/framework/generated/openxr_generators/openxr_replay_consumer_body_generator.py
@@ -110,6 +110,8 @@ class OpenXrReplayConsumerBodyGenerator(
             'xrLocateHandJointsEXT',
             'xrGetHandMeshFB',
             'xrLocateBodyJointsFB',
+            'xrCreateVulkanInstanceKHR',
+            'xrCreateVulkanDeviceKHR',
         ]
 
         # These structures require a customized manager when they are an output struct


### PR DESCRIPTION
Implements #1721.

Decoders
   - XrVulkan*CreateInf::flags decode fixes
Replay
   - Vulkan Replay Consumer
      - Add physical device alias support Set/Get
          - Includes DRY refactor for GetVkObject
      - Add getter for GIPA
      - Refactor CreateInstance and CreateDevice for reuse by OpenXR
   - OpenXr
      - Implement CreateVulkan* functions
      - Add xrGetVulkanGraphicsDevice2KHR support
Encoders
   - Add physical_device enumeration to xrGetVulkanGraphicsDevice2KHR
   - Fix systemID encoding
