### PR TITLE
Update D3D replay codegen for arrays of COM pointers

### DIFF
--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -107,9 +107,12 @@ void Dx12ReplayConsumer::Process_CreateDXGIFactory2(
         Flags,
         riid,
         ppFactory);
-    if(!ppFactory->IsNull()) ppFactory->SetHandleLength(1);
     DxObjectInfo object_info_ppFactory{};
-    ppFactory->SetConsumerData(0, &object_info_ppFactory);
+    if(!ppFactory->IsNull())
+    {
+        ppFactory->SetHandleLength(1);
+        ppFactory->SetConsumerData(0, &object_info_ppFactory);
+    }
     auto replay_result = OverrideCreateDXGIFactory2(return_value,
                                                     Flags,
                                                     riid,
@@ -351,9 +354,12 @@ void Dx12ReplayConsumer::Process_D3D12CreateDevice(
         riid,
         ppDevice);
     auto in_pAdapter = GetObjectInfo(pAdapter);
-    if(!ppDevice->IsNull()) ppDevice->SetHandleLength(1);
     DxObjectInfo object_info_ppDevice{};
-    ppDevice->SetConsumerData(0, &object_info_ppDevice);
+    if(!ppDevice->IsNull())
+    {
+        ppDevice->SetHandleLength(1);
+        ppDevice->SetConsumerData(0, &object_info_ppDevice);
+    }
     auto replay_result = OverrideD3D12CreateDevice(return_value,
                                                    in_pAdapter,
                                                    MinimumFeatureLevel,
@@ -1482,9 +1488,12 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetBuffer(
             Buffer,
             riid,
             ppSurface);
-        if(!ppSurface->IsNull()) ppSurface->SetHandleLength(1);
         DxObjectInfo object_info_ppSurface{};
-        ppSurface->SetConsumerData(0, &object_info_ppSurface);
+        if(!ppSurface->IsNull())
+        {
+            ppSurface->SetHandleLength(1);
+            ppSurface->SetConsumerData(0, &object_info_ppSurface);
+        }
         auto replay_result = OverrideGetBuffer(replay_object,
                                                return_value,
                                                Buffer,
@@ -1894,9 +1903,12 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_CreateSwapChain(
             pDesc,
             ppSwapChain);
         auto in_pDevice = GetObjectInfo(pDevice);
-        if(!ppSwapChain->IsNull()) ppSwapChain->SetHandleLength(1);
         DxObjectInfo object_info_ppSwapChain{};
-        ppSwapChain->SetConsumerData(0, &object_info_ppSwapChain);
+        if(!ppSwapChain->IsNull())
+        {
+            ppSwapChain->SetHandleLength(1);
+            ppSwapChain->SetConsumerData(0, &object_info_ppSwapChain);
+        }
         auto replay_result = OverrideCreateSwapChain(replay_object,
                                                      return_value,
                                                      in_pDevice,
@@ -2012,7 +2024,7 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_CreateSurface(
             Usage,
             pSharedResource,
             ppSurface);
-        if(!ppSurface->IsNull()) ppSurface->SetHandleLength(1);
+        if(!ppSurface->IsNull()) ppSurface->SetHandleLength(NumSurfaces);
         auto out_p_ppSurface    = ppSurface->GetPointer();
         auto out_hp_ppSurface   = ppSurface->GetHandlePointer();
         auto replay_result = reinterpret_cast<IDXGIDevice*>(replay_object->object)->CreateSurface(pDesc->GetPointer(),
@@ -2022,7 +2034,7 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_CreateSurface(
                                                                                                   out_hp_ppSurface);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppSurface, out_hp_ppSurface, format::ApiCall_IDXGIDevice_CreateSurface);
+            AddObjects(out_p_ppSurface, ppSurface->GetLength(), out_hp_ppSurface, NumSurfaces, format::ApiCall_IDXGIDevice_CreateSurface);
         }
         CheckReplayResult("IDXGIDevice_CreateSurface", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice_CreateSurface>::Dispatch(
@@ -3213,9 +3225,12 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForHwnd(
             ppSwapChain);
         auto in_pDevice = GetObjectInfo(pDevice);
         auto in_pRestrictToOutput = GetObjectInfo(pRestrictToOutput);
-        if(!ppSwapChain->IsNull()) ppSwapChain->SetHandleLength(1);
         DxObjectInfo object_info_ppSwapChain{};
-        ppSwapChain->SetConsumerData(0, &object_info_ppSwapChain);
+        if(!ppSwapChain->IsNull())
+        {
+            ppSwapChain->SetHandleLength(1);
+            ppSwapChain->SetConsumerData(0, &object_info_ppSwapChain);
+        }
         auto replay_result = OverrideCreateSwapChainForHwnd(replay_object,
                                                             return_value,
                                                             in_pDevice,
@@ -3269,9 +3284,12 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForCoreWindow(
         auto in_pDevice = GetObjectInfo(pDevice);
         auto in_pWindow = GetObjectInfo(pWindow);
         auto in_pRestrictToOutput = GetObjectInfo(pRestrictToOutput);
-        if(!ppSwapChain->IsNull()) ppSwapChain->SetHandleLength(1);
         DxObjectInfo object_info_ppSwapChain{};
-        ppSwapChain->SetConsumerData(0, &object_info_ppSwapChain);
+        if(!ppSwapChain->IsNull())
+        {
+            ppSwapChain->SetHandleLength(1);
+            ppSwapChain->SetConsumerData(0, &object_info_ppSwapChain);
+        }
         auto replay_result = OverrideCreateSwapChainForCoreWindow(replay_object,
                                                                   return_value,
                                                                   in_pDevice,
@@ -3547,9 +3565,12 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForComposition(
             ppSwapChain);
         auto in_pDevice = GetObjectInfo(pDevice);
         auto in_pRestrictToOutput = GetObjectInfo(pRestrictToOutput);
-        if(!ppSwapChain->IsNull()) ppSwapChain->SetHandleLength(1);
         DxObjectInfo object_info_ppSwapChain{};
-        ppSwapChain->SetConsumerData(0, &object_info_ppSwapChain);
+        if(!ppSwapChain->IsNull())
+        {
+            ppSwapChain->SetHandleLength(1);
+            ppSwapChain->SetConsumerData(0, &object_info_ppSwapChain);
+        }
         auto replay_result = OverrideCreateSwapChainForComposition(replay_object,
                                                                    return_value,
                                                                    in_pDevice,
@@ -4724,9 +4745,12 @@ void Dx12ReplayConsumer::Process_IDXGIFactory4_EnumAdapterByLuid(
             AdapterLuid,
             riid,
             ppvAdapter);
-        if(!ppvAdapter->IsNull()) ppvAdapter->SetHandleLength(1);
         DxObjectInfo object_info_ppvAdapter{};
-        ppvAdapter->SetConsumerData(0, &object_info_ppvAdapter);
+        if(!ppvAdapter->IsNull())
+        {
+            ppvAdapter->SetHandleLength(1);
+            ppvAdapter->SetConsumerData(0, &object_info_ppvAdapter);
+        }
         auto replay_result = OverrideEnumAdapterByLuid(replay_object,
                                                        return_value,
                                                        AdapterLuid,
@@ -8857,9 +8881,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandQueue(
             pDesc,
             riid,
             ppCommandQueue);
-        if(!ppCommandQueue->IsNull()) ppCommandQueue->SetHandleLength(1);
         DxObjectInfo object_info_ppCommandQueue{};
-        ppCommandQueue->SetConsumerData(0, &object_info_ppCommandQueue);
+        if(!ppCommandQueue->IsNull())
+        {
+            ppCommandQueue->SetHandleLength(1);
+            ppCommandQueue->SetConsumerData(0, &object_info_ppCommandQueue);
+        }
         auto replay_result = OverrideCreateCommandQueue(replay_object,
                                                         return_value,
                                                         pDesc,
@@ -8942,9 +8969,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateGraphicsPipelineState(
             riid,
             ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info_ppPipelineState{};
-        ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        if(!ppPipelineState->IsNull())
+        {
+            ppPipelineState->SetHandleLength(1);
+            ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        }
         auto replay_result = OverrideCreateGraphicsPipelineState(replay_object,
                                                                  return_value,
                                                                  pDesc,
@@ -8986,9 +9016,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateComputePipelineState(
             riid,
             ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info_ppPipelineState{};
-        ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        if(!ppPipelineState->IsNull())
+        {
+            ppPipelineState->SetHandleLength(1);
+            ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        }
         auto replay_result = OverrideCreateComputePipelineState(replay_object,
                                                                 return_value,
                                                                 pDesc,
@@ -9037,9 +9070,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandList(
             ppCommandList);
         auto in_pCommandAllocator = GetObjectInfo(pCommandAllocator);
         auto in_pInitialState = GetObjectInfo(pInitialState);
-        if(!ppCommandList->IsNull()) ppCommandList->SetHandleLength(1);
         DxObjectInfo object_info_ppCommandList{};
-        ppCommandList->SetConsumerData(0, &object_info_ppCommandList);
+        if(!ppCommandList->IsNull())
+        {
+            ppCommandList->SetHandleLength(1);
+            ppCommandList->SetConsumerData(0, &object_info_ppCommandList);
+        }
         auto replay_result = OverrideCreateCommandList(replay_object,
                                                        return_value,
                                                        nodeMask,
@@ -9086,9 +9122,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateDescriptorHeap(
             pDescriptorHeapDesc,
             riid,
             ppvHeap);
-        if(!ppvHeap->IsNull()) ppvHeap->SetHandleLength(1);
         DxObjectInfo object_info_ppvHeap{};
-        ppvHeap->SetConsumerData(0, &object_info_ppvHeap);
+        if(!ppvHeap->IsNull())
+        {
+            ppvHeap->SetHandleLength(1);
+            ppvHeap->SetConsumerData(0, &object_info_ppvHeap);
+        }
         auto replay_result = OverrideCreateDescriptorHeap(replay_object,
                                                           return_value,
                                                           pDescriptorHeapDesc,
@@ -9160,9 +9199,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateRootSignature(
             blobLengthInBytes,
             riid,
             ppvRootSignature);
-        if(!ppvRootSignature->IsNull()) ppvRootSignature->SetHandleLength(1);
         DxObjectInfo object_info_ppvRootSignature{};
-        ppvRootSignature->SetConsumerData(0, &object_info_ppvRootSignature);
+        if(!ppvRootSignature->IsNull())
+        {
+            ppvRootSignature->SetHandleLength(1);
+            ppvRootSignature->SetConsumerData(0, &object_info_ppvRootSignature);
+        }
         auto replay_result = OverrideCreateRootSignature(replay_object,
                                                          return_value,
                                                          nodeMask,
@@ -9550,9 +9592,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommittedResource(
             pOptimizedClearValue,
             riidResource,
             ppvResource);
-        if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info_ppvResource{};
-        ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        if(!ppvResource->IsNull())
+        {
+            ppvResource->SetHandleLength(1);
+            ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        }
         auto replay_result = OverrideCreateCommittedResource(replay_object,
                                                              return_value,
                                                              pHeapProperties,
@@ -9602,9 +9647,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateHeap(
             pDesc,
             riid,
             ppvHeap);
-        if(!ppvHeap->IsNull()) ppvHeap->SetHandleLength(1);
         DxObjectInfo object_info_ppvHeap{};
-        ppvHeap->SetConsumerData(0, &object_info_ppvHeap);
+        if(!ppvHeap->IsNull())
+        {
+            ppvHeap->SetHandleLength(1);
+            ppvHeap->SetConsumerData(0, &object_info_ppvHeap);
+        }
         auto replay_result = OverrideCreateHeap(replay_object,
                                                 return_value,
                                                 pDesc,
@@ -9654,9 +9702,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreatePlacedResource(
             riid,
             ppvResource);
         auto in_pHeap = GetObjectInfo(pHeap);
-        if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info_ppvResource{};
-        ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        if(!ppvResource->IsNull())
+        {
+            ppvResource->SetHandleLength(1);
+            ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        }
         auto replay_result = OverrideCreatePlacedResource(replay_object,
                                                           return_value,
                                                           in_pHeap,
@@ -9710,9 +9761,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateReservedResource(
             pOptimizedClearValue,
             riid,
             ppvResource);
-        if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info_ppvResource{};
-        ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        if(!ppvResource->IsNull())
+        {
+            ppvResource->SetHandleLength(1);
+            ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        }
         auto replay_result = OverrideCreateReservedResource(replay_object,
                                                             return_value,
                                                             pDesc,
@@ -9955,9 +10009,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateFence(
             Flags,
             riid,
             ppFence);
-        if(!ppFence->IsNull()) ppFence->SetHandleLength(1);
         DxObjectInfo object_info_ppFence{};
-        ppFence->SetConsumerData(0, &object_info_ppFence);
+        if(!ppFence->IsNull())
+        {
+            ppFence->SetHandleLength(1);
+            ppFence->SetConsumerData(0, &object_info_ppFence);
+        }
         auto replay_result = OverrideCreateFence(replay_object,
                                                  return_value,
                                                  InitialValue,
@@ -10159,9 +10216,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandSignature(
             riid,
             ppvCommandSignature);
         auto in_pRootSignature = GetObjectInfo(pRootSignature);
-        if(!ppvCommandSignature->IsNull()) ppvCommandSignature->SetHandleLength(1);
         DxObjectInfo object_info_ppvCommandSignature{};
-        ppvCommandSignature->SetConsumerData(0, &object_info_ppvCommandSignature);
+        if(!ppvCommandSignature->IsNull())
+        {
+            ppvCommandSignature->SetHandleLength(1);
+            ppvCommandSignature->SetConsumerData(0, &object_info_ppvCommandSignature);
+        }
         auto replay_result = OverrideCreateCommandSignature(replay_object,
                                                             return_value,
                                                             pDesc,
@@ -10327,9 +10387,12 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_LoadGraphicsPipeline(
             riid,
             ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info_ppPipelineState{};
-        ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        if(!ppPipelineState->IsNull())
+        {
+            ppPipelineState->SetHandleLength(1);
+            ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        }
         auto replay_result = OverrideLoadGraphicsPipeline(replay_object,
                                                           return_value,
                                                           pName,
@@ -10375,9 +10438,12 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_LoadComputePipeline(
             riid,
             ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info_ppPipelineState{};
-        ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        if(!ppPipelineState->IsNull())
+        {
+            ppPipelineState->SetHandleLength(1);
+            ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        }
         auto replay_result = OverrideLoadComputePipeline(replay_object,
                                                          return_value,
                                                          pName,
@@ -10479,9 +10545,12 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary1_LoadPipeline(
             riid,
             ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info_ppPipelineState{};
-        ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        if(!ppPipelineState->IsNull())
+        {
+            ppPipelineState->SetHandleLength(1);
+            ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        }
         auto replay_result = OverrideLoadPipeline(replay_object,
                                                   return_value,
                                                   pName,
@@ -10526,9 +10595,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device1_CreatePipelineLibrary(
             BlobLength,
             riid,
             ppPipelineLibrary);
-        if(!ppPipelineLibrary->IsNull()) ppPipelineLibrary->SetHandleLength(1);
         DxObjectInfo object_info_ppPipelineLibrary{};
-        ppPipelineLibrary->SetConsumerData(0, &object_info_ppPipelineLibrary);
+        if(!ppPipelineLibrary->IsNull())
+        {
+            ppPipelineLibrary->SetHandleLength(1);
+            ppPipelineLibrary->SetConsumerData(0, &object_info_ppPipelineLibrary);
+        }
         auto replay_result = OverrideCreatePipelineLibrary(replay_object,
                                                            return_value,
                                                            pLibraryBlob,
@@ -10651,9 +10723,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device2_CreatePipelineState(
             riid,
             ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info_ppPipelineState{};
-        ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        if(!ppPipelineState->IsNull())
+        {
+            ppPipelineState->SetHandleLength(1);
+            ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        }
         auto replay_result = OverrideCreatePipelineState(replay_object,
                                                          return_value,
                                                          pDesc,
@@ -10694,9 +10769,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device3_OpenExistingHeapFromAddress(
             pAddress,
             riid,
             ppvHeap);
-        if(!ppvHeap->IsNull()) ppvHeap->SetHandleLength(1);
         DxObjectInfo object_info_ppvHeap{};
-        ppvHeap->SetConsumerData(0, &object_info_ppvHeap);
+        if(!ppvHeap->IsNull())
+        {
+            ppvHeap->SetHandleLength(1);
+            ppvHeap->SetConsumerData(0, &object_info_ppvHeap);
+        }
         auto replay_result = OverrideOpenExistingHeapFromAddress(replay_object,
                                                                  return_value,
                                                                  pAddress,
@@ -10910,9 +10988,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateCommandList1(
             flags,
             riid,
             ppCommandList);
-        if(!ppCommandList->IsNull()) ppCommandList->SetHandleLength(1);
         DxObjectInfo object_info_ppCommandList{};
-        ppCommandList->SetConsumerData(0, &object_info_ppCommandList);
+        if(!ppCommandList->IsNull())
+        {
+            ppCommandList->SetHandleLength(1);
+            ppCommandList->SetConsumerData(0, &object_info_ppCommandList);
+        }
         auto replay_result = OverrideCreateCommandList1(replay_object,
                                                         return_value,
                                                         nodeMask,
@@ -11009,9 +11090,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateCommittedResource1(
             riidResource,
             ppvResource);
         auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
-        if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info_ppvResource{};
-        ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        if(!ppvResource->IsNull())
+        {
+            ppvResource->SetHandleLength(1);
+            ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        }
         auto replay_result = OverrideCreateCommittedResource1(replay_object,
                                                               return_value,
                                                               pHeapProperties,
@@ -11066,9 +11150,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateHeap1(
             riid,
             ppvHeap);
         auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
-        if(!ppvHeap->IsNull()) ppvHeap->SetHandleLength(1);
         DxObjectInfo object_info_ppvHeap{};
-        ppvHeap->SetConsumerData(0, &object_info_ppvHeap);
+        if(!ppvHeap->IsNull())
+        {
+            ppvHeap->SetHandleLength(1);
+            ppvHeap->SetConsumerData(0, &object_info_ppvHeap);
+        }
         auto replay_result = OverrideCreateHeap1(replay_object,
                                                  return_value,
                                                  pDesc,
@@ -11118,9 +11205,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateReservedResource1(
             riid,
             ppvResource);
         auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
-        if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info_ppvResource{};
-        ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        if(!ppvResource->IsNull())
+        {
+            ppvResource->SetHandleLength(1);
+            ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        }
         auto replay_result = OverrideCreateReservedResource1(replay_object,
                                                              return_value,
                                                              pDesc,
@@ -11694,9 +11784,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_CreateStateObject(
             riid,
             ppStateObject);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        if(!ppStateObject->IsNull()) ppStateObject->SetHandleLength(1);
         DxObjectInfo object_info_ppStateObject{};
-        ppStateObject->SetConsumerData(0, &object_info_ppStateObject);
+        if(!ppStateObject->IsNull())
+        {
+            ppStateObject->SetHandleLength(1);
+            ppStateObject->SetConsumerData(0, &object_info_ppStateObject);
+        }
         auto replay_result = OverrideCreateStateObject(replay_object,
                                                        return_value,
                                                        pDesc,
@@ -12159,9 +12252,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device7_AddToStateObject(
             ppNewStateObject);
         MapStructObjects(pAddition->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         auto in_pStateObjectToGrowFrom = GetObjectInfo(pStateObjectToGrowFrom);
-        if(!ppNewStateObject->IsNull()) ppNewStateObject->SetHandleLength(1);
         DxObjectInfo object_info_ppNewStateObject{};
-        ppNewStateObject->SetConsumerData(0, &object_info_ppNewStateObject);
+        if(!ppNewStateObject->IsNull())
+        {
+            ppNewStateObject->SetHandleLength(1);
+            ppNewStateObject->SetConsumerData(0, &object_info_ppNewStateObject);
+        }
         auto replay_result = OverrideAddToStateObject(replay_object,
                                                       return_value,
                                                       pAddition,
@@ -12297,9 +12393,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreateCommittedResource2(
             riidResource,
             ppvResource);
         auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
-        if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info_ppvResource{};
-        ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        if(!ppvResource->IsNull())
+        {
+            ppvResource->SetHandleLength(1);
+            ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        }
         auto replay_result = OverrideCreateCommittedResource2(replay_object,
                                                               return_value,
                                                               pHeapProperties,
@@ -12360,9 +12459,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreatePlacedResource1(
             riid,
             ppvResource);
         auto in_pHeap = GetObjectInfo(pHeap);
-        if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info_ppvResource{};
-        ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        if(!ppvResource->IsNull())
+        {
+            ppvResource->SetHandleLength(1);
+            ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        }
         auto replay_result = OverrideCreatePlacedResource1(replay_object,
                                                            return_value,
                                                            in_pHeap,
@@ -13198,9 +13300,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device9_CreateCommandQueue1(
             CreatorID,
             riid,
             ppCommandQueue);
-        if(!ppCommandQueue->IsNull()) ppCommandQueue->SetHandleLength(1);
         DxObjectInfo object_info_ppCommandQueue{};
-        ppCommandQueue->SetConsumerData(0, &object_info_ppCommandQueue);
+        if(!ppCommandQueue->IsNull())
+        {
+            ppCommandQueue->SetHandleLength(1);
+            ppCommandQueue->SetConsumerData(0, &object_info_ppCommandQueue);
+        }
         auto replay_result = OverrideCreateCommandQueue1(replay_object,
                                                          return_value,
                                                          pDesc,
@@ -13258,9 +13363,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreateCommittedResource3(
             riidResource,
             ppvResource);
         auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
-        if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info_ppvResource{};
-        ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        if(!ppvResource->IsNull())
+        {
+            ppvResource->SetHandleLength(1);
+            ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        }
         auto replay_result = OverrideCreateCommittedResource3(replay_object,
                                                               return_value,
                                                               pHeapProperties,
@@ -13329,9 +13437,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreatePlacedResource2(
             riid,
             ppvResource);
         auto in_pHeap = GetObjectInfo(pHeap);
-        if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info_ppvResource{};
-        ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        if(!ppvResource->IsNull())
+        {
+            ppvResource->SetHandleLength(1);
+            ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        }
         auto replay_result = OverrideCreatePlacedResource2(replay_object,
                                                            return_value,
                                                            in_pHeap,
@@ -13396,9 +13507,12 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreateReservedResource2(
             riid,
             ppvResource);
         auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
-        if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info_ppvResource{};
-        ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        if(!ppvResource->IsNull())
+        {
+            ppvResource->SetHandleLength(1);
+            ppvResource->SetConsumerData(0, &object_info_ppvResource);
+        }
         auto replay_result = OverrideCreateReservedResource2(replay_object,
                                                              return_value,
                                                              pDesc,
@@ -13917,9 +14031,12 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceFactory_CreateDevice(
             riid,
             ppvDevice);
         auto in_adapter = GetObjectInfo(adapter);
-        if(!ppvDevice->IsNull()) ppvDevice->SetHandleLength(1);
         DxObjectInfo object_info_ppvDevice{};
-        ppvDevice->SetConsumerData(0, &object_info_ppvDevice);
+        if(!ppvDevice->IsNull())
+        {
+            ppvDevice->SetHandleLength(1);
+            ppvDevice->SetConsumerData(0, &object_info_ppvDevice);
+        }
         auto replay_result = OverrideD3D12DeviceFactoryCreateDevice(replay_object,
                                                                     return_value,
                                                                     in_adapter,


### PR DESCRIPTION
Add COM pointer array support to the replay consumer code generator:
- Handle output arrays of COM pointers, adding them to the object table.
- Support variable length arrays of output COM pointers.

For the generated replay override code, the `SetConsumerData` call was also moved behind the same `IsNull` conditional check performed for `SetHandleLength`, because the consumer data won't be set when there are no handles to associate it with. This was primarily done for the array of COM objects case, to skip initialization of a vector of objects, but also applies to the single COM object case.

IDXGIDevice::CreateSurface is currently the only function that outputs an array of COM pointers, but this change was pulled from the D3D11 branch where there are multiple D3D11 cases