### PR TITLE
Fix tracking queue family properties

### DIFF
--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -115,6 +115,11 @@ void VulkanStateTracker::TrackPhysicalDeviceQueueFamilyProperties(VkPhysicalDevi
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
     auto wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device);
+    // If queue family properties were already retrieved with a count larger than the current property_count, we must
+    // not discard those additional properties
+    if (property_count < wrapper->queue_family_properties_count)
+        return;
+
     wrapper->queue_family_properties_call_id = format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties;
     wrapper->queue_family_properties_count   = property_count;
     wrapper->queue_family_properties         = std::make_unique<VkQueueFamilyProperties[]>(property_count);
@@ -129,6 +134,11 @@ void VulkanStateTracker::TrackPhysicalDeviceQueueFamilyProperties2(format::ApiCa
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
     auto wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device);
+    // If queue family properties were already retrieved with a count larger than the current property_count, we must
+    // not discard those additional properties
+    if (property_count < wrapper->queue_family_properties_count)
+        return;
+
     wrapper->queue_family_properties_call_id = call_id;
     wrapper->queue_family_properties_count   = property_count;
     wrapper->queue_family_properties2        = std::make_unique<VkQueueFamilyProperties2[]>(property_count);


### PR DESCRIPTION
Ran into a case where an app did:
`vkGetPhysicalDeviceQueueFamilyProperties()` to get the count
`vkGetPhysicalDeviceQueueFamilyProperties()` with the count
`vkGetPhysicalDeviceQueueFamilyProperties()` with 1

And we just stored the 1. 