### PR TITLE
MacOS: Fix compiler-warning about missing switch-cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,10 +317,6 @@ if(BUILD_WERROR)
         target_compile_options(platform_specific INTERFACE /WX)
     else()
         target_compile_options(platform_specific INTERFACE -Werror)
-        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-            # TODO: Actually fix these warnings
-            target_compile_options(platform_specific INTERFACE -Wno-error=switch)
-        endif()
     endif()
 endif()
 

--- a/framework/decode/vulkan_cpp_structs.cpp
+++ b/framework/decode/vulkan_cpp_structs.cpp
@@ -1236,6 +1236,8 @@ std::string GenerateStruct_VkIndirectExecutionSetCreateInfoEXT(std::ostream&    
             struct_body << "\t\t\t"
                         << "VkIndirectExecutionSetInfoEXT(" << structInfo->info.pShaderInfo << ")" << std::endl;
             break;
+        case VK_INDIRECT_EXECUTION_SET_INFO_TYPE_MAX_ENUM_EXT:
+            break;
     }
 
     out << "\t";
@@ -1279,6 +1281,22 @@ std::string GenerateStruct_VkIndirectCommandsLayoutTokenEXT(std::ostream&       
         case VK_INDIRECT_COMMANDS_TOKEN_TYPE_EXECUTION_SET_EXT:
             struct_body << "\t\t\t"
                         << "VkIndirectCommandsTokenDataEXT(" << structInfo->data.pExecutionSet << ")" << std::endl;
+            break;
+
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_EXT:
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_EXT:
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_COUNT_EXT:
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_COUNT_EXT:
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_DISPATCH_EXT:
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_MESH_TASKS_NV_EXT:
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_MESH_TASKS_COUNT_NV_EXT:
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_MESH_TASKS_EXT:
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_MESH_TASKS_COUNT_EXT:
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_TRACE_RAYS2_EXT:
+        case VK_INDIRECT_COMMANDS_TOKEN_TYPE_MAX_ENUM_EXT:
+            GFXRECON_LOG_ERROR(
+                "GenerateStruct_VkIndirectCommandsLayoutTokenEXT: unhandled case in switch-statement: %d",
+                metaInfo->decoded_type);
             break;
     }
     // offset


### PR DESCRIPTION
- macOS 14.7, clang-1500.3.9.4

fixes warnings:

```
warning: enumeration value 'VK_INDIRECT_EXECUTION_SET_INFO_TYPE_MAX_ENUM_EXT' not handled in switch [-Wswitch]
warning: 11 enumeration values not handled in switch: 'VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_EXT', 'VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_EXT', 'VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_COUNT_EXT'... [-Wswitch]
```

those warnings were not treated as errors but should have? fyi @bradgrantham @MarkY-LunarG 