### PR TITLE
Fix timing mismatch issue for vkGetQueryPoolResults

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3315,12 +3315,13 @@ VkResult VulkanReplayConsumerBase::OverrideGetQueryPoolResults(PFN_vkGetQueryPoo
     VkQueryPool query_pool = query_pool_info->handle;
     size_t      retries    = 0;
 
+    // Some timing mismatch issue was observed when replaying a specific title's trace. At playback time,
+    // vkGetQueryPoolResults returned VK_NOT_READY, while at capture time it returned VK_SUCCESS. Therefore, we handle
+    // the possible timing difference in the same way as vkGetFenceStatus.
     do
     {
         result = func(device, query_pool, firstQuery, queryCount, dataSize, pData->GetOutputPointer(), stride, flags);
-    } while ((((original_result == VK_SUCCESS) && (result == VK_NOT_READY)) ||
-              ((original_result == VK_NOT_READY) && (result == VK_SUCCESS))) &&
-             (++retries <= kMaxQueryPoolResultsRetries));
+    } while ((original_result == VK_SUCCESS) && (result == VK_NOT_READY));
 
     return result;
 }


### PR DESCRIPTION
**The problem**

Some timing mismatch issue was observed when playing back a particular title's trace. vkGetQueryPoolResults returned VK_NOT_READY at playback time, while it returned VK_SUCCESS at the capture time.

**The solution**

The commit adds changes to handle the timing difference between capture time and playback time.

**Result**

Tested the target title with the build of the pull request, it fixed this issue.
