### PR TITLE
Add missing pipeline binaries struct entry

### DIFF
--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -201,6 +201,36 @@ class VulkanStateTracker
         }
     }
 
+    void AddStructGroupEntry(
+        VkDevice                                                                                   parent_handle,
+        uint32_t                                                                                   count,
+        VkPipelineBinaryHandlesInfoKHR*                                                            handle_structs,
+        std::function<vulkan_wrappers::PipelineBinaryKHRWrapper*(VkPipelineBinaryHandlesInfoKHR*)> unwrap_struct_handle,
+        format::ApiCallId                                                                          create_call_id,
+        const util::MemoryOutputStream* create_parameter_buffer)
+    {
+        assert(handle_structs != nullptr);
+        assert(create_parameter_buffer != nullptr);
+
+        GFXRECON_UNREFERENCED_PARAMETER(count);
+        GFXRECON_UNREFERENCED_PARAMETER(unwrap_struct_handle);
+
+        if (handle_structs->pPipelineBinaries != nullptr)
+        {
+            vulkan_state_info::CreateParameters create_parameters = std::make_shared<util::MemoryOutputStream>(
+                create_parameter_buffer->GetData(), create_parameter_buffer->GetDataSize());
+
+            AddGroupHandles<VkDevice, void*, vulkan_wrappers::PipelineBinaryKHRWrapper, void>(
+                parent_handle,
+                nullptr,
+                handle_structs->pipelineBinaryCount,
+                handle_structs->pPipelineBinaries,
+                nullptr,
+                create_call_id,
+                create_parameters);
+        }
+    }
+
     template <typename Wrapper>
     void RemoveEntry(typename Wrapper::HandleType handle)
     {


### PR DESCRIPTION
`VkPipelineBinaryHandlesInfoKHR` contains a dynamic array and must be handled differently. 

Currently any attempt to call `vkCreatePipelineBinariesKHR` would assert in `AddStructGroupEntry`.