### PR TITLE
Adjust output array sizes for D3D12 replay

### DIFF
--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -69,6 +69,23 @@ enum class DxObjectInfoType : uint32_t
 };
 
 //
+// Enumerations for storing variable length array replay sizes.
+//
+enum class VariableLengthArrayIndices : uint32_t
+{
+    kDxgiObjectArrayGetPrivateData = 0,
+    kDxgiOutputArrayGetDisplayModeList,
+    kDxgiOutput1ArrayGetDisplayModeList1,
+    kD3D12ObjectArrayGetPrivateData,
+    kD3D12Device5ArrayEnumerateMetaCommands,
+    kD3D12Device5ArrayEnumerateMetaCommandParameters,
+    kD3D12InfoQueueArrayGetMessage,
+    kD3D12InfoQueueArrayGetStorageFilter,
+    kD3D12InfoQueueArrayGetRetrievalFilter,
+    kD3D12ShaderCacheSessionArrayFindValue
+};
+
+//
 // Structures for storing DirectX object info.
 //
 
@@ -197,11 +214,12 @@ struct DxObjectExtraInfo
 struct DxObjectInfo
 {
     // Standard info stored for all DX objects.
-    IUnknown*                          object{ nullptr };
-    format::HandleId                   capture_id{ format::kNullHandleId };
-    uint64_t                           ref_count{ 1 };
-    uint64_t                           extra_ref{ 0 };
-    std::unique_ptr<DxObjectExtraInfo> extra_info;
+    IUnknown*                                              object{ nullptr };
+    format::HandleId                                       capture_id{ format::kNullHandleId };
+    uint64_t                                               ref_count{ 1 };
+    uint64_t                                               extra_ref{ 0 };
+    std::unique_ptr<DxObjectExtraInfo>                     extra_info;
+    std::unordered_map<VariableLengthArrayIndices, size_t> array_counts;
 };
 
 struct DxgiSwapchainInfo : DxObjectExtraInfo

--- a/framework/generated/dx12_generators/dx12_api_call_encoders_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_api_call_encoders_body_generator.py
@@ -161,7 +161,15 @@ class Dx12ApiCallEncodersBodyGenerator(Dx12ApiCallEncodersHeaderGenerator):
             omit_output_data = ', omit_output_data'
 
         if value.array_length and type(value.array_length) == str:
-            if value.pointer_count == 2:
+            if '_result_bytebuffer_' in value.full_type:
+                # This is a void** pointer to a memory allocation with a size defined by value.array_length,
+                # not a void* array. For this case, we will encode the content of the memory allocation, and
+                # need to dereference the void** pointer.
+                return 'encoder->Encode{}Array(*{}{}, {}{}{});'.format(
+                    function_name, write_parameter_value, value.name,
+                    write_parameter_value, value.array_length, omit_output_data
+                )
+            elif value.pointer_count == 2:
                 method_call = 'Encode{}Array2D'.format(function_name)
                 make_array_2d = ', '.join(self.make_array2d_length_expression(value, caller_values))
                 return 'encoder->{}({}{}, {});'.format(

--- a/framework/generated/dx12_generators/dx12_api_call_encoders_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_api_call_encoders_body_generator.py
@@ -87,6 +87,15 @@ class Dx12ApiCallEncodersBodyGenerator(Dx12ApiCallEncodersHeaderGenerator):
         )
         write(code, file=self.outFile)
 
+    def get_encode_str_array_length(self, array_length, prefix=''):
+        if array_length.startswith('* '):
+            array_length = '({prefix}{} != nullptr) ? {prefix}{} : 0'.format(
+                array_length[2:], array_length.replace(' ', ''), prefix=prefix
+            )
+        else:
+            array_length = prefix + array_length
+        return array_length
+
     def get_encode_struct(self, value, is_generating_struct, is_result):
         """Method override."""
         write_parameter_value = ''
@@ -165,9 +174,12 @@ class Dx12ApiCallEncodersBodyGenerator(Dx12ApiCallEncodersHeaderGenerator):
                 # This is a void** pointer to a memory allocation with a size defined by value.array_length,
                 # not a void* array. For this case, we will encode the content of the memory allocation, and
                 # need to dereference the void** pointer.
-                return 'encoder->Encode{}Array(*{}{}, {}{}{});'.format(
-                    function_name, write_parameter_value, value.name,
-                    write_parameter_value, value.array_length, omit_output_data
+                dereference_expr = '({prefix}{param} != nullptr) ? *{prefix}{param} : nullptr'.format(prefix=write_parameter_value, param=value.name)
+                return 'encoder->Encode{}Array({}, {}{});'.format(
+                    function_name, dereference_expr,
+                    self.get_encode_str_array_length(
+                        value.array_length, write_parameter_value
+                    ), omit_output_data
                 )
             elif value.pointer_count == 2:
                 method_call = 'Encode{}Array2D'.format(function_name)
@@ -176,9 +188,11 @@ class Dx12ApiCallEncodersBodyGenerator(Dx12ApiCallEncodersHeaderGenerator):
                     method_call, write_parameter_value, value.name, make_array_2d
                 )
             else:
-                return 'encoder->Encode{}Array({}{}, {}{}{});'.format(
+                return 'encoder->Encode{}Array({}{}, {}{});'.format(
                     function_name, write_parameter_value, value.name,
-                    write_parameter_value, value.array_length, omit_output_data
+                    self.get_encode_str_array_length(
+                        value.array_length, write_parameter_value
+                    ), omit_output_data
                 )
 
         elif value.pointer_count == 1:
@@ -235,10 +249,17 @@ class Dx12ApiCallEncodersBodyGenerator(Dx12ApiCallEncodersHeaderGenerator):
         elif self.is_class(value):
             if value.array_length and type(value.array_length) == str:
                 if is_generating_struct:
-                    pass
+                    rtn = 'encoder->EncodeObjectArray(value.{}, {}{});'.format(
+                        value.name,
+                        self.get_encode_str_array_length(
+                            value.array_length, 'value.'
+                        ), omit_output_data
+                    )
                 else:
                     rtn = 'encoder->EncodeObjectArray({}, {}{});'.format(
-                        value.name, value.array_length, omit_output_data
+                        value.name,
+                        self.get_encode_str_array_length(value.array_length),
+                        omit_output_data
                     )
             else:
                 if is_generating_struct:

--- a/framework/generated/dx12_generators/dx12_base_generator.py
+++ b/framework/generated/dx12_generators/dx12_base_generator.py
@@ -689,6 +689,7 @@ class Dx12BaseGenerator(BaseGenerator):
         return structs_with_objects
 
     def is_output(self, value):
-        if value.full_type.find('_Out') != -1:
+        if (value.full_type.find('_Out') !=
+            -1) or (value.full_type.find('_Inout') != -1):
             return True
         return False

--- a/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
@@ -349,8 +349,14 @@ class Dx12ReplayConsumerBodyGenerator(
             else:
                 if is_output:
                     length = '1'
-                    if value.array_length:
-                        if isinstance(value.array_length, str) and value.array_length[0] == '*':
+                    # The _result_bytebuffer_ annotation indicates that the parameter is a pointer to a
+                    # pointer to a buffer allocated by the runtime/driver. For this case, only the single
+                    # pointer to the output buffer needs to be allocated.
+                    if value.array_length and (
+                        not '_result_bytebuffer_' in value.full_type
+                    ):
+                        if isinstance(value.array_length,
+                                      str) and value.array_length[0] == '*':
                             length = value.array_length + '->GetPointer()'
                         else:
                             length = value.array_length

--- a/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
@@ -60,6 +60,17 @@ class Dx12ReplayConsumerBodyGenerator(
 
     REPLAY_OVERRIDES = {}
 
+    # API calls with variable length array semantics, with an inout pointer
+    # to an array size that retrieves the expected size of the array when the
+    # pointer to the array is null, but do not have the array pointer labeled
+    # with the 'opt' SAL marking. For these functions, we assume that 'opt' was
+    # accidentally omitted and that the function should be treated as if the
+    # 'opt' were present.
+    EXTRA_VARIABLE_LENGTH_ARRAYS = {
+        'IDXGIObject_GetPrivateData': ['pData'],
+        'ID3D12ShaderCacheSession_FindValue': ['pValue']
+    }
+
     def __init__(
         self,
         source_dict,
@@ -174,6 +185,8 @@ class Dx12ReplayConsumerBodyGenerator(
         add_object_list = []
         set_resource_dimension_layout_list = []
         struct_add_object_list = []
+        pre_call_expr_list = []
+        post_call_expr_list = []
         post_extenal_object_list = []
 
         is_override = name in self.REPLAY_OVERRIDES
@@ -205,6 +218,18 @@ class Dx12ReplayConsumerBodyGenerator(
         code = code[:-1]
         code += ");\n"
 
+        # Generate a dictionary of variable length array size parameter info to be used with
+        # storing and retrieving the array sizes returned by API calls that return the expected
+        # size of the array when the array parameter is null.
+        variable_array_lengths = {}
+        for value in values:
+            if self.is_variable_length_array(name, value):
+                base_length_name = value.array_length.replace('* ', '')
+                variable_array_lengths[base_length_name] = {
+                    'array_value': value,
+                    'length_value': self.find_value(base_length_name, values)
+                }
+
         for value in values:
             is_class = self.is_class(value)
             is_extenal_object = (
@@ -212,12 +237,33 @@ class Dx12ReplayConsumerBodyGenerator(
             ) and not value.is_array
             is_output = self.is_output(value)
             is_struct = self.is_struct(value.base_type)
+            is_variable_length_array = self.is_variable_length_array(
+                name, value
+            )
 
-            if is_output and value.base_type in self.structs_with_objects:
-                struct_add_object_list.append(
-                    'AddStructObjects({0}, {0}->GetPointer(), GetObjectInfoTable());\n'
-                    .format(value.name)
-                )
+            if is_output:
+                if value.base_type in self.structs_with_objects:
+                    struct_add_object_list.append(
+                        'AddStructObjects({0}, {0}->GetPointer(), GetObjectInfoTable());\n'
+                        .format(value.name)
+                    )
+                elif is_variable_length_array:
+                    # This is an optional output array with an array size parameter that is
+                    # also a pointer. This array parameter may adhere to a pattern that, when
+                    # it is null, the API call will return the expected input array size in
+                    # the value pointed to by the array size parameter. In this case, we can
+                    # store the value returned here and use it to allocate an array of this
+                    # stored size on the next call when the array pointer is not null.
+                    if is_object:
+                        post_call_expr_list.append(
+                            self.make_variable_length_array_post_expr(
+                                name, value
+                            )
+                        )
+                    else:
+                        print(
+                            "ERROR: Variable length output array size tracking is not implemented for function calls."
+                        )
 
             if is_class:
                 if is_output:
@@ -348,21 +394,43 @@ class Dx12ReplayConsumerBodyGenerator(
                     arg_list.append('*{}.decoded_value'.format(value.name))
             else:
                 if is_output:
-                    length = '1'
-                    # The _result_bytebuffer_ annotation indicates that the parameter is a pointer to a
-                    # pointer to a buffer allocated by the runtime/driver. For this case, only the single
-                    # pointer to the output buffer needs to be allocated.
-                    if value.array_length and (
-                        not '_result_bytebuffer_' in value.full_type
-                    ):
-                        if isinstance(value.array_length,
-                                      str) and value.array_length[0] == '*':
-                            length = value.array_length + '->GetPointer()'
-                        else:
-                            length = value.array_length
-                    code += '    if(!{}->IsNull())\n    {{\n        {}->AllocateOutputData({});\n    }}\n'.format(
-                        value.name, value.name, length
-                    )
+                    if is_variable_length_array:
+                        length = value.array_length.replace('* ', '')
+                        # Ensure that the array's output data initialization expression is written to the
+                        # file after the size parameter is initialized, storing the expression string now
+                        # and appending it to the code string immediately before generating the API call,
+                        # after all other parameters have been processed.
+                        pre_call_expr_list.append(
+                            '    if(!{}->IsNull() && !{}->IsNull())\n    {{\n        {}->AllocateOutputData({}->GetOutputPointer());\n    }}\n'
+                            .format(
+                                value.name, length, value.name,
+                                value.array_length.replace(' ', '')
+                            )
+                        )
+                    elif value.name in variable_array_lengths:
+                        code += '    if(!{}->IsNull())\n    {{\n        {}->AllocateOutputData(1, {});\n    }}\n'.format(
+                            value.name, value.name,
+                            self.make_variable_length_array_get_count_call(
+                                return_type, name,
+                                **variable_array_lengths[value.name]
+                            )
+                        )
+                    else:
+                        length = '1'
+                        # The _result_bytebuffer_ annotation indicates that the parameter is a pointer to a
+                        # pointer to a buffer allocated by the runtime/driver. For this case, only the single
+                        # pointer to the output buffer needs to be allocated.
+                        if value.array_length and (
+                            not '_result_bytebuffer_' in value.full_type
+                        ):
+                            if isinstance(value.array_length, str
+                                          ) and value.array_length[0] == '*':
+                                length = value.array_length + '->GetPointer()'
+                            else:
+                                length = value.array_length
+                        code += '    if(!{}->IsNull())\n    {{\n        {}->AllocateOutputData({});\n    }}\n'.format(
+                            value.name, value.name, length
+                        )
                 else:
                     map_func = self.MAP_STRUCT_TYPE.get(value.base_type)
                     if map_func:
@@ -431,6 +499,9 @@ class Dx12ReplayConsumerBodyGenerator(
 
                     else:
                         arg_list.append(value.name)
+
+        for e in pre_call_expr_list:
+            code += e
 
         indent_length = len(code)
         code += '    '
@@ -508,6 +579,9 @@ class Dx12ReplayConsumerBodyGenerator(
                 "    }\n"
             )
            
+        for e in post_call_expr_list:
+            code += '    {}'.format(e)
+
         if len(add_object_list) or len(struct_add_object_list):
             scope_indent = '    '
             if return_type == 'HRESULT':
@@ -547,6 +621,55 @@ class Dx12ReplayConsumerBodyGenerator(
         for e in post_extenal_object_list:
             code += '    {}'.format(e)
         return code
+
+    def find_value(self, name, values):
+        for value in values:
+            if value.name == name:
+                return value
+
+    def is_variable_length_array(self, name, value):
+        return value.is_array and value.array_length and isinstance(
+            value.array_length, str
+        ) and value.array_length.startswith('*') and (
+            ('_opt_' in value.full_type) or (
+                (name in self.EXTRA_VARIABLE_LENGTH_ARRAYS) and
+                (value.name in self.EXTRA_VARIABLE_LENGTH_ARRAYS[name])
+            )
+        )
+
+    def get_variable_length_array_index_id(self, name):
+        class_name = name[:name.find('_')][1:].replace('DXGI', 'Dxgi')
+        method_name = name[name.find('_') + 1:]
+        index_id = 'VariableLengthArrayIndices::k{}Array{}'.format(
+            class_name, method_name
+        )
+        return index_id
+
+    def make_variable_length_array_post_expr(self, name, value):
+        """Generate expressions to store the result of the count query for an array containing a variable number of values."""
+        index_id = self.get_variable_length_array_index_id(name)
+
+        length_name = value.array_length
+        base_length_name = length_name.replace('* ', '')
+        return 'if ({}->IsNull() && !{}->IsNull()) {{ SetOutputArrayCount(object_id, {}, {}->GetOutputPointer()); }}\n'.format(
+            value.name, base_length_name, index_id,
+            length_name.replace(' ', '')
+        )
+
+    def make_variable_length_array_get_count_call(
+        self, return_type, name, array_value, length_value
+    ):
+        """Generate expression to call a function that retrieves the count of an array containing a variable number of values."""
+        return_value = 'S_OK'
+        if (return_type == 'HRESULT'):
+            return_value = 'return_value'
+
+        index_id = self.get_variable_length_array_index_id(name)
+
+        return 'GetOutputArrayCount("{}", {}, object_id, {}, {}, {})'.format(
+            name.replace('_', '::'), return_value, index_id, length_value.name,
+            array_value.name
+        )
 
     def __load_replay_overrides(self, filename):
         overrides = json.loads(open(filename, 'r').read())

--- a/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
@@ -502,18 +502,22 @@ class Dx12ReplayConsumerBodyGenerator(
                 "    }\n"
             )
            
-        if return_type == 'HRESULT':
-            if len(add_object_list) or len(struct_add_object_list):
-                code += ("    if (SUCCEEDED(replay_result))\n" "    {\n")
-                for e in add_object_list:
+        if len(add_object_list) or len(struct_add_object_list):
+            scope_indent = '    '
+            if return_type == 'HRESULT':
+                code += "    if (SUCCEEDED(replay_result))\n    {\n"
+                scope_indent += '    '
+            for e in add_object_list:
+                code += scope_indent + '{}'.format(e)
+            for e in struct_add_object_list:
+                code += scope_indent + '{}'.format(e)
+            if is_resource_creation_methods:
+                for e in set_resource_dimension_layout_list:
                     code += '        {}'.format(e)
-                for e in struct_add_object_list:
-                    code += '        {}'.format(e)
-                if is_resource_creation_methods:
-                    for e in set_resource_dimension_layout_list:
-                        code += '        {}'.format(e)
+            if return_type == 'HRESULT':
                 code += "    }\n"
 
+        if return_type == 'HRESULT':
             code += (
                 '    CheckReplayResult("{}", return_value, replay_result);\n'.
                 format(name)

--- a/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
@@ -425,7 +425,10 @@ class Dx12ReplayConsumerBodyGenerator(
                         ):
                             if isinstance(value.array_length, str
                                           ) and value.array_length[0] == '*':
-                                length = value.array_length + '->GetPointer()'
+                                length = '!{}->IsNull() ? {}->GetPointer() : 0'.format(
+                                    value.array_length.replace('* ', ''),
+                                    value.array_length.replace(' ', '')
+                                )
                             else:
                                 length = value.array_length
                         code += '    if(!{}->IsNull())\n    {{\n        {}->AllocateOutputData({});\n    }}\n'.format(

--- a/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
@@ -328,8 +328,13 @@ class Dx12WrapperBodyGenerator(Dx12BaseGenerator):
                         tuple[0], tuple[1]
                     )
                 else:
+                    array_length = tuple[2]
+                    if array_length.startswith('* '):
+                        array_length = '({} != nullptr) ? {} : 0'.format(
+                            array_length[2:], array_length.replace(' ', '')
+                        )
                     expr += indent + 'WrapObjectArray({}, {}, {}, nullptr);\n'.format(
-                        tuple[0], tuple[1], tuple[2]
+                        tuple[0], tuple[1], array_length
                     )
 
             for value in params_wrap_struct:

--- a/framework/generated/generated_dx12_api_call_encoders.cpp
+++ b/framework/generated/generated_dx12_api_call_encoders.cpp
@@ -215,7 +215,7 @@ void Encode_IDXGIObject_GetPrivateData(
         }
         EncodeStruct(encoder, Name);
         encoder->EncodeUInt32Ptr(pDataSize, omit_output_data);
-        encoder->EncodeVoidArray(pData, * pDataSize, omit_output_data);
+        encoder->EncodeVoidArray(pData, (pDataSize != nullptr) ? *pDataSize : 0, omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
     }
@@ -3850,7 +3850,7 @@ void Encode_ID3D12Object_GetPrivateData(
         }
         EncodeStruct(encoder, guid);
         encoder->EncodeUInt32Ptr(pDataSize, omit_output_data);
-        encoder->EncodeVoidArray(pData, * pDataSize, omit_output_data);
+        encoder->EncodeVoidArray(pData, (pDataSize != nullptr) ? *pDataSize : 0, omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
     }
@@ -9076,7 +9076,7 @@ void Encode_ID3D12ShaderCacheSession_FindValue(
         }
         encoder->EncodeVoidArray(pKey, KeySize);
         encoder->EncodeUInt32Value(KeySize);
-        encoder->EncodeVoidArray(pValue, * pValueSize, omit_output_data);
+        encoder->EncodeVoidArray(pValue, (pValueSize != nullptr) ? *pValueSize : 0, omit_output_data);
         encoder->EncodeUInt32Ptr(pValueSize, omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();

--- a/framework/generated/generated_dx12_api_call_encoders.cpp
+++ b/framework/generated/generated_dx12_api_call_encoders.cpp
@@ -214,7 +214,7 @@ void Encode_IDXGIObject_GetPrivateData(
             omit_output_data = true;
         }
         EncodeStruct(encoder, Name);
-        encoder->EncodeUInt32Ptr(pDataSize);
+        encoder->EncodeUInt32Ptr(pDataSize, omit_output_data);
         encoder->EncodeVoidArray(pData, * pDataSize, omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
@@ -574,7 +574,7 @@ void Encode_IDXGIOutput_GetDisplayModeList(
         }
         encoder->EncodeEnumValue(EnumFormat);
         encoder->EncodeUInt32Value(Flags);
-        encoder->EncodeUInt32Ptr(pNumModes);
+        encoder->EncodeUInt32Ptr(pNumModes, omit_output_data);
         EncodeStructArray(encoder, pDesc, ((pNumModes == nullptr) ? 0 : *pNumModes), omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
@@ -2188,7 +2188,7 @@ void Encode_IDXGIOutput1_GetDisplayModeList1(
         }
         encoder->EncodeEnumValue(EnumFormat);
         encoder->EncodeUInt32Value(Flags);
-        encoder->EncodeUInt32Ptr(pNumModes);
+        encoder->EncodeUInt32Ptr(pNumModes, omit_output_data);
         EncodeStructArray(encoder, pDesc, ((pNumModes == nullptr) ? 0 : *pNumModes), omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
@@ -3849,7 +3849,7 @@ void Encode_ID3D12Object_GetPrivateData(
             omit_output_data = true;
         }
         EncodeStruct(encoder, guid);
-        encoder->EncodeUInt32Ptr(pDataSize);
+        encoder->EncodeUInt32Ptr(pDataSize, omit_output_data);
         encoder->EncodeVoidArray(pData, * pDataSize, omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
@@ -8100,7 +8100,7 @@ void Encode_ID3D12Device5_EnumerateMetaCommands(
         {
             omit_output_data = true;
         }
-        encoder->EncodeUInt32Ptr(pNumMetaCommands);
+        encoder->EncodeUInt32Ptr(pNumMetaCommands, omit_output_data);
         EncodeStructArray(encoder, pDescs, ((pNumMetaCommands == nullptr) ? 0 : *pNumMetaCommands), omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
@@ -8127,7 +8127,7 @@ void Encode_ID3D12Device5_EnumerateMetaCommandParameters(
         EncodeStruct(encoder, CommandId);
         encoder->EncodeEnumValue(Stage);
         encoder->EncodeUInt32Ptr(pTotalStructureSizeInBytes, omit_output_data);
-        encoder->EncodeUInt32Ptr(pParameterCount);
+        encoder->EncodeUInt32Ptr(pParameterCount, omit_output_data);
         EncodeStructArray(encoder, pParameterDescs, ((pParameterCount == nullptr) ? 0 : *pParameterCount), omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
@@ -9077,7 +9077,7 @@ void Encode_ID3D12ShaderCacheSession_FindValue(
         encoder->EncodeVoidArray(pKey, KeySize);
         encoder->EncodeUInt32Value(KeySize);
         encoder->EncodeVoidArray(pValue, * pValueSize, omit_output_data);
-        encoder->EncodeUInt32Ptr(pValueSize);
+        encoder->EncodeUInt32Ptr(pValueSize, omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
     }
@@ -10605,7 +10605,7 @@ void Encode_ID3D12InfoQueue_GetMessage(
         }
         encoder->EncodeUInt64Value(MessageIndex);
         EncodeStructArray(encoder, pMessage, ((pMessageByteLength == nullptr) ? 0 : *pMessageByteLength), omit_output_data);
-        encoder->EncodeSizeTPtr(pMessageByteLength);
+        encoder->EncodeSizeTPtr(pMessageByteLength, omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
     }
@@ -10717,7 +10717,7 @@ void Encode_ID3D12InfoQueue_GetStorageFilter(
             omit_output_data = true;
         }
         EncodeStructArray(encoder, pFilter, ((pFilterByteLength == nullptr) ? 0 : *pFilterByteLength), omit_output_data);
-        encoder->EncodeSizeTPtr(pFilterByteLength);
+        encoder->EncodeSizeTPtr(pFilterByteLength, omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
     }
@@ -10842,7 +10842,7 @@ void Encode_ID3D12InfoQueue_GetRetrievalFilter(
             omit_output_data = true;
         }
         EncodeStructArray(encoder, pFilter, ((pFilterByteLength == nullptr) ? 0 : *pFilterByteLength), omit_output_data);
-        encoder->EncodeSizeTPtr(pFilterByteLength);
+        encoder->EncodeSizeTPtr(pFilterByteLength, omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
     }
@@ -11127,7 +11127,7 @@ void Encode_ID3D12InfoQueue1_RegisterMessageCallback(
         encoder->EncodeFunctionPtr(CallbackFunc);
         encoder->EncodeEnumValue(CallbackFilterFlags);
         encoder->EncodeVoidPtr(pContext);
-        encoder->EncodeUInt32Ptr(pCallbackCookie);
+        encoder->EncodeUInt32Ptr(pCallbackCookie, omit_output_data);
         encoder->EncodeInt32Value(return_value);
         D3D12CaptureManager::Get()->EndMethodCallCapture();
     }

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -522,12 +522,16 @@ void Dx12ReplayConsumer::Process_IDXGIObject_GetPrivateData(
             Name,
             pDataSize,
             pData);
+        if(!pDataSize->IsNull())
+        {
+            pDataSize->AllocateOutputData(1);
+        }
         if(!pData->IsNull())
         {
             pData->AllocateOutputData(* pDataSize->GetPointer());
         }
         auto replay_result = reinterpret_cast<IDXGIObject*>(replay_object->object)->GetPrivateData(*Name.decoded_value,
-                                                                                                   pDataSize->GetPointer(),
+                                                                                                   pDataSize->GetOutputPointer(),
                                                                                                    pData->GetOutputPointer());
         CheckReplayResult("IDXGIObject_GetPrivateData", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIObject_GetPrivateData>::Dispatch(
@@ -1052,13 +1056,17 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetDisplayModeList(
             Flags,
             pNumModes,
             pDesc);
+        if(!pNumModes->IsNull())
+        {
+            pNumModes->AllocateOutputData(1);
+        }
         if(!pDesc->IsNull())
         {
             pDesc->AllocateOutputData(* pNumModes->GetPointer());
         }
         auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetDisplayModeList(EnumFormat,
                                                                                                        Flags,
-                                                                                                       pNumModes->GetPointer(),
+                                                                                                       pNumModes->GetOutputPointer(),
                                                                                                        pDesc->GetOutputPointer());
         CheckReplayResult("IDXGIOutput_GetDisplayModeList", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetDisplayModeList>::Dispatch(
@@ -3408,13 +3416,17 @@ void Dx12ReplayConsumer::Process_IDXGIOutput1_GetDisplayModeList1(
             Flags,
             pNumModes,
             pDesc);
+        if(!pNumModes->IsNull())
+        {
+            pNumModes->AllocateOutputData(1);
+        }
         if(!pDesc->IsNull())
         {
             pDesc->AllocateOutputData(* pNumModes->GetPointer());
         }
         auto replay_result = reinterpret_cast<IDXGIOutput1*>(replay_object->object)->GetDisplayModeList1(EnumFormat,
                                                                                                          Flags,
-                                                                                                         pNumModes->GetPointer(),
+                                                                                                         pNumModes->GetOutputPointer(),
                                                                                                          pDesc->GetOutputPointer());
         CheckReplayResult("IDXGIOutput1_GetDisplayModeList1", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput1_GetDisplayModeList1>::Dispatch(
@@ -5027,12 +5039,16 @@ void Dx12ReplayConsumer::Process_ID3D12Object_GetPrivateData(
             guid,
             pDataSize,
             pData);
+        if(!pDataSize->IsNull())
+        {
+            pDataSize->AllocateOutputData(1);
+        }
         if(!pData->IsNull())
         {
             pData->AllocateOutputData(* pDataSize->GetPointer());
         }
         auto replay_result = reinterpret_cast<ID3D12Object*>(replay_object->object)->GetPrivateData(*guid.decoded_value,
-                                                                                                    pDataSize->GetPointer(),
+                                                                                                    pDataSize->GetOutputPointer(),
                                                                                                     pData->GetOutputPointer());
         CheckReplayResult("ID3D12Object_GetPrivateData", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Object_GetPrivateData>::Dispatch(
@@ -9786,6 +9802,10 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetResourceTiling(
         {
             pStandardTileShapeForNonPackedMips->AllocateOutputData(1);
         }
+        if(!pNumSubresourceTilings->IsNull())
+        {
+            pNumSubresourceTilings->AllocateOutputData(1);
+        }
         if(!pSubresourceTilingsForNonPackedMips->IsNull())
         {
             pSubresourceTilingsForNonPackedMips->AllocateOutputData(* pNumSubresourceTilings->GetPointer());
@@ -9794,7 +9814,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetResourceTiling(
                                                                                   pNumTilesForEntireResource->GetOutputPointer(),
                                                                                   pPackedMipDesc->GetOutputPointer(),
                                                                                   pStandardTileShapeForNonPackedMips->GetOutputPointer(),
-                                                                                  pNumSubresourceTilings->GetPointer(),
+                                                                                  pNumSubresourceTilings->GetOutputPointer(),
                                                                                   FirstSubresourceTilingToGet,
                                                                                   pSubresourceTilingsForNonPackedMips->GetOutputPointer());
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetResourceTiling>::Dispatch(
@@ -11036,11 +11056,15 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_EnumerateMetaCommands(
             replay_object,
             pNumMetaCommands,
             pDescs);
+        if(!pNumMetaCommands->IsNull())
+        {
+            pNumMetaCommands->AllocateOutputData(1);
+        }
         if(!pDescs->IsNull())
         {
             pDescs->AllocateOutputData(* pNumMetaCommands->GetPointer());
         }
-        auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->EnumerateMetaCommands(pNumMetaCommands->GetPointer(),
+        auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->EnumerateMetaCommands(pNumMetaCommands->GetOutputPointer(),
                                                                                                             pDescs->GetOutputPointer());
         CheckReplayResult("ID3D12Device5_EnumerateMetaCommands", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommands>::Dispatch(
@@ -11078,6 +11102,10 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_EnumerateMetaCommandParameters(
         {
             pTotalStructureSizeInBytes->AllocateOutputData(1);
         }
+        if(!pParameterCount->IsNull())
+        {
+            pParameterCount->AllocateOutputData(1);
+        }
         if(!pParameterDescs->IsNull())
         {
             pParameterDescs->AllocateOutputData(* pParameterCount->GetPointer());
@@ -11085,7 +11113,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_EnumerateMetaCommandParameters(
         auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->EnumerateMetaCommandParameters(*CommandId.decoded_value,
                                                                                                                      Stage,
                                                                                                                      pTotalStructureSizeInBytes->GetOutputPointer(),
-                                                                                                                     pParameterCount->GetPointer(),
+                                                                                                                     pParameterCount->GetOutputPointer(),
                                                                                                                      pParameterDescs->GetOutputPointer());
         CheckReplayResult("ID3D12Device5_EnumerateMetaCommandParameters", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommandParameters>::Dispatch(
@@ -12443,10 +12471,14 @@ void Dx12ReplayConsumer::Process_ID3D12ShaderCacheSession_FindValue(
         {
             pValue->AllocateOutputData(* pValueSize->GetPointer());
         }
+        if(!pValueSize->IsNull())
+        {
+            pValueSize->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<ID3D12ShaderCacheSession*>(replay_object->object)->FindValue(pKey->GetPointer(),
                                                                                                            KeySize,
                                                                                                            pValue->GetOutputPointer(),
-                                                                                                           pValueSize->GetPointer());
+                                                                                                           pValueSize->GetOutputPointer());
         CheckReplayResult("ID3D12ShaderCacheSession_FindValue", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_FindValue>::Dispatch(
             this,
@@ -14939,9 +14971,13 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetMessage(
         {
             pMessage->AllocateOutputData(* pMessageByteLength->GetPointer());
         }
+        if(!pMessageByteLength->IsNull())
+        {
+            pMessageByteLength->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetMessage(MessageIndex,
                                                                                                    pMessage->GetOutputPointer(),
-                                                                                                   pMessageByteLength->GetPointer());
+                                                                                                   pMessageByteLength->GetOutputPointer());
         CheckReplayResult("ID3D12InfoQueue_GetMessage", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMessage>::Dispatch(
             this,
@@ -15117,8 +15153,12 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetStorageFilter(
         {
             pFilter->AllocateOutputData(* pFilterByteLength->GetPointer());
         }
+        if(!pFilterByteLength->IsNull())
+        {
+            pFilterByteLength->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetStorageFilter(pFilter->GetOutputPointer(),
-                                                                                                         pFilterByteLength->GetPointer());
+                                                                                                         pFilterByteLength->GetOutputPointer());
         CheckReplayResult("ID3D12InfoQueue_GetStorageFilter", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetStorageFilter>::Dispatch(
             this,
@@ -15297,8 +15337,12 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetRetrievalFilter(
         {
             pFilter->AllocateOutputData(* pFilterByteLength->GetPointer());
         }
+        if(!pFilterByteLength->IsNull())
+        {
+            pFilterByteLength->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetRetrievalFilter(pFilter->GetOutputPointer(),
-                                                                                                           pFilterByteLength->GetPointer());
+                                                                                                           pFilterByteLength->GetOutputPointer());
         CheckReplayResult("ID3D12InfoQueue_GetRetrievalFilter", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetRetrievalFilter>::Dispatch(
             this,
@@ -15713,10 +15757,14 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue1_RegisterMessageCallback(
             pContext,
             pCallbackCookie);
         auto in_pContext = PreProcessExternalObject(pContext, format::ApiCallId::ApiCall_ID3D12InfoQueue1_RegisterMessageCallback, "ID3D12InfoQueue1_RegisterMessageCallback");
+        if(!pCallbackCookie->IsNull())
+        {
+            pCallbackCookie->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<ID3D12InfoQueue1*>(replay_object->object)->RegisterMessageCallback(reinterpret_cast<D3D12MessageFunc>(CallbackFunc),
                                                                                                                  CallbackFilterFlags,
                                                                                                                  in_pContext,
-                                                                                                                 pCallbackCookie->GetPointer());
+                                                                                                                 pCallbackCookie->GetOutputPointer());
         CheckReplayResult("ID3D12InfoQueue1_RegisterMessageCallback", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue1_RegisterMessageCallback>::Dispatch(
             this,

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -9812,7 +9812,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetResourceTiling(
         }
         if(!pSubresourceTilingsForNonPackedMips->IsNull())
         {
-            pSubresourceTilingsForNonPackedMips->AllocateOutputData(* pNumSubresourceTilings->GetPointer());
+            pSubresourceTilingsForNonPackedMips->AllocateOutputData(!pNumSubresourceTilings->IsNull() ? *pNumSubresourceTilings->GetPointer() : 0);
         }
         reinterpret_cast<ID3D12Device*>(replay_object->object)->GetResourceTiling(in_pTiledResource,
                                                                                   pNumTilesForEntireResource->GetOutputPointer(),

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -524,15 +524,16 @@ void Dx12ReplayConsumer::Process_IDXGIObject_GetPrivateData(
             pData);
         if(!pDataSize->IsNull())
         {
-            pDataSize->AllocateOutputData(1);
+            pDataSize->AllocateOutputData(1, GetOutputArrayCount("IDXGIObject::GetPrivateData", return_value, object_id, VariableLengthArrayIndices::kDxgiObjectArrayGetPrivateData, pDataSize, pData));
         }
-        if(!pData->IsNull())
+        if(!pData->IsNull() && !pDataSize->IsNull())
         {
-            pData->AllocateOutputData(* pDataSize->GetPointer());
+            pData->AllocateOutputData(*pDataSize->GetOutputPointer());
         }
         auto replay_result = reinterpret_cast<IDXGIObject*>(replay_object->object)->GetPrivateData(*Name.decoded_value,
                                                                                                    pDataSize->GetOutputPointer(),
                                                                                                    pData->GetOutputPointer());
+        if (pData->IsNull() && !pDataSize->IsNull()) { SetOutputArrayCount(object_id, VariableLengthArrayIndices::kDxgiObjectArrayGetPrivateData, *pDataSize->GetOutputPointer()); }
         CheckReplayResult("IDXGIObject_GetPrivateData", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIObject_GetPrivateData>::Dispatch(
             this,
@@ -1058,16 +1059,17 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetDisplayModeList(
             pDesc);
         if(!pNumModes->IsNull())
         {
-            pNumModes->AllocateOutputData(1);
+            pNumModes->AllocateOutputData(1, GetOutputArrayCount("IDXGIOutput::GetDisplayModeList", return_value, object_id, VariableLengthArrayIndices::kDxgiOutputArrayGetDisplayModeList, pNumModes, pDesc));
         }
-        if(!pDesc->IsNull())
+        if(!pDesc->IsNull() && !pNumModes->IsNull())
         {
-            pDesc->AllocateOutputData(* pNumModes->GetPointer());
+            pDesc->AllocateOutputData(*pNumModes->GetOutputPointer());
         }
         auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetDisplayModeList(EnumFormat,
                                                                                                        Flags,
                                                                                                        pNumModes->GetOutputPointer(),
                                                                                                        pDesc->GetOutputPointer());
+        if (pDesc->IsNull() && !pNumModes->IsNull()) { SetOutputArrayCount(object_id, VariableLengthArrayIndices::kDxgiOutputArrayGetDisplayModeList, *pNumModes->GetOutputPointer()); }
         CheckReplayResult("IDXGIOutput_GetDisplayModeList", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetDisplayModeList>::Dispatch(
             this,
@@ -3418,16 +3420,17 @@ void Dx12ReplayConsumer::Process_IDXGIOutput1_GetDisplayModeList1(
             pDesc);
         if(!pNumModes->IsNull())
         {
-            pNumModes->AllocateOutputData(1);
+            pNumModes->AllocateOutputData(1, GetOutputArrayCount("IDXGIOutput1::GetDisplayModeList1", return_value, object_id, VariableLengthArrayIndices::kDxgiOutput1ArrayGetDisplayModeList1, pNumModes, pDesc));
         }
-        if(!pDesc->IsNull())
+        if(!pDesc->IsNull() && !pNumModes->IsNull())
         {
-            pDesc->AllocateOutputData(* pNumModes->GetPointer());
+            pDesc->AllocateOutputData(*pNumModes->GetOutputPointer());
         }
         auto replay_result = reinterpret_cast<IDXGIOutput1*>(replay_object->object)->GetDisplayModeList1(EnumFormat,
                                                                                                          Flags,
                                                                                                          pNumModes->GetOutputPointer(),
                                                                                                          pDesc->GetOutputPointer());
+        if (pDesc->IsNull() && !pNumModes->IsNull()) { SetOutputArrayCount(object_id, VariableLengthArrayIndices::kDxgiOutput1ArrayGetDisplayModeList1, *pNumModes->GetOutputPointer()); }
         CheckReplayResult("IDXGIOutput1_GetDisplayModeList1", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput1_GetDisplayModeList1>::Dispatch(
             this,
@@ -5041,15 +5044,16 @@ void Dx12ReplayConsumer::Process_ID3D12Object_GetPrivateData(
             pData);
         if(!pDataSize->IsNull())
         {
-            pDataSize->AllocateOutputData(1);
+            pDataSize->AllocateOutputData(1, GetOutputArrayCount("ID3D12Object::GetPrivateData", return_value, object_id, VariableLengthArrayIndices::kD3D12ObjectArrayGetPrivateData, pDataSize, pData));
         }
-        if(!pData->IsNull())
+        if(!pData->IsNull() && !pDataSize->IsNull())
         {
-            pData->AllocateOutputData(* pDataSize->GetPointer());
+            pData->AllocateOutputData(*pDataSize->GetOutputPointer());
         }
         auto replay_result = reinterpret_cast<ID3D12Object*>(replay_object->object)->GetPrivateData(*guid.decoded_value,
                                                                                                     pDataSize->GetOutputPointer(),
                                                                                                     pData->GetOutputPointer());
+        if (pData->IsNull() && !pDataSize->IsNull()) { SetOutputArrayCount(object_id, VariableLengthArrayIndices::kD3D12ObjectArrayGetPrivateData, *pDataSize->GetOutputPointer()); }
         CheckReplayResult("ID3D12Object_GetPrivateData", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Object_GetPrivateData>::Dispatch(
             this,
@@ -11058,14 +11062,15 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_EnumerateMetaCommands(
             pDescs);
         if(!pNumMetaCommands->IsNull())
         {
-            pNumMetaCommands->AllocateOutputData(1);
+            pNumMetaCommands->AllocateOutputData(1, GetOutputArrayCount("ID3D12Device5::EnumerateMetaCommands", return_value, object_id, VariableLengthArrayIndices::kD3D12Device5ArrayEnumerateMetaCommands, pNumMetaCommands, pDescs));
         }
-        if(!pDescs->IsNull())
+        if(!pDescs->IsNull() && !pNumMetaCommands->IsNull())
         {
-            pDescs->AllocateOutputData(* pNumMetaCommands->GetPointer());
+            pDescs->AllocateOutputData(*pNumMetaCommands->GetOutputPointer());
         }
         auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->EnumerateMetaCommands(pNumMetaCommands->GetOutputPointer(),
                                                                                                             pDescs->GetOutputPointer());
+        if (pDescs->IsNull() && !pNumMetaCommands->IsNull()) { SetOutputArrayCount(object_id, VariableLengthArrayIndices::kD3D12Device5ArrayEnumerateMetaCommands, *pNumMetaCommands->GetOutputPointer()); }
         CheckReplayResult("ID3D12Device5_EnumerateMetaCommands", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommands>::Dispatch(
             this,
@@ -11104,17 +11109,18 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_EnumerateMetaCommandParameters(
         }
         if(!pParameterCount->IsNull())
         {
-            pParameterCount->AllocateOutputData(1);
+            pParameterCount->AllocateOutputData(1, GetOutputArrayCount("ID3D12Device5::EnumerateMetaCommandParameters", return_value, object_id, VariableLengthArrayIndices::kD3D12Device5ArrayEnumerateMetaCommandParameters, pParameterCount, pParameterDescs));
         }
-        if(!pParameterDescs->IsNull())
+        if(!pParameterDescs->IsNull() && !pParameterCount->IsNull())
         {
-            pParameterDescs->AllocateOutputData(* pParameterCount->GetPointer());
+            pParameterDescs->AllocateOutputData(*pParameterCount->GetOutputPointer());
         }
         auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->EnumerateMetaCommandParameters(*CommandId.decoded_value,
                                                                                                                      Stage,
                                                                                                                      pTotalStructureSizeInBytes->GetOutputPointer(),
                                                                                                                      pParameterCount->GetOutputPointer(),
                                                                                                                      pParameterDescs->GetOutputPointer());
+        if (pParameterDescs->IsNull() && !pParameterCount->IsNull()) { SetOutputArrayCount(object_id, VariableLengthArrayIndices::kD3D12Device5ArrayEnumerateMetaCommandParameters, *pParameterCount->GetOutputPointer()); }
         CheckReplayResult("ID3D12Device5_EnumerateMetaCommandParameters", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommandParameters>::Dispatch(
             this,
@@ -12467,18 +12473,19 @@ void Dx12ReplayConsumer::Process_ID3D12ShaderCacheSession_FindValue(
             KeySize,
             pValue,
             pValueSize);
-        if(!pValue->IsNull())
-        {
-            pValue->AllocateOutputData(* pValueSize->GetPointer());
-        }
         if(!pValueSize->IsNull())
         {
-            pValueSize->AllocateOutputData(1);
+            pValueSize->AllocateOutputData(1, GetOutputArrayCount("ID3D12ShaderCacheSession::FindValue", return_value, object_id, VariableLengthArrayIndices::kD3D12ShaderCacheSessionArrayFindValue, pValueSize, pValue));
+        }
+        if(!pValue->IsNull() && !pValueSize->IsNull())
+        {
+            pValue->AllocateOutputData(*pValueSize->GetOutputPointer());
         }
         auto replay_result = reinterpret_cast<ID3D12ShaderCacheSession*>(replay_object->object)->FindValue(pKey->GetPointer(),
                                                                                                            KeySize,
                                                                                                            pValue->GetOutputPointer(),
                                                                                                            pValueSize->GetOutputPointer());
+        if (pValue->IsNull() && !pValueSize->IsNull()) { SetOutputArrayCount(object_id, VariableLengthArrayIndices::kD3D12ShaderCacheSessionArrayFindValue, *pValueSize->GetOutputPointer()); }
         CheckReplayResult("ID3D12ShaderCacheSession_FindValue", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_FindValue>::Dispatch(
             this,
@@ -14967,17 +14974,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetMessage(
             MessageIndex,
             pMessage,
             pMessageByteLength);
-        if(!pMessage->IsNull())
-        {
-            pMessage->AllocateOutputData(* pMessageByteLength->GetPointer());
-        }
         if(!pMessageByteLength->IsNull())
         {
-            pMessageByteLength->AllocateOutputData(1);
+            pMessageByteLength->AllocateOutputData(1, GetOutputArrayCount("ID3D12InfoQueue::GetMessage", return_value, object_id, VariableLengthArrayIndices::kD3D12InfoQueueArrayGetMessage, pMessageByteLength, pMessage));
+        }
+        if(!pMessage->IsNull() && !pMessageByteLength->IsNull())
+        {
+            pMessage->AllocateOutputData(*pMessageByteLength->GetOutputPointer());
         }
         auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetMessage(MessageIndex,
                                                                                                    pMessage->GetOutputPointer(),
                                                                                                    pMessageByteLength->GetOutputPointer());
+        if (pMessage->IsNull() && !pMessageByteLength->IsNull()) { SetOutputArrayCount(object_id, VariableLengthArrayIndices::kD3D12InfoQueueArrayGetMessage, *pMessageByteLength->GetOutputPointer()); }
         CheckReplayResult("ID3D12InfoQueue_GetMessage", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMessage>::Dispatch(
             this,
@@ -15149,16 +15157,17 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetStorageFilter(
             replay_object,
             pFilter,
             pFilterByteLength);
-        if(!pFilter->IsNull())
-        {
-            pFilter->AllocateOutputData(* pFilterByteLength->GetPointer());
-        }
         if(!pFilterByteLength->IsNull())
         {
-            pFilterByteLength->AllocateOutputData(1);
+            pFilterByteLength->AllocateOutputData(1, GetOutputArrayCount("ID3D12InfoQueue::GetStorageFilter", return_value, object_id, VariableLengthArrayIndices::kD3D12InfoQueueArrayGetStorageFilter, pFilterByteLength, pFilter));
+        }
+        if(!pFilter->IsNull() && !pFilterByteLength->IsNull())
+        {
+            pFilter->AllocateOutputData(*pFilterByteLength->GetOutputPointer());
         }
         auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetStorageFilter(pFilter->GetOutputPointer(),
                                                                                                          pFilterByteLength->GetOutputPointer());
+        if (pFilter->IsNull() && !pFilterByteLength->IsNull()) { SetOutputArrayCount(object_id, VariableLengthArrayIndices::kD3D12InfoQueueArrayGetStorageFilter, *pFilterByteLength->GetOutputPointer()); }
         CheckReplayResult("ID3D12InfoQueue_GetStorageFilter", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetStorageFilter>::Dispatch(
             this,
@@ -15333,16 +15342,17 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetRetrievalFilter(
             replay_object,
             pFilter,
             pFilterByteLength);
-        if(!pFilter->IsNull())
-        {
-            pFilter->AllocateOutputData(* pFilterByteLength->GetPointer());
-        }
         if(!pFilterByteLength->IsNull())
         {
-            pFilterByteLength->AllocateOutputData(1);
+            pFilterByteLength->AllocateOutputData(1, GetOutputArrayCount("ID3D12InfoQueue::GetRetrievalFilter", return_value, object_id, VariableLengthArrayIndices::kD3D12InfoQueueArrayGetRetrievalFilter, pFilterByteLength, pFilter));
+        }
+        if(!pFilter->IsNull() && !pFilterByteLength->IsNull())
+        {
+            pFilter->AllocateOutputData(*pFilterByteLength->GetOutputPointer());
         }
         auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetRetrievalFilter(pFilter->GetOutputPointer(),
                                                                                                            pFilterByteLength->GetOutputPointer());
+        if (pFilter->IsNull() && !pFilterByteLength->IsNull()) { SetOutputArrayCount(object_id, VariableLengthArrayIndices::kD3D12InfoQueueArrayGetRetrievalFilter, *pFilterByteLength->GetOutputPointer()); }
         CheckReplayResult("ID3D12InfoQueue_GetRetrievalFilter", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetRetrievalFilter>::Dispatch(
             this,

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -522,9 +522,13 @@ void Dx12ReplayConsumer::Process_IDXGIObject_GetPrivateData(
             Name,
             pDataSize,
             pData);
+        if(!pData->IsNull())
+        {
+            pData->AllocateOutputData(* pDataSize->GetPointer());
+        }
         auto replay_result = reinterpret_cast<IDXGIObject*>(replay_object->object)->GetPrivateData(*Name.decoded_value,
                                                                                                    pDataSize->GetPointer(),
-                                                                                                   pData->GetPointer());
+                                                                                                   pData->GetOutputPointer());
         CheckReplayResult("IDXGIObject_GetPrivateData", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIObject_GetPrivateData>::Dispatch(
             this,
@@ -699,7 +703,11 @@ void Dx12ReplayConsumer::Process_IDXGIResource_GetEvictionPriority(
             call_info,
             replay_object,
             pEvictionPriority);
-        auto replay_result = reinterpret_cast<IDXGIResource*>(replay_object->object)->GetEvictionPriority(pEvictionPriority->GetPointer());
+        if(!pEvictionPriority->IsNull())
+        {
+            pEvictionPriority->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIResource*>(replay_object->object)->GetEvictionPriority(pEvictionPriority->GetOutputPointer());
         CheckReplayResult("IDXGIResource_GetEvictionPriority", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIResource_GetEvictionPriority>::Dispatch(
             this,
@@ -775,7 +783,11 @@ void Dx12ReplayConsumer::Process_IDXGISurface_GetDesc(
             call_info,
             replay_object,
             pDesc);
-        auto replay_result = reinterpret_cast<IDXGISurface*>(replay_object->object)->GetDesc(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISurface*>(replay_object->object)->GetDesc(pDesc->GetOutputPointer());
         CheckReplayResult("IDXGISurface_GetDesc", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISurface_GetDesc>::Dispatch(
             this,
@@ -801,7 +813,11 @@ void Dx12ReplayConsumer::Process_IDXGISurface_Map(
             replay_object,
             pLockedRect,
             MapFlags);
-        auto replay_result = reinterpret_cast<IDXGISurface*>(replay_object->object)->Map(pLockedRect->GetPointer(),
+        if(!pLockedRect->IsNull())
+        {
+            pLockedRect->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISurface*>(replay_object->object)->Map(pLockedRect->GetOutputPointer(),
                                                                                          MapFlags);
         CheckReplayResult("IDXGISurface_Map", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISurface_Map>::Dispatch(
@@ -942,7 +958,11 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter_GetDesc(
             call_info,
             replay_object,
             pDesc);
-        auto replay_result = reinterpret_cast<IDXGIAdapter*>(replay_object->object)->GetDesc(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIAdapter*>(replay_object->object)->GetDesc(pDesc->GetOutputPointer());
         CheckReplayResult("IDXGIAdapter_GetDesc", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter_GetDesc>::Dispatch(
             this,
@@ -968,8 +988,12 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter_CheckInterfaceSupport(
             replay_object,
             InterfaceName,
             pUMDVersion);
+        if(!pUMDVersion->IsNull())
+        {
+            pUMDVersion->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIAdapter*>(replay_object->object)->CheckInterfaceSupport(*InterfaceName.decoded_value,
-                                                                                                           pUMDVersion->GetPointer());
+                                                                                                           pUMDVersion->GetOutputPointer());
         CheckReplayResult("IDXGIAdapter_CheckInterfaceSupport", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter_CheckInterfaceSupport>::Dispatch(
             this,
@@ -994,7 +1018,11 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetDesc(
             call_info,
             replay_object,
             pDesc);
-        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetDesc(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetDesc(pDesc->GetOutputPointer());
         CheckReplayResult("IDXGIOutput_GetDesc", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetDesc>::Dispatch(
             this,
@@ -1024,10 +1052,14 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetDisplayModeList(
             Flags,
             pNumModes,
             pDesc);
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(* pNumModes->GetPointer());
+        }
         auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetDisplayModeList(EnumFormat,
                                                                                                        Flags,
                                                                                                        pNumModes->GetPointer(),
-                                                                                                       pDesc->GetPointer());
+                                                                                                       pDesc->GetOutputPointer());
         CheckReplayResult("IDXGIOutput_GetDisplayModeList", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetDisplayModeList>::Dispatch(
             this,
@@ -1058,9 +1090,13 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_FindClosestMatchingMode(
             pModeToMatch,
             pClosestMatch,
             pConcernedDevice);
+        if(!pClosestMatch->IsNull())
+        {
+            pClosestMatch->AllocateOutputData(1);
+        }
         auto in_pConcernedDevice = MapObject<IUnknown>(pConcernedDevice);
         auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->FindClosestMatchingMode(pModeToMatch->GetPointer(),
-                                                                                                            pClosestMatch->GetPointer(),
+                                                                                                            pClosestMatch->GetOutputPointer(),
                                                                                                             in_pConcernedDevice);
         CheckReplayResult("IDXGIOutput_FindClosestMatchingMode", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_FindClosestMatchingMode>::Dispatch(
@@ -1156,7 +1192,11 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetGammaControlCapabilities(
             call_info,
             replay_object,
             pGammaCaps);
-        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetGammaControlCapabilities(pGammaCaps->GetPointer());
+        if(!pGammaCaps->IsNull())
+        {
+            pGammaCaps->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetGammaControlCapabilities(pGammaCaps->GetOutputPointer());
         CheckReplayResult("IDXGIOutput_GetGammaControlCapabilities", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetGammaControlCapabilities>::Dispatch(
             this,
@@ -1204,7 +1244,11 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetGammaControl(
             call_info,
             replay_object,
             pArray);
-        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetGammaControl(pArray->GetPointer());
+        if(!pArray->IsNull())
+        {
+            pArray->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetGammaControl(pArray->GetOutputPointer());
         CheckReplayResult("IDXGIOutput_GetGammaControl", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetGammaControl>::Dispatch(
             this,
@@ -1278,7 +1322,11 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetFrameStatistics(
             call_info,
             replay_object,
             pStats);
-        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetFrameStatistics(pStats->GetPointer());
+        if(!pStats->IsNull())
+        {
+            pStats->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetFrameStatistics(pStats->GetOutputPointer());
         CheckReplayResult("IDXGIOutput_GetFrameStatistics", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetFrameStatistics>::Dispatch(
             this,
@@ -1406,10 +1454,14 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetFullscreenState(
             replay_object,
             pFullscreen,
             ppTarget);
+        if(!pFullscreen->IsNull())
+        {
+            pFullscreen->AllocateOutputData(1);
+        }
         if(!ppTarget->IsNull()) ppTarget->SetHandleLength(1);
         auto out_p_ppTarget    = ppTarget->GetPointer();
         auto out_hp_ppTarget   = ppTarget->GetHandlePointer();
-        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetFullscreenState(pFullscreen->GetPointer(),
+        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetFullscreenState(pFullscreen->GetOutputPointer(),
                                                                                                           out_hp_ppTarget);
         if (SUCCEEDED(replay_result))
         {
@@ -1439,7 +1491,11 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetDesc(
             call_info,
             replay_object,
             pDesc);
-        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetDesc(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetDesc(pDesc->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain_GetDesc", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetDesc>::Dispatch(
             this,
@@ -1560,7 +1616,11 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetFrameStatistics(
             call_info,
             replay_object,
             pStats);
-        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetFrameStatistics(pStats->GetPointer());
+        if(!pStats->IsNull())
+        {
+            pStats->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetFrameStatistics(pStats->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain_GetFrameStatistics", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetFrameStatistics>::Dispatch(
             this,
@@ -1584,7 +1644,11 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetLastPresentCount(
             call_info,
             replay_object,
             pLastPresentCount);
-        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetLastPresentCount(pLastPresentCount->GetPointer());
+        if(!pLastPresentCount->IsNull())
+        {
+            pLastPresentCount->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetLastPresentCount(pLastPresentCount->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain_GetLastPresentCount", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetLastPresentCount>::Dispatch(
             this,
@@ -1864,8 +1928,12 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_QueryResourceResidency(
             pResidencyStatus,
             NumResources);
         auto in_ppResources = MapObjects<IUnknown>(ppResources, NumResources);
+        if(!pResidencyStatus->IsNull())
+        {
+            pResidencyStatus->AllocateOutputData(NumResources);
+        }
         auto replay_result = reinterpret_cast<IDXGIDevice*>(replay_object->object)->QueryResourceResidency(in_ppResources,
-                                                                                                           pResidencyStatus->GetPointer(),
+                                                                                                           pResidencyStatus->GetOutputPointer(),
                                                                                                            NumResources);
         CheckReplayResult("IDXGIDevice_QueryResourceResidency", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice_QueryResourceResidency>::Dispatch(
@@ -1916,7 +1984,11 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_GetGPUThreadPriority(
             call_info,
             replay_object,
             pPriority);
-        auto replay_result = reinterpret_cast<IDXGIDevice*>(replay_object->object)->GetGPUThreadPriority(pPriority->GetPointer());
+        if(!pPriority->IsNull())
+        {
+            pPriority->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIDevice*>(replay_object->object)->GetGPUThreadPriority(pPriority->GetOutputPointer());
         CheckReplayResult("IDXGIDevice_GetGPUThreadPriority", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice_GetGPUThreadPriority>::Dispatch(
             this,
@@ -1995,7 +2067,11 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter1_GetDesc1(
             call_info,
             replay_object,
             pDesc);
-        auto replay_result = reinterpret_cast<IDXGIAdapter1*>(replay_object->object)->GetDesc1(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIAdapter1*>(replay_object->object)->GetDesc1(pDesc->GetOutputPointer());
         CheckReplayResult("IDXGIAdapter1_GetDesc1", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter1_GetDesc1>::Dispatch(
             this,
@@ -2043,7 +2119,11 @@ void Dx12ReplayConsumer::Process_IDXGIDevice1_GetMaximumFrameLatency(
             call_info,
             replay_object,
             pMaxLatency);
-        auto replay_result = reinterpret_cast<IDXGIDevice1*>(replay_object->object)->GetMaximumFrameLatency(pMaxLatency->GetPointer());
+        if(!pMaxLatency->IsNull())
+        {
+            pMaxLatency->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIDevice1*>(replay_object->object)->GetMaximumFrameLatency(pMaxLatency->GetOutputPointer());
         CheckReplayResult("IDXGIDevice1_GetMaximumFrameLatency", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice1_GetMaximumFrameLatency>::Dispatch(
             this,
@@ -2108,7 +2188,11 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_GetDesc(
             call_info,
             replay_object,
             pDesc);
-        reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->GetDesc(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->GetDesc(pDesc->GetOutputPointer());
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetDesc>::Dispatch(
             this,
             call_info,
@@ -2135,11 +2219,15 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_AcquireNextFrame(
             TimeoutInMilliseconds,
             pFrameInfo,
             ppDesktopResource);
+        if(!pFrameInfo->IsNull())
+        {
+            pFrameInfo->AllocateOutputData(1);
+        }
         if(!ppDesktopResource->IsNull()) ppDesktopResource->SetHandleLength(1);
         auto out_p_ppDesktopResource    = ppDesktopResource->GetPointer();
         auto out_hp_ppDesktopResource   = ppDesktopResource->GetHandlePointer();
         auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->AcquireNextFrame(TimeoutInMilliseconds,
-                                                                                                                pFrameInfo->GetPointer(),
+                                                                                                                pFrameInfo->GetOutputPointer(),
                                                                                                                 out_hp_ppDesktopResource);
         if (SUCCEEDED(replay_result))
         {
@@ -2174,9 +2262,17 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_GetFrameDirtyRects(
             DirtyRectsBufferSize,
             pDirtyRectsBuffer,
             pDirtyRectsBufferSizeRequired);
+        if(!pDirtyRectsBuffer->IsNull())
+        {
+            pDirtyRectsBuffer->AllocateOutputData(DirtyRectsBufferSize/sizeof tagRECT);
+        }
+        if(!pDirtyRectsBufferSizeRequired->IsNull())
+        {
+            pDirtyRectsBufferSizeRequired->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->GetFrameDirtyRects(DirtyRectsBufferSize,
-                                                                                                                  pDirtyRectsBuffer->GetPointer(),
-                                                                                                                  pDirtyRectsBufferSizeRequired->GetPointer());
+                                                                                                                  pDirtyRectsBuffer->GetOutputPointer(),
+                                                                                                                  pDirtyRectsBufferSizeRequired->GetOutputPointer());
         CheckReplayResult("IDXGIOutputDuplication_GetFrameDirtyRects", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFrameDirtyRects>::Dispatch(
             this,
@@ -2206,9 +2302,17 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_GetFrameMoveRects(
             MoveRectsBufferSize,
             pMoveRectBuffer,
             pMoveRectsBufferSizeRequired);
+        if(!pMoveRectBuffer->IsNull())
+        {
+            pMoveRectBuffer->AllocateOutputData(MoveRectsBufferSize/sizeof DXGI_OUTDUPL_MOVE_RECT);
+        }
+        if(!pMoveRectsBufferSizeRequired->IsNull())
+        {
+            pMoveRectsBufferSizeRequired->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->GetFrameMoveRects(MoveRectsBufferSize,
-                                                                                                                 pMoveRectBuffer->GetPointer(),
-                                                                                                                 pMoveRectsBufferSizeRequired->GetPointer());
+                                                                                                                 pMoveRectBuffer->GetOutputPointer(),
+                                                                                                                 pMoveRectsBufferSizeRequired->GetOutputPointer());
         CheckReplayResult("IDXGIOutputDuplication_GetFrameMoveRects", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFrameMoveRects>::Dispatch(
             this,
@@ -2240,10 +2344,22 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_GetFramePointerShape(
             pPointerShapeBuffer,
             pPointerShapeBufferSizeRequired,
             pPointerShapeInfo);
+        if(!pPointerShapeBuffer->IsNull())
+        {
+            pPointerShapeBuffer->AllocateOutputData(PointerShapeBufferSize);
+        }
+        if(!pPointerShapeBufferSizeRequired->IsNull())
+        {
+            pPointerShapeBufferSizeRequired->AllocateOutputData(1);
+        }
+        if(!pPointerShapeInfo->IsNull())
+        {
+            pPointerShapeInfo->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->GetFramePointerShape(PointerShapeBufferSize,
-                                                                                                                    pPointerShapeBuffer->GetPointer(),
-                                                                                                                    pPointerShapeBufferSizeRequired->GetPointer(),
-                                                                                                                    pPointerShapeInfo->GetPointer());
+                                                                                                                    pPointerShapeBuffer->GetOutputPointer(),
+                                                                                                                    pPointerShapeBufferSizeRequired->GetOutputPointer(),
+                                                                                                                    pPointerShapeInfo->GetOutputPointer());
         CheckReplayResult("IDXGIOutputDuplication_GetFramePointerShape", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFramePointerShape>::Dispatch(
             this,
@@ -2270,7 +2386,11 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_MapDesktopSurface(
             call_info,
             replay_object,
             pLockedRect);
-        auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->MapDesktopSurface(pLockedRect->GetPointer());
+        if(!pLockedRect->IsNull())
+        {
+            pLockedRect->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->MapDesktopSurface(pLockedRect->GetOutputPointer());
         CheckReplayResult("IDXGIOutputDuplication_MapDesktopSurface", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_MapDesktopSurface>::Dispatch(
             this,
@@ -2343,9 +2463,13 @@ void Dx12ReplayConsumer::Process_IDXGISurface2_GetResource(
         if(!ppParentResource->IsNull()) ppParentResource->SetHandleLength(1);
         auto out_p_ppParentResource    = ppParentResource->GetPointer();
         auto out_hp_ppParentResource   = ppParentResource->GetHandlePointer();
+        if(!pSubresourceIndex->IsNull())
+        {
+            pSubresourceIndex->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGISurface2*>(replay_object->object)->GetResource(*riid.decoded_value,
                                                                                                   out_hp_ppParentResource,
-                                                                                                  pSubresourceIndex->GetPointer());
+                                                                                                  pSubresourceIndex->GetOutputPointer());
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppParentResource, out_hp_ppParentResource, format::ApiCall_IDXGISurface2_GetResource);
@@ -2491,9 +2615,13 @@ void Dx12ReplayConsumer::Process_IDXGIDevice2_ReclaimResources(
             ppResources,
             pDiscarded);
         auto in_ppResources = MapObjects<IDXGIResource>(ppResources, NumResources);
+        if(!pDiscarded->IsNull())
+        {
+            pDiscarded->AllocateOutputData(NumResources);
+        }
         auto replay_result = reinterpret_cast<IDXGIDevice2*>(replay_object->object)->ReclaimResources(NumResources,
                                                                                                       in_ppResources,
-                                                                                                      pDiscarded->GetPointer());
+                                                                                                      pDiscarded->GetOutputPointer());
         CheckReplayResult("IDXGIDevice2_ReclaimResources", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice2_ReclaimResources>::Dispatch(
             this,
@@ -2544,7 +2672,11 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetDesc1(
             call_info,
             replay_object,
             pDesc);
-        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetDesc1(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetDesc1(pDesc->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain1_GetDesc1", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetDesc1>::Dispatch(
             this,
@@ -2568,7 +2700,11 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetFullscreenDesc(
             call_info,
             replay_object,
             pDesc);
-        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetFullscreenDesc(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetFullscreenDesc(pDesc->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain1_GetFullscreenDesc", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetFullscreenDesc>::Dispatch(
             this,
@@ -2767,7 +2903,11 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetBackgroundColor(
             call_info,
             replay_object,
             pColor);
-        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetBackgroundColor(pColor->GetPointer());
+        if(!pColor->IsNull())
+        {
+            pColor->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetBackgroundColor(pColor->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain1_GetBackgroundColor", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetBackgroundColor>::Dispatch(
             this,
@@ -2815,7 +2955,11 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetRotation(
             call_info,
             replay_object,
             pRotation);
-        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetRotation(pRotation->GetPointer());
+        if(!pRotation->IsNull())
+        {
+            pRotation->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetRotation(pRotation->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain1_GetRotation", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetRotation>::Dispatch(
             this,
@@ -2969,8 +3113,12 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_GetSharedResourceAdapterLuid(
             hResource,
             pLuid);
         auto in_hResource = static_cast<HANDLE>(PreProcessExternalObject(hResource, format::ApiCallId::ApiCall_IDXGIFactory2_GetSharedResourceAdapterLuid, "IDXGIFactory2_GetSharedResourceAdapterLuid"));
+        if(!pLuid->IsNull())
+        {
+            pLuid->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->GetSharedResourceAdapterLuid(in_hResource,
-                                                                                                                   pLuid->GetPointer());
+                                                                                                                   pLuid->GetOutputPointer());
         CheckReplayResult("IDXGIFactory2_GetSharedResourceAdapterLuid", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_GetSharedResourceAdapterLuid>::Dispatch(
             this,
@@ -3000,9 +3148,13 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_RegisterStereoStatusWindow(
             wMsg,
             pdwCookie);
         auto in_WindowHandle = static_cast<HWND>(PreProcessExternalObject(WindowHandle, format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusWindow, "IDXGIFactory2_RegisterStereoStatusWindow"));
+        if(!pdwCookie->IsNull())
+        {
+            pdwCookie->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->RegisterStereoStatusWindow(in_WindowHandle,
                                                                                                                  wMsg,
-                                                                                                                 pdwCookie->GetPointer());
+                                                                                                                 pdwCookie->GetOutputPointer());
         CheckReplayResult("IDXGIFactory2_RegisterStereoStatusWindow", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusWindow>::Dispatch(
             this,
@@ -3031,8 +3183,12 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_RegisterStereoStatusEvent(
             hEvent,
             pdwCookie);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusEvent, "IDXGIFactory2_RegisterStereoStatusEvent"));
+        if(!pdwCookie->IsNull())
+        {
+            pdwCookie->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->RegisterStereoStatusEvent(in_hEvent,
-                                                                                                                pdwCookie->GetPointer());
+                                                                                                                pdwCookie->GetOutputPointer());
         CheckReplayResult("IDXGIFactory2_RegisterStereoStatusEvent", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusEvent>::Dispatch(
             this,
@@ -3084,9 +3240,13 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_RegisterOcclusionStatusWindow(
             wMsg,
             pdwCookie);
         auto in_WindowHandle = static_cast<HWND>(PreProcessExternalObject(WindowHandle, format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusWindow, "IDXGIFactory2_RegisterOcclusionStatusWindow"));
+        if(!pdwCookie->IsNull())
+        {
+            pdwCookie->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->RegisterOcclusionStatusWindow(in_WindowHandle,
                                                                                                                     wMsg,
-                                                                                                                    pdwCookie->GetPointer());
+                                                                                                                    pdwCookie->GetOutputPointer());
         CheckReplayResult("IDXGIFactory2_RegisterOcclusionStatusWindow", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusWindow>::Dispatch(
             this,
@@ -3115,8 +3275,12 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_RegisterOcclusionStatusEvent(
             hEvent,
             pdwCookie);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusEvent, "IDXGIFactory2_RegisterOcclusionStatusEvent"));
+        if(!pdwCookie->IsNull())
+        {
+            pdwCookie->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->RegisterOcclusionStatusEvent(in_hEvent,
-                                                                                                                   pdwCookie->GetPointer());
+                                                                                                                   pdwCookie->GetOutputPointer());
         CheckReplayResult("IDXGIFactory2_RegisterOcclusionStatusEvent", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusEvent>::Dispatch(
             this,
@@ -3210,7 +3374,11 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter2_GetDesc2(
             call_info,
             replay_object,
             pDesc);
-        auto replay_result = reinterpret_cast<IDXGIAdapter2*>(replay_object->object)->GetDesc2(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIAdapter2*>(replay_object->object)->GetDesc2(pDesc->GetOutputPointer());
         CheckReplayResult("IDXGIAdapter2_GetDesc2", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter2_GetDesc2>::Dispatch(
             this,
@@ -3240,10 +3408,14 @@ void Dx12ReplayConsumer::Process_IDXGIOutput1_GetDisplayModeList1(
             Flags,
             pNumModes,
             pDesc);
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(* pNumModes->GetPointer());
+        }
         auto replay_result = reinterpret_cast<IDXGIOutput1*>(replay_object->object)->GetDisplayModeList1(EnumFormat,
                                                                                                          Flags,
                                                                                                          pNumModes->GetPointer(),
-                                                                                                         pDesc->GetPointer());
+                                                                                                         pDesc->GetOutputPointer());
         CheckReplayResult("IDXGIOutput1_GetDisplayModeList1", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput1_GetDisplayModeList1>::Dispatch(
             this,
@@ -3274,9 +3446,13 @@ void Dx12ReplayConsumer::Process_IDXGIOutput1_FindClosestMatchingMode1(
             pModeToMatch,
             pClosestMatch,
             pConcernedDevice);
+        if(!pClosestMatch->IsNull())
+        {
+            pClosestMatch->AllocateOutputData(1);
+        }
         auto in_pConcernedDevice = MapObject<IUnknown>(pConcernedDevice);
         auto replay_result = reinterpret_cast<IDXGIOutput1*>(replay_object->object)->FindClosestMatchingMode1(pModeToMatch->GetPointer(),
-                                                                                                              pClosestMatch->GetPointer(),
+                                                                                                              pClosestMatch->GetOutputPointer(),
                                                                                                               in_pConcernedDevice);
         CheckReplayResult("IDXGIOutput1_FindClosestMatchingMode1", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput1_FindClosestMatchingMode1>::Dispatch(
@@ -3413,8 +3589,16 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain2_GetSourceSize(
             replay_object,
             pWidth,
             pHeight);
-        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->GetSourceSize(pWidth->GetPointer(),
-                                                                                                      pHeight->GetPointer());
+        if(!pWidth->IsNull())
+        {
+            pWidth->AllocateOutputData(1);
+        }
+        if(!pHeight->IsNull())
+        {
+            pHeight->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->GetSourceSize(pWidth->GetOutputPointer(),
+                                                                                                      pHeight->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain2_GetSourceSize", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetSourceSize>::Dispatch(
             this,
@@ -3463,7 +3647,11 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain2_GetMaximumFrameLatency(
             call_info,
             replay_object,
             pMaxLatency);
-        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->GetMaximumFrameLatency(pMaxLatency->GetPointer());
+        if(!pMaxLatency->IsNull())
+        {
+            pMaxLatency->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->GetMaximumFrameLatency(pMaxLatency->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain2_GetMaximumFrameLatency", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetMaximumFrameLatency>::Dispatch(
             this,
@@ -3531,7 +3719,11 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain2_GetMatrixTransform(
             call_info,
             replay_object,
             pMatrix);
-        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->GetMatrixTransform(pMatrix->GetPointer());
+        if(!pMatrix->IsNull())
+        {
+            pMatrix->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->GetMatrixTransform(pMatrix->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain2_GetMatrixTransform", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetMatrixTransform>::Dispatch(
             this,
@@ -3703,7 +3895,11 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_GetSourceRect(
             call_info,
             replay_object,
             pRect);
-        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->GetSourceRect(pRect->GetPointer());
+        if(!pRect->IsNull())
+        {
+            pRect->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->GetSourceRect(pRect->GetOutputPointer());
         CheckReplayResult("IDXGIDecodeSwapChain_GetSourceRect", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetSourceRect>::Dispatch(
             this,
@@ -3727,7 +3923,11 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_GetTargetRect(
             call_info,
             replay_object,
             pRect);
-        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->GetTargetRect(pRect->GetPointer());
+        if(!pRect->IsNull())
+        {
+            pRect->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->GetTargetRect(pRect->GetOutputPointer());
         CheckReplayResult("IDXGIDecodeSwapChain_GetTargetRect", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetTargetRect>::Dispatch(
             this,
@@ -3753,8 +3953,16 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_GetDestSize(
             replay_object,
             pWidth,
             pHeight);
-        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->GetDestSize(pWidth->GetPointer(),
-                                                                                                         pHeight->GetPointer());
+        if(!pWidth->IsNull())
+        {
+            pWidth->AllocateOutputData(1);
+        }
+        if(!pHeight->IsNull())
+        {
+            pHeight->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->GetDestSize(pWidth->GetOutputPointer(),
+                                                                                                         pHeight->GetOutputPointer());
         CheckReplayResult("IDXGIDecodeSwapChain_GetDestSize", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetDestSize>::Dispatch(
             this,
@@ -3928,7 +4136,11 @@ void Dx12ReplayConsumer::Process_IDXGISwapChainMedia_GetFrameStatisticsMedia(
             call_info,
             replay_object,
             pStats);
-        auto replay_result = reinterpret_cast<IDXGISwapChainMedia*>(replay_object->object)->GetFrameStatisticsMedia(pStats->GetPointer());
+        if(!pStats->IsNull())
+        {
+            pStats->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGISwapChainMedia*>(replay_object->object)->GetFrameStatisticsMedia(pStats->GetOutputPointer());
         CheckReplayResult("IDXGISwapChainMedia_GetFrameStatisticsMedia", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChainMedia_GetFrameStatisticsMedia>::Dispatch(
             this,
@@ -3980,9 +4192,17 @@ void Dx12ReplayConsumer::Process_IDXGISwapChainMedia_CheckPresentDurationSupport
             DesiredPresentDuration,
             pClosestSmallerPresentDuration,
             pClosestLargerPresentDuration);
+        if(!pClosestSmallerPresentDuration->IsNull())
+        {
+            pClosestSmallerPresentDuration->AllocateOutputData(1);
+        }
+        if(!pClosestLargerPresentDuration->IsNull())
+        {
+            pClosestLargerPresentDuration->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGISwapChainMedia*>(replay_object->object)->CheckPresentDurationSupport(DesiredPresentDuration,
-                                                                                                                        pClosestSmallerPresentDuration->GetPointer(),
-                                                                                                                        pClosestLargerPresentDuration->GetPointer());
+                                                                                                                        pClosestSmallerPresentDuration->GetOutputPointer(),
+                                                                                                                        pClosestLargerPresentDuration->GetOutputPointer());
         CheckReplayResult("IDXGISwapChainMedia_CheckPresentDurationSupport", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChainMedia_CheckPresentDurationSupport>::Dispatch(
             this,
@@ -4013,9 +4233,13 @@ void Dx12ReplayConsumer::Process_IDXGIOutput3_CheckOverlaySupport(
             pConcernedDevice,
             pFlags);
         auto in_pConcernedDevice = MapObject<IUnknown>(pConcernedDevice);
+        if(!pFlags->IsNull())
+        {
+            pFlags->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIOutput3*>(replay_object->object)->CheckOverlaySupport(EnumFormat,
                                                                                                          in_pConcernedDevice,
-                                                                                                         pFlags->GetPointer());
+                                                                                                         pFlags->GetOutputPointer());
         CheckReplayResult("IDXGIOutput3_CheckOverlaySupport", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput3_CheckOverlaySupport>::Dispatch(
             this,
@@ -4063,8 +4287,12 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain3_CheckColorSpaceSupport(
             replay_object,
             ColorSpace,
             pColorSpaceSupport);
+        if(!pColorSpaceSupport->IsNull())
+        {
+            pColorSpaceSupport->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGISwapChain3*>(replay_object->object)->CheckColorSpaceSupport(ColorSpace,
-                                                                                                               pColorSpaceSupport->GetPointer());
+                                                                                                               pColorSpaceSupport->GetOutputPointer());
         CheckReplayResult("IDXGISwapChain3_CheckColorSpaceSupport", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain3_CheckColorSpaceSupport>::Dispatch(
             this,
@@ -4171,10 +4399,14 @@ void Dx12ReplayConsumer::Process_IDXGIOutput4_CheckOverlayColorSpaceSupport(
             pConcernedDevice,
             pFlags);
         auto in_pConcernedDevice = MapObject<IUnknown>(pConcernedDevice);
+        if(!pFlags->IsNull())
+        {
+            pFlags->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIOutput4*>(replay_object->object)->CheckOverlayColorSpaceSupport(Format,
                                                                                                                    ColorSpace,
                                                                                                                    in_pConcernedDevice,
-                                                                                                                   pFlags->GetPointer());
+                                                                                                                   pFlags->GetOutputPointer());
         CheckReplayResult("IDXGIOutput4_CheckOverlayColorSpaceSupport", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput4_CheckOverlayColorSpaceSupport>::Dispatch(
             this,
@@ -4278,8 +4510,12 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter3_RegisterHardwareContentProtection
             hEvent,
             pdwCookie);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent, "IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent"));
+        if(!pdwCookie->IsNull())
+        {
+            pdwCookie->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIAdapter3*>(replay_object->object)->RegisterHardwareContentProtectionTeardownStatusEvent(in_hEvent,
-                                                                                                                                           pdwCookie->GetPointer());
+                                                                                                                                           pdwCookie->GetOutputPointer());
         CheckReplayResult("IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent>::Dispatch(
             this,
@@ -4330,9 +4566,13 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter3_QueryVideoMemoryInfo(
             NodeIndex,
             MemorySegmentGroup,
             pVideoMemoryInfo);
+        if(!pVideoMemoryInfo->IsNull())
+        {
+            pVideoMemoryInfo->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIAdapter3*>(replay_object->object)->QueryVideoMemoryInfo(NodeIndex,
                                                                                                            MemorySegmentGroup,
-                                                                                                           pVideoMemoryInfo->GetPointer());
+                                                                                                           pVideoMemoryInfo->GetOutputPointer());
         CheckReplayResult("IDXGIAdapter3_QueryVideoMemoryInfo", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter3_QueryVideoMemoryInfo>::Dispatch(
             this,
@@ -4393,8 +4633,12 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNo
             hEvent,
             pdwCookie);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent, "IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent"));
+        if(!pdwCookie->IsNull())
+        {
+            pdwCookie->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIAdapter3*>(replay_object->object)->RegisterVideoMemoryBudgetChangeNotificationEvent(in_hEvent,
-                                                                                                                                       pdwCookie->GetPointer());
+                                                                                                                                       pdwCookie->GetOutputPointer());
         CheckReplayResult("IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent>::Dispatch(
             this,
@@ -4563,9 +4807,13 @@ void Dx12ReplayConsumer::Process_IDXGIDevice4_ReclaimResources1(
             ppResources,
             pResults);
         auto in_ppResources = MapObjects<IDXGIResource>(ppResources, NumResources);
+        if(!pResults->IsNull())
+        {
+            pResults->AllocateOutputData(NumResources);
+        }
         auto replay_result = reinterpret_cast<IDXGIDevice4*>(replay_object->object)->ReclaimResources1(NumResources,
                                                                                                        in_ppResources,
-                                                                                                       pResults->GetPointer());
+                                                                                                       pResults->GetOutputPointer());
         CheckReplayResult("IDXGIDevice4_ReclaimResources1", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice4_ReclaimResources1>::Dispatch(
             this,
@@ -4591,7 +4839,11 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter4_GetDesc3(
             call_info,
             replay_object,
             pDesc);
-        auto replay_result = reinterpret_cast<IDXGIAdapter4*>(replay_object->object)->GetDesc3(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIAdapter4*>(replay_object->object)->GetDesc3(pDesc->GetOutputPointer());
         CheckReplayResult("IDXGIAdapter4_GetDesc3", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter4_GetDesc3>::Dispatch(
             this,
@@ -4615,7 +4867,11 @@ void Dx12ReplayConsumer::Process_IDXGIOutput6_GetDesc1(
             call_info,
             replay_object,
             pDesc);
-        auto replay_result = reinterpret_cast<IDXGIOutput6*>(replay_object->object)->GetDesc1(pDesc->GetPointer());
+        if(!pDesc->IsNull())
+        {
+            pDesc->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIOutput6*>(replay_object->object)->GetDesc1(pDesc->GetOutputPointer());
         CheckReplayResult("IDXGIOutput6_GetDesc1", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput6_GetDesc1>::Dispatch(
             this,
@@ -4639,7 +4895,11 @@ void Dx12ReplayConsumer::Process_IDXGIOutput6_CheckHardwareCompositionSupport(
             call_info,
             replay_object,
             pFlags);
-        auto replay_result = reinterpret_cast<IDXGIOutput6*>(replay_object->object)->CheckHardwareCompositionSupport(pFlags->GetPointer());
+        if(!pFlags->IsNull())
+        {
+            pFlags->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<IDXGIOutput6*>(replay_object->object)->CheckHardwareCompositionSupport(pFlags->GetOutputPointer());
         CheckReplayResult("IDXGIOutput6_CheckHardwareCompositionSupport", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput6_CheckHardwareCompositionSupport>::Dispatch(
             this,
@@ -4709,8 +4969,12 @@ void Dx12ReplayConsumer::Process_IDXGIFactory7_RegisterAdaptersChangedEvent(
             hEvent,
             pdwCookie);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIFactory7_RegisterAdaptersChangedEvent, "IDXGIFactory7_RegisterAdaptersChangedEvent"));
+        if(!pdwCookie->IsNull())
+        {
+            pdwCookie->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<IDXGIFactory7*>(replay_object->object)->RegisterAdaptersChangedEvent(in_hEvent,
-                                                                                                                   pdwCookie->GetPointer());
+                                                                                                                   pdwCookie->GetOutputPointer());
         CheckReplayResult("IDXGIFactory7_RegisterAdaptersChangedEvent", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory7_RegisterAdaptersChangedEvent>::Dispatch(
             this,
@@ -4763,9 +5027,13 @@ void Dx12ReplayConsumer::Process_ID3D12Object_GetPrivateData(
             guid,
             pDataSize,
             pData);
+        if(!pData->IsNull())
+        {
+            pData->AllocateOutputData(* pDataSize->GetPointer());
+        }
         auto replay_result = reinterpret_cast<ID3D12Object*>(replay_object->object)->GetPrivateData(*guid.decoded_value,
                                                                                                     pDataSize->GetPointer(),
-                                                                                                    pData->GetPointer());
+                                                                                                    pData->GetOutputPointer());
         CheckReplayResult("ID3D12Object_GetPrivateData", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Object_GetPrivateData>::Dispatch(
             this,
@@ -4935,7 +5203,11 @@ void Dx12ReplayConsumer::Process_ID3D12VersionedRootSignatureDeserializer_GetRoo
             replay_object,
             convertToVersion,
             ppDesc);
-        auto in_ppDesc    = ppDesc->GetPointer();
+        if(!ppDesc->IsNull())
+        {
+            ppDesc->AllocateOutputData(1);
+        }
+        auto in_ppDesc    = ppDesc->GetOutputPointer();
         auto replay_result = reinterpret_cast<ID3D12VersionedRootSignatureDeserializer*>(replay_object->object)->GetRootSignatureDescAtVersion(convertToVersion,
                                                                                                                                                const_cast<const D3D12_VERSIONED_ROOT_SIGNATURE_DESC**>(&in_ppDesc));
         CheckReplayResult("ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion", return_value, replay_result);
@@ -5152,8 +5424,16 @@ void Dx12ReplayConsumer::Process_ID3D12Resource_GetHeapProperties(
             replay_object,
             pHeapProperties,
             pHeapFlags);
-        auto replay_result = reinterpret_cast<ID3D12Resource*>(replay_object->object)->GetHeapProperties(pHeapProperties->GetPointer(),
-                                                                                                         pHeapFlags->GetPointer());
+        if(!pHeapProperties->IsNull())
+        {
+            pHeapProperties->AllocateOutputData(1);
+        }
+        if(!pHeapFlags->IsNull())
+        {
+            pHeapFlags->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<ID3D12Resource*>(replay_object->object)->GetHeapProperties(pHeapProperties->GetOutputPointer(),
+                                                                                                         pHeapFlags->GetOutputPointer());
         CheckReplayResult("ID3D12Resource_GetHeapProperties", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Resource_GetHeapProperties>::Dispatch(
             this,
@@ -8079,7 +8359,11 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_GetTimestampFrequency(
             call_info,
             replay_object,
             pFrequency);
-        auto replay_result = reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->GetTimestampFrequency(pFrequency->GetPointer());
+        if(!pFrequency->IsNull())
+        {
+            pFrequency->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->GetTimestampFrequency(pFrequency->GetOutputPointer());
         CheckReplayResult("ID3D12CommandQueue_GetTimestampFrequency", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_GetTimestampFrequency>::Dispatch(
             this,
@@ -8105,8 +8389,16 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_GetClockCalibration(
             replay_object,
             pGpuTimestamp,
             pCpuTimestamp);
-        auto replay_result = reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->GetClockCalibration(pGpuTimestamp->GetPointer(),
-                                                                                                               pCpuTimestamp->GetPointer());
+        if(!pGpuTimestamp->IsNull())
+        {
+            pGpuTimestamp->AllocateOutputData(1);
+        }
+        if(!pCpuTimestamp->IsNull())
+        {
+            pCpuTimestamp->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->GetClockCalibration(pGpuTimestamp->GetOutputPointer(),
+                                                                                                               pCpuTimestamp->GetOutputPointer());
         CheckReplayResult("ID3D12CommandQueue_GetClockCalibration", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_GetClockCalibration>::Dispatch(
             this,
@@ -9308,14 +9600,30 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetCopyableFootprints(
             pNumRows,
             pRowSizeInBytes,
             pTotalBytes);
+        if(!pLayouts->IsNull())
+        {
+            pLayouts->AllocateOutputData(NumSubresources);
+        }
+        if(!pNumRows->IsNull())
+        {
+            pNumRows->AllocateOutputData(NumSubresources);
+        }
+        if(!pRowSizeInBytes->IsNull())
+        {
+            pRowSizeInBytes->AllocateOutputData(NumSubresources);
+        }
+        if(!pTotalBytes->IsNull())
+        {
+            pTotalBytes->AllocateOutputData(1);
+        }
         reinterpret_cast<ID3D12Device*>(replay_object->object)->GetCopyableFootprints(pResourceDesc->GetPointer(),
                                                                                       FirstSubresource,
                                                                                       NumSubresources,
                                                                                       BaseOffset,
-                                                                                      pLayouts->GetPointer(),
-                                                                                      pNumRows->GetPointer(),
-                                                                                      pRowSizeInBytes->GetPointer(),
-                                                                                      pTotalBytes->GetPointer());
+                                                                                      pLayouts->GetOutputPointer(),
+                                                                                      pNumRows->GetOutputPointer(),
+                                                                                      pRowSizeInBytes->GetOutputPointer(),
+                                                                                      pTotalBytes->GetOutputPointer());
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetCopyableFootprints>::Dispatch(
             this,
             call_info,
@@ -9466,13 +9774,29 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetResourceTiling(
             FirstSubresourceTilingToGet,
             pSubresourceTilingsForNonPackedMips);
         auto in_pTiledResource = MapObject<ID3D12Resource>(pTiledResource);
+        if(!pNumTilesForEntireResource->IsNull())
+        {
+            pNumTilesForEntireResource->AllocateOutputData(1);
+        }
+        if(!pPackedMipDesc->IsNull())
+        {
+            pPackedMipDesc->AllocateOutputData(1);
+        }
+        if(!pStandardTileShapeForNonPackedMips->IsNull())
+        {
+            pStandardTileShapeForNonPackedMips->AllocateOutputData(1);
+        }
+        if(!pSubresourceTilingsForNonPackedMips->IsNull())
+        {
+            pSubresourceTilingsForNonPackedMips->AllocateOutputData(* pNumSubresourceTilings->GetPointer());
+        }
         reinterpret_cast<ID3D12Device*>(replay_object->object)->GetResourceTiling(in_pTiledResource,
-                                                                                  pNumTilesForEntireResource->GetPointer(),
-                                                                                  pPackedMipDesc->GetPointer(),
-                                                                                  pStandardTileShapeForNonPackedMips->GetPointer(),
+                                                                                  pNumTilesForEntireResource->GetOutputPointer(),
+                                                                                  pPackedMipDesc->GetOutputPointer(),
+                                                                                  pStandardTileShapeForNonPackedMips->GetOutputPointer(),
                                                                                   pNumSubresourceTilings->GetPointer(),
                                                                                   FirstSubresourceTilingToGet,
-                                                                                  pSubresourceTilingsForNonPackedMips->GetPointer());
+                                                                                  pSubresourceTilingsForNonPackedMips->GetOutputPointer());
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetResourceTiling>::Dispatch(
             this,
             call_info,
@@ -9664,7 +9988,11 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_Serialize(
             replay_object,
             pData,
             DataSizeInBytes);
-        auto replay_result = reinterpret_cast<ID3D12PipelineLibrary*>(replay_object->object)->Serialize(pData->GetPointer(),
+        if(!pData->IsNull())
+        {
+            pData->AllocateOutputData(DataSizeInBytes);
+        }
+        auto replay_result = reinterpret_cast<ID3D12PipelineLibrary*>(replay_object->object)->Serialize(pData->GetOutputPointer(),
                                                                                                         DataSizeInBytes);
         CheckReplayResult("ID3D12PipelineLibrary_Serialize", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_Serialize>::Dispatch(
@@ -10354,10 +10682,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_GetResourceAllocationInfo1(
             numResourceDescs,
             pResourceDescs,
             pResourceAllocationInfo1);
+        if(!pResourceAllocationInfo1->IsNull())
+        {
+            pResourceAllocationInfo1->AllocateOutputData(numResourceDescs);
+        }
         auto replay_result = reinterpret_cast<ID3D12Device4*>(replay_object->object)->GetResourceAllocationInfo1(visibleMask,
                                                                                                                  numResourceDescs,
                                                                                                                  pResourceDescs->GetPointer(),
-                                                                                                                 pResourceAllocationInfo1->GetPointer());
+                                                                                                                 pResourceAllocationInfo1->GetOutputPointer());
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device4_GetResourceAllocationInfo1>::Dispatch(
             this,
             call_info,
@@ -10704,8 +11036,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_EnumerateMetaCommands(
             replay_object,
             pNumMetaCommands,
             pDescs);
+        if(!pDescs->IsNull())
+        {
+            pDescs->AllocateOutputData(* pNumMetaCommands->GetPointer());
+        }
         auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->EnumerateMetaCommands(pNumMetaCommands->GetPointer(),
-                                                                                                            pDescs->GetPointer());
+                                                                                                            pDescs->GetOutputPointer());
         CheckReplayResult("ID3D12Device5_EnumerateMetaCommands", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommands>::Dispatch(
             this,
@@ -10738,11 +11074,19 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_EnumerateMetaCommandParameters(
             pTotalStructureSizeInBytes,
             pParameterCount,
             pParameterDescs);
+        if(!pTotalStructureSizeInBytes->IsNull())
+        {
+            pTotalStructureSizeInBytes->AllocateOutputData(1);
+        }
+        if(!pParameterDescs->IsNull())
+        {
+            pParameterDescs->AllocateOutputData(* pParameterCount->GetPointer());
+        }
         auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->EnumerateMetaCommandParameters(*CommandId.decoded_value,
                                                                                                                      Stage,
-                                                                                                                     pTotalStructureSizeInBytes->GetPointer(),
+                                                                                                                     pTotalStructureSizeInBytes->GetOutputPointer(),
                                                                                                                      pParameterCount->GetPointer(),
-                                                                                                                     pParameterDescs->GetPointer());
+                                                                                                                     pParameterDescs->GetOutputPointer());
         CheckReplayResult("ID3D12Device5_EnumerateMetaCommandParameters", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommandParameters>::Dispatch(
             this,
@@ -10865,6 +11209,10 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_GetRaytracingAccelerationStructur
             pDesc,
             pInfo);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
+        if(!pInfo->IsNull())
+        {
+            pInfo->AllocateOutputData(1);
+        }
         OverrideGetRaytracingAccelerationStructurePrebuildInfo(replay_object,
                                                                pDesc,
                                                                pInfo);
@@ -11031,7 +11379,11 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedData_GetAutoBreadcru
             call_info,
             replay_object,
             pOutput);
-        auto replay_result = reinterpret_cast<ID3D12DeviceRemovedExtendedData*>(replay_object->object)->GetAutoBreadcrumbsOutput(pOutput->GetPointer());
+        if(!pOutput->IsNull())
+        {
+            pOutput->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<ID3D12DeviceRemovedExtendedData*>(replay_object->object)->GetAutoBreadcrumbsOutput(pOutput->GetOutputPointer());
         if (SUCCEEDED(replay_result))
         {
             AddStructObjects(pOutput, pOutput->GetPointer(), GetObjectInfoTable());
@@ -11084,7 +11436,11 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedData1_GetAutoBreadcr
             call_info,
             replay_object,
             pOutput);
-        auto replay_result = reinterpret_cast<ID3D12DeviceRemovedExtendedData1*>(replay_object->object)->GetAutoBreadcrumbsOutput1(pOutput->GetPointer());
+        if(!pOutput->IsNull())
+        {
+            pOutput->AllocateOutputData(1);
+        }
+        auto replay_result = reinterpret_cast<ID3D12DeviceRemovedExtendedData1*>(replay_object->object)->GetAutoBreadcrumbsOutput1(pOutput->GetOutputPointer());
         if (SUCCEEDED(replay_result))
         {
             AddStructObjects(pOutput, pOutput->GetPointer(), GetObjectInfoTable());
@@ -11197,10 +11553,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device6_SetBackgroundProcessingMode(
             hEventToSignalUponCompletion,
             pbFurtherMeasurementsDesired);
         auto in_hEventToSignalUponCompletion = static_cast<HANDLE>(PreProcessExternalObject(hEventToSignalUponCompletion, format::ApiCallId::ApiCall_ID3D12Device6_SetBackgroundProcessingMode, "ID3D12Device6_SetBackgroundProcessingMode"));
+        if(!pbFurtherMeasurementsDesired->IsNull())
+        {
+            pbFurtherMeasurementsDesired->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<ID3D12Device6*>(replay_object->object)->SetBackgroundProcessingMode(Mode,
                                                                                                                   MeasurementsAction,
                                                                                                                   in_hEventToSignalUponCompletion,
-                                                                                                                  pbFurtherMeasurementsDesired->GetPointer());
+                                                                                                                  pbFurtherMeasurementsDesired->GetOutputPointer());
         CheckReplayResult("ID3D12Device6_SetBackgroundProcessingMode", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device6_SetBackgroundProcessingMode>::Dispatch(
             this,
@@ -11339,10 +11699,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_GetResourceAllocationInfo2(
             numResourceDescs,
             pResourceDescs,
             pResourceAllocationInfo1);
+        if(!pResourceAllocationInfo1->IsNull())
+        {
+            pResourceAllocationInfo1->AllocateOutputData(numResourceDescs);
+        }
         auto replay_result = reinterpret_cast<ID3D12Device8*>(replay_object->object)->GetResourceAllocationInfo2(visibleMask,
                                                                                                                  numResourceDescs,
                                                                                                                  pResourceDescs->GetPointer(),
-                                                                                                                 pResourceAllocationInfo1->GetPointer());
+                                                                                                                 pResourceAllocationInfo1->GetOutputPointer());
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device8_GetResourceAllocationInfo2>::Dispatch(
             this,
             call_info,
@@ -11536,14 +11900,30 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_GetCopyableFootprints1(
             pNumRows,
             pRowSizeInBytes,
             pTotalBytes);
+        if(!pLayouts->IsNull())
+        {
+            pLayouts->AllocateOutputData(NumSubresources);
+        }
+        if(!pNumRows->IsNull())
+        {
+            pNumRows->AllocateOutputData(NumSubresources);
+        }
+        if(!pRowSizeInBytes->IsNull())
+        {
+            pRowSizeInBytes->AllocateOutputData(NumSubresources);
+        }
+        if(!pTotalBytes->IsNull())
+        {
+            pTotalBytes->AllocateOutputData(1);
+        }
         reinterpret_cast<ID3D12Device8*>(replay_object->object)->GetCopyableFootprints1(pResourceDesc->GetPointer(),
                                                                                         FirstSubresource,
                                                                                         NumSubresources,
                                                                                         BaseOffset,
-                                                                                        pLayouts->GetPointer(),
-                                                                                        pNumRows->GetPointer(),
-                                                                                        pRowSizeInBytes->GetPointer(),
-                                                                                        pTotalBytes->GetPointer());
+                                                                                        pLayouts->GetOutputPointer(),
+                                                                                        pNumRows->GetOutputPointer(),
+                                                                                        pRowSizeInBytes->GetOutputPointer(),
+                                                                                        pTotalBytes->GetOutputPointer());
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device8_GetCopyableFootprints1>::Dispatch(
             this,
             call_info,
@@ -12059,9 +12439,13 @@ void Dx12ReplayConsumer::Process_ID3D12ShaderCacheSession_FindValue(
             KeySize,
             pValue,
             pValueSize);
+        if(!pValue->IsNull())
+        {
+            pValue->AllocateOutputData(* pValueSize->GetPointer());
+        }
         auto replay_result = reinterpret_cast<ID3D12ShaderCacheSession*>(replay_object->object)->FindValue(pKey->GetPointer(),
                                                                                                            KeySize,
-                                                                                                           pValue->GetPointer(),
+                                                                                                           pValue->GetOutputPointer(),
                                                                                                            pValueSize->GetPointer());
         CheckReplayResult("ID3D12ShaderCacheSession_FindValue", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_FindValue>::Dispatch(
@@ -12514,12 +12898,16 @@ void Dx12ReplayConsumer::Process_ID3D12Device12_GetResourceAllocationInfo3(
             pNumCastableFormats,
             ppCastableFormats,
             pResourceAllocationInfo1);
+        if(!pResourceAllocationInfo1->IsNull())
+        {
+            pResourceAllocationInfo1->AllocateOutputData(numResourceDescs);
+        }
         auto replay_result = reinterpret_cast<ID3D12Device12*>(replay_object->object)->GetResourceAllocationInfo3(visibleMask,
                                                                                                                   numResourceDescs,
                                                                                                                   pResourceDescs->GetPointer(),
                                                                                                                   pNumCastableFormats->GetPointer(),
                                                                                                                   ppCastableFormats->GetPointer(),
-                                                                                                                  pResourceAllocationInfo1->GetPointer());
+                                                                                                                  pResourceAllocationInfo1->GetOutputPointer());
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device12_GetResourceAllocationInfo3>::Dispatch(
             this,
             call_info,
@@ -12588,9 +12976,13 @@ void Dx12ReplayConsumer::Process_ID3D12VirtualizationGuestDevice_CreateFenceFd(
             FenceValue,
             pFenceFd);
         auto in_pFence = MapObject<ID3D12Fence>(pFence);
+        if(!pFenceFd->IsNull())
+        {
+            pFenceFd->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<ID3D12VirtualizationGuestDevice*>(replay_object->object)->CreateFenceFd(in_pFence,
                                                                                                                       FenceValue,
-                                                                                                                      pFenceFd->GetPointer());
+                                                                                                                      pFenceFd->GetOutputPointer());
         CheckReplayResult("ID3D12VirtualizationGuestDevice_CreateFenceFd", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12VirtualizationGuestDevice_CreateFenceFd>::Dispatch(
             this,
@@ -12977,7 +13369,11 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceConfiguration_GetEnabledExperimenta
             replay_object,
             pGuids,
             NumGuids);
-        auto replay_result = reinterpret_cast<ID3D12DeviceConfiguration*>(replay_object->object)->GetEnabledExperimentalFeatures(pGuids->GetPointer(),
+        if(!pGuids->IsNull())
+        {
+            pGuids->AllocateOutputData(NumGuids);
+        }
+        auto replay_result = reinterpret_cast<ID3D12DeviceConfiguration*>(replay_object->object)->GetEnabledExperimentalFeatures(pGuids->GetOutputPointer(),
                                                                                                                                  NumGuids);
         CheckReplayResult("ID3D12DeviceConfiguration_GetEnabledExperimentalFeatures", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_GetEnabledExperimentalFeatures>::Dispatch(
@@ -13446,9 +13842,13 @@ void Dx12ReplayConsumer::Process_ID3DDestructionNotifier_RegisterDestructionCall
             pData,
             pCallbackID);
         auto in_pData = PreProcessExternalObject(pData, format::ApiCallId::ApiCall_ID3DDestructionNotifier_RegisterDestructionCallback, "ID3DDestructionNotifier_RegisterDestructionCallback");
+        if(!pCallbackID->IsNull())
+        {
+            pCallbackID->AllocateOutputData(1);
+        }
         auto replay_result = reinterpret_cast<ID3DDestructionNotifier*>(replay_object->object)->RegisterDestructionCallback(reinterpret_cast<PFN_DESTRUCTION_CALLBACK>(callbackFn),
                                                                                                                             in_pData,
-                                                                                                                            pCallbackID->GetPointer());
+                                                                                                                            pCallbackID->GetOutputPointer());
         CheckReplayResult("ID3DDestructionNotifier_RegisterDestructionCallback", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3DDestructionNotifier_RegisterDestructionCallback>::Dispatch(
             this,
@@ -13767,8 +14167,12 @@ void Dx12ReplayConsumer::Process_ID3D12DebugDevice1_GetDebugParameter(
             Type,
             pData,
             DataSize);
+        if(!pData->IsNull())
+        {
+            pData->AllocateOutputData(DataSize);
+        }
         auto replay_result = reinterpret_cast<ID3D12DebugDevice1*>(replay_object->object)->GetDebugParameter(Type,
-                                                                                                             pData->GetPointer(),
+                                                                                                             pData->GetOutputPointer(),
                                                                                                              DataSize);
         CheckReplayResult("ID3D12DebugDevice1_GetDebugParameter", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugDevice1_GetDebugParameter>::Dispatch(
@@ -13923,8 +14327,12 @@ void Dx12ReplayConsumer::Process_ID3D12DebugDevice2_GetDebugParameter(
             Type,
             pData,
             DataSize);
+        if(!pData->IsNull())
+        {
+            pData->AllocateOutputData(DataSize);
+        }
         auto replay_result = reinterpret_cast<ID3D12DebugDevice2*>(replay_object->object)->GetDebugParameter(Type,
-                                                                                                             pData->GetPointer(),
+                                                                                                             pData->GetOutputPointer(),
                                                                                                              DataSize);
         CheckReplayResult("ID3D12DebugDevice2_GetDebugParameter", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugDevice2_GetDebugParameter>::Dispatch(
@@ -14113,8 +14521,12 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList1_GetDebugParameter(
             Type,
             pData,
             DataSize);
+        if(!pData->IsNull())
+        {
+            pData->AllocateOutputData(DataSize);
+        }
         auto replay_result = reinterpret_cast<ID3D12DebugCommandList1*>(replay_object->object)->GetDebugParameter(Type,
-                                                                                                                  pData->GetPointer(),
+                                                                                                                  pData->GetOutputPointer(),
                                                                                                                   DataSize);
         CheckReplayResult("ID3D12DebugCommandList1_GetDebugParameter", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList1_GetDebugParameter>::Dispatch(
@@ -14253,8 +14665,12 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList2_GetDebugParameter(
             Type,
             pData,
             DataSize);
+        if(!pData->IsNull())
+        {
+            pData->AllocateOutputData(DataSize);
+        }
         auto replay_result = reinterpret_cast<ID3D12DebugCommandList2*>(replay_object->object)->GetDebugParameter(Type,
-                                                                                                                  pData->GetPointer(),
+                                                                                                                  pData->GetOutputPointer(),
                                                                                                                   DataSize);
         CheckReplayResult("ID3D12DebugCommandList2_GetDebugParameter", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList2_GetDebugParameter>::Dispatch(
@@ -14519,8 +14935,12 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetMessage(
             MessageIndex,
             pMessage,
             pMessageByteLength);
+        if(!pMessage->IsNull())
+        {
+            pMessage->AllocateOutputData(* pMessageByteLength->GetPointer());
+        }
         auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetMessage(MessageIndex,
-                                                                                                   pMessage->GetPointer(),
+                                                                                                   pMessage->GetOutputPointer(),
                                                                                                    pMessageByteLength->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_GetMessage", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMessage>::Dispatch(
@@ -14693,7 +15113,11 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetStorageFilter(
             replay_object,
             pFilter,
             pFilterByteLength);
-        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetStorageFilter(pFilter->GetPointer(),
+        if(!pFilter->IsNull())
+        {
+            pFilter->AllocateOutputData(* pFilterByteLength->GetPointer());
+        }
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetStorageFilter(pFilter->GetOutputPointer(),
                                                                                                          pFilterByteLength->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_GetStorageFilter", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetStorageFilter>::Dispatch(
@@ -14869,7 +15293,11 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetRetrievalFilter(
             replay_object,
             pFilter,
             pFilterByteLength);
-        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetRetrievalFilter(pFilter->GetPointer(),
+        if(!pFilter->IsNull())
+        {
+            pFilter->AllocateOutputData(* pFilterByteLength->GetPointer());
+        }
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetRetrievalFilter(pFilter->GetOutputPointer(),
                                                                                                            pFilterByteLength->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_GetRetrievalFilter", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetRetrievalFilter>::Dispatch(

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -1271,8 +1271,14 @@ class BaseGenerator(OutputGenerator):
                     type_name = 'StringDecoder'
             elif type_name == 'void':
                 if value.is_array:
-                    # If this was an array (void*) it was encoded as an array of bytes.
-                    type_name = 'PointerDecoder<uint8_t>'
+                    if (self.is_dx12_class() and count > 1):
+                        # If this was a pointer to memory (void**) allocated internally by the implementation, it was encoded as
+                        # an array of bytes but must be retrieved as a pointer to a memory allocation. For this case, the array
+                        # length value defines the size of the memory referenced by the single retrieved pointer.
+                        type_name = 'PointerDecoder<uint8_t, void*>'
+                    else:
+                        # If this was an array (void*) it was encoded as an array of bytes.
+                        type_name = 'PointerDecoder<uint8_t>'
                 elif count > 1:
                     # If this was a pointer to a pointer to an unknown object (void**), it was encoded as a pointer to a 64-bit address value.
                     # So, we specify uint64_t as the decode type and void* as the type to be used for Vulkan API call output parameters.


### PR DESCRIPTION
This PR adds D3D12 replay support for adjusting the size of the memory allocated for variable length output array parameters to match the actual size reported at replay, which may be different than the size reported at capture.  It is based on the implementation of an existing Vulkan replay feature providing the same functionality.

A simple way to test this change is to find an application that calls IDXGIOutput::GetDisplayModeList and make a capture of it running through a remote desktop session. Then replay the capture on the local device. Fewer values will be reported for the remote desktop session than the local session. With this change, replay will report something similar to:
> [gfxrecon] INFO - Replay adjusted the IDXGIOutput::GetDisplayModeList array count: capture count = 1, replay count = 54

Prior to this change replay would report:
> [gfxrecon] WARNING - IDXGIOutput_GetDisplayModeList returned DXGI_ERROR_MORE_DATA, which does not match the value returned at capture S_OK.

The commits submitted with this PR were taken from the branch associated with #1698. Two of the earlier commits adjust array processing for some D3D11 specific cases, to handle the SAL result_bytebuffer annotation and process objects created by functions that do not return an HRESULT value, which modify the same Python code that was later modified for the array size adjustment. They were included to avoid conflicts arising from their removal but could be removed if required.