### PR TITLE
openxr: Disable replay w/ unknown extensions

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -57,6 +57,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/openxr_decoder_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/openxr_decoder_base.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/openxr_enum_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/openxr_feature_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/openxr_feature_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/openxr_handle_mapping_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/openxr_handle_mapping_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/openxr_next_node.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -89,6 +89,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/openxr_decoder_base.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/openxr_detection_consumer.h
                     ${CMAKE_CURRENT_LIST_DIR}/openxr_enum_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/openxr_feature_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/openxr_feature_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/openxr_handle_mapping_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/openxr_handle_mapping_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/openxr_json_consumer_base.h

--- a/framework/decode/dx_replay_options.h
+++ b/framework/decode/dx_replay_options.h
@@ -56,13 +56,7 @@ struct DxReplayOptions : public ReplayOptions
     bool                 override_object_names{ false };
     bool                 enable_dump_resources{ false };
     DumpResourcesTarget  dump_resources_target{};
-
-    util::ScreenshotFormat       screenshot_format{ util::ScreenshotFormat::kBmp };
-    std::vector<ScreenshotRange> screenshot_ranges;
-    std::string                  screenshot_dir;
-    std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
-    std::string                  replace_dir;
-    int32_t                      memory_usage{ kDefaultBatchingMemoryUsage };
+    int32_t              memory_usage{ kDefaultBatchingMemoryUsage };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/openxr_feature_util.cpp
+++ b/framework/decode/openxr_feature_util.cpp
@@ -1,0 +1,125 @@
+/*
+** Copyright (c) 2020-2024 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifdef ENABLE_OPENXR_SUPPORT
+
+#include "decode/openxr_feature_util.h"
+
+#include "util/logging.h"
+#include "util/platform.h"
+
+#include <cassert>
+#include <set>
+#include <string>
+#include <algorithm>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(feature_util)
+
+XrResult GetApiLayers(PFN_xrEnumerateApiLayerProperties enum_layer_pros, std::vector<XrApiLayerProperties>* layers)
+{
+    assert(layers != nullptr);
+
+    XrResult result = XR_ERROR_INITIALIZATION_FAILED;
+
+    if (enum_layer_pros != nullptr)
+    {
+        uint32_t layer_count = 0;
+        result               = enum_layer_pros(layer_count, nullptr, nullptr);
+
+        if ((result == XR_SUCCESS) && (layer_count > 0))
+        {
+            layers->assign(layer_count, { XR_TYPE_API_LAYER_PROPERTIES, nullptr });
+            result = enum_layer_pros(static_cast<uint32_t>(layers->size()), &layer_count, layers->data());
+        }
+    }
+
+    return result;
+}
+
+bool IsSupportedApiLayer(const std::vector<XrApiLayerProperties>& properties, const char* layer)
+{
+    assert(layer != nullptr);
+
+    auto pred = [layer](const XrApiLayerProperties& property) { return strcmp(property.layerName, layer) == 0; };
+    return std::any_of(properties.begin(), properties.end(), pred);
+}
+
+XrResult GetInstanceExtensions(PFN_xrEnumerateInstanceExtensionProperties enum_ext_props,
+                               std::vector<XrExtensionProperties>*        properties)
+{
+    assert(properties != nullptr);
+
+    XrResult result = XR_ERROR_INITIALIZATION_FAILED;
+
+    if (enum_ext_props != nullptr)
+    {
+        uint32_t count = 0;
+        result         = enum_ext_props(nullptr, 0, &count, nullptr);
+
+        if ((result == XR_SUCCESS) && (count > 0))
+        {
+            properties->assign(count, { XR_TYPE_EXTENSION_PROPERTIES, nullptr });
+            result = enum_ext_props(nullptr, static_cast<uint32_t>(properties->size()), &count, properties->data());
+        }
+    }
+
+    return result;
+}
+
+bool IsSupportedExtension(const std::vector<XrExtensionProperties>& properties, const char* extension)
+{
+    assert(extension != nullptr);
+
+    auto pred = [extension](const XrExtensionProperties& property) {
+        return strcmp(property.extensionName, extension) == 0;
+    };
+    return std::any_of(properties.begin(), properties.end(), pred);
+}
+
+void RemoveUnsupportedExtensions(const std::vector<XrExtensionProperties>& properties,
+                                 std::vector<const char*>*                 extensions)
+{
+    assert(extensions != nullptr);
+
+    auto extensionIter = extensions->begin();
+    while (extensionIter != extensions->end())
+    {
+        if (!IsSupportedExtension(properties, *extensionIter))
+        {
+            GFXRECON_LOG_WARNING("Extension %s, which is not supported by the replay device, will not be enabled",
+                                 *extensionIter);
+            extensionIter = extensions->erase(extensionIter);
+        }
+        else
+        {
+            ++extensionIter;
+        }
+    }
+}
+
+GFXRECON_END_NAMESPACE(feature_util)
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // ENABLE_OPENXR_SUPPORT

--- a/framework/decode/openxr_feature_util.h
+++ b/framework/decode/openxr_feature_util.h
@@ -1,6 +1,5 @@
 /*
-** Copyright (c) 2019-2020 Valve Corporation
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2020-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -21,25 +20,37 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef GFXRECON_DECODE_OPENXR_REPLAY_OPTIONS_H
-#define GFXRECON_DECODE_OPENXR_REPLAY_OPTIONS_H
+#ifndef GFXRECON_DECODE_OPENXR_FEATURE_FILTER_UTIL_H
+#define GFXRECON_DECODE_OPENXR_FEATURE_FILTER_UTIL_H
 
-#include "decode/replay_options.h"
+#ifdef ENABLE_OPENXR_SUPPORT
+
 #include "util/defines.h"
 
-#include <functional>
-#include <string>
+#include "openxr/openxr.h"
+
 #include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(feature_util)
 
-struct OpenXrReplayOptions : public ReplayOptions
-{
-    // TODO: Add options as needed
-};
+XrResult GetApiLayers(PFN_xrEnumerateApiLayerProperties instance_layer_proc, std::vector<XrApiLayerProperties>* layers);
 
+bool IsSupportedApiLayer(const std::vector<XrApiLayerProperties>& properties, const char* layer);
+
+XrResult GetInstanceExtensions(PFN_xrEnumerateInstanceExtensionProperties instance_extension_proc,
+                               std::vector<XrExtensionProperties>*        properties);
+
+bool IsSupportedExtension(const std::vector<XrExtensionProperties>& properties, const char* extension);
+
+void RemoveUnsupportedExtensions(const std::vector<XrExtensionProperties>& properties,
+                                 std::vector<const char*>*                 extensions);
+
+GFXRECON_END_NAMESPACE(feature_util)
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_DECODE_OPENXR_REPLAY_OPTIONS_H
+#endif // ENABLE_OPENXR_SUPPORT
+
+#endif // GFXRECON_DECODE_OPENXR_FEATURE_FILTER_UTIL_H

--- a/framework/decode/openxr_replay_options.h
+++ b/framework/decode/openxr_replay_options.h
@@ -36,8 +36,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 struct OpenXrReplayOptions : public ReplayOptions
 {
-    bool        enable_openxr{ true };
-    std::string replace_dir;
+    bool enable_openxr{ true };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -41,25 +41,32 @@ struct ScreenshotRange
 
 struct ReplayOptions
 {
-    bool        enable_validation_layer{ false };
-    bool        sync_queue_submissions{ false };
-    bool        enable_debug_device_lost{ false };
-    bool        create_dummy_allocations{ false };
-    bool        omit_null_hardware_buffers{ false };
-    bool        quit_after_measurement_frame_range{ false };
-    bool        flush_measurement_frame_range{ false };
-    bool        flush_inside_measurement_range{ false };
-    bool        force_windowed{ false };
-    uint32_t    windowed_width{ 0 };
-    uint32_t    windowed_height{ 0 };
-    bool        force_windowed_origin{ false };
-    int32_t     window_topleft_x{ 0 };
-    int32_t     window_topleft_y{ 0 };
-    int32_t     override_gpu_index{ -1 };
-    std::string capture_filename;
-    bool        enable_print_block_info{ false };
-    int64_t     block_index_from{ -1 };
-    int64_t     block_index_to{ -1 };
+    bool                         enable_validation_layer{ false };
+    bool                         sync_queue_submissions{ false };
+    bool                         enable_debug_device_lost{ false };
+    bool                         create_dummy_allocations{ false };
+    bool                         omit_null_hardware_buffers{ false };
+    bool                         quit_after_measurement_frame_range{ false };
+    bool                         flush_measurement_frame_range{ false };
+    bool                         flush_inside_measurement_range{ false };
+    bool                         force_windowed{ false };
+    uint32_t                     windowed_width{ 0 };
+    uint32_t                     windowed_height{ 0 };
+    bool                         force_windowed_origin{ false };
+    int32_t                      window_topleft_x{ 0 };
+    int32_t                      window_topleft_y{ 0 };
+    int32_t                      override_gpu_index{ -1 };
+    std::string                  capture_filename;
+    bool                         enable_print_block_info{ false };
+    int64_t                      block_index_from{ -1 };
+    int64_t                      block_index_to{ -1 };
+    bool                         skip_failed_allocations{ false };
+    bool                         remove_unsupported_features{ false };
+    util::ScreenshotFormat       screenshot_format{ util::ScreenshotFormat::kBmp };
+    std::vector<ScreenshotRange> screenshot_ranges;
+    std::string                  screenshot_dir;
+    std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
+    uint32_t                     screenshot_width, screenshot_height;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5696,7 +5696,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
            (pShaderModule != nullptr) && !pShaderModule->IsNull());
 
     auto original_info = pCreateInfo->GetPointer();
-    if (original_result < 0 || options_.replace_dir.empty())
+    if (original_result < 0 || options_.replace_shader_dir.empty())
     {
         VkResult vk_res = func(
             device_info->handle, original_info, GetAllocationCallbacks(pAllocator), pShaderModule->GetHandlePointer());
@@ -5747,7 +5747,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
     const size_t            orig_size = original_info->codeSize;
     uint64_t                handle_id = *pShaderModule->GetPointer();
     std::string             file_name = "sh" + std::to_string(handle_id);
-    std::string             file_path = util::filepath::Join(options_.replace_dir, file_name);
+    std::string             file_path = util::filepath::Join(options_.replace_shader_dir, file_name);
 
     FILE*   fp     = nullptr;
     int32_t result = util::platform::FileOpen(&fp, file_path.c_str(), "rb");

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -57,9 +57,7 @@ static constexpr int kUnspecifiedColorAttachment = -1;
 struct VulkanReplayOptions : public ReplayOptions
 {
     bool                         enable_vulkan{ true };
-    bool                         skip_failed_allocations{ false };
     bool                         omit_pipeline_cache_data{ false };
-    bool                         remove_unsupported_features{ false };
     bool                         use_colorspace_fallback{ false };
     bool                         offscreen_swapchain_frame_boundary{ false };
     util::SwapchainOption        swapchain_option{ util::SwapchainOption::kVirtual };
@@ -67,13 +65,9 @@ struct VulkanReplayOptions : public ReplayOptions
     int32_t                      override_gpu_group_index{ -1 };
     int32_t                      surface_index{ -1 };
     CreateResourceAllocator      create_resource_allocator;
-    util::ScreenshotFormat       screenshot_format{ util::ScreenshotFormat::kBmp };
-    std::vector<ScreenshotRange> screenshot_ranges;
-    std::string                  screenshot_dir;
-    std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
     uint32_t                     screenshot_width, screenshot_height;
     float                        screenshot_scale;
-    std::string                  replace_dir;
+    std::string                  replace_shader_dir;
     SkipGetFenceStatus           skip_get_fence_status{ SkipGetFenceStatus::NoSkip };
     std::vector<util::UintRange> skip_get_fence_ranges;
     bool                         wait_before_present{ false };

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -1010,7 +1010,7 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
         replay_options.virtual_swapchain_skip_blit = true;
     }
 
-    replay_options.replace_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);
+    replay_options.replace_shader_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);
     replay_options.create_resource_allocator =
         GetCreateResourceAllocatorFunc(arg_parser, filename, replay_options, tracked_object_info_table);
 


### PR DESCRIPTION
Move some replay options into the base class for sharing among all the paths.  Update the OpenXR replay options to be read during replay execution.
Remove unknown extensions if the replay option is enabled.