### PR TITLE
openxr: Unknown events in capture but not replay

### DIFF
--- a/framework/decode/openxr_replay_consumer_base.cpp
+++ b/framework/decode/openxr_replay_consumer_base.cpp
@@ -951,7 +951,7 @@ void OpenXrReplayConsumerBase::Process_xrPollEvent(const ApiCallInfo&           
                             sleep_time = kMaxSleepLimitNs;
                         }
                     }
-                    else
+                    else if (options_.ignore_unhandled_unknown_capture_events)
                     {
                         // If this is an event we don't know anything about (it is unknown to GFXR), then
                         // add it to the list of events we check against in the future.

--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -484,7 +484,7 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
 
     VulkanReplayConsumerBase* vulkan_replay_consumer_ = nullptr;
 
-    std::deque<XrEventDataBuffer> unhandled_events_from_replay_;
+    std::deque<XrEventDataBuffer> events_already_triggered_in_replay_;
     std::deque<XrEventDataBuffer> unhandled_events_from_capture_;
 
     // Replay specific state:

--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -484,8 +484,8 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
 
     VulkanReplayConsumerBase* vulkan_replay_consumer_ = nullptr;
 
-    std::vector<XrEventDataBuffer> received_events_;
-    std::vector<XrEventDataBuffer> skipped_unhandled_events_;
+    std::deque<XrEventDataBuffer> unhandled_events_from_replay_;
+    std::deque<XrEventDataBuffer> unhandled_events_from_capture_;
 
     // Replay specific state:
 

--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -485,6 +485,7 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
     VulkanReplayConsumerBase* vulkan_replay_consumer_ = nullptr;
 
     std::vector<XrEventDataBuffer> received_events_;
+    std::vector<XrEventDataBuffer> skipped_unhandled_events_;
 
     // Replay specific state:
 

--- a/framework/decode/openxr_replay_options.h
+++ b/framework/decode/openxr_replay_options.h
@@ -24,6 +24,8 @@
 #ifndef GFXRECON_DECODE_OPENXR_REPLAY_OPTIONS_H
 #define GFXRECON_DECODE_OPENXR_REPLAY_OPTIONS_H
 
+#if ENABLE_OPENXR_SUPPORT
+
 #include "decode/replay_options.h"
 #include "util/defines.h"
 
@@ -36,10 +38,12 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 struct OpenXrReplayOptions : public ReplayOptions
 {
-    // TODO: Add options as needed
+    bool ignore_unhandled_unknown_capture_events{ true };
 };
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // ENABLE_OPENXR_SUPPORT
 
 #endif // GFXRECON_DECODE_OPENXR_REPLAY_OPTIONS_H

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -156,7 +156,8 @@ void android_main(struct android_app* app)
                                                      replay_options.preload_measurement_range,
                                                      measurement_file_name);
 
-                vulkan_replay_consumer.SetFatalErrorHandler([](const char* message) { throw std::runtime_error(message); });
+                vulkan_replay_consumer.SetFatalErrorHandler(
+                    [](const char* message) { throw std::runtime_error(message); });
                 vulkan_replay_consumer.SetFpsInfo(&fps_info);
 
                 vulkan_decoder.AddConsumer(&vulkan_replay_consumer);
@@ -164,7 +165,8 @@ void android_main(struct android_app* app)
                 application->SetPauseFrame(GetPauseFrame(arg_parser));
 
 #if ENABLE_OPENXR_SUPPORT
-                gfxrecon::decode::OpenXrReplayOptions  openxr_replay_options = {};
+                gfxrecon::decode::OpenXrReplayOptions openxr_replay_options =
+                    GetOpenXrReplayOptions(arg_parser, filename);
                 gfxrecon::decode::OpenXrDecoder        openxr_decoder;
                 gfxrecon::decode::OpenXrReplayConsumer openxr_replay_consumer(application, openxr_replay_options);
                 openxr_replay_consumer.SetVulkanReplayConsumer(&vulkan_replay_consumer);

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -297,7 +297,7 @@ int main(int argc, const char** argv)
 #endif
 
 #if ENABLE_OPENXR_SUPPORT
-            gfxrecon::decode::OpenXrReplayOptions  openxr_replay_options = {};
+            gfxrecon::decode::OpenXrReplayOptions  openxr_replay_options = GetOpenXrReplayOptions(arg_parser, filename);
             gfxrecon::decode::OpenXrDecoder        openxr_decoder;
             gfxrecon::decode::OpenXrReplayConsumer openxr_replay_consumer(application, openxr_replay_options);
             openxr_replay_consumer.SetVulkanReplayConsumer(&vulkan_replay_consumer);

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -356,6 +356,14 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tArguments becomes three indices, submit index, command index,");
     GFXRECON_WRITE_CONSOLE("          \t\tdrawcall index. The command index is based on its in ExecuteCommandLists.");
 #endif
+
+#if ENABLE_OPENXR_SUPPORT
+    GFXRECON_WRITE_CONSOLE("")
+    GFXRECON_WRITE_CONSOLE("OpenXR only:")
+    GFXRECON_WRITE_CONSOLE("  --openxr-fail-on-unknown-capture-events");
+    GFXRECON_WRITE_CONSOLE("          \t\tFail on any unhandled unknown events that are recorded in the capture");
+    GFXRECON_WRITE_CONSOLE("          \t\tfile but that do not occur during a replay. ()");
+#endif
 }
 
 #endif // GFXRECON_REPLAY_SETTINGS_H

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -39,6 +39,7 @@
 #include "decode/vulkan_tracked_object_info_table.h"
 
 #ifdef ENABLE_OPENXR_SUPPORT
+#include "decode/openxr_replay_options.h"
 #include "generated/generated_openxr_decoder.h"
 #endif
 #include "generated/generated_vulkan_decoder.h"
@@ -137,6 +138,10 @@ const char kPreloadMeasurementRangeOption[]       = "--preload-measurement-range
 const char kDxTwoPassReplay[]             = "--dx12-two-pass-replay";
 const char kDxOverrideObjectNames[]       = "--dx12-override-object-names";
 const char kBatchingMemoryUsageArgument[] = "--batching-memory-usage";
+#endif
+
+#if ENABLE_OPENXR_SUPPORT
+const char kOpenXrFailOnUnknownCaptureEvents[] = "--openxr-fail-on-unknown-capture-events";
 #endif
 
 const char kDumpResourcesArgument[]               = "--dump-resources";
@@ -1167,6 +1172,22 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
     replay_options.screenshot_format      = GetScreenshotFormat(arg_parser);
     replay_options.screenshot_dir         = GetScreenshotDir(arg_parser);
     replay_options.screenshot_file_prefix = arg_parser.GetArgumentValue(kScreenshotFilePrefixArgument);
+    return replay_options;
+}
+#endif
+
+#if ENABLE_OPENXR_SUPPORT
+static gfxrecon::decode::OpenXrReplayOptions GetOpenXrReplayOptions(const gfxrecon::util::ArgumentParser& arg_parser,
+                                                                    const std::string&                    filename)
+{
+    gfxrecon::decode::OpenXrReplayOptions replay_options;
+    GetReplayOptions(replay_options, arg_parser, filename);
+
+    if (arg_parser.IsOptionSet(kOpenXrFailOnUnknownCaptureEvents))
+    {
+        replay_options.ignore_unhandled_unknown_capture_events = false;
+    }
+
     return replay_options;
 }
 #endif


### PR DESCRIPTION
Some unknown events were triggered in some OpenXR captures on the Meta Quest headset, but are not showing up during my replay run. So, if the event is not known by GFXR and it's not handled, just continue onward as if nothing happened, but keep track of the event in case it shows up at some point in the future.