### PR TITLE
Add acceleration structure meta-commands

### DIFF
--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -26,6 +26,8 @@ target_sources(gfxrecon_encode
                    ${GFXRECON_SOURCE_DIR}/framework/encode/struct_pointer_encoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_capture_manager.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_capture_manager.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_device_address_tracker.h
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_device_address_tracker.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrappers.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrapper_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrapper_util.cpp

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -186,19 +186,25 @@ class ApiDecoder
         std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
         const uint8_t*                                                  build_inputs_data) = 0;
 
-    virtual void DispatchGetDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header){};
+    virtual void DispatchGetDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header) {};
 
-    virtual void DispatchGetDx12RuntimeInfo(const format::Dx12RuntimeInfoCommandHeader& runtime_info_header){};
+    virtual void DispatchGetDx12RuntimeInfo(const format::Dx12RuntimeInfoCommandHeader& runtime_info_header) {};
 
-    virtual void SetCurrentBlockIndex(uint64_t block_index){};
+    virtual void SetCurrentBlockIndex(uint64_t block_index) {};
 
-    virtual void SetCurrentApiCallId(format::ApiCallId api_call_id){};
+    virtual void SetCurrentApiCallId(format::ApiCallId api_call_id) {};
 
     virtual void DispatchSetTlasToBlasDependencyCommand(format::HandleId                     tlas,
-                                                        const std::vector<format::HandleId>& blases){};
+                                                        const std::vector<format::HandleId>& blases) {};
 
     virtual void DispatchSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                        const char*                             env_string){};
+                                                        const char*                             env_string) {};
+
+    virtual void DispatchVulkanAccelerationStructuresBuildMetaCommand(const uint8_t* parameter_buffer,
+                                                                      size_t         buffer_size) {};
+
+    virtual void DispatchVulkanAccelerationStructuresCopyMetaCommand(const uint8_t* parameter_buffer,
+                                                                     size_t         buffer_size) {};
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -186,28 +186,28 @@ class ApiDecoder
         std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
         const uint8_t*                                                  build_inputs_data) = 0;
 
-    virtual void DispatchGetDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header) {};
+    virtual void DispatchGetDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header){};
 
-    virtual void DispatchGetDx12RuntimeInfo(const format::Dx12RuntimeInfoCommandHeader& runtime_info_header) {};
+    virtual void DispatchGetDx12RuntimeInfo(const format::Dx12RuntimeInfoCommandHeader& runtime_info_header){};
 
-    virtual void SetCurrentBlockIndex(uint64_t block_index) {};
+    virtual void SetCurrentBlockIndex(uint64_t block_index){};
 
-    virtual void SetCurrentApiCallId(format::ApiCallId api_call_id) {};
+    virtual void SetCurrentApiCallId(format::ApiCallId api_call_id){};
 
     virtual void DispatchSetTlasToBlasDependencyCommand(format::HandleId                     tlas,
-                                                        const std::vector<format::HandleId>& blases) {};
+                                                        const std::vector<format::HandleId>& blases){};
 
     virtual void DispatchSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                        const char*                             env_string) {};
+                                                        const char*                             env_string){};
 
     virtual void DispatchVulkanAccelerationStructuresBuildMetaCommand(const uint8_t* parameter_buffer,
-                                                                      size_t         buffer_size) {};
+                                                                      size_t         buffer_size){};
 
     virtual void DispatchVulkanAccelerationStructuresCopyMetaCommand(const uint8_t* parameter_buffer,
-                                                                     size_t         buffer_size) {};
+                                                                     size_t         buffer_size){};
 
     virtual void DispatchVulkanAccelerationStructuresWritePropertiesMetaCommand(const uint8_t* parameter_buffer,
-                                                                                size_t         buffer_size) {};
+                                                                                size_t         buffer_size){};
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -205,6 +205,9 @@ class ApiDecoder
 
     virtual void DispatchVulkanAccelerationStructuresCopyMetaCommand(const uint8_t* parameter_buffer,
                                                                      size_t         buffer_size) {};
+
+    virtual void DispatchVulkanAccelerationStructuresWritePropertiesMetaCommand(const uint8_t* parameter_buffer,
+                                                                                size_t         buffer_size) {};
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -1842,6 +1842,77 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             decoder->DispatchSetEnvironmentVariablesCommand(header, env_string);
         }
     }
+    else if (meta_data_type == format::MetaDataType::kVulkanBuildAccelerationStructuresCommand)
+    {
+        format::VulkanMetaBuildAccelerationStructuresHeader header{};
+        size_t parameter_buffer_size = static_cast<size_t>(block_header.size) - sizeof(meta_data_id);
+        success                      = ReadParameterBuffer(parameter_buffer_size);
+
+        if (success)
+        {
+            for (auto decoder : decoders_)
+            {
+                if (decoder->SupportsMetaDataId(meta_data_id))
+                {
+                    DecodeAllocator::Begin();
+
+                    decoder->DispatchVulkanAccelerationStructuresBuildMetaCommand(parameter_buffer_.data(),
+                                                                                  parameter_buffer_size);
+
+                    DecodeAllocator::End();
+                }
+            }
+        }
+        else
+        {
+            HandleBlockReadError(kErrorReadingBlockHeader,
+                                 "Failed to read acceleration structure init meta-data block header");
+        }
+    }
+    else if (meta_data_type == format::MetaDataType::kVulkanCopyAccelerationStructuresCommand)
+    {
+        format::VulkanCopyAccelerationStructuresCommandHeader header{};
+        size_t parameter_buffer_size = static_cast<size_t>(block_header.size) - sizeof(meta_data_id);
+        success                      = ReadParameterBuffer(parameter_buffer_size);
+
+        if (success)
+        {
+            for (auto decoder : decoders_)
+            {
+                if (decoder->SupportsMetaDataId(meta_data_id))
+                {
+                    DecodeAllocator::Begin();
+
+                    decoder->DispatchVulkanAccelerationStructuresCopyMetaCommand(parameter_buffer_.data(),
+                                                                                 parameter_buffer_size);
+
+                    DecodeAllocator::End();
+                }
+            }
+        }
+    }
+    else if (meta_data_type == format::MetaDataType::kVulkanWriteAccelerationStructuresPropertiesCommand)
+    {
+        format::VulkanCopyAccelerationStructuresCommandHeader header{};
+        size_t parameter_buffer_size = static_cast<size_t>(block_header.size) - sizeof(meta_data_id);
+        success                      = ReadParameterBuffer(parameter_buffer_size);
+
+        if (success)
+        {
+            for (auto decoder : decoders_)
+            {
+                if (decoder->SupportsMetaDataId(meta_data_id))
+                {
+                    DecodeAllocator::Begin();
+
+                    decoder->DispatchVulkanAccelerationStructuresWritePropertiesMetaCommand(parameter_buffer_.data(),
+                                                                                            parameter_buffer_size);
+
+                    DecodeAllocator::End();
+                }
+            }
+        }
+    }
     else
     {
         if ((meta_data_type == format::MetaDataType::kReserved23) ||

--- a/framework/decode/metadata_consumer_base.h
+++ b/framework/decode/metadata_consumer_base.h
@@ -26,6 +26,7 @@
 
 #include "util/defines.h"
 #include "format/format.h"
+#include "generated/generated_vulkan_struct_decoders.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -107,8 +108,24 @@ class MetadataConsumerBase
 
     virtual void SetCurrentBlockIndex(uint64_t block_index) {}
 
+    virtual void ProcessBuildVulkanAccelerationStructuresMetaCommand(
+        format::HandleId                                                           device_id,
+        uint32_t                                                                   info_count,
+        StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* geometry_infos,
+        StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>*   range_infos,
+        std::vector<std::vector<VkAccelerationStructureInstanceKHR>>&              instance_buffers_data)
+    {}
+
+    virtual void ProcessCopyVulkanAccelerationStructuresMetaCommand(
+        format::HandleId device_id, StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* copy_infos)
+    {}
+
+    virtual void ProcessVulkanAccelerationStructuresWritePropertiesMetaCommand(
+        format::HandleId device_id, VkQueryType query_type, format::HandleId acceleration_structure_id)
+    {}
+
   protected:
-    uint64_t block_index_;
+    uint64_t block_index_ = 0;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -625,24 +625,24 @@ void VulkanDecoderBase::DispatchVulkanAccelerationStructuresCopyMetaCommand(cons
     }
 }
 
-//void VulkanDecoderBase::DispatchVulkanAccelerationStructuresWritePropertiesMetaCommand(const uint8_t* parameter_buffer,
-//                                                                                       size_t         buffer_size)
-//{
-//    format::HandleId device_id;
-//    VkQueryType      query_type;
-//    format::HandleId acceleration_structure_id;
-//
-//    std::size_t bytes_read = ValueDecoder::DecodeHandleIdValue(parameter_buffer, sizeof(format::HandleId), &device_id);
-//    bytes_read += ValueDecoder::DecodeEnumValue(parameter_buffer + bytes_read, sizeof(VkQueryType), &query_type);
-//    bytes_read += ValueDecoder::DecodeHandleIdValue(
-//        parameter_buffer + bytes_read, sizeof(format::HandleId), &acceleration_structure_id);
-//
-//    for (auto consumer : consumers_)
-//    {
-//        consumer->ProcessVulkanAccelerationStructuresWritePropertiesMetaCommand(
-//            device_id, query_type, acceleration_structure_id);
-//    }
-//}
+void VulkanDecoderBase::DispatchVulkanAccelerationStructuresWritePropertiesMetaCommand(const uint8_t* parameter_buffer,
+                                                                                       size_t         buffer_size)
+{
+    format::HandleId device_id;
+    VkQueryType      query_type;
+    format::HandleId acceleration_structure_id;
+
+    std::size_t bytes_read = ValueDecoder::DecodeHandleIdValue(parameter_buffer, sizeof(format::HandleId), &device_id);
+    bytes_read += ValueDecoder::DecodeEnumValue(parameter_buffer + bytes_read, sizeof(VkQueryType), &query_type);
+    bytes_read += ValueDecoder::DecodeHandleIdValue(
+        parameter_buffer + bytes_read, sizeof(format::HandleId), &acceleration_structure_id);
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessVulkanAccelerationStructuresWritePropertiesMetaCommand(
+            device_id, query_type, acceleration_structure_id);
+    }
+}
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -568,5 +568,81 @@ void VulkanDecoderBase::SetCurrentBlockIndex(uint64_t block_index)
     }
 }
 
+void VulkanDecoderBase::DispatchVulkanAccelerationStructuresBuildMetaCommand(const uint8_t* parameter_buffer,
+                                                                             size_t         buffer_size)
+{
+
+    format::HandleId                                                          device_id;
+    StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR> pInfos;
+    StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>   ppRangeInfos;
+
+    std::size_t bytes_read = ValueDecoder::DecodeHandleIdValue(parameter_buffer, buffer_size, &device_id);
+    bytes_read += pInfos.Decode(parameter_buffer + bytes_read, buffer_size - bytes_read);
+    bytes_read += ppRangeInfos.Decode(parameter_buffer + bytes_read, buffer_size - bytes_read);
+
+    std::vector<std::vector<VkAccelerationStructureInstanceKHR>> instance_buffers;
+    if (bytes_read < buffer_size)
+    {
+        for (uint32_t i = 0; i < pInfos.GetLength(); ++i)
+        {
+            if (pInfos.GetPointer()[i].type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR)
+            {
+                continue;
+            }
+
+            uint32_t geometry_count = pInfos.GetPointer()[i].geometryCount;
+            for (uint32_t g = 0; g < geometry_count; ++g)
+            {
+                instance_buffers.emplace_back(ppRangeInfos.GetPointer()[g]->primitiveCount);
+                util::platform::MemoryCopy(instance_buffers.back().data(),
+                                           instance_buffers.back().size() * sizeof(VkAccelerationStructureInstanceKHR),
+                                           parameter_buffer + bytes_read,
+                                           instance_buffers.back().size() * sizeof(VkAccelerationStructureInstanceKHR));
+                bytes_read += instance_buffers.back().size() * sizeof(VkAccelerationStructureInstanceKHR);
+            }
+        }
+    }
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessBuildVulkanAccelerationStructuresMetaCommand(
+            device_id, pInfos.GetLength(), &pInfos, &ppRangeInfos, instance_buffers);
+    }
+}
+
+void VulkanDecoderBase::DispatchVulkanAccelerationStructuresCopyMetaCommand(const uint8_t* parameter_buffer,
+                                                                            size_t         buffer_size)
+{
+    format::HandleId                                                 device_id;
+    StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR> pInfos;
+
+    std::size_t bytes_read = ValueDecoder::DecodeHandleIdValue(parameter_buffer, buffer_size, &device_id);
+    pInfos.Decode(parameter_buffer + bytes_read, buffer_size - bytes_read);
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessCopyVulkanAccelerationStructuresMetaCommand(device_id, &pInfos);
+    }
+}
+
+//void VulkanDecoderBase::DispatchVulkanAccelerationStructuresWritePropertiesMetaCommand(const uint8_t* parameter_buffer,
+//                                                                                       size_t         buffer_size)
+//{
+//    format::HandleId device_id;
+//    VkQueryType      query_type;
+//    format::HandleId acceleration_structure_id;
+//
+//    std::size_t bytes_read = ValueDecoder::DecodeHandleIdValue(parameter_buffer, sizeof(format::HandleId), &device_id);
+//    bytes_read += ValueDecoder::DecodeEnumValue(parameter_buffer + bytes_read, sizeof(VkQueryType), &query_type);
+//    bytes_read += ValueDecoder::DecodeHandleIdValue(
+//        parameter_buffer + bytes_read, sizeof(format::HandleId), &acceleration_structure_id);
+//
+//    for (auto consumer : consumers_)
+//    {
+//        consumer->ProcessVulkanAccelerationStructuresWritePropertiesMetaCommand(
+//            device_id, query_type, acceleration_structure_id);
+//    }
+//}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -200,6 +200,12 @@ class VulkanDecoderBase : public ApiDecoder
 
     virtual void SetCurrentBlockIndex(uint64_t block_index) override;
 
+    void DispatchVulkanAccelerationStructuresBuildMetaCommand(const uint8_t* parameter_buffer,
+                                                              size_t         buffer_size) override;
+
+    void DispatchVulkanAccelerationStructuresCopyMetaCommand(const uint8_t* parameter_buffer,
+                                                             size_t         buffer_size) override;
+
   protected:
     const std::vector<VulkanConsumer*>& GetConsumers() const { return consumers_; }
 

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -206,6 +206,9 @@ class VulkanDecoderBase : public ApiDecoder
     void DispatchVulkanAccelerationStructuresCopyMetaCommand(const uint8_t* parameter_buffer,
                                                              size_t         buffer_size) override;
 
+    void DispatchVulkanAccelerationStructuresWritePropertiesMetaCommand(const uint8_t* parameter_buffer,
+                                                                        size_t         buffer_size) override;
+
   protected:
     const std::vector<VulkanConsumer*>& GetConsumers() const { return consumers_; }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -9363,6 +9363,75 @@ void VulkanReplayConsumerBase::Process_vkCreateRayTracingPipelinesKHR(
     }
 }
 
+void VulkanReplayConsumerBase::ProcessCopyVulkanAccelerationStructuresMetaCommand(
+    format::HandleId device, StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* copy_infos)
+{
+    DeviceInfo* device_info = GetObjectInfoTable().GetDeviceInfo(device);
+    GFXRECON_ASSERT(device_info != nullptr);
+
+    auto allocator = device_info->allocator.get();
+    GFXRECON_ASSERT(allocator != nullptr);
+
+    if (allocator->SupportsOpaqueDeviceAddresses() || !loading_trim_state_)
+    {
+        return;
+    }
+
+    MapStructArrayHandles(copy_infos->GetMetaStructPointer(), copy_infos->GetLength(), GetObjectInfoTable());
+
+    // TODO: implement
+    //    acceleration_structure_builders_[device]->ProcessCopyVulkanAccelerationStructuresMetaCommand(
+    //        copy_infos->GetLength(), copy_infos->GetPointer());
+}
+
+void VulkanReplayConsumerBase::ProcessBuildVulkanAccelerationStructuresMetaCommand(
+    format::HandleId                                                           device,
+    uint32_t                                                                   info_count,
+    StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
+    StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>*   ppRangeInfos,
+    std::vector<std::vector<VkAccelerationStructureInstanceKHR>>&              instance_buffers_data)
+{
+    DeviceInfo* device_info = GetObjectInfoTable().GetDeviceInfo(device);
+    GFXRECON_ASSERT(device_info != nullptr);
+
+    auto allocator = device_info->allocator.get();
+    GFXRECON_ASSERT(allocator != nullptr);
+
+    // TODO: really questioning "SupportsOpaqueDeviceAddresses" condition
+    if (allocator->SupportsOpaqueDeviceAddresses() || !loading_trim_state_)
+    {
+        return;
+    }
+
+    MapStructArrayHandles(pInfos->GetMetaStructPointer(), pInfos->GetLength(), GetObjectInfoTable());
+
+    // TODO: implement
+    //    acceleration_structure_builders_[device]->ProcessBuildVulkanAccelerationStructuresMetaCommand(
+    //        info_count, pInfos->GetPointer(), ppRangeInfos->GetPointer(), instance_buffers_data);
+}
+
+void VulkanReplayConsumerBase::ProcessVulkanAccelerationStructuresWritePropertiesMetaCommand(
+    format::HandleId device_id, VkQueryType query_type, format::HandleId acceleration_structure_id)
+{
+    DeviceInfo* device_info = GetObjectInfoTable().GetDeviceInfo(device_id);
+    GFXRECON_ASSERT(device_info != nullptr);
+
+    auto allocator = device_info->allocator.get();
+    GFXRECON_ASSERT(allocator != nullptr);
+
+    if (allocator->SupportsOpaqueDeviceAddresses() || !loading_trim_state_)
+    {
+        return;
+    }
+
+    VkAccelerationStructureKHR acceleration_structure = MapHandle<AccelerationStructureKHRInfo>(
+        acceleration_structure_id, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+
+    // TODO: implement
+    //    acceleration_structure_builders_[device_id]->ProcessVulkanAccelerationStructuresWritePropertiesMetaCommand(
+    //        query_type, acceleration_structure);
+}
+
 void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
     PFN_vkUpdateDescriptorSets                          func,
     const DeviceInfo*                                   device_info,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -9397,7 +9397,6 @@ void VulkanReplayConsumerBase::ProcessBuildVulkanAccelerationStructuresMetaComma
     auto allocator = device_info->allocator.get();
     GFXRECON_ASSERT(allocator != nullptr);
 
-    // TODO: really questioning "SupportsOpaqueDeviceAddresses" condition
     if (allocator->SupportsOpaqueDeviceAddresses() || !loading_trim_state_)
     {
         return;

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -189,16 +189,29 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                                                 format::HandleId   commandBuffer,
                                                                 StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>*
                                                                     pPushDescriptorSetWithTemplateInfo) override;
-    virtual void Process_vkCreateRayTracingPipelinesKHR(
-        const ApiCallInfo&                                               call_info,
-        VkResult                                                         returnValue,
-        format::HandleId                                                 device,
-        format::HandleId                                                 deferredOperation,
-        format::HandleId                                                 pipelineCache,
-        uint32_t                                                         createInfoCount,
-        StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
-        StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
-        HandlePointerDecoder<VkPipeline>*                                pPipelines) override;
+    void         Process_vkCreateRayTracingPipelinesKHR(
+                const ApiCallInfo&                                               call_info,
+                VkResult                                                         returnValue,
+                format::HandleId                                                 device,
+                format::HandleId                                                 deferredOperation,
+                format::HandleId                                                 pipelineCache,
+                uint32_t                                                         createInfoCount,
+                StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
+                StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
+                HandlePointerDecoder<VkPipeline>*                                pPipelines) override;
+
+    void ProcessBuildVulkanAccelerationStructuresMetaCommand(
+        format::HandleId                                                           device,
+        uint32_t                                                                   info_count,
+        StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
+        StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>*   ppRangeInfos,
+        std::vector<std::vector<VkAccelerationStructureInstanceKHR>>&              instance_buffers_data) override;
+
+    void ProcessCopyVulkanAccelerationStructuresMetaCommand(
+        format::HandleId device, StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* copy_infos) override;
+
+    void ProcessVulkanAccelerationStructuresWritePropertiesMetaCommand(
+        format::HandleId device_id, VkQueryType query_type, format::HandleId acceleration_structure_id) override;
 
     template <typename T>
     void AllowCompileDuringPipelineCreation(uint32_t create_info_count, const T* create_infos)

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -93,6 +93,8 @@ target_sources(gfxrecon_encode
                     ${CMAKE_CURRENT_LIST_DIR}/struct_pointer_encoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_capture_manager.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_capture_manager.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_address_tracker.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_address_tracker.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_wrappers.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_wrapper_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_wrapper_util.cpp

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -100,7 +100,7 @@ void VulkanCaptureManager::DestroyInstance()
 
 void VulkanCaptureManager::WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id)
 {
-    VulkanStateWriter state_writer(file_stream, GetCompressor(), thread_id);
+    VulkanStateWriter state_writer(file_stream, GetCompressor(), thread_id, [] { return GetUniqueId(); });
     uint64_t          n_blocks = state_tracker_->WriteState(&state_writer, GetCurrentFrame());
     common_manager_->IncrementBlockIndex(n_blocks);
 }

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -961,9 +961,9 @@ VulkanCaptureManager::OverrideCreateAccelerationStructureKHR(VkDevice           
         VkDeviceAddress address =
             device_table->GetAccelerationStructureDeviceAddressKHR(device_unwrapped, &address_info);
 
-        accel_struct_wrapper->device_id = device_wrapper->handle_id;
-        accel_struct_wrapper->address   = address;
-        accel_struct_wrapper->type      = modified_create_info->type;
+        accel_struct_wrapper->device  = device_wrapper;
+        accel_struct_wrapper->address = address;
+        accel_struct_wrapper->type    = modified_create_info->type;
 
         if (IsCaptureModeTrack())
         {

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -986,7 +986,6 @@ void VulkanCaptureManager::OverrideCmdBuildAccelerationStructuresKHR(
 {
     if (IsCaptureModeTrack())
     {
-//        state_tracker_->TrackTLASBuildCommand(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
         state_tracker_->TrackAccelerationStructureBuildCommand(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
     }
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -962,8 +962,8 @@ VulkanCaptureManager::OverrideCreateAccelerationStructureKHR(VkDevice           
             device_table->GetAccelerationStructureDeviceAddressKHR(device_unwrapped, &address_info);
 
         accel_struct_wrapper->device_id = device_wrapper->handle_id;
-        accel_struct_wrapper->address = address;
-        accel_struct_wrapper->type    = modified_create_info->type;
+        accel_struct_wrapper->address   = address;
+        accel_struct_wrapper->type      = modified_create_info->type;
 
         if (IsCaptureModeTrack())
         {

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -857,12 +857,16 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
                                              vulkan_wrappers::BufferWrapper>(
             device, vulkan_wrappers::NoParentWrapper::kHandleValue, pBuffer, GetUniqueId);
 
+        auto buffer_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::BufferWrapper>(*pBuffer);
+        GFXRECON_ASSERT(buffer_wrapper)
+        buffer_wrapper->created_size = modified_create_info->size;
+        buffer_wrapper->usage        = pCreateInfo->usage;
+
         if (uses_address)
         {
             // If the buffer has a device address, write the 'set buffer address' command before writing the API call to
             // create the buffer.  The address will need to be passed to vkCreateBuffer through the pCreateInfo pNext
             // list.
-            auto buffer_wrapper            = vulkan_wrappers::GetWrapper<vulkan_wrappers::BufferWrapper>(*pBuffer);
             VkBufferDeviceAddressInfo info = { VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO };
             info.pNext                     = nullptr;
             info.buffer                    = buffer_wrapper->handle;
@@ -984,7 +988,8 @@ void VulkanCaptureManager::OverrideCmdBuildAccelerationStructuresKHR(
 {
     if (IsCaptureModeTrack())
     {
-        state_tracker_->TrackTLASBuildCommand(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
+//        state_tracker_->TrackTLASBuildCommand(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
+        state_tracker_->TrackAccelerationStructureBuildCommand(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
     }
 
     const VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(commandBuffer);

--- a/framework/encode/vulkan_device_address_tracker.cpp
+++ b/framework/encode/vulkan_device_address_tracker.cpp
@@ -41,8 +41,8 @@ VulkanDeviceAddressTracker& VulkanDeviceAddressTracker::operator=(VulkanDeviceAd
 void swap(VulkanDeviceAddressTracker& lhs, VulkanDeviceAddressTracker& rhs) noexcept
 {
     std::lock(lhs.mutex_, rhs.mutex_);
-    std::lock_guard<std::shared_mutex> lock_lhs(lhs.mutex_, std::adopt_lock);
-    std::lock_guard<std::shared_mutex> lock_rhs(rhs.mutex_, std::adopt_lock);
+    std::lock_guard lock_lhs(lhs.mutex_, std::adopt_lock);
+    std::lock_guard lock_rhs(rhs.mutex_, std::adopt_lock);
     std::swap(lhs.buffer_addresses_, rhs.buffer_addresses_);
     std::swap(lhs.acceleration_structure_addresses_, rhs.acceleration_structure_addresses_);
 }

--- a/framework/encode/vulkan_device_address_tracker.cpp
+++ b/framework/encode/vulkan_device_address_tracker.cpp
@@ -99,7 +99,7 @@ VkBuffer VulkanDeviceAddressTracker::GetBufferByDeviceAddress(VkDeviceAddress de
             // not found
             if (address_it == buffer_addresses_.begin())
             {
-                return nullptr;
+                return VK_NULL_HANDLE;
             }
 
             // decrement iterator, now pointing to the first VkDeviceAddress that is lower than device_address
@@ -120,7 +120,7 @@ VkAccelerationStructureKHR
 VulkanDeviceAddressTracker::GetAccelerationStructureByDeviceAddress(VkDeviceAddress device_address) const
 {
     std::shared_lock lock(mutex_);
-    auto address_it = acceleration_structure_addresses_.find(device_address);
+    auto             address_it = acceleration_structure_addresses_.find(device_address);
     if (address_it != acceleration_structure_addresses_.end())
     {
         return address_it->second;

--- a/framework/encode/vulkan_device_address_tracker.cpp
+++ b/framework/encode/vulkan_device_address_tracker.cpp
@@ -1,0 +1,104 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "encode/vulkan_device_address_tracker.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+void encode::VulkanDeviceAddressTracker::TrackBuffer(const vulkan_wrappers::BufferWrapper* wrapper)
+{
+    if (wrapper != nullptr && wrapper->handle != VK_NULL_HANDLE && wrapper->address != 0 && wrapper->created_size != 0)
+    {
+        _buffer_addresses[wrapper->address] = { wrapper->handle, wrapper->created_size };
+    }
+}
+
+void VulkanDeviceAddressTracker::RemoveBuffer(const vulkan_wrappers::BufferWrapper* wrapper)
+{
+    if (wrapper != nullptr)
+    {
+        _buffer_addresses.erase(wrapper->address);
+    }
+}
+
+void VulkanDeviceAddressTracker::TrackAccelerationStructure(
+    const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper)
+{
+    if (wrapper != nullptr && wrapper->handle != VK_NULL_HANDLE && wrapper->address != 0)
+    {
+        _acceleration_structure_addresses[wrapper->address] = wrapper->handle;
+    }
+}
+
+void VulkanDeviceAddressTracker::RemoveAccelerationStructure(
+    const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper)
+{
+    if (wrapper != nullptr)
+    {
+        _acceleration_structure_addresses.erase(wrapper->address);
+    }
+}
+
+VkBuffer VulkanDeviceAddressTracker::GetBufferByDeviceAddress(VkDeviceAddress device_address) const
+{
+    if (!_buffer_addresses.empty())
+    {
+        // find first address equal or greater
+        auto address_it = _buffer_addresses.lower_bound(device_address);
+
+        if (address_it == _buffer_addresses.end() || address_it->first > device_address)
+        {
+            // not found
+            if (address_it == _buffer_addresses.begin())
+            {
+                return nullptr;
+            }
+
+            // decrement iterator, now pointing to the first VkDeviceAddress that is lower than device_address
+            address_it--;
+        }
+        // found_address is lower or equal to device_address
+        const auto& [found_address, buffer_item] = *address_it;
+
+        if (device_address < found_address + buffer_item.size)
+        {
+            return buffer_item.handle;
+        }
+    }
+    return VK_NULL_HANDLE;
+}
+
+VkAccelerationStructureKHR
+VulkanDeviceAddressTracker::GetAccelerationStructureByDeviceAddress(VkDeviceAddress device_address) const
+{
+    auto address_it = _acceleration_structure_addresses.find(device_address);
+    if (address_it != _acceleration_structure_addresses.end())
+    {
+        return address_it->second;
+    }
+    return VK_NULL_HANDLE;
+}
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_device_address_tracker.h
+++ b/framework/encode/vulkan_device_address_tracker.h
@@ -97,8 +97,8 @@ class VulkanDeviceAddressTracker
   private:
     struct buffer_item_t
     {
-        VkBuffer handle = VK_NULL_HANDLE;
-        size_t   size   = 0;
+        VkBuffer     handle = VK_NULL_HANDLE;
+        VkDeviceSize size   = 0;
     };
     //! use a sorted (BST-based) map to look-up ranges
     std::map<VkDeviceAddress, buffer_item_t> buffer_addresses_;

--- a/framework/encode/vulkan_device_address_tracker.h
+++ b/framework/encode/vulkan_device_address_tracker.h
@@ -1,0 +1,109 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_ENCODE_VULKAN_DEVICE_ADDRESS_TRACKER_H
+#define GFXRECON_ENCODE_VULKAN_DEVICE_ADDRESS_TRACKER_H
+
+#include "encode/vulkan_handle_wrappers.h"
+#include <map>
+#include <unordered_map>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+class VulkanDeviceAddressTracker
+{
+  public:
+    VulkanDeviceAddressTracker() = default;
+
+    //! prevent copying
+    VulkanDeviceAddressTracker(const VulkanDeviceAddressTracker&) = delete;
+
+    //! allow moving
+    VulkanDeviceAddressTracker(VulkanDeviceAddressTracker&&) = default;
+
+    ~VulkanDeviceAddressTracker() = default;
+
+    /**
+     * @brief   Track an existing buffer by its VkDeviceAddress.
+     *
+     * @param   buffer  a provided buffer-handle
+     * @param   address a device-address
+     * @param   size    buffer-size in bytes
+     */
+    void TrackBuffer(const vulkan_wrappers::BufferWrapper* wrapper);
+
+    /**
+     * @brief   Stop tracking of a currently tracked buffer.
+     *
+     * @param   wrapper a provided buffer-wrapper.
+     */
+    void RemoveBuffer(const vulkan_wrappers::BufferWrapper* wrapper);
+
+    /**
+     * @brief   Track an existing acceleration-structure by its VkDeviceAddress.
+     *
+     * @param   wrapper a provided acceleration-structure wrapper containing a handle and device-address.
+     */
+    void TrackAccelerationStructure(const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper);
+
+    /**
+     * @brief   Stop tracking of a currently tracked acceleration-structure.
+     *
+     * @param   wrapper a provided acceleration-structure wrapper.
+     */
+    void RemoveAccelerationStructure(const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper);
+
+    /**
+     * @brief   Retrieve a buffer by providing a VkDeviceAddress within its range.
+     *
+     * @param   device_address  a capture-time VkDeviceAddress pointing inside a buffer.
+     * @return  a found VkBuffer-handle or VK_NULL_HANDLE.
+     */
+    [[nodiscard]] VkBuffer GetBufferByDeviceAddress(VkDeviceAddress device_address) const;
+
+    /**
+     * @brief   Retrieve an acceleration-structure by providing a capture-time VkDeviceAddress.
+     *
+     * @param   device_address  a capture-time VkDeviceAddress for an acceleration-structure.
+     * @return  a found AccelerationStructureKHR-handle or VK_NULL_HANDLE.
+     */
+    [[nodiscard]] VkAccelerationStructureKHR
+    GetAccelerationStructureByDeviceAddress(VkDeviceAddress device_address) const;
+
+  private:
+    struct buffer_item_t
+    {
+        VkBuffer handle = VK_NULL_HANDLE;
+        size_t   size   = 0;
+    };
+    //! use a sorted (BST-based) map to look-up ranges
+    std::map<VkDeviceAddress, buffer_item_t> _buffer_addresses;
+
+    std::unordered_map<VkDeviceAddress, VkAccelerationStructureKHR> _acceleration_structure_addresses;
+};
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_ENCODE_VULKAN_DEVICE_ADDRESS_TRACKER_H

--- a/framework/encode/vulkan_device_address_tracker.h
+++ b/framework/encode/vulkan_device_address_tracker.h
@@ -25,6 +25,7 @@
 #define GFXRECON_ENCODE_VULKAN_DEVICE_ADDRESS_TRACKER_H
 
 #include "encode/vulkan_handle_wrappers.h"
+#include <shared_mutex>
 #include <map>
 #include <unordered_map>
 
@@ -40,9 +41,13 @@ class VulkanDeviceAddressTracker
     VulkanDeviceAddressTracker(const VulkanDeviceAddressTracker&) = delete;
 
     //! allow moving
-    VulkanDeviceAddressTracker(VulkanDeviceAddressTracker&&) = default;
+    VulkanDeviceAddressTracker(VulkanDeviceAddressTracker&&) noexcept;
 
     ~VulkanDeviceAddressTracker() = default;
+
+    VulkanDeviceAddressTracker& operator=(VulkanDeviceAddressTracker);
+
+    friend void swap(VulkanDeviceAddressTracker& lhs, VulkanDeviceAddressTracker& rhs) noexcept;
 
     /**
      * @brief   Track an existing buffer by its VkDeviceAddress.
@@ -98,9 +103,11 @@ class VulkanDeviceAddressTracker
         size_t   size   = 0;
     };
     //! use a sorted (BST-based) map to look-up ranges
-    std::map<VkDeviceAddress, buffer_item_t> _buffer_addresses;
+    std::map<VkDeviceAddress, buffer_item_t> buffer_addresses_;
 
-    std::unordered_map<VkDeviceAddress, VkAccelerationStructureKHR> _acceleration_structure_addresses;
+    std::unordered_map<VkDeviceAddress, VkAccelerationStructureKHR> acceleration_structure_addresses_;
+
+    mutable std::shared_mutex mutex_;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_device_address_tracker.h
+++ b/framework/encode/vulkan_device_address_tracker.h
@@ -56,28 +56,28 @@ class VulkanDeviceAddressTracker
     /**
      * @brief   Stop tracking of a currently tracked buffer.
      *
-     * @param   wrapper a provided buffer-wrapper.
+     * @param   wrapper     provided buffer-wrapper.
      */
     void RemoveBuffer(const vulkan_wrappers::BufferWrapper* wrapper);
 
     /**
      * @brief   Track an existing acceleration-structure by its VkDeviceAddress.
      *
-     * @param   wrapper a provided acceleration-structure wrapper containing a handle and device-address.
+     * @param   wrapper     provided acceleration-structure wrapper containing a handle and device-address.
      */
     void TrackAccelerationStructure(const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper);
 
     /**
      * @brief   Stop tracking of a currently tracked acceleration-structure.
      *
-     * @param   wrapper a provided acceleration-structure wrapper.
+     * @param   wrapper     provided acceleration-structure wrapper.
      */
     void RemoveAccelerationStructure(const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper);
 
     /**
      * @brief   Retrieve a buffer by providing a VkDeviceAddress within its range.
      *
-     * @param   device_address  a capture-time VkDeviceAddress pointing inside a buffer.
+     * @param   device_address      VkDeviceAddress pointing inside a buffer.
      * @return  a found VkBuffer-handle or VK_NULL_HANDLE.
      */
     [[nodiscard]] VkBuffer GetBufferByDeviceAddress(VkDeviceAddress device_address) const;
@@ -85,7 +85,7 @@ class VulkanDeviceAddressTracker
     /**
      * @brief   Retrieve an acceleration-structure by providing a capture-time VkDeviceAddress.
      *
-     * @param   device_address  a capture-time VkDeviceAddress for an acceleration-structure.
+     * @param   device_address      VkDeviceAddress for an acceleration-structure.
      * @return  a found AccelerationStructureKHR-handle or VK_NULL_HANDLE.
      */
     [[nodiscard]] VkAccelerationStructureKHR

--- a/framework/encode/vulkan_device_address_tracker.h
+++ b/framework/encode/vulkan_device_address_tracker.h
@@ -52,9 +52,7 @@ class VulkanDeviceAddressTracker
     /**
      * @brief   Track an existing buffer by its VkDeviceAddress.
      *
-     * @param   buffer  a provided buffer-handle
-     * @param   address a device-address
-     * @param   size    buffer-size in bytes
+     * @param   wrapper     provided buffer-wrapper.
      */
     void TrackBuffer(const vulkan_wrappers::BufferWrapper* wrapper);
 

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -103,7 +103,7 @@ Wrapper* GetWrapper(const typename Wrapper::HandleType& handle)
 {
     if (handle == VK_NULL_HANDLE)
     {
-        return 0;
+        return nullptr;
     }
     auto wrapper = state_handle_table_.GetWrapper<Wrapper>(handle);
     if (wrapper == nullptr)

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -328,6 +328,17 @@ inline void CreateWrappedHandle<DeviceWrapper, NoParentWrapper, QueueWrapper>(
 }
 
 template <>
+inline void CreateWrappedHandle<DeviceWrapper, NoParentWrapper, CommandPoolWrapper>(VkDevice device,
+                                                                                    NoParentWrapper::HandleType,
+                                                                                    VkCommandPool*  handle,
+                                                                                    PFN_GetHandleId get_id)
+{
+    CreateWrappedNonDispatchHandle<CommandPoolWrapper>(handle, get_id);
+    auto pool_wrapper    = GetWrapper<CommandPoolWrapper>(*handle);
+    pool_wrapper->device = GetWrapper<DeviceWrapper>(device);
+}
+
+template <>
 inline void CreateWrappedHandle<DeviceWrapper, CommandPoolWrapper, CommandBufferWrapper>(VkDevice         parent,
                                                                                          VkCommandPool    co_parent,
                                                                                          VkCommandBuffer* handle,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -210,10 +210,11 @@ struct BufferWrapper : public HandleWrapper<VkBuffer>
     const void*                bind_pnext{ nullptr };
     std::unique_ptr<uint8_t[]> bind_pnext_memory;
 
-    format::HandleId bind_memory_id{ format::kNullHandleId };
-    VkDeviceSize     bind_offset{ 0 };
-    uint32_t         queue_family_index{ 0 };
-    VkDeviceSize     created_size{ 0 };
+    format::HandleId   bind_memory_id{ format::kNullHandleId };
+    VkDeviceSize       bind_offset{ 0 };
+    uint32_t           queue_family_index{ 0 };
+    VkDeviceSize       created_size{ 0 };
+    VkBufferUsageFlags usage{ 0 };
 
     // State tracking info for buffers with device addresses.
     format::HandleId device_id{ format::kNullHandleId };
@@ -510,6 +511,55 @@ struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStru
 
     // List of BLASes this AS references. Used only while tracking.
     std::vector<AccelerationStructureKHRWrapper*> blas;
+
+    VkAccelerationStructureTypeKHR type_;
+    // Only used when tracking
+
+    struct ASInputBuffer
+    {
+        // Required data to correctly create a buffer
+        VkBuffer           handle{ VK_NULL_HANDLE };
+        format::HandleId   handle_id{ format::kNullHandleId };
+        DeviceWrapper*     bind_device{ nullptr };
+        uint32_t           queue_family_index{ 0 };
+        VkDeviceSize       created_size{ 0 };
+        VkBufferUsageFlags usage{ 0 };
+
+        bool destroyed{ false };
+
+        VkDeviceAddress capture_address{ 0 };
+        VkDeviceAddress actual_address{ 0 };
+
+        std::vector<uint8_t> bytes;
+
+        VkMemoryRequirements memory_requirements{};
+        format::HandleId     bind_memory{};
+        VkDeviceMemory       bind_memory_handle{ VK_NULL_HANDLE };
+    };
+
+    struct AccelerationStructureKHRBuildCommandData
+    {
+        VkAccelerationStructureBuildGeometryInfoKHR           geometry_info;
+        std::unique_ptr<uint8_t[]>                            geometry_info_memory;
+        std::vector<VkAccelerationStructureBuildRangeInfoKHR> build_range_infos;
+        std::vector<ASInputBuffer>                            input_buffers;
+    };
+    std::optional<AccelerationStructureKHRBuildCommandData> latest_update_command_{ std::nullopt };
+    std::optional<AccelerationStructureKHRBuildCommandData> latest_build_command_{ std::nullopt };
+
+    struct AccelerationStructureCopyCommandData
+    {
+        format::HandleId                   device;
+        VkCopyAccelerationStructureInfoKHR info;
+    };
+    std::optional<AccelerationStructureCopyCommandData> latest_copy_command_{ std::nullopt };
+
+    struct AccelerationStructureWritePropertiesCommandData
+    {
+        format::HandleId device;
+        VkQueryType      query_type;
+    };
+    std::optional<AccelerationStructureWritePropertiesCommandData> latest_write_properties_command_{ std::nullopt };
 };
 
 struct AccelerationStructureNVWrapper : public HandleWrapper<VkAccelerationStructureNV>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -512,7 +512,7 @@ struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStru
     // List of BLASes this AS references. Used only while tracking.
     std::vector<AccelerationStructureKHRWrapper*> blas;
 
-    VkAccelerationStructureTypeKHR type_;
+    VkAccelerationStructureTypeKHR type;
     // Only used when tracking
 
     struct ASInputBuffer

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -506,8 +506,8 @@ struct SwapchainKHRWrapper : public HandleWrapper<VkSwapchainKHR>
 struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStructureKHR>
 {
     // State tracking info for buffers with device addresses.
-    format::HandleId device_id{ format::kNullHandleId };
-    VkDeviceAddress  address{ 0 };
+    DeviceWrapper*  device{ nullptr };
+    VkDeviceAddress address{ 0 };
 
     // List of BLASes this AS references. Used only while tracking.
     std::vector<AccelerationStructureKHRWrapper*> blas;

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1628,13 +1628,7 @@ void VulkanStateTracker::DestroyState(vulkan_wrappers::DeviceMemoryWrapper* wrap
 
 void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferWrapper* wrapper)
 {
-    assert(wrapper != nullptr);
-    //    auto memory_wrapper = state_table_.GetDeviceMemoryWrapper(wrapper->bind_memory_id);
-    //    if (memory_wrapper)
-    //    {
-    //        memory_wrapper->bound_buffers.erase(wrapper);
-    //    }
-    //
+    GFXRECON_ASSERT(wrapper != nullptr);
     device_address_tracker_.RemoveBuffer(wrapper);
 
     state_table_.VisitWrappers([&wrapper, this](vulkan_wrappers::AccelerationStructureKHRWrapper* acc_wrapper) {

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1627,12 +1627,12 @@ void VulkanStateTracker::DestroyState(vulkan_wrappers::DeviceMemoryWrapper* wrap
 void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferWrapper* wrapper)
 {
     assert(wrapper != nullptr);
-//    auto memory_wrapper = state_table_.GetDeviceMemoryWrapper(wrapper->bind_memory_id);
-//    if (memory_wrapper)
-//    {
-//        memory_wrapper->bound_buffers.erase(wrapper);
-//    }
-//
+    //    auto memory_wrapper = state_table_.GetDeviceMemoryWrapper(wrapper->bind_memory_id);
+    //    if (memory_wrapper)
+    //    {
+    //        memory_wrapper->bound_buffers.erase(wrapper);
+    //    }
+    //
     device_address_tracker_.RemoveBuffer(wrapper);
 
     state_table_.VisitWrappers([&wrapper, this](vulkan_wrappers::AccelerationStructureKHRWrapper* acc_wrapper) {
@@ -1648,17 +1648,17 @@ void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferW
                 if (wrapper->handle_id == buffer.handle_id)
                 {
                     buffer.destroyed              = true;
-//                    auto [resource_util, created] = resource_utils.try_emplace(
-//                        buffer.bind_device->handle_id,
-//                        graphics::VulkanResourcesUtil(buffer.bind_device->handle,
-//                                                      buffer.bind_device->physical_device->handle,
-//                                                      buffer.bind_device->layer_table,
-//                                                      *buffer.bind_device->physical_device->layer_table_ref,
-//                                                      buffer.bind_device->physical_device->memory_properties));
-//                    buffer.bind_device->layer_table.GetBufferMemoryRequirements(
-//                        buffer.bind_device->handle, buffer.handle, &buffer.memory_requirements);
-//                    resource_util->second.ReadFromBufferResource(
-//                        buffer.handle, buffer.created_size, 0, buffer.queue_family_index, buffer.bytes);
+                    auto [resource_util, created] = resource_utils_.try_emplace(
+                        buffer.bind_device->handle,
+                        graphics::VulkanResourcesUtil(buffer.bind_device->handle,
+                                                      buffer.bind_device->physical_device->handle,
+                                                      buffer.bind_device->layer_table,
+                                                      *buffer.bind_device->physical_device->layer_table_ref,
+                                                      buffer.bind_device->physical_device->memory_properties));
+                    buffer.bind_device->layer_table.GetBufferMemoryRequirements(
+                        buffer.bind_device->handle, buffer.handle, &buffer.memory_requirements);
+                    resource_util->second.ReadFromBufferResource(
+                        buffer.handle, buffer.created_size, 0, buffer.queue_family_index, buffer.bytes);
                 }
             }
         }

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1766,8 +1766,8 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
                     // VkAccelerationStructureInstanceKHR::accelerationStructureReference referes to
                     const uint64_t as_reference = instances[b].accelerationStructureReference;
 
-                    if(auto as_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::AccelerationStructureKHRWrapper>(
-                        device_address_tracker_.GetAccelerationStructureByDeviceAddress(as_reference)))
+                    if (auto as_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::AccelerationStructureKHRWrapper>(
+                            device_address_tracker_.GetAccelerationStructureByDeviceAddress(as_reference)))
                     {
                         tlas_wrapper->blas.push_back(as_wrapper);
                     }

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -397,28 +397,29 @@ void VulkanStateTracker::TrackAccelerationStructureBuildCommand(
 
         vulkan_wrappers::AccelerationStructureKHRWrapper::AccelerationStructureKHRBuildCommandData dst_command{};
         // Extract command information for 1 AccelerationStructure
-        for (uint32_t geometry = 0; geometry < p_infos[info].geometryCount; ++geometry)
+        for (uint32_t g = 0; g < p_infos[info].geometryCount; ++g)
         {
-            // TODO: pGeometries vs ppGeometries -> handle both cases
+            auto geometry =
+                p_infos[info].pGeometries != nullptr ? p_infos[info].pGeometries + g : p_infos[info].ppGeometries[g];
 
             std::vector<VkDeviceAddress> to_extract;
-            switch (p_infos[info].pGeometries[geometry].geometryType)
+            switch (geometry->geometryType)
             {
                 case VkGeometryTypeKHR::VK_GEOMETRY_TYPE_TRIANGLES_KHR:
                 {
-                    to_extract = { p_infos[info].pGeometries[geometry].geometry.triangles.vertexData.deviceAddress,
-                                   p_infos[info].pGeometries[geometry].geometry.triangles.indexData.deviceAddress,
-                                   p_infos[info].pGeometries[geometry].geometry.triangles.transformData.deviceAddress };
+                    to_extract = { geometry->geometry.triangles.vertexData.deviceAddress,
+                                   geometry->geometry.triangles.indexData.deviceAddress,
+                                   geometry->geometry.triangles.transformData.deviceAddress };
                     break;
                 }
                 case VkGeometryTypeKHR::VK_GEOMETRY_TYPE_AABBS_KHR:
                 {
-                    to_extract = { p_infos[info].pGeometries[geometry].geometry.aabbs.data.deviceAddress };
+                    to_extract = { geometry->geometry.aabbs.data.deviceAddress };
                     break;
                 }
                 case VkGeometryTypeKHR::VK_GEOMETRY_TYPE_INSTANCES_KHR:
                 {
-                    to_extract = { p_infos[info].pGeometries[geometry].geometry.instances.data.deviceAddress };
+                    to_extract = { geometry->geometry.instances.data.deviceAddress };
                     break;
                 }
                 case VK_GEOMETRY_TYPE_MAX_ENUM_KHR:
@@ -486,7 +487,7 @@ void VulkanStateTracker::TrackAccelerationStructureBuildCommand(
                     address, primitive_count, pp_buildRange_infos[info]->primitiveOffset
                 };
 
-                cmd_buf_wrapper->tlas_build_info_map.emplace_back(std::make_pair(wrapper, std::move(tlas_info)));
+                cmd_buf_wrapper->tlas_build_info_map.emplace_back(wrapper, tlas_info);
             }
         }
     }

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1631,7 +1631,11 @@ void VulkanStateTracker::DestroyState(vulkan_wrappers::DeviceMemoryWrapper* wrap
 void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferWrapper* wrapper)
 {
     GFXRECON_ASSERT(wrapper != nullptr);
-    device_address_trackers_[wrapper->bind_device->handle].RemoveBuffer(wrapper);
+
+    if (wrapper != nullptr && wrapper->bind_device != nullptr)
+    {
+        device_address_trackers_[wrapper->bind_device->handle].RemoveBuffer(wrapper);
+    }
 
     state_table_.VisitWrappers([&wrapper, this](vulkan_wrappers::AccelerationStructureKHRWrapper* acc_wrapper) {
         GFXRECON_ASSERT(acc_wrapper);
@@ -1666,6 +1670,7 @@ void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferW
 void VulkanStateTracker::DestroyState(vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper)
 {
     assert(wrapper != nullptr);
+    assert(wrapper->device != nullptr);
     wrapper->create_parameters = nullptr;
     device_address_trackers_[wrapper->device->handle].RemoveAccelerationStructure(wrapper);
 }

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -497,8 +497,10 @@ class VulkanStateTracker
     // Keeps track of device memories' device addresses
     std::unordered_map<VkDeviceAddress, const vulkan_wrappers::DeviceMemoryWrapper*> device_memory_addresses_map;
 
-    // Keeps track of buffer- and acceleration structures' device addresses
+    // Keeps track of buffer- and acceleration-structure device addresses
     encode::VulkanDeviceAddressTracker device_address_tracker_;
+
+    std::map<VkDevice, graphics::VulkanResourcesUtil> resource_utils_;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -391,10 +391,6 @@ class VulkanStateTracker
                                                     VkAccelerationStructureKHR accel_struct,
                                                     VkDeviceAddress            address);
 
-    //    void TrackTLASBuildCommand(VkCommandBuffer                                        command_buffer,
-    //                               uint32_t                                               info_count,
-    //                               const VkAccelerationStructureBuildGeometryInfoKHR*     infos,
-    //                               const VkAccelerationStructureBuildRangeInfoKHR* const* pp_buildRange_infos);
     void
          TrackAccelerationStructureBuildCommand(VkCommandBuffer                                        command_buffer,
                                                 uint32_t                                               info_count,

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -494,7 +494,7 @@ class VulkanStateTracker
     std::unordered_map<VkDeviceAddress, const vulkan_wrappers::DeviceMemoryWrapper*> device_memory_addresses_map;
 
     // Keeps track of buffer- and acceleration-structure device addresses
-    encode::VulkanDeviceAddressTracker device_address_tracker_;
+    std::unordered_map<VkDevice, encode::VulkanDeviceAddressTracker> device_address_trackers_;
 
     std::map<VkDevice, graphics::VulkanResourcesUtil> resource_utils_;
 };

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -497,10 +497,7 @@ class VulkanStateTracker
     // Keeps track of device memories' device addresses
     std::unordered_map<VkDeviceAddress, const vulkan_wrappers::DeviceMemoryWrapper*> device_memory_addresses_map;
 
-    // Keeps track of acceleration structures' device addresses
-    // TODO: refactor with encode::VulkanDeviceAddressTracker
-    std::unordered_map<VkDeviceAddress, vulkan_wrappers::AccelerationStructureKHRWrapper*> as_device_addresses_map;
-
+    // Keeps track of buffer- and acceleration structures' device addresses
     encode::VulkanDeviceAddressTracker device_address_tracker_;
 };
 

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -25,6 +25,7 @@
 
 #include "encode/descriptor_update_template_info.h"
 #include "encode/vulkan_handle_wrappers.h"
+#include "encode/vulkan_device_address_tracker.h"
 #include "generated/generated_vulkan_state_table.h"
 #include "encode/vulkan_state_tracker_initializers.h"
 #include "encode/vulkan_state_writer.h"
@@ -390,10 +391,15 @@ class VulkanStateTracker
                                                     VkAccelerationStructureKHR accel_struct,
                                                     VkDeviceAddress            address);
 
-    void TrackTLASBuildCommand(VkCommandBuffer                                        command_buffer,
-                               uint32_t                                               info_count,
-                               const VkAccelerationStructureBuildGeometryInfoKHR*     infos,
-                               const VkAccelerationStructureBuildRangeInfoKHR* const* pp_buildRange_infos);
+    //    void TrackTLASBuildCommand(VkCommandBuffer                                        command_buffer,
+    //                               uint32_t                                               info_count,
+    //                               const VkAccelerationStructureBuildGeometryInfoKHR*     infos,
+    //                               const VkAccelerationStructureBuildRangeInfoKHR* const* pp_buildRange_infos);
+    void
+         TrackAccelerationStructureBuildCommand(VkCommandBuffer                                        command_buffer,
+                                                uint32_t                                               info_count,
+                                                const VkAccelerationStructureBuildGeometryInfoKHR*     infos,
+                                                const VkAccelerationStructureBuildRangeInfoKHR* const* pp_buildRange_infos);
 
     void TrackDeviceMemoryDeviceAddress(VkDevice device, VkDeviceMemory memory, VkDeviceAddress address);
 
@@ -479,6 +485,8 @@ class VulkanStateTracker
 
     void DestroyState(vulkan_wrappers::DeviceMemoryWrapper* wrapper);
 
+    void DestroyState(vulkan_wrappers::BufferWrapper* wrapper);
+
     void DestroyState(vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper);
 
     void TrackQuerySubmissions(vulkan_wrappers::CommandBufferWrapper* command_wrapper);
@@ -490,7 +498,10 @@ class VulkanStateTracker
     std::unordered_map<VkDeviceAddress, const vulkan_wrappers::DeviceMemoryWrapper*> device_memory_addresses_map;
 
     // Keeps track of acceleration structures' device addresses
+    // TODO: refactor with encode::VulkanDeviceAddressTracker
     std::unordered_map<VkDeviceAddress, vulkan_wrappers::AccelerationStructureKHRWrapper*> as_device_addresses_map;
+
+    encode::VulkanDeviceAddressTracker device_address_tracker_;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -392,10 +392,10 @@ class VulkanStateTracker
                                                     VkDeviceAddress            address);
 
     void
-         TrackAccelerationStructureBuildCommand(VkCommandBuffer                                        command_buffer,
-                                                uint32_t                                               info_count,
-                                                const VkAccelerationStructureBuildGeometryInfoKHR*     infos,
-                                                const VkAccelerationStructureBuildRangeInfoKHR* const* pp_buildRange_infos);
+    TrackAccelerationStructureBuildCommand(VkCommandBuffer                                        command_buffer,
+                                           uint32_t                                               info_count,
+                                           const VkAccelerationStructureBuildGeometryInfoKHR*     infos,
+                                           const VkAccelerationStructureBuildRangeInfoKHR* const* pp_buildRange_infos);
 
     void TrackDeviceMemoryDeviceAddress(VkDevice device, VkDeviceMemory memory, VkDeviceAddress address);
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -27,6 +27,7 @@
 #include "encode/vulkan_state_info.h"
 #include "format/format_util.h"
 #include "util/logging.h"
+#include "custom_vulkan_array_size_2d.h"
 
 #include <algorithm>
 #include <array>
@@ -78,11 +79,12 @@ static bool IsImageReadable(VkMemoryPropertyFlags                       property
                                                    (memory_wrapper->mapped_size == VK_WHOLE_SIZE)))));
 }
 
-VulkanStateWriter::VulkanStateWriter(util::FileOutputStream* output_stream,
-                                     util::Compressor*       compressor,
-                                     format::ThreadId        thread_id) :
-    output_stream_(output_stream),
-    compressor_(compressor), thread_id_(thread_id), encoder_(&parameter_stream_)
+VulkanStateWriter::VulkanStateWriter(util::FileOutputStream*           output_stream,
+                                     util::Compressor*                 compressor,
+                                     format::ThreadId                  thread_id,
+                                     std::function<format::HandleId()> get_unique_id_fn) :
+    output_stream_(output_stream), compressor_(compressor), thread_id_(thread_id), encoder_(&parameter_stream_),
+    get_unique_id_(std::move(get_unique_id_fn))
 {
     assert(output_stream != nullptr);
 }
@@ -159,6 +161,7 @@ uint64_t VulkanStateWriter::WriteState(const VulkanStateTable& state_table, uint
     WritePipelineState(state_table);
     WriteAccelerationStructureKHRState(state_table);
     WriteTlasToBlasDependenciesMetadata(state_table);
+    WriteAccelerationStructureStateMetaCommands(state_table);
     StandardCreateWrite<vulkan_wrappers::AccelerationStructureNVWrapper>(state_table);
     StandardCreateWrite<vulkan_wrappers::ShaderEXTWrapper>(state_table);
 
@@ -1164,14 +1167,219 @@ void VulkanStateWriter::WriteBufferState(const VulkanStateTable& state_table)
     });
 }
 
+void VulkanStateWriter::BeginAccelerationStructuresSection(format::HandleId device_id, uint64_t max_resource_size)
+{
+    uint64_t max_staging_copy_size = 0;
+
+    format::BeginResourceInitCommand begin_cmd{};
+    begin_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(begin_cmd);
+    begin_cmd.meta_header.block_header.type = format::kMetaDataBlock;
+    begin_cmd.meta_header.meta_data_id =
+        format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kBeginResourceInitCommand);
+    begin_cmd.thread_id         = thread_id_;
+    begin_cmd.device_id         = device_id;
+    begin_cmd.max_resource_size = max_resource_size;
+    // Our buffers should not need staging copy as the memroy should be host visible and coherent
+    begin_cmd.max_copy_size = 0;
+
+    output_stream_->Write(&begin_cmd, sizeof(begin_cmd));
+    ++blocks_written_;
+}
+
+void VulkanStateWriter::WriteASInputBufferState(ASInputBuffer& buffer)
+{
+    const VkAllocationCallbacks* alloc_callbacks = nullptr;
+    // Issue a new create call, creating the buffer we want, and replacing data
+    vulkan_wrappers::DeviceWrapper* device_wrapper = buffer.bind_device;
+
+    VkBufferCreateInfo create_info{ VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+                                    nullptr,
+                                    {},
+                                    buffer.created_size,
+                                    buffer.usage,
+                                    VK_SHARING_MODE_EXCLUSIVE,
+                                    1,
+                                    &buffer.queue_family_index };
+    device_wrapper->layer_table.CreateBuffer(device_wrapper->handle, &create_info, nullptr, &buffer.handle);
+
+    buffer.handle_id = get_unique_id_();
+    // Write down this new call
+    parameter_stream_.Clear();
+    encoder_.EncodeHandleIdValue(device_wrapper->handle_id);
+    EncodeStructPtr(&encoder_, &create_info);
+    EncodeStructPtr(&encoder_, alloc_callbacks);
+    encoder_.EncodeHandleIdPtr(&buffer.handle_id);
+    encoder_.EncodeEnumValue(VK_SUCCESS);
+    WriteFunctionCall(format::ApiCallId::ApiCall_vkCreateBuffer, &parameter_stream_);
+}
+
+void VulkanStateWriter::WriteASInputMemoryState(ASInputBuffer& buffer)
+{
+    const VkAllocationCallbacks*    alloc_callbacks = nullptr;
+    vulkan_wrappers::DeviceWrapper* device_wrapper  = buffer.bind_device;
+
+    // Write allocate memory call
+    VkMemoryAllocateInfo allocate_info{ VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, nullptr };
+    allocate_info.allocationSize = buffer.memory_requirements.size;
+
+    VkMemoryAllocateFlagsInfo memory_allocate_flags_info{ VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO, nullptr };
+    memory_allocate_flags_info.flags =
+        VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT | VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT;
+    allocate_info.pNext = &memory_allocate_flags_info;
+
+    uint32_t              mem_type_index = 0;
+    VkMemoryPropertyFlags desired_flags{};
+    VkMemoryPropertyFlags found_flags{};
+    graphics::FindMemoryTypeIndex(buffer.bind_device->physical_device->memory_properties,
+                                  buffer.memory_requirements.memoryTypeBits,
+                                  desired_flags,
+                                  &mem_type_index,
+                                  &found_flags);
+    allocate_info.memoryTypeIndex = mem_type_index;
+    buffer.bind_memory            = get_unique_id_();
+
+    device_wrapper->layer_table.AllocateMemory(
+        device_wrapper->handle, &allocate_info, alloc_callbacks, &buffer.bind_memory_handle);
+    device_wrapper->layer_table.BindBufferMemory(device_wrapper->handle, buffer.handle, buffer.bind_memory_handle, 0);
+
+    VkBufferDeviceAddressInfoKHR pInfo{ VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR, nullptr, buffer.handle };
+    buffer.actual_address = device_wrapper->layer_table.GetBufferDeviceAddressKHR(device_wrapper->handle, &pInfo);
+
+    VkDeviceMemoryOpaqueCaptureAddressInfo info{ VK_STRUCTURE_TYPE_DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO,
+                                                 nullptr,
+                                                 buffer.bind_memory_handle };
+
+    uint64_t address = 0;
+    if (device_wrapper->physical_device->instance_api_version >= VK_MAKE_VERSION(1, 2, 0))
+    {
+        address = device_wrapper->layer_table.GetDeviceMemoryOpaqueCaptureAddress(device_wrapper->handle, &info);
+    }
+    else
+    {
+        address = device_wrapper->layer_table.GetDeviceMemoryOpaqueCaptureAddressKHR(device_wrapper->handle, &info);
+    }
+
+    WriteSetOpaqueAddressCommand(device_wrapper->handle_id, buffer.bind_memory, address);
+
+    parameter_stream_.Clear();
+    encoder_.EncodeHandleIdValue(device_wrapper->handle_id);
+    EncodeStructPtr(&encoder_, &allocate_info);
+    EncodeStructPtr(&encoder_, alloc_callbacks);
+    encoder_.EncodeHandleIdPtr(&buffer.bind_memory);
+    encoder_.EncodeEnumValue(VK_SUCCESS);
+    WriteFunctionCall(format::ApiCallId::ApiCall_vkAllocateMemory, &parameter_stream_);
+    parameter_stream_.Clear();
+
+    encoder_.EncodeHandleIdValue(buffer.bind_device->handle_id);
+    encoder_.EncodeHandleIdValue(buffer.handle_id);
+    encoder_.EncodeHandleIdValue(buffer.bind_memory);
+    encoder_.EncodeUInt64Value(0);
+    encoder_.EncodeEnumValue(VK_SUCCESS);
+    WriteFunctionCall(format::ApiCall_vkBindBufferMemory, &parameter_stream_);
+    parameter_stream_.Clear();
+
+    // Manual encoding because tmp objects are not in the state table
+    encoder_.EncodeHandleIdValue(device_wrapper->handle_id);
+    encoder_.EncodeStructPtrPreamble(&pInfo);
+    encoder_.EncodeEnumValue(pInfo.sType);
+    EncodePNextStruct(&encoder_, pInfo.pNext);
+    encoder_.EncodeHandleIdValue(buffer.handle_id);
+    encoder_.EncodeVkDeviceAddressValue(buffer.actual_address);
+
+    auto call_id = device_wrapper->physical_device->instance_api_version >= VK_MAKE_VERSION(1, 2, 0)
+                       ? format::ApiCall_vkGetBufferDeviceAddress
+                       : format::ApiCall_vkGetBufferDeviceAddressKHR;
+    WriteFunctionCall(call_id, &parameter_stream_);
+    parameter_stream_.Clear();
+}
+
+void VulkanStateWriter::InitializeASInputBuffer(ASInputBuffer& buffer)
+{
+    parameter_stream_.Clear();
+
+    format::HandleId device_id = buffer.bind_device->handle_id;
+
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, buffer.created_size);
+
+    auto                            data_size = static_cast<size_t>(buffer.created_size);
+    format::InitBufferCommandHeader upload_cmd{};
+
+    upload_cmd.meta_header.block_header.type = format::kMetaDataBlock;
+    upload_cmd.meta_header.meta_data_id =
+        format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kInitBufferCommand);
+    upload_cmd.thread_id = thread_id_;
+    upload_cmd.device_id = device_id;
+    upload_cmd.buffer_id = buffer.handle_id;
+    upload_cmd.data_size = data_size;
+
+    const uint8_t* bytes = buffer.bytes.data();
+    if (compressor_ != nullptr)
+    {
+        size_t compressed_size = compressor_->Compress(data_size, bytes, &compressed_parameter_buffer_, 0);
+
+        if ((compressed_size > 0) && (compressed_size < data_size))
+        {
+            upload_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
+
+            bytes     = compressed_parameter_buffer_.data();
+            data_size = compressed_size;
+        }
+    }
+
+    // Calculate size of packet with compressed or uncompressed data size.
+    upload_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(upload_cmd) + data_size;
+
+    output_stream_->Write(&upload_cmd, sizeof(upload_cmd));
+    output_stream_->Write(bytes, data_size);
+    ++blocks_written_;
+}
+
+void VulkanStateWriter::WriteDestroyASInputBuffer(ASInputBuffer& buffer)
+{
+    const VkAllocationCallbacks*    callbacks      = nullptr;
+    vulkan_wrappers::DeviceWrapper* device_wrapper = buffer.bind_device;
+
+    parameter_stream_.Clear();
+
+    encoder_.EncodeHandleIdValue(buffer.bind_device->handle_id);
+    encoder_.EncodeHandleIdValue(buffer.handle_id);
+    EncodeStructPtr(&encoder_, callbacks);
+    WriteFunctionCall(format::ApiCall_vkDestroyBuffer, &parameter_stream_);
+    device_wrapper->layer_table.DestroyBuffer(device_wrapper->handle, buffer.handle, callbacks);
+
+    parameter_stream_.Clear();
+
+    encoder_.EncodeHandleIdValue(buffer.bind_device->handle_id);
+    encoder_.EncodeHandleIdValue(buffer.bind_memory);
+    EncodeStructPtr(&encoder_, callbacks);
+    WriteFunctionCall(format::ApiCall_vkFreeMemory, &parameter_stream_);
+    device_wrapper->layer_table.FreeMemory(device_wrapper->handle, buffer.bind_memory_handle, callbacks);
+
+    parameter_stream_.Clear();
+}
+
+void VulkanStateWriter::EndAccelerationStructureSection(format::HandleId device_id)
+{
+    format::EndResourceInitCommand end_cmd{};
+    end_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(end_cmd);
+    end_cmd.meta_header.block_header.type = format::kMetaDataBlock;
+    end_cmd.meta_header.meta_data_id =
+        format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kEndResourceInitCommand);
+    end_cmd.thread_id = thread_id_;
+    end_cmd.device_id = device_id;
+
+    output_stream_->Write(&end_cmd, sizeof(end_cmd));
+    ++blocks_written_;
+}
+
 void VulkanStateWriter::WriteTlasToBlasDependenciesMetadata(const VulkanStateTable& state_table)
 {
     state_table.VisitWrappers([&](const vulkan_wrappers::AccelerationStructureKHRWrapper* tlas) {
         assert(tlas != nullptr);
 
-        if (tlas->blas.size())
+        if (!tlas->blas.empty())
         {
-            format::ParentToChildDependencyHeader tlas_to_blas;
+            format::ParentToChildDependencyHeader tlas_to_blas{};
 
             const size_t blas_count                    = tlas->blas.size();
             tlas_to_blas.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
@@ -1194,6 +1402,288 @@ void VulkanStateWriter::WriteTlasToBlasDependenciesMetadata(const VulkanStateTab
             ++blocks_written_;
         }
     });
+}
+
+// Rename this to represent the whole acc structure prepare process
+void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const VulkanStateTable& state_table)
+{
+    struct AccelerationStructureCommands
+    {
+        std::vector<AccelerationStructureBuildCommandData*>           blas_build;
+        std::vector<AccelerationStructureBuildCommandData*>           tlas_build;
+        std::vector<AccelerationStructureWritePropertiesCommandData> write_properties;
+        AccelerationStructureCopyCommandData                         copies;
+        std::vector<AccelerationStructureBuildCommandData*>           blas_update;
+        std::vector<AccelerationStructureBuildCommandData*>           tlas_update;
+    };
+
+    std::unordered_map<format::HandleId, AccelerationStructureCommands> commands;
+    size_t                                                              max_resource_size = 0;
+
+    state_table.VisitWrappers([&](vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper) {
+        assert(wrapper != nullptr);
+
+        auto&                                                      per_device_container = commands[wrapper->device_id];
+        std::vector<AccelerationStructureBuildCommandData*>* build_container      = nullptr;
+        std::vector<AccelerationStructureBuildCommandData*>* update_container     = nullptr;
+
+        if (wrapper->type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR)
+        {
+            build_container  = &per_device_container.blas_build;
+            update_container = &per_device_container.blas_update;
+        }
+        else if (wrapper->type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR)
+        {
+            build_container  = &per_device_container.tlas_build;
+            update_container = &per_device_container.tlas_update;
+        }
+
+        if (wrapper->latest_build_command_)
+        {
+            build_container->push_back(&wrapper->latest_build_command_.value());
+            for (const vulkan_wrappers::AccelerationStructureKHRWrapper::ASInputBuffer& buffer :
+                 wrapper->latest_build_command_->input_buffers)
+            {
+                max_resource_size = std::max(max_resource_size, buffer.bytes.size());
+            }
+        }
+
+        if (wrapper->latest_update_command_)
+        {
+            update_container->push_back(&wrapper->latest_update_command_.value());
+            for (const vulkan_wrappers::AccelerationStructureKHRWrapper::ASInputBuffer& buffer :
+                 wrapper->latest_update_command_->input_buffers)
+            {
+                max_resource_size = std::max(max_resource_size, buffer.bytes.size());
+            }
+        }
+
+        if (wrapper->latest_copy_command_)
+        {
+            per_device_container.copies.infos.push_back(wrapper->latest_copy_command_.value().info);
+        }
+
+        if (wrapper->latest_write_properties_command_)
+        {
+            per_device_container.write_properties.push_back(
+                { wrapper->latest_write_properties_command_->query_type, wrapper->handle_id });
+        }
+    });
+
+    for (auto& [device, command] : commands)
+    {
+        BeginAccelerationStructuresSection(device, max_resource_size);
+
+        for (auto& blas_build : command.blas_build)
+        {
+            WriteAccelerationStructureBuildState(device, *blas_build);
+        }
+
+        for (const auto& cmd_properties : command.write_properties)
+        {
+            EncodeAccelerationStructureWritePropertiesCommand(device, cmd_properties);
+        }
+
+        EncodeAccelerationStructureCopyMetaCommand(device, command.copies);
+
+        for (auto& tlas_build : command.tlas_build)
+        {
+            WriteAccelerationStructureBuildState(device, *tlas_build);
+        }
+
+        for (auto& blas_update : command.blas_update)
+        {
+            WriteAccelerationStructureBuildState(device, *blas_update);
+        }
+
+        for (auto& tlas_update : command.tlas_update)
+        {
+            WriteAccelerationStructureBuildState(device, *tlas_update);
+        }
+        EndAccelerationStructureSection(device);
+    }
+}
+
+void VulkanStateWriter::WriteAccelerationStructureBuildState(const gfxrecon::format::HandleId&      device,
+                                                             AccelerationStructureBuildCommandData& command)
+{
+    for (ASInputBuffer& buffer : command.input_buffers)
+    {
+        if (!buffer.destroyed)
+        {
+            continue;
+        }
+        WriteASInputBufferState(buffer);
+        WriteASInputMemoryState(buffer);
+        InitializeASInputBuffer(buffer);
+    }
+
+    UpdateAddresses(command);
+    EncodeAccelerationStructureBuildMetaCommand(device, command);
+    for (ASInputBuffer& buffer : command.input_buffers)
+    {
+        if (!buffer.destroyed)
+        {
+            continue;
+        }
+        WriteDestroyASInputBuffer(buffer);
+    }
+}
+
+void VulkanStateWriter::UpdateAddresses(AccelerationStructureBuildCommandData& command)
+{
+    if (command.input_buffers.empty())
+    {
+        return;
+    }
+
+    std::vector<VkDeviceAddress*> addresses_to_replace;
+    for (uint32_t g = 0; g < command.geometry_info.geometryCount; ++g)
+    {
+        switch (command.geometry_info.pGeometries[g].geometryType)
+        {
+            case VkGeometryTypeKHR::VK_GEOMETRY_TYPE_TRIANGLES_KHR:
+            {
+                addresses_to_replace = {
+                    const_cast<VkDeviceAddress*>(
+                        &command.geometry_info.pGeometries[g].geometry.triangles.vertexData.deviceAddress),
+                    const_cast<VkDeviceAddress*>(
+                        &command.geometry_info.pGeometries[g].geometry.triangles.indexData.deviceAddress),
+                    const_cast<VkDeviceAddress*>(
+                        &command.geometry_info.pGeometries[g].geometry.triangles.transformData.deviceAddress)
+                };
+                break;
+            }
+            case VkGeometryTypeKHR::VK_GEOMETRY_TYPE_AABBS_KHR:
+            {
+                addresses_to_replace = { const_cast<VkDeviceAddress*>(
+                    &command.geometry_info.pGeometries[g].geometry.aabbs.data.deviceAddress) };
+                break;
+            }
+            case VkGeometryTypeKHR::VK_GEOMETRY_TYPE_INSTANCES_KHR:
+            {
+                addresses_to_replace = { const_cast<VkDeviceAddress*>(
+                    &command.geometry_info.pGeometries[g].geometry.instances.data.deviceAddress) };
+                break;
+            }
+            case VK_GEOMETRY_TYPE_MAX_ENUM_KHR:
+                break;
+        }
+    }
+    // O(geometryCount * 3) at worst, improve?
+    for (VkDeviceAddress* address : addresses_to_replace)
+    {
+        for (const ASInputBuffer& buffer : command.input_buffers)
+        {
+            if (!buffer.destroyed)
+            {
+                continue;
+            }
+            if (buffer.capture_address == *address)
+            {
+                *address = buffer.actual_address;
+            }
+        }
+    }
+}
+
+void VulkanStateWriter::EncodeAccelerationStructureBuildMetaCommand(
+    format::HandleId device_id, const AccelerationStructureBuildCommandData& command)
+{
+    using RangeInfoArraySize = encode::ArraySize2D<VkCommandBuffer,
+                                                   uint32_t,
+                                                   const VkAccelerationStructureBuildGeometryInfoKHR*,
+                                                   const VkAccelerationStructureBuildRangeInfoKHR* const*>;
+
+    parameter_stream_.Clear();
+
+    format::VulkanMetaBuildAccelerationStructuresHeader header{};
+    header.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
+    header.meta_header.block_header.size = GetMetaDataBlockBaseSize(header);
+    header.meta_header.meta_data_id      = format::MakeMetaDataId(
+        format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kVulkanBuildAccelerationStructuresCommand);
+
+    encoder_.EncodeHandleIdValue(device_id);
+
+    EncodeStructArray(&encoder_, &command.geometry_info, 1);
+
+    const VkAccelerationStructureBuildRangeInfoKHR* ptr = command.build_range_infos.data();
+    EncodeStructArray2D(&encoder_, &ptr, RangeInfoArraySize(VK_NULL_HANDLE, 1, &command.geometry_info, &ptr));
+
+    header.meta_header.block_header.size += parameter_stream_.GetDataSize();
+    output_stream_->Write(&header, sizeof(header));
+    output_stream_->Write(parameter_stream_.GetData(), parameter_stream_.GetDataSize());
+    parameter_stream_.Clear();
+
+    ++blocks_written_;
+}
+
+void VulkanStateWriter::EncodeAccelerationStructureCopyMetaCommand(format::HandleId device_id,
+                                                                   const AccelerationStructureCopyCommandData& command)
+{
+    parameter_stream_.Clear();
+
+    format::VulkanCopyAccelerationStructuresCommandHeader header{};
+    header.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
+    header.meta_header.block_header.size = GetMetaDataBlockBaseSize(header);
+    header.meta_header.meta_data_id      = format::MakeMetaDataId(
+        format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kVulkanCopyAccelerationStructuresCommand);
+
+    encoder_.EncodeHandleIdValue(device_id);
+    EncodeStructArray(&encoder_, command.infos.data(), command.infos.size());
+
+    header.meta_header.block_header.size += parameter_stream_.GetDataSize();
+
+    output_stream_->Write(&header, sizeof(header));
+    output_stream_->Write(parameter_stream_.GetData(), parameter_stream_.GetDataSize());
+
+    parameter_stream_.Clear();
+
+    ++blocks_written_;
+}
+
+void VulkanStateWriter::EncodeAccelerationStructureWritePropertiesCommand(
+    format::HandleId device_id, const AccelerationStructureWritePropertiesCommandData& command)
+{
+    parameter_stream_.Clear();
+
+    format::VulkanWriteAccelerationStructuresPropertiesCommandHeader header{};
+
+    header.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
+    header.meta_header.block_header.size = GetMetaDataBlockBaseSize(header);
+    header.meta_header.meta_data_id =
+        format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_Vulkan,
+                               format::MetaDataType::kVulkanWriteAccelerationStructuresPropertiesCommand);
+
+    encoder_.EncodeHandleIdValue(device_id);
+    encoder_.EncodeEnumValue(command.query_type);
+    encoder_.EncodeHandleIdValue(command.acceleration_structure);
+
+    header.meta_header.block_header.size += parameter_stream_.GetDataSize();
+
+    output_stream_->Write(&header, sizeof(header));
+    output_stream_->Write(parameter_stream_.GetData(), parameter_stream_.GetDataSize());
+
+    parameter_stream_.Clear();
+
+    ++blocks_written_;
+}
+
+void VulkanStateWriter::WriteGetAccelerationStructureDeviceAddressKHRCall(
+    const VulkanStateTable& state_table, const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper)
+{
+    parameter_stream_.Clear();
+    auto device_wrapper = state_table.GetDeviceWrapper(wrapper->device_id);
+    encoder_.EncodeVulkanHandleValue<vulkan_wrappers::DeviceWrapper>(device_wrapper->handle);
+    VkAccelerationStructureDeviceAddressInfoKHR info{ VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR,
+                                                      nullptr,
+                                                      wrapper->handle };
+
+    EncodeStructPtr(&encoder_, &info);
+    encoder_.EncodeVkDeviceAddressValue(vulkan_wrappers::GetDeviceTable(device_wrapper->handle)
+                                            ->GetAccelerationStructureDeviceAddressKHR(device_wrapper->handle, &info));
+    WriteFunctionCall(format::ApiCallId::ApiCall_vkGetAccelerationStructureDeviceAddressKHR, &parameter_stream_);
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteRayTracingPipelinePropertiesState(const VulkanStateTable& state_table)
@@ -1227,8 +1717,8 @@ void VulkanStateWriter::WriteAccelerationStructureKHRState(const VulkanStateTabl
             // vkCreateAccelerationStructKHR through the VkAccelerationStructureCreateInfoKHR::deviceAddress.
             WriteSetOpaqueAddressCommand(wrapper->device_id, wrapper->handle_id, wrapper->address);
         }
-
         WriteFunctionCall(wrapper->create_call_id, wrapper->create_parameters.get());
+        WriteGetAccelerationStructureDeviceAddressKHRCall(state_table, wrapper);
     });
 }
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -83,7 +83,8 @@ VulkanStateWriter::VulkanStateWriter(util::FileOutputStream*           output_st
                                      util::Compressor*                 compressor,
                                      format::ThreadId                  thread_id,
                                      std::function<format::HandleId()> get_unique_id_fn) :
-    output_stream_(output_stream), compressor_(compressor), thread_id_(thread_id), encoder_(&parameter_stream_),
+    output_stream_(output_stream),
+    compressor_(compressor), thread_id_(thread_id), encoder_(&parameter_stream_),
     get_unique_id_(std::move(get_unique_id_fn))
 {
     assert(output_stream != nullptr);
@@ -1414,12 +1415,12 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
 {
     struct AccelerationStructureCommands
     {
-        std::vector<AccelerationStructureBuildCommandData*>           blas_build;
-        std::vector<AccelerationStructureBuildCommandData*>           tlas_build;
+        std::vector<AccelerationStructureBuildCommandData*>          blas_build;
+        std::vector<AccelerationStructureBuildCommandData*>          tlas_build;
         std::vector<AccelerationStructureWritePropertiesCommandData> write_properties;
         AccelerationStructureCopyCommandData                         copies;
-        std::vector<AccelerationStructureBuildCommandData*>           blas_update;
-        std::vector<AccelerationStructureBuildCommandData*>           tlas_update;
+        std::vector<AccelerationStructureBuildCommandData*>          blas_update;
+        std::vector<AccelerationStructureBuildCommandData*>          tlas_update;
     };
 
     std::unordered_map<format::HandleId, AccelerationStructureCommands> commands;
@@ -1428,7 +1429,7 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
     state_table.VisitWrappers([&](vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper) {
         assert(wrapper != nullptr);
 
-        auto&                                                      per_device_container = commands[wrapper->device_id];
+        auto&                                                per_device_container = commands[wrapper->device_id];
         std::vector<AccelerationStructureBuildCommandData*>* build_container      = nullptr;
         std::vector<AccelerationStructureBuildCommandData*>* update_container     = nullptr;
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1509,24 +1509,22 @@ void VulkanStateWriter::WriteAccelerationStructureBuildState(const gfxrecon::for
 {
     for (ASInputBuffer& buffer : command.input_buffers)
     {
-        if (!buffer.destroyed)
+        if (buffer.destroyed)
         {
-            continue;
+            WriteASInputBufferState(buffer);
+            WriteASInputMemoryState(buffer);
+            InitializeASInputBuffer(buffer);
         }
-        WriteASInputBufferState(buffer);
-        WriteASInputMemoryState(buffer);
-        InitializeASInputBuffer(buffer);
     }
 
     UpdateAddresses(command);
     EncodeAccelerationStructureBuildMetaCommand(device, command);
     for (ASInputBuffer& buffer : command.input_buffers)
     {
-        if (!buffer.destroyed)
+        if (buffer.destroyed)
         {
-            continue;
+            WriteDestroyASInputBuffer(buffer);
         }
-        WriteDestroyASInputBuffer(buffer);
     }
 }
 

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -382,7 +382,7 @@ class VulkanStateWriter
     WriteGetAccelerationStructureDeviceAddressKHRCall(const VulkanStateTable& state_table,
                                                       const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper);
 
-    void UpdateAddresses(AccelerationStructureBuildCommandData& command);
+    static void UpdateAddresses(AccelerationStructureBuildCommandData& command);
 
     using ASInputBuffer = vulkan_wrappers::AccelerationStructureKHRWrapper::ASInputBuffer;
     void BeginAccelerationStructuresSection(format::HandleId device_id, uint64_t max_resource_size);

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -47,7 +47,10 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 class VulkanStateWriter
 {
   public:
-    VulkanStateWriter(util::FileOutputStream* output_stream, util::Compressor* compressor, format::ThreadId thread_id);
+    VulkanStateWriter(util::FileOutputStream*           output_stream,
+                      util::Compressor*                 compressor,
+                      format::ThreadId                  thread_id,
+                      std::function<format::HandleId()> get_unique_id_fn);
 
     // Returns number of blocks written to the output_stream.
     uint64_t WriteState(const VulkanStateTable& state_table, uint64_t frame_number);
@@ -348,6 +351,47 @@ class VulkanStateWriter
 
     void WriteTlasToBlasDependenciesMetadata(const VulkanStateTable& state_table);
 
+    void WriteAccelerationStructureStateMetaCommands(const VulkanStateTable& state_table);
+
+    using AccelerationStructureBuildCommandData =
+        vulkan_wrappers::AccelerationStructureKHRWrapper::AccelerationStructureKHRBuildCommandData;
+
+    void WriteAccelerationStructureBuildState(const gfxrecon::format::HandleId&      device,
+                                              AccelerationStructureBuildCommandData& command);
+
+    void EncodeAccelerationStructureBuildMetaCommand(format::HandleId                             device_id,
+                                                     const AccelerationStructureBuildCommandData& command);
+
+    struct AccelerationStructureCopyCommandData
+    {
+        std::vector<VkCopyAccelerationStructureInfoKHR> infos;
+    };
+    void EncodeAccelerationStructureCopyMetaCommand(format::HandleId                            device_id,
+                                                    const AccelerationStructureCopyCommandData& command);
+
+    struct AccelerationStructureWritePropertiesCommandData
+    {
+        VkQueryType      query_type;
+        format::HandleId acceleration_structure;
+    };
+    void
+    EncodeAccelerationStructureWritePropertiesCommand(format::HandleId                                       device_id,
+                                                      const AccelerationStructureWritePropertiesCommandData& command);
+
+    void
+    WriteGetAccelerationStructureDeviceAddressKHRCall(const VulkanStateTable& state_table,
+                                                      const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper);
+
+    void UpdateAddresses(AccelerationStructureBuildCommandData& command);
+
+    using ASInputBuffer = vulkan_wrappers::AccelerationStructureKHRWrapper::ASInputBuffer;
+    void BeginAccelerationStructuresSection(format::HandleId device_id, uint64_t max_resource_size);
+    void WriteASInputBufferState(ASInputBuffer& buffer);
+    void WriteASInputMemoryState(ASInputBuffer& buffer);
+    void InitializeASInputBuffer(ASInputBuffer& buffer);
+    void WriteDestroyASInputBuffer(ASInputBuffer& buffer);
+    void EndAccelerationStructureSection(format::HandleId device_id);
+
   private:
     util::FileOutputStream*  output_stream_;
     util::Compressor*        compressor_;
@@ -356,6 +400,9 @@ class VulkanStateWriter
     util::MemoryOutputStream parameter_stream_;
     ParameterEncoder         encoder_;
     uint64_t                 blocks_written_{ 0 };
+
+    // helper to retrieve a unique id, e.g. from a CaptureManager
+    std::function<format::HandleId()> get_unique_id_;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -156,6 +156,9 @@ enum class MetaDataType : uint16_t
     kReserved31                             = 31,
     kSetEnvironmentVariablesCommand         = 32,
     kViewRelativeLocation                   = 33,
+    kVulkanBuildAccelerationStructuresCommand           = 33,
+    kVulkanCopyAccelerationStructuresCommand            = 34,
+    kVulkanWriteAccelerationStructuresPropertiesCommand = 35,
 };
 
 // MetaDataId is stored in the capture file and its type must be uint32_t to avoid breaking capture file compatibility.

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -150,15 +150,12 @@ enum class MetaDataType : uint16_t
     kReserved25                             = 25,
     kDx12RuntimeInfoCommand                 = 26,
     kParentToChildDependency                = 27,
-    kReserved28                             = 28,
-    kReserved29                             = 29,
-    kReserved30                             = 30,
+    kVulkanBuildAccelerationStructuresCommand           = 28,
+    kVulkanCopyAccelerationStructuresCommand            = 29,
+    kVulkanWriteAccelerationStructuresPropertiesCommand = 30,
     kReserved31                             = 31,
     kSetEnvironmentVariablesCommand         = 32,
     kViewRelativeLocation                   = 33,
-    kVulkanBuildAccelerationStructuresCommand           = 33,
-    kVulkanCopyAccelerationStructuresCommand            = 34,
-    kVulkanWriteAccelerationStructuresPropertiesCommand = 35,
 };
 
 // MetaDataId is stored in the capture file and its type must be uint32_t to avoid breaking capture file compatibility.
@@ -664,6 +661,21 @@ struct SetEnvironmentVariablesCommand
 
     // In the capture file, a string will immediately follow this block
     // containing a list of environment variables and their values
+};
+
+struct VulkanMetaBuildAccelerationStructuresHeader
+{
+    format::MetaDataHeader meta_header;
+};
+
+struct VulkanWriteAccelerationStructuresPropertiesCommandHeader
+{
+    format::MetaDataHeader meta_header;
+};
+
+struct VulkanCopyAccelerationStructuresCommandHeader
+{
+    format::MetaDataHeader meta_header;
 };
 
 // Restore size_t to normal behavior.


### PR DESCRIPTION
- Extend capture/tracking to cover acceleration-structures (AS) and dependencies
- Add meta-commands to rebuild AS during replay
- create all stubs in replay, implement in follow-up

this PR belongs to [portable raytracing initiative](https://github.com/LunarG/gfxreconstruct/issues/1526)