### PR TITLE
Base change set to resolve dev <-> openxr_experimental inconsistencies

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -5,6 +5,9 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/annotation_handler.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/api_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/common_consumer_base.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/common_handle_mapping_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/common_object_info_table.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/common_struct_handle_mappers.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/copy_shaders.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/custom_vulkan_struct_decoders.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/custom_vulkan_struct_decoders.cpp

--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/common_handle_mapping_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/common_object_info_table.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/common_struct_handle_mappers.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/common_object_info_table.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/copy_shaders.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/custom_vulkan_struct_decoders.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/custom_vulkan_struct_decoders.cpp

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/common_handle_mapping_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/common_object_info_table.h
                     ${CMAKE_CURRENT_LIST_DIR}/common_struct_handle_mappers.h
+                    ${CMAKE_CURRENT_LIST_DIR}/common_object_info_table.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/copy_shaders.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_struct_decoders.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_struct_decoders.cpp

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -33,6 +33,9 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/annotation_handler.h
                     ${CMAKE_CURRENT_LIST_DIR}/api_decoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/common_consumer_base.h
+                    ${CMAKE_CURRENT_LIST_DIR}/common_handle_mapping_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/common_object_info_table.h
+                    ${CMAKE_CURRENT_LIST_DIR}/common_struct_handle_mappers.h
                     ${CMAKE_CURRENT_LIST_DIR}/copy_shaders.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_struct_decoders.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_struct_decoders.cpp

--- a/framework/decode/common_handle_mapping_util.h
+++ b/framework/decode/common_handle_mapping_util.h
@@ -205,8 +205,8 @@ template <typename T>
 static void AddHandleArrayAsync(format::HandleId        parent_id,
                                 const format::HandleId* ids,
                                 size_t                  ids_len,
-                                VulkanObjectInfoTable*  object_info_table,
-                                void (VulkanObjectInfoTable::*AddFunc)(T&&),
+                                CommonObjectInfoTable*  object_info_table,
+                                void (CommonObjectInfoTable::*AddFunc)(T&&),
                                 std::shared_future<handle_create_result_t<typename T::HandleType>> future)
 {
     static_assert(has_handle_future_v<T>, "handle-type does not support asynchronous creation");
@@ -231,9 +231,9 @@ template <typename T>
 static void AddHandleArrayAsync(format::HandleId        parent_id,
                                 const format::HandleId* ids,
                                 size_t                  ids_len,
-                                VulkanObjectInfoTable*  object_info_table,
+                                CommonObjectInfoTable*  object_info_table,
                                 std::vector<T>&&        initial_infos,
-                                void (VulkanObjectInfoTable::*AddFunc)(T&&),
+                                void (CommonObjectInfoTable::*AddFunc)(T&&),
                                 std::shared_future<handle_create_result_t<typename T::HandleType>> future)
 {
     static_assert(has_handle_future_v<T>, "handle-type does not support asynchronous creation");

--- a/framework/decode/common_handle_mapping_util.h
+++ b/framework/decode/common_handle_mapping_util.h
@@ -1,0 +1,275 @@
+/*
+** Copyright (c) 2020-2024 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_COMMON_HANDLE_MAPPING_UTIL_H
+#define GFXRECON_DECODE_COMMON_HANDLE_MAPPING_UTIL_H
+
+#include "decode/common_object_info_table.h"
+#include "format/format.h"
+#include "util/defines.h"
+#include "util/logging.h"
+
+#include <cassert>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(handle_mapping)
+
+template <typename T>
+static typename T::HandleType MapHandle(format::HandleId             id,
+                                        const CommonObjectInfoTable& object_info_table,
+                                        const T* (CommonObjectInfoTable::*GetInfoFunc)(format::HandleId) const)
+{
+    typename T::HandleType handle = 0;
+
+    if (id != format::kNullHandleId)
+    {
+        const T* info = (object_info_table.*GetInfoFunc)(id);
+
+        if (info != nullptr)
+        {
+            handle = info->handle;
+
+            if constexpr (has_handle_future_v<T>)
+            {
+                if (info->handle == VK_NULL_HANDLE && info->future.valid())
+                {
+                    const auto& [result, async_handles] = info->future.get();
+                    handle                              = async_handles[info->future_handle_index];
+                }
+            }
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING("Failed to map handle for object id %" PRIu64, id);
+        }
+    }
+
+    return handle;
+}
+
+template <typename T>
+static typename T::HandleType* MapHandleArray(HandlePointerDecoder<typename T::HandleType>* handles_pointer,
+                                              const CommonObjectInfoTable&                  object_info_table,
+                                              const T* (CommonObjectInfoTable::*GetInfoFunc)(format::HandleId) const)
+{
+    assert(handles_pointer != nullptr);
+
+    typename T::HandleType* handles = nullptr;
+
+    if (!handles_pointer->IsNull())
+    {
+        size_t                  len = handles_pointer->GetLength();
+        const format::HandleId* ids = handles_pointer->GetPointer();
+
+        handles_pointer->SetHandleLength(len);
+
+        handles = handles_pointer->GetHandlePointer();
+
+        for (size_t i = 0; i < len; ++i)
+        {
+            if (ids[i] != format::kNullHandleId)
+            {
+                const T* info = (object_info_table.*GetInfoFunc)(ids[i]);
+                if (info != nullptr)
+                {
+                    handles[i] = info->handle;
+
+                    if constexpr (has_handle_future_v<T>)
+                    {
+                        if (info->handle == VK_NULL_HANDLE && info->future.valid())
+                        {
+                            const auto& [result, async_handles] = info->future.get();
+                            handles[i]                          = async_handles[info->future_handle_index];
+                        }
+                    }
+                }
+                else
+                {
+                    handles[i] = 0;
+                    GFXRECON_LOG_WARNING("Failed to map handle for object id %" PRIu64, ids[i]);
+                }
+            }
+        }
+    }
+
+    return handles;
+}
+
+template <typename T>
+static void AddHandle(format::HandleId             parent_id,
+                      format::HandleId             id,
+                      const typename T::HandleType handle,
+                      T&&                          initial_info,
+                      CommonObjectInfoTable*       object_info_table,
+                      void (CommonObjectInfoTable::*AddFunc)(T&&))
+{
+    assert(object_info_table != nullptr);
+
+    initial_info.handle     = handle;
+    initial_info.capture_id = id;
+    initial_info.parent_id  = parent_id;
+    (object_info_table->*AddFunc)(std::forward<T>(initial_info));
+}
+
+template <typename T>
+static void AddHandle(format::HandleId       parent_id,
+                      format::HandleId       id,
+                      typename T::HandleType handle,
+                      CommonObjectInfoTable* object_info_table,
+                      void (CommonObjectInfoTable::*AddFunc)(T&&))
+{
+    assert(object_info_table != nullptr);
+
+    T info;
+    info.handle     = handle;
+    info.capture_id = id;
+    info.parent_id  = parent_id;
+    (object_info_table->*AddFunc)(std::move(info));
+}
+
+template <typename T>
+static void AddHandleArray(format::HandleId              parent_id,
+                           const format::HandleId*       ids,
+                           size_t                        ids_len,
+                           const typename T::HandleType* handles,
+                           size_t                        handles_len,
+                           std::vector<T>&&              initial_infos,
+                           CommonObjectInfoTable*        object_info_table,
+                           void (CommonObjectInfoTable::*AddFunc)(T&&))
+{
+    assert(object_info_table != nullptr);
+
+    if ((ids != nullptr) && (handles != nullptr))
+    {
+        size_t len = std::min(ids_len, handles_len);
+
+        assert(len <= initial_infos.size());
+
+        for (size_t i = 0; i < len; ++i)
+        {
+            auto info_iter        = std::next(initial_infos.begin(), i);
+            info_iter->handle     = handles[i];
+            info_iter->capture_id = ids[i];
+            info_iter->parent_id  = parent_id;
+            (object_info_table->*AddFunc)(std::move(*info_iter));
+        }
+    }
+}
+
+template <typename T>
+static void AddHandleArray(format::HandleId              parent_id,
+                           const format::HandleId*       ids,
+                           size_t                        ids_len,
+                           const typename T::HandleType* handles,
+                           size_t                        handles_len,
+                           CommonObjectInfoTable*        object_info_table,
+                           void (CommonObjectInfoTable::*AddFunc)(T&&))
+{
+    assert(object_info_table != nullptr);
+
+    if ((ids != nullptr) && (handles != nullptr))
+    {
+        size_t len = std::min(ids_len, handles_len);
+        for (size_t i = 0; i < len; ++i)
+        {
+            T info;
+            info.handle     = handles[i];
+            info.capture_id = ids[i];
+            info.parent_id  = parent_id;
+            (object_info_table->*AddFunc)(std::move(info));
+        }
+    }
+}
+
+template <typename T>
+static void AddHandleArrayAsync(format::HandleId        parent_id,
+                                const format::HandleId* ids,
+                                size_t                  ids_len,
+                                VulkanObjectInfoTable*  object_info_table,
+                                void (VulkanObjectInfoTable::*AddFunc)(T&&),
+                                std::shared_future<handle_create_result_t<typename T::HandleType>> future)
+{
+    static_assert(has_handle_future_v<T>, "handle-type does not support asynchronous creation");
+    assert(object_info_table != nullptr);
+
+    if (ids != nullptr)
+    {
+        for (size_t i = 0; i < ids_len; ++i)
+        {
+            T info;
+            info.handle              = VK_NULL_HANDLE; // handle does not yet exist
+            info.capture_id          = ids[i];
+            info.parent_id           = parent_id;
+            info.future              = future;
+            info.future_handle_index = i;
+            (object_info_table->*AddFunc)(std::move(info));
+        }
+    }
+}
+
+template <typename T>
+static void AddHandleArrayAsync(format::HandleId        parent_id,
+                                const format::HandleId* ids,
+                                size_t                  ids_len,
+                                VulkanObjectInfoTable*  object_info_table,
+                                std::vector<T>&&        initial_infos,
+                                void (VulkanObjectInfoTable::*AddFunc)(T&&),
+                                std::shared_future<handle_create_result_t<typename T::HandleType>> future)
+{
+    static_assert(has_handle_future_v<T>, "handle-type does not support asynchronous creation");
+    assert(object_info_table != nullptr);
+
+    if (ids != nullptr)
+    {
+        assert(ids_len <= initial_infos.size());
+
+        for (size_t i = 0; i < ids_len; ++i)
+        {
+            auto info_iter                 = std::next(initial_infos.begin(), i);
+            info_iter->handle              = VK_NULL_HANDLE; // handle does not yet exist
+            info_iter->capture_id          = ids[i];
+            info_iter->parent_id           = parent_id;
+            info_iter->future              = future;
+            info_iter->future_handle_index = i;
+            (object_info_table->*AddFunc)(std::move(*info_iter));
+        }
+    }
+}
+
+inline void RemoveHandle(format::HandleId       id,
+                         CommonObjectInfoTable* object_info_table,
+                         void (CommonObjectInfoTable::*RemoveFunc)(format::HandleId))
+{
+    assert(object_info_table != nullptr);
+
+    if (id != format::kNullHandleId)
+    {
+        (object_info_table->*RemoveFunc)(id);
+    }
+}
+
+GFXRECON_END_NAMESPACE(handle_mapping)
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_COMMON_HANDLE_MAPPING_UTIL_H

--- a/framework/decode/common_object_info_table.cpp
+++ b/framework/decode/common_object_info_table.cpp
@@ -21,31 +21,40 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef GFXRECON_DECODE_COMMON_OBJECT_TABLE_H
-#define GFXRECON_DECODE_COMMON_OBJECT_TABLE_H
-
-#include "decode/vulkan_object_info_table.h"
+#include "decode/common_object_info_table.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-// This class combines all Object info tables into one so that multi-API
-// capture can work by allowing various API entrypoints access to all
-// available objects.   For example, OpenXR objects will be in a shared
-// table with Vulkan objects.
+CommonObjectInfoTable* CommonObjectInfoTable::singleton_          = nullptr;
+uint32_t               CommonObjectInfoTable::singleton_refcount_ = 0;
 
-class CommonObjectInfoTable : public VulkanObjectInfoTable
+CommonObjectInfoTable* CommonObjectInfoTable::GetSingleton()
 {
-  public:
-    static CommonObjectInfoTable* GetSingleton();
-    static void                   ReleaseSingleton();
+    if (!singleton_)
+    {
+        singleton_          = new CommonObjectInfoTable();
+        singleton_refcount_ = 1;
+    }
+    return singleton_;
+}
 
-  private:
-    static CommonObjectInfoTable* singleton_;
-    static uint32_t               singleton_refcount_;
-};
+void CommonObjectInfoTable::ReleaseSingleton()
+{
+    if (singleton_)
+    {
+        singleton_refcount_--;
+        if (singleton_refcount_ == 0)
+        {
+            delete singleton_;
+            singleton_ = nullptr;
+        }
+    }
+    else
+    {
+        assert(singleton_refcount_ == 0);
+    }
+}
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
-
-#endif // GFXRECON_DECODE_COMMON_OBJECT_TABLE_H

--- a/framework/decode/common_object_info_table.h
+++ b/framework/decode/common_object_info_table.h
@@ -1,5 +1,6 @@
 /*
-** Copyright (c) 2019-2020 LunarG, Inc.
+** Copyright (c) 2018-2021 Valve Corporation
+** Copyright (c) 2018-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -20,32 +21,23 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef GFXRECON_DECODE_CUSTOM_STRUCT_HANDLE_MAPPERS_H
-#define GFXRECON_DECODE_CUSTOM_STRUCT_HANDLE_MAPPERS_H
+#ifndef GFXRECON_DECODE_COMMON_OBJECT_TABLE_H
+#define GFXRECON_DECODE_COMMON_OBJECT_TABLE_H
 
-#include "decode/common_object_info_table.h"
-#include "decode/custom_vulkan_struct_decoders_forward.h"
-#include "decode/vulkan_pnext_node.h"
-#include "util/defines.h"
-
-#include "vulkan/vulkan.h"
+#include "decode/vulkan_object_info_table.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-void MapStructHandles(VkDescriptorType               type,
-                      Decoded_VkDescriptorImageInfo* wrapper,
-                      const CommonObjectInfoTable&   object_info_table);
+// This class combines all Object info tables into one so that multi-API
+// capture can work by allowing various API entrypoints access to all
+// available objects.   For example, OpenXR objects will be in a shared
+// table with Vulkan objects.
 
-void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const CommonObjectInfoTable& object_info_table);
-
-void MapStructHandles(Decoded_VkAccelerationStructureGeometryKHR* wrapper,
-                      const CommonObjectInfoTable&                object_info_table);
-
-void MapStructHandles(Decoded_VkAccelerationStructureBuildGeometryInfoKHR* wrapper,
-                      const CommonObjectInfoTable&                         object_info_table);
+class CommonObjectInfoTable : public VulkanObjectInfoTable
+{};
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_DECODE_CUSTOM_STRUCT_HANDLE_MAPPERS_H
+#endif // GFXRECON_DECODE_COMMON_OBJECT_TABLE_H

--- a/framework/decode/common_struct_handle_mappers.h
+++ b/framework/decode/common_struct_handle_mappers.h
@@ -1,0 +1,69 @@
+/*
+** Copyright (c) 2020-2024 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_COMMON_HANDLE_MAPPERS_H
+#define GFXRECON_DECODE_COMMON_HANDLE_MAPPERS_H
+
+template <typename T>
+void MapStructArrayHandles(T* structs, size_t len, const CommonObjectInfoTable& object_info_table)
+{
+    if (structs != nullptr)
+    {
+        for (size_t i = 0; i < len; ++i)
+        {
+            MapStructHandles(&structs[i], object_info_table);
+        }
+    }
+}
+
+template <typename T>
+void AddStructArrayHandles(format::HandleId               parent_id,
+                           const T*                       id_wrappers,
+                           size_t                         id_len,
+                           const typename T::struct_type* handle_structs,
+                           size_t                         handle_len,
+                           CommonObjectInfoTable*         object_info_table)
+{
+    if (id_wrappers != nullptr && handle_structs != nullptr)
+    {
+        // TODO: Improved handling of array size mismatch.
+        size_t len = std::min(id_len, handle_len);
+        for (size_t i = 0; i < len; ++i)
+        {
+            AddStructHandles(parent_id, &id_wrappers[i], &handle_structs[i], object_info_table);
+        }
+    }
+}
+
+template <typename T>
+void SetStructArrayHandleLengths(T* wrappers, size_t len)
+{
+    if (wrappers != nullptr)
+    {
+        for (size_t i = 0; i < len; ++i)
+        {
+            SetStructHandleLengths(&wrappers[i]);
+        }
+    }
+}
+
+#endif // GFXRECON_DECODE_COMMON_HANDLE_MAPPERS_H

--- a/framework/decode/custom_vulkan_struct_handle_mappers.cpp
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.cpp
@@ -43,14 +43,14 @@ void MapStructHandles(VkDescriptorType               type,
         if ((type == VK_DESCRIPTOR_TYPE_SAMPLER) || (type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER))
         {
             // TODO: This should be ignored if the descriptor set layout was created with an immutable sampler.
-            value->sampler = handle_mapping::MapHandle<SamplerInfo>(
-                wrapper->sampler, object_info_table, &VulkanObjectInfoTable::GetSamplerInfo);
+            value->sampler = handle_mapping::MapHandle<VulkanSamplerInfo>(
+                wrapper->sampler, object_info_table, &VulkanObjectInfoTable::GetVkSamplerInfo);
         }
 
         if (type != VK_DESCRIPTOR_TYPE_SAMPLER)
         {
-            value->imageView = handle_mapping::MapHandle<ImageViewInfo>(
-                wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo);
+            value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(
+                wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
         }
     }
 }
@@ -66,8 +66,8 @@ void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectI
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
         }
 
-        value->dstSet = handle_mapping::MapHandle<DescriptorSetInfo>(
-            wrapper->dstSet, object_mapper, &VulkanObjectInfoTable::GetDescriptorSetInfo);
+        value->dstSet = handle_mapping::MapHandle<VulkanDescriptorSetInfo>(
+            wrapper->dstSet, object_mapper, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
 
         switch (value->descriptorType)
         {
@@ -95,8 +95,8 @@ void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectI
                 break;
             case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
             case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-                value->pTexelBufferView = handle_mapping::MapHandleArray<BufferViewInfo>(
-                    &wrapper->pTexelBufferView, object_mapper, &VulkanObjectInfoTable::GetBufferViewInfo);
+                value->pTexelBufferView = handle_mapping::MapHandleArray<VulkanBufferViewInfo>(
+                    &wrapper->pTexelBufferView, object_mapper, &VulkanObjectInfoTable::GetVkBufferViewInfo);
                 break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
                 // TODO
@@ -145,15 +145,15 @@ void MapStructHandles(Decoded_VkAccelerationStructureBuildGeometryInfoKHR* wrapp
     {
         VkAccelerationStructureBuildGeometryInfoKHR* value = wrapper->decoded_value;
 
-        value->srcAccelerationStructure = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(
+        value->srcAccelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(
             wrapper->srcAccelerationStructure,
             object_info_table,
-            &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+            &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
 
-        value->dstAccelerationStructure = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(
+        value->dstAccelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(
             wrapper->dstAccelerationStructure,
             object_info_table,
-            &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+            &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
 
         MapStructArrayHandles<Decoded_VkAccelerationStructureGeometryKHR>(
             wrapper->pGeometries->GetMetaStructPointer(), wrapper->pGeometries->GetLength(), object_info_table);

--- a/framework/decode/custom_vulkan_struct_handle_mappers.cpp
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.cpp
@@ -34,7 +34,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 void MapStructHandles(VkDescriptorType               type,
                       Decoded_VkDescriptorImageInfo* wrapper,
-                      const VulkanObjectInfoTable&   object_info_table)
+                      const CommonObjectInfoTable&   object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -44,18 +44,18 @@ void MapStructHandles(VkDescriptorType               type,
         {
             // TODO: This should be ignored if the descriptor set layout was created with an immutable sampler.
             value->sampler = handle_mapping::MapHandle<VulkanSamplerInfo>(
-                wrapper->sampler, object_info_table, &VulkanObjectInfoTable::GetVkSamplerInfo);
+                wrapper->sampler, object_info_table, &CommonObjectInfoTable::GetVkSamplerInfo);
         }
 
         if (type != VK_DESCRIPTOR_TYPE_SAMPLER)
         {
             value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(
-                wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
+                wrapper->imageView, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo);
         }
     }
 }
 
-void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectInfoTable& object_mapper)
+void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const CommonObjectInfoTable& object_mapper)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -67,7 +67,7 @@ void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectI
         }
 
         value->dstSet = handle_mapping::MapHandle<VulkanDescriptorSetInfo>(
-            wrapper->dstSet, object_mapper, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
+            wrapper->dstSet, object_mapper, &CommonObjectInfoTable::GetVkDescriptorSetInfo);
 
         switch (value->descriptorType)
         {
@@ -96,7 +96,7 @@ void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectI
             case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
             case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
                 value->pTexelBufferView = handle_mapping::MapHandleArray<VulkanBufferViewInfo>(
-                    &wrapper->pTexelBufferView, object_mapper, &VulkanObjectInfoTable::GetVkBufferViewInfo);
+                    &wrapper->pTexelBufferView, object_mapper, &CommonObjectInfoTable::GetVkBufferViewInfo);
                 break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
                 // TODO
@@ -114,7 +114,7 @@ void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectI
 }
 
 void MapStructHandles(Decoded_VkAccelerationStructureGeometryKHR* wrapper,
-                      const VulkanObjectInfoTable&                object_info_table)
+                      const CommonObjectInfoTable&                object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -139,7 +139,7 @@ void MapStructHandles(Decoded_VkAccelerationStructureGeometryKHR* wrapper,
 }
 
 void MapStructHandles(Decoded_VkAccelerationStructureBuildGeometryInfoKHR* wrapper,
-                      const VulkanObjectInfoTable&                         object_info_table)
+                      const CommonObjectInfoTable&                         object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -148,12 +148,12 @@ void MapStructHandles(Decoded_VkAccelerationStructureBuildGeometryInfoKHR* wrapp
         value->srcAccelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(
             wrapper->srcAccelerationStructure,
             object_info_table,
-            &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
+            &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo);
 
         value->dstAccelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(
             wrapper->dstAccelerationStructure,
             object_info_table,
-            &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
+            &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo);
 
         MapStructArrayHandles<Decoded_VkAccelerationStructureGeometryKHR>(
             wrapper->pGeometries->GetMetaStructPointer(), wrapper->pGeometries->GetLength(), object_info_table);

--- a/framework/decode/decoder_util.h
+++ b/framework/decode/decoder_util.h
@@ -50,7 +50,7 @@ bool IsComplete(std::vector<T>& consumers, uint64_t block_index)
 }
 
 static VkQueue GetDeviceQueue(const encode::VulkanDeviceTable* device_table,
-                              const DeviceInfo*                device_info,
+                              const VulkanDeviceInfo*          device_info,
                               uint32_t                         queue_family_index,
                               uint32_t                         queue_index)
 {

--- a/framework/decode/pointer_decoder_base.h
+++ b/framework/decode/pointer_decoder_base.h
@@ -71,6 +71,59 @@ class PointerDecoderBase
 
     size_t GetLength() const { return len_; }
 
+    static bool PeekAttributesAndType(const uint8_t* buffer,
+                                      size_t         buffer_size,
+                                      bool&          is_null,
+                                      bool&          is_struct,
+                                      bool&          has_length,
+                                      size_t&        length,
+                                      uint32_t&      structure_type)
+    {
+        bool     success    = true;
+        size_t   bytes_read = 0;
+        uint32_t attrib     = 0;
+        uint64_t address;
+
+        is_null    = true;
+        is_struct  = false;
+        has_length = false;
+
+        bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &attrib);
+
+        if ((attrib & format::PointerAttributes::kIsNull) != format::PointerAttributes::kIsNull)
+        {
+            is_null = false;
+            if ((attrib & format::PointerAttributes::kHasAddress) == format::PointerAttributes::kHasAddress)
+            {
+                // Not interested right now, but need to read it if it's present
+                bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &address);
+            }
+
+            has_length = true;
+            if (((attrib & format::PointerAttributes::kIsArray) == format::PointerAttributes::kIsArray) ||
+                ((attrib & format::PointerAttributes::kIsArray2D) == format::PointerAttributes::kIsArray2D) ||
+                ((attrib & format::PointerAttributes::kIsString) == format::PointerAttributes::kIsString) ||
+                ((attrib & format::PointerAttributes::kIsWString) == format::PointerAttributes::kIsWString))
+            {
+                bytes_read +=
+                    ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &length);
+            }
+            else
+            {
+                length = 1;
+            }
+
+            if ((attrib & format::PointerAttributes::kIsStruct) == format::PointerAttributes::kIsStruct)
+            {
+                is_struct = true;
+                bytes_read +=
+                    ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &structure_type);
+            }
+        }
+
+        return success;
+    }
+
   protected:
     size_t DecodeAttributes(const uint8_t* buffer, size_t buffer_size)
     {

--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -67,7 +67,7 @@ inline void WriteImageFile(const std::string&     filename,
 }
 
 void ScreenshotHandler::WriteImage(const std::string&                      filename_prefix,
-                                   const DeviceInfo*                       device_info,
+                                   const VulkanDeviceInfo*                 device_info,
                                    const encode::VulkanDeviceTable*        device_table,
                                    const VkPhysicalDeviceMemoryProperties& memory_properties,
                                    VulkanResourceAllocator*                allocator,

--- a/framework/decode/screenshot_handler.h
+++ b/framework/decode/screenshot_handler.h
@@ -53,7 +53,7 @@ class ScreenshotHandler : public ScreenshotHandlerBase
     {}
 
     void WriteImage(const std::string&                      filename_prefix,
-                    const DeviceInfo*                       device_info,
+                    const VulkanDeviceInfo*                 device_info,
                     const encode::VulkanDeviceTable*        device_table,
                     const VkPhysicalDeviceMemoryProperties& memory_properties,
                     VulkanResourceAllocator*                allocator,

--- a/framework/decode/test/main.cpp
+++ b/framework/decode/test/main.cpp
@@ -28,6 +28,7 @@
 
 #include "decode/vulkan_handle_mapping_util.h"
 #include "decode/vulkan_object_info.h"
+#include "decode/common_object_info_table.h"
 #include "format/format.h"
 #include "format/format_util.h"
 
@@ -46,7 +47,7 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
 {
     gfxrecon::util::Log::Init(gfxrecon::util::Log::kErrorSeverity);
 
-    gfxrecon::decode::VulkanObjectInfoTable info_table;
+    gfxrecon::decode::CommonObjectInfoTable info_table;
 
     // Basic add.
     gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::VulkanBufferInfo>(
@@ -54,7 +55,7 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
         kBufferIds[0],
         kBufferHandles[0],
         &info_table,
-        &gfxrecon::decode::VulkanObjectInfoTable::AddVkBufferInfo);
+        &gfxrecon::decode::CommonObjectInfoTable::AddVkBufferInfo);
 
     SECTION("Add a total of four entries to the object table")
     {
@@ -66,7 +67,7 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
             &kBufferHandles[1],
             1,
             &info_table,
-            &gfxrecon::decode::VulkanObjectInfoTable::AddVkBufferInfo);
+            &gfxrecon::decode::CommonObjectInfoTable::AddVkBufferInfo);
 
         // Array add with info and different ID/handle counts.
         gfxrecon::decode::handle_mapping::AddHandleArray<gfxrecon::decode::VulkanBufferInfo>(
@@ -77,7 +78,7 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
             2,
             std::vector<gfxrecon::decode::VulkanBufferInfo>(1),
             &info_table,
-            &gfxrecon::decode::VulkanObjectInfoTable::AddVkBufferInfo);
+            &gfxrecon::decode::CommonObjectInfoTable::AddVkBufferInfo);
 
         // Add with info.
         gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::VulkanBufferInfo>(
@@ -86,7 +87,7 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
             kBufferHandles[3],
             gfxrecon::decode::VulkanBufferInfo{},
             &info_table,
-            &gfxrecon::decode::VulkanObjectInfoTable::AddVkBufferInfo);
+            &gfxrecon::decode::CommonObjectInfoTable::AddVkBufferInfo);
 
         std::vector<const gfxrecon::decode::VulkanBufferInfo*> buffers;
         info_table.VisitVkBufferInfo(
@@ -102,7 +103,7 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
             kBufferIds[0],
             kBufferHandles[0],
             &info_table,
-            &gfxrecon::decode::VulkanObjectInfoTable::AddVkBufferInfo);
+            &gfxrecon::decode::CommonObjectInfoTable::AddVkBufferInfo);
 
         std::vector<const gfxrecon::decode::VulkanBufferInfo*> buffers;
         info_table.VisitVkBufferInfo(
@@ -114,7 +115,7 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
     SECTION("Remove an entry from the object table")
     {
         gfxrecon::decode::handle_mapping::RemoveHandle(
-            kBufferIds[0], &info_table, &gfxrecon::decode::VulkanObjectInfoTable::RemoveVkBufferInfo);
+            kBufferIds[0], &info_table, &gfxrecon::decode::CommonObjectInfoTable::RemoveVkBufferInfo);
 
         std::vector<const gfxrecon::decode::VulkanBufferInfo*> buffers;
         info_table.VisitVkBufferInfo(
@@ -126,7 +127,7 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
     SECTION("Buffer ID 12 maps to a valid buffer handle")
     {
         auto buffer = gfxrecon::decode::handle_mapping::MapHandle<gfxrecon::decode::VulkanBufferInfo>(
-            kBufferIds[0], info_table, &gfxrecon::decode::VulkanObjectInfoTable::GetVkBufferInfo);
+            kBufferIds[0], info_table, &gfxrecon::decode::CommonObjectInfoTable::GetVkBufferInfo);
 
         REQUIRE(buffer == kBufferHandles[0]);
     }
@@ -134,7 +135,7 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
     SECTION("Invalid buffer ID 99 does not map to a valid buffer handle")
     {
         auto buffer = gfxrecon::decode::handle_mapping::MapHandle<gfxrecon::decode::VulkanBufferInfo>(
-            99, info_table, &gfxrecon::decode::VulkanObjectInfoTable::GetVkBufferInfo);
+            99, info_table, &gfxrecon::decode::CommonObjectInfoTable::GetVkBufferInfo);
 
         REQUIRE(buffer == VK_NULL_HANDLE);
     }

--- a/framework/decode/test/main.cpp
+++ b/framework/decode/test/main.cpp
@@ -28,7 +28,6 @@
 
 #include "decode/vulkan_handle_mapping_util.h"
 #include "decode/vulkan_object_info.h"
-#include "decode/vulkan_object_info_table.h"
 #include "format/format.h"
 #include "format/format_util.h"
 
@@ -37,9 +36,9 @@
 #include <vector>
 
 const VkBuffer                   kBufferHandles[] = { gfxrecon::format::FromHandleId<VkBuffer>(0xabcd),
-                                    gfxrecon::format::FromHandleId<VkBuffer>(0xbcda),
-                                    gfxrecon::format::FromHandleId<VkBuffer>(0xcdab),
-                                    gfxrecon::format::FromHandleId<VkBuffer>(0xdabc) };
+                                                      gfxrecon::format::FromHandleId<VkBuffer>(0xbcda),
+                                                      gfxrecon::format::FromHandleId<VkBuffer>(0xcdab),
+                                                      gfxrecon::format::FromHandleId<VkBuffer>(0xdabc) };
 const gfxrecon::format::HandleId kBufferIds[]     = { 12, 24, 48, 96 };
 const gfxrecon::format::HandleId kDeviceId        = 6;
 
@@ -50,62 +49,64 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
     gfxrecon::decode::VulkanObjectInfoTable info_table;
 
     // Basic add.
-    gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::BufferInfo>(
+    gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::VulkanBufferInfo>(
         kDeviceId,
         kBufferIds[0],
         kBufferHandles[0],
         &info_table,
-        &gfxrecon::decode::VulkanObjectInfoTable::AddBufferInfo);
+        &gfxrecon::decode::VulkanObjectInfoTable::AddVkBufferInfo);
 
     SECTION("Add a total of four entries to the object table")
     {
         // Basic array add.
-        gfxrecon::decode::handle_mapping::AddHandleArray<gfxrecon::decode::BufferInfo>(
+        gfxrecon::decode::handle_mapping::AddHandleArray<gfxrecon::decode::VulkanBufferInfo>(
             kDeviceId,
             &kBufferIds[1],
             1,
             &kBufferHandles[1],
             1,
             &info_table,
-            &gfxrecon::decode::VulkanObjectInfoTable::AddBufferInfo);
+            &gfxrecon::decode::VulkanObjectInfoTable::AddVkBufferInfo);
 
         // Array add with info and different ID/handle counts.
-        gfxrecon::decode::handle_mapping::AddHandleArray<gfxrecon::decode::BufferInfo>(
+        gfxrecon::decode::handle_mapping::AddHandleArray<gfxrecon::decode::VulkanBufferInfo>(
             kDeviceId,
             &kBufferIds[2],
             1,
             &kBufferHandles[2],
             2,
-            std::vector<gfxrecon::decode::BufferInfo>(1),
+            std::vector<gfxrecon::decode::VulkanBufferInfo>(1),
             &info_table,
-            &gfxrecon::decode::VulkanObjectInfoTable::AddBufferInfo);
+            &gfxrecon::decode::VulkanObjectInfoTable::AddVkBufferInfo);
 
         // Add with info.
-        gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::BufferInfo>(
+        gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::VulkanBufferInfo>(
             kDeviceId,
             kBufferIds[3],
             kBufferHandles[3],
-            gfxrecon::decode::BufferInfo{},
+            gfxrecon::decode::VulkanBufferInfo{},
             &info_table,
-            &gfxrecon::decode::VulkanObjectInfoTable::AddBufferInfo);
+            &gfxrecon::decode::VulkanObjectInfoTable::AddVkBufferInfo);
 
-        std::vector<const gfxrecon::decode::BufferInfo*> buffers;
-        info_table.VisitBufferInfo([&buffers](const gfxrecon::decode::BufferInfo* info) { buffers.push_back(info); });
+        std::vector<const gfxrecon::decode::VulkanBufferInfo*> buffers;
+        info_table.VisitVkBufferInfo(
+            [&buffers](const gfxrecon::decode::VulkanBufferInfo* info) { buffers.push_back(info); });
 
         REQUIRE(buffers.size() == 4);
     }
 
     SECTION("Add a duplicate entry to the object table, which is ignored")
     {
-        gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::BufferInfo>(
+        gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::VulkanBufferInfo>(
             kDeviceId,
             kBufferIds[0],
             kBufferHandles[0],
             &info_table,
-            &gfxrecon::decode::VulkanObjectInfoTable::AddBufferInfo);
+            &gfxrecon::decode::VulkanObjectInfoTable::AddVkBufferInfo);
 
-        std::vector<const gfxrecon::decode::BufferInfo*> buffers;
-        info_table.VisitBufferInfo([&buffers](const gfxrecon::decode::BufferInfo* info) { buffers.push_back(info); });
+        std::vector<const gfxrecon::decode::VulkanBufferInfo*> buffers;
+        info_table.VisitVkBufferInfo(
+            [&buffers](const gfxrecon::decode::VulkanBufferInfo* info) { buffers.push_back(info); });
 
         REQUIRE(buffers.size() == 1);
     }
@@ -113,26 +114,27 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
     SECTION("Remove an entry from the object table")
     {
         gfxrecon::decode::handle_mapping::RemoveHandle(
-            kBufferIds[0], &info_table, &gfxrecon::decode::VulkanObjectInfoTable::RemoveBufferInfo);
+            kBufferIds[0], &info_table, &gfxrecon::decode::VulkanObjectInfoTable::RemoveVkBufferInfo);
 
-        std::vector<const gfxrecon::decode::BufferInfo*> buffers;
-        info_table.VisitBufferInfo([&buffers](const gfxrecon::decode::BufferInfo* info) { buffers.push_back(info); });
+        std::vector<const gfxrecon::decode::VulkanBufferInfo*> buffers;
+        info_table.VisitVkBufferInfo(
+            [&buffers](const gfxrecon::decode::VulkanBufferInfo* info) { buffers.push_back(info); });
 
         REQUIRE(buffers.size() == 0);
     }
 
     SECTION("Buffer ID 12 maps to a valid buffer handle")
     {
-        auto buffer = gfxrecon::decode::handle_mapping::MapHandle<gfxrecon::decode::BufferInfo>(
-            kBufferIds[0], info_table, &gfxrecon::decode::VulkanObjectInfoTable::GetBufferInfo);
+        auto buffer = gfxrecon::decode::handle_mapping::MapHandle<gfxrecon::decode::VulkanBufferInfo>(
+            kBufferIds[0], info_table, &gfxrecon::decode::VulkanObjectInfoTable::GetVkBufferInfo);
 
         REQUIRE(buffer == kBufferHandles[0]);
     }
 
     SECTION("Invalid buffer ID 99 does not map to a valid buffer handle")
     {
-        auto buffer = gfxrecon::decode::handle_mapping::MapHandle<gfxrecon::decode::BufferInfo>(
-            99, info_table, &gfxrecon::decode::VulkanObjectInfoTable::GetBufferInfo);
+        auto buffer = gfxrecon::decode::handle_mapping::MapHandle<gfxrecon::decode::VulkanBufferInfo>(
+            99, info_table, &gfxrecon::decode::VulkanObjectInfoTable::GetVkBufferInfo);
 
         REQUIRE(buffer == VK_NULL_HANDLE);
     }

--- a/framework/decode/vulkan_captured_swapchain.cpp
+++ b/framework/decode/vulkan_captured_swapchain.cpp
@@ -30,7 +30,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 VkResult VulkanCapturedSwapchain::CreateSwapchainKHR(VkResult                              original_result,
                                                      PFN_vkCreateSwapchainKHR              func,
-                                                     const DeviceInfo*                     device_info,
+                                                     const VulkanDeviceInfo*               device_info,
                                                      const VkSwapchainCreateInfoKHR*       create_info,
                                                      const VkAllocationCallbacks*          allocator,
                                                      HandlePointerDecoder<VkSwapchainKHR>* swapchain,
@@ -47,10 +47,10 @@ VkResult VulkanCapturedSwapchain::CreateSwapchainKHR(VkResult                   
     return func(device, create_info, allocator, replay_swapchain);
 }
 
-void VulkanCapturedSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
-                                                  const DeviceInfo*            device_info,
-                                                  const SwapchainKHRInfo*      swapchain_info,
-                                                  const VkAllocationCallbacks* allocator)
+void VulkanCapturedSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
+                                                  const VulkanDeviceInfo*       device_info,
+                                                  const VulkanSwapchainKHRInfo* swapchain_info,
+                                                  const VkAllocationCallbacks*  allocator)
 {
     VkDevice       device    = VK_NULL_HANDLE;
     VkSwapchainKHR swapchain = VK_NULL_HANDLE;
@@ -70,8 +70,8 @@ void VulkanCapturedSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    f
 
 VkResult VulkanCapturedSwapchain::GetSwapchainImagesKHR(VkResult                    original_result,
                                                         PFN_vkGetSwapchainImagesKHR func,
-                                                        const DeviceInfo*           device_info,
-                                                        SwapchainKHRInfo*           swapchain_info,
+                                                        const VulkanDeviceInfo*     device_info,
+                                                        VulkanSwapchainKHRInfo*     swapchain_info,
                                                         uint32_t                    capture_image_count,
                                                         uint32_t*                   image_count,
                                                         VkImage*                    images)
@@ -104,8 +104,8 @@ VkResult VulkanCapturedSwapchain::GetSwapchainImagesKHR(VkResult                
 
 VkResult VulkanCapturedSwapchain::AcquireNextImageKHR(VkResult                  original_result,
                                                       PFN_vkAcquireNextImageKHR func,
-                                                      const DeviceInfo*         device_info,
-                                                      SwapchainKHRInfo*         swapchain_info,
+                                                      const VulkanDeviceInfo*   device_info,
+                                                      VulkanSwapchainKHRInfo*   swapchain_info,
                                                       uint64_t                  timeout,
                                                       VkSemaphore               semaphore,
                                                       VkFence                   fence,
@@ -140,8 +140,8 @@ VkResult VulkanCapturedSwapchain::AcquireNextImageKHR(VkResult                  
 
 VkResult VulkanCapturedSwapchain::AcquireNextImage2KHR(VkResult                         original_result,
                                                        PFN_vkAcquireNextImage2KHR       func,
-                                                       const DeviceInfo*                device_info,
-                                                       SwapchainKHRInfo*                swapchain_info,
+                                                       const VulkanDeviceInfo*          device_info,
+                                                       VulkanSwapchainKHRInfo*          swapchain_info,
                                                        const VkAcquireNextImageInfoKHR* acquire_info,
                                                        uint32_t                         capture_image_index,
                                                        uint32_t*                        image_index)
@@ -168,12 +168,12 @@ VkResult VulkanCapturedSwapchain::AcquireNextImage2KHR(VkResult                 
     return result;
 }
 
-VkResult VulkanCapturedSwapchain::QueuePresentKHR(VkResult                              original_result,
-                                                  PFN_vkQueuePresentKHR                 func,
-                                                  const std::vector<uint32_t>&          capture_image_indices,
-                                                  const std::vector<SwapchainKHRInfo*>& swapchain_infos,
-                                                  const QueueInfo*                      queue_info,
-                                                  const VkPresentInfoKHR*               present_info)
+VkResult VulkanCapturedSwapchain::QueuePresentKHR(VkResult                                    original_result,
+                                                  PFN_vkQueuePresentKHR                       func,
+                                                  const std::vector<uint32_t>&                capture_image_indices,
+                                                  const std::vector<VulkanSwapchainKHRInfo*>& swapchain_infos,
+                                                  const VulkanQueueInfo*                      queue_info,
+                                                  const VkPresentInfoKHR*                     present_info)
 {
     VkQueue queue = VK_NULL_HANDLE;
 
@@ -187,7 +187,7 @@ VkResult VulkanCapturedSwapchain::QueuePresentKHR(VkResult                      
 
 VkResult VulkanCapturedSwapchain::CreateRenderPass(VkResult                      original_result,
                                                    PFN_vkCreateRenderPass        func,
-                                                   const DeviceInfo*             device_info,
+                                                   const VulkanDeviceInfo*       device_info,
                                                    const VkRenderPassCreateInfo* create_info,
                                                    const VkAllocationCallbacks*  allocator,
                                                    VkRenderPass*                 render_pass)
@@ -204,7 +204,7 @@ VkResult VulkanCapturedSwapchain::CreateRenderPass(VkResult                     
 
 VkResult VulkanCapturedSwapchain::CreateRenderPass2(VkResult                       original_result,
                                                     PFN_vkCreateRenderPass2        func,
-                                                    const DeviceInfo*              device_info,
+                                                    const VulkanDeviceInfo*        device_info,
                                                     const VkRenderPassCreateInfo2* create_info,
                                                     const VkAllocationCallbacks*   allocator,
                                                     VkRenderPass*                  render_pass)
@@ -219,17 +219,17 @@ VkResult VulkanCapturedSwapchain::CreateRenderPass2(VkResult                    
     return func(device, create_info, allocator, render_pass);
 }
 
-void VulkanCapturedSwapchain::CmdPipelineBarrier(PFN_vkCmdPipelineBarrier     func,
-                                                 const CommandBufferInfo*     command_buffer_info,
-                                                 VkPipelineStageFlags         src_stage_mask,
-                                                 VkPipelineStageFlags         dst_stage_mask,
-                                                 VkDependencyFlags            dependency_flags,
-                                                 uint32_t                     memory_barrier_count,
-                                                 const VkMemoryBarrier*       memory_barriers,
-                                                 uint32_t                     buffer_memory_barrier_count,
-                                                 const VkBufferMemoryBarrier* buffer_memory_barriers,
-                                                 uint32_t                     image_memory_barrier_count,
-                                                 const VkImageMemoryBarrier*  image_memory_barriers)
+void VulkanCapturedSwapchain::CmdPipelineBarrier(PFN_vkCmdPipelineBarrier       func,
+                                                 const VulkanCommandBufferInfo* command_buffer_info,
+                                                 VkPipelineStageFlags           src_stage_mask,
+                                                 VkPipelineStageFlags           dst_stage_mask,
+                                                 VkDependencyFlags              dependency_flags,
+                                                 uint32_t                       memory_barrier_count,
+                                                 const VkMemoryBarrier*         memory_barriers,
+                                                 uint32_t                       buffer_memory_barrier_count,
+                                                 const VkBufferMemoryBarrier*   buffer_memory_barriers,
+                                                 uint32_t                       image_memory_barrier_count,
+                                                 const VkImageMemoryBarrier*    image_memory_barriers)
 {
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
 
@@ -251,7 +251,7 @@ void VulkanCapturedSwapchain::CmdPipelineBarrier(PFN_vkCmdPipelineBarrier     fu
 }
 
 void VulkanCapturedSwapchain::CmdPipelineBarrier2(PFN_vkCmdPipelineBarrier2 func,
-                                                  CommandBufferInfo*        command_buffer_info,
+                                                  VulkanCommandBufferInfo*  command_buffer_info,
                                                   const VkDependencyInfo*   pDependencyInfo)
 {
 
@@ -266,8 +266,8 @@ void VulkanCapturedSwapchain::CmdPipelineBarrier2(PFN_vkCmdPipelineBarrier2 func
 }
 
 void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateCommand(
-    const DeviceInfo*                                   device_info,
-    SwapchainKHRInfo*                                   swapchain_info,
+    const VulkanDeviceInfo*                             device_info,
+    VulkanSwapchainKHRInfo*                             swapchain_info,
     uint32_t                                            last_presented_image,
     const std::vector<format::SwapchainImageStateInfo>& image_info,
     const VulkanObjectInfoTable&                        object_info_table,
@@ -279,7 +279,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateCommand(
     VkPhysicalDevice physical_device = device_info->parent;
     assert(physical_device != VK_NULL_HANDLE);
 
-    const SurfaceKHRInfo* surface_info = object_info_table.GetSurfaceKHRInfo(swapchain_info->surface_id);
+    const VulkanSurfaceKHRInfo* surface_info = object_info_table.GetVkSurfaceKHRInfo(swapchain_info->surface_id);
     if (surface_info->surface_creation_skipped)
     {
         return;
@@ -342,8 +342,8 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateCommand(
 }
 
 void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
-    const DeviceInfo*                                   device_info,
-    SwapchainKHRInfo*                                   swapchain_info,
+    const VulkanDeviceInfo*                             device_info,
+    VulkanSwapchainKHRInfo*                             swapchain_info,
     const std::vector<format::SwapchainImageStateInfo>& image_info,
     const VulkanObjectInfoTable&                        object_info_table,
     SwapchainImageTracker&                              swapchain_image_tracker)
@@ -406,7 +406,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
 
         for (size_t i = 0; i < image_info.size(); ++i)
         {
-            const ImageInfo* image_entry = object_info_table.GetImageInfo(image_info[i].image_id);
+            const VulkanImageInfo* image_entry = object_info_table.GetVkImageInfo(image_info[i].image_id);
 
             // Pre-acquire and transition swapchain images while processing trimming state snapshot.
             if (image_entry != nullptr)
@@ -541,8 +541,8 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
 }
 
 void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
-    const DeviceInfo*                                   device_info,
-    SwapchainKHRInfo*                                   swapchain_info,
+    const VulkanDeviceInfo*                             device_info,
+    VulkanSwapchainKHRInfo*                             swapchain_info,
     uint32_t                                            last_presented_image,
     const std::vector<format::SwapchainImageStateInfo>& image_info,
     const VulkanObjectInfoTable&                        object_info_table)
@@ -624,7 +624,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
         // Acquire, transition to the present source layout, and present each image.
         for (size_t i = 0; i < image_info.size(); ++i)
         {
-            const ImageInfo* image_entry = object_info_table.GetImageInfo(image_info[i].image_id);
+            const VulkanImageInfo* image_entry = object_info_table.GetVkImageInfo(image_info[i].image_id);
 
             if (image_entry != nullptr)
             {
@@ -719,7 +719,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
         // acquired on replay is the same image acquired by the first captured frame.
         for (size_t i = 0; i < image_info.size(); ++i)
         {
-            const ImageInfo* image_entry = object_info_table.GetImageInfo(image_info[i].image_id);
+            const VulkanImageInfo* image_entry = object_info_table.GetVkImageInfo(image_info[i].image_id);
 
             if ((image_entry != nullptr) && ((image_info[i].acquired) || (i <= last_presented_image)))
             {

--- a/framework/decode/vulkan_captured_swapchain.cpp
+++ b/framework/decode/vulkan_captured_swapchain.cpp
@@ -270,7 +270,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateCommand(
     VulkanSwapchainKHRInfo*                             swapchain_info,
     uint32_t                                            last_presented_image,
     const std::vector<format::SwapchainImageStateInfo>& image_info,
-    const VulkanObjectInfoTable&                        object_info_table,
+    const CommonObjectInfoTable&                        object_info_table,
     SwapchainImageTracker&                              swapchain_image_tracker)
 {
     VkDevice       device    = device_info->handle;
@@ -345,7 +345,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
     const VulkanDeviceInfo*                             device_info,
     VulkanSwapchainKHRInfo*                             swapchain_info,
     const std::vector<format::SwapchainImageStateInfo>& image_info,
-    const VulkanObjectInfoTable&                        object_info_table,
+    const CommonObjectInfoTable&                        object_info_table,
     SwapchainImageTracker&                              swapchain_image_tracker)
 {
     VkDevice device = device_info->handle;
@@ -545,7 +545,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
     VulkanSwapchainKHRInfo*                             swapchain_info,
     uint32_t                                            last_presented_image,
     const std::vector<format::SwapchainImageStateInfo>& image_info,
-    const VulkanObjectInfoTable&                        object_info_table)
+    const CommonObjectInfoTable&                        object_info_table)
 {
     auto device = device_info->handle;
     assert(device_table_ != nullptr);

--- a/framework/decode/vulkan_captured_swapchain.h
+++ b/framework/decode/vulkan_captured_swapchain.h
@@ -35,29 +35,29 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
 
     virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
                                         PFN_vkCreateSwapchainKHR              func,
-                                        const DeviceInfo*                     device_info,
+                                        const VulkanDeviceInfo*               device_info,
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
                                         const encode::VulkanDeviceTable*      device_table) override;
 
-    virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
-                                     const DeviceInfo*            device_info,
-                                     const SwapchainKHRInfo*      swapchain_info,
-                                     const VkAllocationCallbacks* allocator) override;
+    virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
+                                     const VulkanDeviceInfo*       device_info,
+                                     const VulkanSwapchainKHRInfo* swapchain_info,
+                                     const VkAllocationCallbacks*  allocator) override;
 
     virtual VkResult GetSwapchainImagesKHR(VkResult                    original_result,
                                            PFN_vkGetSwapchainImagesKHR func,
-                                           const DeviceInfo*           device_info,
-                                           SwapchainKHRInfo*           swapchain_info,
+                                           const VulkanDeviceInfo*     device_info,
+                                           VulkanSwapchainKHRInfo*     swapchain_info,
                                            uint32_t                    capture_image_count,
                                            uint32_t*                   image_count,
                                            VkImage*                    images) override;
 
     virtual VkResult AcquireNextImageKHR(VkResult                  original_result,
                                          PFN_vkAcquireNextImageKHR func,
-                                         const DeviceInfo*         device_info,
-                                         SwapchainKHRInfo*         swapchain_info,
+                                         const VulkanDeviceInfo*   device_info,
+                                         VulkanSwapchainKHRInfo*   swapchain_info,
                                          uint64_t                  timeout,
                                          VkSemaphore               semaphore,
                                          VkFence                   fence,
@@ -66,52 +66,52 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
 
     virtual VkResult AcquireNextImage2KHR(VkResult                         original_result,
                                           PFN_vkAcquireNextImage2KHR       func,
-                                          const DeviceInfo*                device_info,
-                                          SwapchainKHRInfo*                swapchain_info,
+                                          const VulkanDeviceInfo*          device_info,
+                                          VulkanSwapchainKHRInfo*          swapchain_info,
                                           const VkAcquireNextImageInfoKHR* acquire_info,
                                           uint32_t                         capture_image_index,
                                           uint32_t*                        image_index) override;
 
-    virtual VkResult QueuePresentKHR(VkResult                              original_result,
-                                     PFN_vkQueuePresentKHR                 func,
-                                     const std::vector<uint32_t>&          capture_image_indices,
-                                     const std::vector<SwapchainKHRInfo*>& swapchain_infos,
-                                     const QueueInfo*                      queue_info,
-                                     const VkPresentInfoKHR*               present_info) override;
+    virtual VkResult QueuePresentKHR(VkResult                                    original_result,
+                                     PFN_vkQueuePresentKHR                       func,
+                                     const std::vector<uint32_t>&                capture_image_indices,
+                                     const std::vector<VulkanSwapchainKHRInfo*>& swapchain_infos,
+                                     const VulkanQueueInfo*                      queue_info,
+                                     const VkPresentInfoKHR*                     present_info) override;
 
     virtual VkResult CreateRenderPass(VkResult                      original_result,
                                       PFN_vkCreateRenderPass        func,
-                                      const DeviceInfo*             device_info,
+                                      const VulkanDeviceInfo*       device_info,
                                       const VkRenderPassCreateInfo* create_info,
                                       const VkAllocationCallbacks*  allocator,
                                       VkRenderPass*                 render_pass) override;
 
     virtual VkResult CreateRenderPass2(VkResult                       original_result,
                                        PFN_vkCreateRenderPass2        func,
-                                       const DeviceInfo*              device_info,
+                                       const VulkanDeviceInfo*        device_info,
                                        const VkRenderPassCreateInfo2* create_info,
                                        const VkAllocationCallbacks*   allocator,
                                        VkRenderPass*                  render_pass) override;
 
-    virtual void CmdPipelineBarrier(PFN_vkCmdPipelineBarrier     func,
-                                    const CommandBufferInfo*     command_buffer_info,
-                                    VkPipelineStageFlags         src_stage_mask,
-                                    VkPipelineStageFlags         dst_stage_mask,
-                                    VkDependencyFlags            dependency_flags,
-                                    uint32_t                     memory_barrier_count,
-                                    const VkMemoryBarrier*       memory_barriers,
-                                    uint32_t                     buffer_memory_barrier_count,
-                                    const VkBufferMemoryBarrier* buffer_memory_barriers,
-                                    uint32_t                     image_memory_barrier_count,
-                                    const VkImageMemoryBarrier*  image_memory_barriers) override;
+    virtual void CmdPipelineBarrier(PFN_vkCmdPipelineBarrier       func,
+                                    const VulkanCommandBufferInfo* command_buffer_info,
+                                    VkPipelineStageFlags           src_stage_mask,
+                                    VkPipelineStageFlags           dst_stage_mask,
+                                    VkDependencyFlags              dependency_flags,
+                                    uint32_t                       memory_barrier_count,
+                                    const VkMemoryBarrier*         memory_barriers,
+                                    uint32_t                       buffer_memory_barrier_count,
+                                    const VkBufferMemoryBarrier*   buffer_memory_barriers,
+                                    uint32_t                       image_memory_barrier_count,
+                                    const VkImageMemoryBarrier*    image_memory_barriers) override;
 
     virtual void CmdPipelineBarrier2(PFN_vkCmdPipelineBarrier2 func,
-                                     CommandBufferInfo*        command_buffer_info,
+                                     VulkanCommandBufferInfo*  command_buffer_info,
                                      const VkDependencyInfo*   pDependencyInfo) override;
 
-    virtual void ProcessSetSwapchainImageStateCommand(const DeviceInfo* device_info,
-                                                      SwapchainKHRInfo* swapchain_info,
-                                                      uint32_t          last_presented_image,
+    virtual void ProcessSetSwapchainImageStateCommand(const VulkanDeviceInfo* device_info,
+                                                      VulkanSwapchainKHRInfo* swapchain_info,
+                                                      uint32_t                last_presented_image,
                                                       const std::vector<format::SwapchainImageStateInfo>& image_info,
                                                       const VulkanObjectInfoTable& object_info_table,
                                                       SwapchainImageTracker&       swapchain_image_tracker) override;
@@ -119,8 +119,8 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
   private:
     // When processing swapchain image state for the trimming state setup, acquire all swapchain images to transition to
     // the expected layout and keep them acquired until first use.
-    void ProcessSetSwapchainImageStatePreAcquire(const DeviceInfo*                                   device_info,
-                                                 SwapchainKHRInfo*                                   swapchain_info,
+    void ProcessSetSwapchainImageStatePreAcquire(const VulkanDeviceInfo*                             device_info,
+                                                 VulkanSwapchainKHRInfo*                             swapchain_info,
                                                  const std::vector<format::SwapchainImageStateInfo>& image_info,
                                                  const VulkanObjectInfoTable&                        object_info_table,
                                                  SwapchainImageTracker& swapchain_image_tracker);
@@ -128,9 +128,9 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
     // When processing swapchain image state for the trimming state setup, acquire an image, transition it to
     // the expected layout, and then call queue present if the image is not expected to be in the acquired state so that
     // no more than one image is acquired at a time.
-    void ProcessSetSwapchainImageStateQueueSubmit(const DeviceInfo* device_info,
-                                                  SwapchainKHRInfo* swapchain_info,
-                                                  uint32_t          last_presented_image,
+    void ProcessSetSwapchainImageStateQueueSubmit(const VulkanDeviceInfo* device_info,
+                                                  VulkanSwapchainKHRInfo* swapchain_info,
+                                                  uint32_t                last_presented_image,
                                                   const std::vector<format::SwapchainImageStateInfo>& image_info,
                                                   const VulkanObjectInfoTable& object_info_table);
 };

--- a/framework/decode/vulkan_captured_swapchain.h
+++ b/framework/decode/vulkan_captured_swapchain.h
@@ -113,7 +113,7 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
                                                       VulkanSwapchainKHRInfo* swapchain_info,
                                                       uint32_t                last_presented_image,
                                                       const std::vector<format::SwapchainImageStateInfo>& image_info,
-                                                      const VulkanObjectInfoTable& object_info_table,
+                                                      const CommonObjectInfoTable& object_info_table,
                                                       SwapchainImageTracker&       swapchain_image_tracker) override;
 
   private:
@@ -122,7 +122,7 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
     void ProcessSetSwapchainImageStatePreAcquire(const VulkanDeviceInfo*                             device_info,
                                                  VulkanSwapchainKHRInfo*                             swapchain_info,
                                                  const std::vector<format::SwapchainImageStateInfo>& image_info,
-                                                 const VulkanObjectInfoTable&                        object_info_table,
+                                                 const CommonObjectInfoTable&                        object_info_table,
                                                  SwapchainImageTracker& swapchain_image_tracker);
 
     // When processing swapchain image state for the trimming state setup, acquire an image, transition it to
@@ -132,7 +132,7 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
                                                   VulkanSwapchainKHRInfo* swapchain_info,
                                                   uint32_t                last_presented_image,
                                                   const std::vector<format::SwapchainImageStateInfo>& image_info,
-                                                  const VulkanObjectInfoTable& object_info_table);
+                                                  const CommonObjectInfoTable& object_info_table);
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_device_address_tracker.cpp
+++ b/framework/decode/vulkan_device_address_tracker.cpp
@@ -30,7 +30,7 @@ VulkanDeviceAddressTracker::VulkanDeviceAddressTracker(const VulkanObjectInfoTab
     _object_info_table(object_info_table)
 {}
 
-void decode::VulkanDeviceAddressTracker::TrackBuffer(const decode::BufferInfo* buffer_info)
+void decode::VulkanDeviceAddressTracker::TrackBuffer(const decode::VulkanBufferInfo* buffer_info)
 {
     if (buffer_info != nullptr && buffer_info->capture_address != 0)
     {
@@ -38,7 +38,7 @@ void decode::VulkanDeviceAddressTracker::TrackBuffer(const decode::BufferInfo* b
     }
 }
 
-void VulkanDeviceAddressTracker::RemoveBuffer(const BufferInfo* buffer_info)
+void VulkanDeviceAddressTracker::RemoveBuffer(const VulkanBufferInfo* buffer_info)
 {
     if (buffer_info != nullptr)
     {
@@ -47,7 +47,7 @@ void VulkanDeviceAddressTracker::RemoveBuffer(const BufferInfo* buffer_info)
 }
 
 void VulkanDeviceAddressTracker::TrackAccelerationStructure(
-    const AccelerationStructureKHRInfo* acceleration_structure_info)
+    const VulkanAccelerationStructureKHRInfo* acceleration_structure_info)
 {
     if (acceleration_structure_info != nullptr && acceleration_structure_info->capture_address != 0)
     {
@@ -57,7 +57,7 @@ void VulkanDeviceAddressTracker::TrackAccelerationStructure(
 }
 
 void VulkanDeviceAddressTracker::RemoveAccelerationStructure(
-    const AccelerationStructureKHRInfo* acceleration_structure_info)
+    const VulkanAccelerationStructureKHRInfo* acceleration_structure_info)
 {
     if (acceleration_structure_info != nullptr)
     {
@@ -65,13 +65,13 @@ void VulkanDeviceAddressTracker::RemoveAccelerationStructure(
     }
 }
 
-const decode::BufferInfo*
+const decode::VulkanBufferInfo*
 decode::VulkanDeviceAddressTracker::GetBufferByCaptureDeviceAddress(VkDeviceAddress capture_address) const
 {
     return GetBufferInfo(capture_address, _buffer_capture_addresses);
 }
 
-const BufferInfo*
+const VulkanBufferInfo*
 VulkanDeviceAddressTracker::GetBufferInfo(VkDeviceAddress                                         device_address,
                                           const VulkanDeviceAddressTracker::buffer_address_map_t& address_map) const
 {
@@ -93,7 +93,7 @@ VulkanDeviceAddressTracker::GetBufferInfo(VkDeviceAddress                       
         }
         // found_address is lower or equal to device_address
         const auto& [found_address, buffer_handle] = *address_it;
-        const BufferInfo* found_buffer             = _object_info_table.GetBufferInfo(buffer_handle);
+        const VulkanBufferInfo* found_buffer       = _object_info_table.GetVkBufferInfo(buffer_handle);
 
         if (found_buffer != nullptr)
         {
@@ -106,15 +106,15 @@ VulkanDeviceAddressTracker::GetBufferInfo(VkDeviceAddress                       
     return nullptr;
 }
 
-const AccelerationStructureKHRInfo*
+const VulkanAccelerationStructureKHRInfo*
 VulkanDeviceAddressTracker::GetAccelerationStructureByCaptureDeviceAddress(VkDeviceAddress capture_address) const
 {
     auto address_it = _acceleration_structure_capture_addresses.find(capture_address);
     if (address_it != _acceleration_structure_capture_addresses.end())
     {
         const auto& [found_address, acceleration_structure_handle] = *address_it;
-        const AccelerationStructureKHRInfo* found_acceleration_structure_info =
-            _object_info_table.GetAccelerationStructureKHRInfo(acceleration_structure_handle);
+        const VulkanAccelerationStructureKHRInfo* found_acceleration_structure_info =
+            _object_info_table.GetVkAccelerationStructureKHRInfo(acceleration_structure_handle);
 
         if (found_acceleration_structure_info != nullptr)
         {

--- a/framework/decode/vulkan_device_address_tracker.h
+++ b/framework/decode/vulkan_device_address_tracker.h
@@ -49,14 +49,14 @@ class VulkanDeviceAddressTracker
      *
      * @param   buffer_info a provided buffer_info containing a buffer-handle and associated device-addresses.
      */
-    void TrackBuffer(const BufferInfo* buffer_info);
+    void TrackBuffer(const VulkanBufferInfo* buffer_info);
 
     /**
      * @brief   RemoveBuffer will stop tracking of a currently tracked buffer.
      *
      * @param   buffer_info a provided buffer_info.
      */
-    void RemoveBuffer(const BufferInfo* buffer_info);
+    void RemoveBuffer(const VulkanBufferInfo* buffer_info);
 
     /**
      * @brief   Track an existing acceleration-structure by its capture-time VkDeviceAddress.
@@ -64,14 +64,14 @@ class VulkanDeviceAddressTracker
      * @param   acceleration_structure_info a provided acceleration-structure containing a handle and associated
      *                                      device-addresses.
      */
-    void TrackAccelerationStructure(const AccelerationStructureKHRInfo* acceleration_structure_info);
+    void TrackAccelerationStructure(const VulkanAccelerationStructureKHRInfo* acceleration_structure_info);
 
     /**
      * @brief   RemoveAccelerationStructure will stop tracking of a currently tracked acceleration-structure.
      *
      * @param   acceleration_structure_info a provided acceleration-structure-info.
      */
-    void RemoveAccelerationStructure(const AccelerationStructureKHRInfo* acceleration_structure_info);
+    void RemoveAccelerationStructure(const VulkanAccelerationStructureKHRInfo* acceleration_structure_info);
 
     /**
      * @brief   Retrieve a buffer by providing a capture-time VkDeviceAddress within its range.
@@ -79,7 +79,7 @@ class VulkanDeviceAddressTracker
      * @param   capture_address  a capture-time VkDeviceAddress pointing inside a buffer.
      * @return  a const-pointer to a found BufferInfo or nullptr.
      */
-    [[nodiscard]] const BufferInfo* GetBufferByCaptureDeviceAddress(VkDeviceAddress capture_address) const;
+    [[nodiscard]] const VulkanBufferInfo* GetBufferByCaptureDeviceAddress(VkDeviceAddress capture_address) const;
 
     /**
      * @brief   Retrieve an acceleration-structure by providing a capture-time VkDeviceAddress.
@@ -87,15 +87,15 @@ class VulkanDeviceAddressTracker
      * @param   capture_address  a capture-time VkDeviceAddress for an acceleration-structure.
      * @return  a const-pointer to a found AccelerationStructureKHRInfo or nullptr.
      */
-    [[nodiscard]] const AccelerationStructureKHRInfo*
+    [[nodiscard]] const VulkanAccelerationStructureKHRInfo*
     GetAccelerationStructureByCaptureDeviceAddress(VkDeviceAddress capture_address) const;
 
   private:
     //! use a sorted (BST-based) map
     using buffer_address_map_t = std::map<VkDeviceAddress, format::HandleId>;
 
-    [[nodiscard]] const BufferInfo* GetBufferInfo(VkDeviceAddress             device_address,
-                                                  const buffer_address_map_t& address_map) const;
+    [[nodiscard]] const VulkanBufferInfo* GetBufferInfo(VkDeviceAddress             device_address,
+                                                        const buffer_address_map_t& address_map) const;
 
     const VulkanObjectInfoTable&                          _object_info_table;
     buffer_address_map_t                                  _buffer_capture_addresses;

--- a/framework/decode/vulkan_handle_mapping_util.cpp
+++ b/framework/decode/vulkan_handle_mapping_util.cpp
@@ -35,127 +35,127 @@ uint64_t MapHandle(uint64_t object, VkObjectType object_type, const VulkanObject
     {
         case VK_OBJECT_TYPE_INSTANCE:
             return format::ToHandleId(
-                MapHandle<InstanceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetInstanceInfo));
+                MapHandle<VulkanInstanceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkInstanceInfo));
         case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
-            return format::ToHandleId(MapHandle<PhysicalDeviceInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+            return format::ToHandleId(MapHandle<VulkanPhysicalDeviceInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
         case VK_OBJECT_TYPE_DEVICE:
             return format::ToHandleId(
-                MapHandle<DeviceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDeviceInfo));
+                MapHandle<VulkanDeviceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkDeviceInfo));
         case VK_OBJECT_TYPE_QUEUE:
             return format::ToHandleId(
-                MapHandle<QueueInfo>(object, object_info_table, &VulkanObjectInfoTable::GetQueueInfo));
+                MapHandle<VulkanQueueInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkQueueInfo));
         case VK_OBJECT_TYPE_SEMAPHORE:
             return format::ToHandleId(
-                MapHandle<SemaphoreInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo));
+                MapHandle<VulkanSemaphoreInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo));
         case VK_OBJECT_TYPE_COMMAND_BUFFER:
-            return format::ToHandleId(
-                MapHandle<CommandBufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetCommandBufferInfo));
+            return format::ToHandleId(MapHandle<VulkanCommandBufferInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkCommandBufferInfo));
         case VK_OBJECT_TYPE_FENCE:
             return format::ToHandleId(
-                MapHandle<FenceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetFenceInfo));
+                MapHandle<VulkanFenceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo));
         case VK_OBJECT_TYPE_DEVICE_MEMORY:
-            return format::ToHandleId(
-                MapHandle<DeviceMemoryInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo));
+            return format::ToHandleId(MapHandle<VulkanDeviceMemoryInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo));
         case VK_OBJECT_TYPE_BUFFER:
             return format::ToHandleId(
-                MapHandle<BufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetBufferInfo));
+                MapHandle<VulkanBufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo));
         case VK_OBJECT_TYPE_IMAGE:
             return format::ToHandleId(
-                MapHandle<ImageInfo>(object, object_info_table, &VulkanObjectInfoTable::GetImageInfo));
+                MapHandle<VulkanImageInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo));
         case VK_OBJECT_TYPE_EVENT:
             return format::ToHandleId(
-                MapHandle<EventInfo>(object, object_info_table, &VulkanObjectInfoTable::GetEventInfo));
+                MapHandle<VulkanEventInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkEventInfo));
         case VK_OBJECT_TYPE_QUERY_POOL:
             return format::ToHandleId(
-                MapHandle<QueryPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetQueryPoolInfo));
+                MapHandle<VulkanQueryPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkQueryPoolInfo));
         case VK_OBJECT_TYPE_BUFFER_VIEW:
-            return format::ToHandleId(
-                MapHandle<BufferViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetBufferViewInfo));
+            return format::ToHandleId(MapHandle<VulkanBufferViewInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkBufferViewInfo));
         case VK_OBJECT_TYPE_IMAGE_VIEW:
             return format::ToHandleId(
-                MapHandle<ImageViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo));
+                MapHandle<VulkanImageViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo));
         case VK_OBJECT_TYPE_SHADER_MODULE:
-            return format::ToHandleId(
-                MapHandle<ShaderModuleInfo>(object, object_info_table, &VulkanObjectInfoTable::GetShaderModuleInfo));
+            return format::ToHandleId(MapHandle<VulkanShaderModuleInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkShaderModuleInfo));
         case VK_OBJECT_TYPE_PIPELINE_CACHE:
-            return format::ToHandleId(
-                MapHandle<PipelineCacheInfo>(object, object_info_table, &VulkanObjectInfoTable::GetPipelineCacheInfo));
+            return format::ToHandleId(MapHandle<VulkanPipelineCacheInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineCacheInfo));
         case VK_OBJECT_TYPE_PIPELINE_LAYOUT:
-            return format::ToHandleId(MapHandle<PipelineLayoutInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo));
+            return format::ToHandleId(MapHandle<VulkanPipelineLayoutInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo));
         case VK_OBJECT_TYPE_RENDER_PASS:
-            return format::ToHandleId(
-                MapHandle<RenderPassInfo>(object, object_info_table, &VulkanObjectInfoTable::GetRenderPassInfo));
+            return format::ToHandleId(MapHandle<VulkanRenderPassInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo));
         case VK_OBJECT_TYPE_PIPELINE:
             return format::ToHandleId(
-                MapHandle<PipelineInfo>(object, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo));
+                MapHandle<VulkanPipelineInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo));
         case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT:
-            return format::ToHandleId(MapHandle<DescriptorSetLayoutInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetLayoutInfo));
+            return format::ToHandleId(MapHandle<VulkanDescriptorSetLayoutInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo));
         case VK_OBJECT_TYPE_SAMPLER:
             return format::ToHandleId(
-                MapHandle<SamplerInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSamplerInfo));
+                MapHandle<VulkanSamplerInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkSamplerInfo));
         case VK_OBJECT_TYPE_DESCRIPTOR_POOL:
-            return format::ToHandleId(MapHandle<DescriptorPoolInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorPoolInfo));
+            return format::ToHandleId(MapHandle<VulkanDescriptorPoolInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorPoolInfo));
         case VK_OBJECT_TYPE_DESCRIPTOR_SET:
-            return format::ToHandleId(
-                MapHandle<DescriptorSetInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetInfo));
+            return format::ToHandleId(MapHandle<VulkanDescriptorSetInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetInfo));
         case VK_OBJECT_TYPE_FRAMEBUFFER:
-            return format::ToHandleId(
-                MapHandle<FramebufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetFramebufferInfo));
+            return format::ToHandleId(MapHandle<VulkanFramebufferInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkFramebufferInfo));
         case VK_OBJECT_TYPE_COMMAND_POOL:
-            return format::ToHandleId(
-                MapHandle<CommandPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetCommandPoolInfo));
+            return format::ToHandleId(MapHandle<VulkanCommandPoolInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkCommandPoolInfo));
         case VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION:
-            return format::ToHandleId(MapHandle<SamplerYcbcrConversionInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetSamplerYcbcrConversionInfo));
+            return format::ToHandleId(MapHandle<VulkanSamplerYcbcrConversionInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkSamplerYcbcrConversionInfo));
         case VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE:
-            return format::ToHandleId(MapHandle<DescriptorUpdateTemplateInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorUpdateTemplateInfo));
+            return format::ToHandleId(MapHandle<VulkanDescriptorUpdateTemplateInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorUpdateTemplateInfo));
         case VK_OBJECT_TYPE_SURFACE_KHR:
-            return format::ToHandleId(
-                MapHandle<SurfaceKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanSurfaceKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo));
         case VK_OBJECT_TYPE_SWAPCHAIN_KHR:
-            return format::ToHandleId(
-                MapHandle<SwapchainKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSwapchainKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanSwapchainKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo));
         case VK_OBJECT_TYPE_DISPLAY_KHR:
-            return format::ToHandleId(
-                MapHandle<DisplayKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDisplayKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanDisplayKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDisplayKHRInfo));
         case VK_OBJECT_TYPE_DISPLAY_MODE_KHR:
-            return format::ToHandleId(MapHandle<DisplayModeKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDisplayModeKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanDisplayModeKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo));
         case VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT:
-            return format::ToHandleId(MapHandle<DebugReportCallbackEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDebugReportCallbackEXTInfo));
+            return format::ToHandleId(MapHandle<VulkanDebugReportCallbackEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDebugReportCallbackEXTInfo));
         case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
-            return format::ToHandleId(MapHandle<DebugUtilsMessengerEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDebugUtilsMessengerEXTInfo));
+            return format::ToHandleId(MapHandle<VulkanDebugUtilsMessengerEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDebugUtilsMessengerEXTInfo));
         case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
-            return format::ToHandleId(MapHandle<AccelerationStructureKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanAccelerationStructureKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo));
         case VK_OBJECT_TYPE_VALIDATION_CACHE_EXT:
-            return format::ToHandleId(MapHandle<ValidationCacheEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetValidationCacheEXTInfo));
+            return format::ToHandleId(MapHandle<VulkanValidationCacheEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo));
         case VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL:
-            return format::ToHandleId(MapHandle<PerformanceConfigurationINTELInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetPerformanceConfigurationINTELInfo));
+            return format::ToHandleId(MapHandle<VulkanPerformanceConfigurationINTELInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkPerformanceConfigurationINTELInfo));
         case VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR:
-            return format::ToHandleId(MapHandle<DeferredOperationKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanDeferredOperationKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo));
         case VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV:
-            return format::ToHandleId(MapHandle<IndirectCommandsLayoutNVInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetIndirectCommandsLayoutNVInfo));
+            return format::ToHandleId(MapHandle<VulkanIndirectCommandsLayoutNVInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo));
         case VK_OBJECT_TYPE_MICROMAP_EXT:
-            return format::ToHandleId(
-                MapHandle<MicromapEXTInfo>(object, object_info_table, &VulkanObjectInfoTable::GetMicromapEXTInfo));
+            return format::ToHandleId(MapHandle<VulkanMicromapEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo));
         case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
-            return format::ToHandleId(MapHandle<PrivateDataSlotEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetPrivateDataSlotInfo));
+            return format::ToHandleId(MapHandle<VulkanPrivateDataSlotEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkPrivateDataSlotInfo));
         case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
-            return format::ToHandleId(MapHandle<AccelerationStructureNVInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureNVInfo));
+            return format::ToHandleId(MapHandle<VulkanAccelerationStructureNVInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo));
         case VK_OBJECT_TYPE_UNKNOWN:
             // No conversion will be performed for unknown objects.
             GFXRECON_LOG_WARNING("Skipping handle unwrapping for unknown debug marker object type.");
@@ -174,109 +174,109 @@ MapHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type, const VulkanO
     {
         case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT:
             return format::ToHandleId(
-                MapHandle<InstanceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetInstanceInfo));
+                MapHandle<VulkanInstanceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkInstanceInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT:
-            return format::ToHandleId(MapHandle<PhysicalDeviceInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+            return format::ToHandleId(MapHandle<VulkanPhysicalDeviceInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT:
             return format::ToHandleId(
-                MapHandle<DeviceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDeviceInfo));
+                MapHandle<VulkanDeviceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkDeviceInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT:
             return format::ToHandleId(
-                MapHandle<QueueInfo>(object, object_info_table, &VulkanObjectInfoTable::GetQueueInfo));
+                MapHandle<VulkanQueueInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkQueueInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT:
             return format::ToHandleId(
-                MapHandle<SemaphoreInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo));
+                MapHandle<VulkanSemaphoreInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT:
-            return format::ToHandleId(
-                MapHandle<CommandBufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetCommandBufferInfo));
+            return format::ToHandleId(MapHandle<VulkanCommandBufferInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkCommandBufferInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT:
             return format::ToHandleId(
-                MapHandle<FenceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetFenceInfo));
+                MapHandle<VulkanFenceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT:
-            return format::ToHandleId(
-                MapHandle<DeviceMemoryInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo));
+            return format::ToHandleId(MapHandle<VulkanDeviceMemoryInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT:
             return format::ToHandleId(
-                MapHandle<BufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetBufferInfo));
+                MapHandle<VulkanBufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT:
             return format::ToHandleId(
-                MapHandle<ImageInfo>(object, object_info_table, &VulkanObjectInfoTable::GetImageInfo));
+                MapHandle<VulkanImageInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT:
             return format::ToHandleId(
-                MapHandle<EventInfo>(object, object_info_table, &VulkanObjectInfoTable::GetEventInfo));
+                MapHandle<VulkanEventInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkEventInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT:
             return format::ToHandleId(
-                MapHandle<QueryPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetQueryPoolInfo));
+                MapHandle<VulkanQueryPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkQueryPoolInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT:
-            return format::ToHandleId(
-                MapHandle<BufferViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetBufferViewInfo));
+            return format::ToHandleId(MapHandle<VulkanBufferViewInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkBufferViewInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT:
             return format::ToHandleId(
-                MapHandle<ImageViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo));
+                MapHandle<VulkanImageViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT:
-            return format::ToHandleId(
-                MapHandle<ShaderModuleInfo>(object, object_info_table, &VulkanObjectInfoTable::GetShaderModuleInfo));
+            return format::ToHandleId(MapHandle<VulkanShaderModuleInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkShaderModuleInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT:
-            return format::ToHandleId(
-                MapHandle<PipelineCacheInfo>(object, object_info_table, &VulkanObjectInfoTable::GetPipelineCacheInfo));
+            return format::ToHandleId(MapHandle<VulkanPipelineCacheInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineCacheInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT:
-            return format::ToHandleId(MapHandle<PipelineLayoutInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo));
+            return format::ToHandleId(MapHandle<VulkanPipelineLayoutInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT:
-            return format::ToHandleId(
-                MapHandle<RenderPassInfo>(object, object_info_table, &VulkanObjectInfoTable::GetRenderPassInfo));
+            return format::ToHandleId(MapHandle<VulkanRenderPassInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT:
             return format::ToHandleId(
-                MapHandle<PipelineInfo>(object, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo));
+                MapHandle<VulkanPipelineInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT:
-            return format::ToHandleId(MapHandle<DescriptorSetLayoutInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetLayoutInfo));
+            return format::ToHandleId(MapHandle<VulkanDescriptorSetLayoutInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT:
             return format::ToHandleId(
-                MapHandle<SamplerInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSamplerInfo));
+                MapHandle<VulkanSamplerInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkSamplerInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT:
-            return format::ToHandleId(MapHandle<DescriptorPoolInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorPoolInfo));
+            return format::ToHandleId(MapHandle<VulkanDescriptorPoolInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorPoolInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT:
-            return format::ToHandleId(
-                MapHandle<DescriptorSetInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetInfo));
+            return format::ToHandleId(MapHandle<VulkanDescriptorSetInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT:
-            return format::ToHandleId(
-                MapHandle<FramebufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetFramebufferInfo));
+            return format::ToHandleId(MapHandle<VulkanFramebufferInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkFramebufferInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT:
-            return format::ToHandleId(
-                MapHandle<CommandPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetCommandPoolInfo));
+            return format::ToHandleId(MapHandle<VulkanCommandPoolInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkCommandPoolInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT:
-            return format::ToHandleId(
-                MapHandle<SurfaceKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanSurfaceKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT:
-            return format::ToHandleId(
-                MapHandle<SwapchainKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSwapchainKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanSwapchainKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT:
-            return format::ToHandleId(MapHandle<DebugReportCallbackEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDebugReportCallbackEXTInfo));
+            return format::ToHandleId(MapHandle<VulkanDebugReportCallbackEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDebugReportCallbackEXTInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT:
-            return format::ToHandleId(
-                MapHandle<DisplayKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDisplayKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanDisplayKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDisplayKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT:
-            return format::ToHandleId(MapHandle<DisplayModeKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDisplayModeKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanDisplayModeKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT:
-            return format::ToHandleId(MapHandle<ValidationCacheEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetValidationCacheEXTInfo));
+            return format::ToHandleId(MapHandle<VulkanValidationCacheEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT:
-            return format::ToHandleId(MapHandle<SamplerYcbcrConversionInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetSamplerYcbcrConversionInfo));
+            return format::ToHandleId(MapHandle<VulkanSamplerYcbcrConversionInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkSamplerYcbcrConversionInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
-            return format::ToHandleId(MapHandle<DescriptorUpdateTemplateInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorUpdateTemplateInfo));
+            return format::ToHandleId(MapHandle<VulkanDescriptorUpdateTemplateInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorUpdateTemplateInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
-            return format::ToHandleId(MapHandle<AccelerationStructureKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo));
+            return format::ToHandleId(MapHandle<VulkanAccelerationStructureKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
-            return format::ToHandleId(MapHandle<AccelerationStructureNVInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureNVInfo));
+            return format::ToHandleId(MapHandle<VulkanAccelerationStructureNVInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:
             // No conversion will be performed for unknown objects.
             GFXRECON_LOG_WARNING("Skipping handle mapping for unknown debug marker object type.");

--- a/framework/decode/vulkan_handle_mapping_util.cpp
+++ b/framework/decode/vulkan_handle_mapping_util.cpp
@@ -29,133 +29,133 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 GFXRECON_BEGIN_NAMESPACE(handle_mapping)
 
-uint64_t MapHandle(uint64_t object, VkObjectType object_type, const VulkanObjectInfoTable& object_info_table)
+uint64_t MapHandle(uint64_t object, VkObjectType object_type, const CommonObjectInfoTable& object_info_table)
 {
     switch (object_type)
     {
         case VK_OBJECT_TYPE_INSTANCE:
             return format::ToHandleId(
-                MapHandle<VulkanInstanceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkInstanceInfo));
+                MapHandle<VulkanInstanceInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkInstanceInfo));
         case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
             return format::ToHandleId(MapHandle<VulkanPhysicalDeviceInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
         case VK_OBJECT_TYPE_DEVICE:
             return format::ToHandleId(
-                MapHandle<VulkanDeviceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkDeviceInfo));
+                MapHandle<VulkanDeviceInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkDeviceInfo));
         case VK_OBJECT_TYPE_QUEUE:
             return format::ToHandleId(
-                MapHandle<VulkanQueueInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkQueueInfo));
+                MapHandle<VulkanQueueInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkQueueInfo));
         case VK_OBJECT_TYPE_SEMAPHORE:
             return format::ToHandleId(
-                MapHandle<VulkanSemaphoreInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo));
+                MapHandle<VulkanSemaphoreInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo));
         case VK_OBJECT_TYPE_COMMAND_BUFFER:
             return format::ToHandleId(MapHandle<VulkanCommandBufferInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkCommandBufferInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkCommandBufferInfo));
         case VK_OBJECT_TYPE_FENCE:
             return format::ToHandleId(
-                MapHandle<VulkanFenceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo));
+                MapHandle<VulkanFenceInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkFenceInfo));
         case VK_OBJECT_TYPE_DEVICE_MEMORY:
             return format::ToHandleId(MapHandle<VulkanDeviceMemoryInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo));
         case VK_OBJECT_TYPE_BUFFER:
             return format::ToHandleId(
-                MapHandle<VulkanBufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo));
+                MapHandle<VulkanBufferInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo));
         case VK_OBJECT_TYPE_IMAGE:
             return format::ToHandleId(
-                MapHandle<VulkanImageInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo));
+                MapHandle<VulkanImageInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkImageInfo));
         case VK_OBJECT_TYPE_EVENT:
             return format::ToHandleId(
-                MapHandle<VulkanEventInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkEventInfo));
+                MapHandle<VulkanEventInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkEventInfo));
         case VK_OBJECT_TYPE_QUERY_POOL:
             return format::ToHandleId(
-                MapHandle<VulkanQueryPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkQueryPoolInfo));
+                MapHandle<VulkanQueryPoolInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkQueryPoolInfo));
         case VK_OBJECT_TYPE_BUFFER_VIEW:
             return format::ToHandleId(MapHandle<VulkanBufferViewInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkBufferViewInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkBufferViewInfo));
         case VK_OBJECT_TYPE_IMAGE_VIEW:
             return format::ToHandleId(
-                MapHandle<VulkanImageViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo));
+                MapHandle<VulkanImageViewInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo));
         case VK_OBJECT_TYPE_SHADER_MODULE:
             return format::ToHandleId(MapHandle<VulkanShaderModuleInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkShaderModuleInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkShaderModuleInfo));
         case VK_OBJECT_TYPE_PIPELINE_CACHE:
             return format::ToHandleId(MapHandle<VulkanPipelineCacheInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineCacheInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkPipelineCacheInfo));
         case VK_OBJECT_TYPE_PIPELINE_LAYOUT:
             return format::ToHandleId(MapHandle<VulkanPipelineLayoutInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo));
         case VK_OBJECT_TYPE_RENDER_PASS:
             return format::ToHandleId(MapHandle<VulkanRenderPassInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkRenderPassInfo));
         case VK_OBJECT_TYPE_PIPELINE:
             return format::ToHandleId(
-                MapHandle<VulkanPipelineInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo));
+                MapHandle<VulkanPipelineInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo));
         case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT:
             return format::ToHandleId(MapHandle<VulkanDescriptorSetLayoutInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetLayoutInfo));
         case VK_OBJECT_TYPE_SAMPLER:
             return format::ToHandleId(
-                MapHandle<VulkanSamplerInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkSamplerInfo));
+                MapHandle<VulkanSamplerInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkSamplerInfo));
         case VK_OBJECT_TYPE_DESCRIPTOR_POOL:
             return format::ToHandleId(MapHandle<VulkanDescriptorPoolInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorPoolInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDescriptorPoolInfo));
         case VK_OBJECT_TYPE_DESCRIPTOR_SET:
             return format::ToHandleId(MapHandle<VulkanDescriptorSetInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetInfo));
         case VK_OBJECT_TYPE_FRAMEBUFFER:
             return format::ToHandleId(MapHandle<VulkanFramebufferInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkFramebufferInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkFramebufferInfo));
         case VK_OBJECT_TYPE_COMMAND_POOL:
             return format::ToHandleId(MapHandle<VulkanCommandPoolInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkCommandPoolInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkCommandPoolInfo));
         case VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION:
             return format::ToHandleId(MapHandle<VulkanSamplerYcbcrConversionInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkSamplerYcbcrConversionInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkSamplerYcbcrConversionInfo));
         case VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE:
             return format::ToHandleId(MapHandle<VulkanDescriptorUpdateTemplateInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorUpdateTemplateInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDescriptorUpdateTemplateInfo));
         case VK_OBJECT_TYPE_SURFACE_KHR:
             return format::ToHandleId(MapHandle<VulkanSurfaceKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkSurfaceKHRInfo));
         case VK_OBJECT_TYPE_SWAPCHAIN_KHR:
             return format::ToHandleId(MapHandle<VulkanSwapchainKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkSwapchainKHRInfo));
         case VK_OBJECT_TYPE_DISPLAY_KHR:
             return format::ToHandleId(MapHandle<VulkanDisplayKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDisplayKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDisplayKHRInfo));
         case VK_OBJECT_TYPE_DISPLAY_MODE_KHR:
             return format::ToHandleId(MapHandle<VulkanDisplayModeKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDisplayModeKHRInfo));
         case VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT:
             return format::ToHandleId(MapHandle<VulkanDebugReportCallbackEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDebugReportCallbackEXTInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDebugReportCallbackEXTInfo));
         case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
             return format::ToHandleId(MapHandle<VulkanDebugUtilsMessengerEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDebugUtilsMessengerEXTInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDebugUtilsMessengerEXTInfo));
         case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
             return format::ToHandleId(MapHandle<VulkanAccelerationStructureKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo));
         case VK_OBJECT_TYPE_VALIDATION_CACHE_EXT:
             return format::ToHandleId(MapHandle<VulkanValidationCacheEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkValidationCacheEXTInfo));
         case VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL:
             return format::ToHandleId(MapHandle<VulkanPerformanceConfigurationINTELInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkPerformanceConfigurationINTELInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkPerformanceConfigurationINTELInfo));
         case VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR:
             return format::ToHandleId(MapHandle<VulkanDeferredOperationKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDeferredOperationKHRInfo));
         case VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV:
             return format::ToHandleId(MapHandle<VulkanIndirectCommandsLayoutNVInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo));
         case VK_OBJECT_TYPE_MICROMAP_EXT:
             return format::ToHandleId(MapHandle<VulkanMicromapEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkMicromapEXTInfo));
         case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
             return format::ToHandleId(MapHandle<VulkanPrivateDataSlotEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkPrivateDataSlotInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkPrivateDataSlotInfo));
         case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
             return format::ToHandleId(MapHandle<VulkanAccelerationStructureNVInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo));
         case VK_OBJECT_TYPE_UNKNOWN:
             // No conversion will be performed for unknown objects.
             GFXRECON_LOG_WARNING("Skipping handle unwrapping for unknown debug marker object type.");
@@ -168,115 +168,115 @@ uint64_t MapHandle(uint64_t object, VkObjectType object_type, const VulkanObject
 }
 
 uint64_t
-MapHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type, const VulkanObjectInfoTable& object_info_table)
+MapHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type, const CommonObjectInfoTable& object_info_table)
 {
     switch (object_type)
     {
         case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanInstanceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkInstanceInfo));
+                MapHandle<VulkanInstanceInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkInstanceInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT:
             return format::ToHandleId(MapHandle<VulkanPhysicalDeviceInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanDeviceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkDeviceInfo));
+                MapHandle<VulkanDeviceInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkDeviceInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanQueueInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkQueueInfo));
+                MapHandle<VulkanQueueInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkQueueInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanSemaphoreInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo));
+                MapHandle<VulkanSemaphoreInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT:
             return format::ToHandleId(MapHandle<VulkanCommandBufferInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkCommandBufferInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkCommandBufferInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanFenceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo));
+                MapHandle<VulkanFenceInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkFenceInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT:
             return format::ToHandleId(MapHandle<VulkanDeviceMemoryInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanBufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo));
+                MapHandle<VulkanBufferInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanImageInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo));
+                MapHandle<VulkanImageInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkImageInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanEventInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkEventInfo));
+                MapHandle<VulkanEventInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkEventInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanQueryPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkQueryPoolInfo));
+                MapHandle<VulkanQueryPoolInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkQueryPoolInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT:
             return format::ToHandleId(MapHandle<VulkanBufferViewInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkBufferViewInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkBufferViewInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanImageViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo));
+                MapHandle<VulkanImageViewInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT:
             return format::ToHandleId(MapHandle<VulkanShaderModuleInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkShaderModuleInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkShaderModuleInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT:
             return format::ToHandleId(MapHandle<VulkanPipelineCacheInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineCacheInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkPipelineCacheInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT:
             return format::ToHandleId(MapHandle<VulkanPipelineLayoutInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT:
             return format::ToHandleId(MapHandle<VulkanRenderPassInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkRenderPassInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanPipelineInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo));
+                MapHandle<VulkanPipelineInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT:
             return format::ToHandleId(MapHandle<VulkanDescriptorSetLayoutInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetLayoutInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT:
             return format::ToHandleId(
-                MapHandle<VulkanSamplerInfo>(object, object_info_table, &VulkanObjectInfoTable::GetVkSamplerInfo));
+                MapHandle<VulkanSamplerInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkSamplerInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT:
             return format::ToHandleId(MapHandle<VulkanDescriptorPoolInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorPoolInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDescriptorPoolInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT:
             return format::ToHandleId(MapHandle<VulkanDescriptorSetInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT:
             return format::ToHandleId(MapHandle<VulkanFramebufferInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkFramebufferInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkFramebufferInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT:
             return format::ToHandleId(MapHandle<VulkanCommandPoolInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkCommandPoolInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkCommandPoolInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT:
             return format::ToHandleId(MapHandle<VulkanSurfaceKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkSurfaceKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT:
             return format::ToHandleId(MapHandle<VulkanSwapchainKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkSwapchainKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT:
             return format::ToHandleId(MapHandle<VulkanDebugReportCallbackEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDebugReportCallbackEXTInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDebugReportCallbackEXTInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT:
             return format::ToHandleId(MapHandle<VulkanDisplayKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDisplayKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDisplayKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT:
             return format::ToHandleId(MapHandle<VulkanDisplayModeKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDisplayModeKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT:
             return format::ToHandleId(MapHandle<VulkanValidationCacheEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkValidationCacheEXTInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT:
             return format::ToHandleId(MapHandle<VulkanSamplerYcbcrConversionInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkSamplerYcbcrConversionInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkSamplerYcbcrConversionInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
             return format::ToHandleId(MapHandle<VulkanDescriptorUpdateTemplateInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorUpdateTemplateInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkDescriptorUpdateTemplateInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
             return format::ToHandleId(MapHandle<VulkanAccelerationStructureKHRInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
             return format::ToHandleId(MapHandle<VulkanAccelerationStructureNVInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo));
+                object, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:
             // No conversion will be performed for unknown objects.
             GFXRECON_LOG_WARNING("Skipping handle mapping for unknown debug marker object type.");

--- a/framework/decode/vulkan_handle_mapping_util.h
+++ b/framework/decode/vulkan_handle_mapping_util.h
@@ -23,146 +23,30 @@
 #ifndef GFXRECON_DECODE_VULKAN_HANDLE_MAPPING_UTIL_H
 #define GFXRECON_DECODE_VULKAN_HANDLE_MAPPING_UTIL_H
 
-#include "decode/vulkan_object_info_table.h"
-#include "format/format.h"
+#include "decode/common_handle_mapping_util.h"
 #include "generated/generated_vulkan_struct_decoders.h"
-#include "util/defines.h"
-#include "util/logging.h"
 
 #include "vulkan/vulkan.h"
-
-#include <cassert>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 GFXRECON_BEGIN_NAMESPACE(handle_mapping)
 
-template <typename T>
-static typename T::HandleType MapHandle(format::HandleId             id,
-                                        const VulkanObjectInfoTable& object_info_table,
-                                        const T* (VulkanObjectInfoTable::*GetInfoFunc)(format::HandleId) const)
-{
-    typename T::HandleType handle = VK_NULL_HANDLE;
-
-    if (id != format::kNullHandleId)
-    {
-        const T* info = (object_info_table.*GetInfoFunc)(id);
-
-        if (info != nullptr)
-        {
-            handle = info->handle;
-
-            if constexpr (has_handle_future_v<T>)
-            {
-                if (info->handle == VK_NULL_HANDLE && info->future.valid())
-                {
-                    const auto& [result, async_handles] = info->future.get();
-                    handle                              = async_handles[info->future_handle_index];
-                }
-            }
-        }
-        else
-        {
-            GFXRECON_LOG_WARNING("Failed to map handle for object id %" PRIu64, id);
-        }
-    }
-    return handle;
-}
-
-uint64_t MapHandle(uint64_t object, VkObjectType object_type, const VulkanObjectInfoTable& object_info_table);
+uint64_t MapHandle(uint64_t object, VkObjectType object_type, const CommonObjectInfoTable& object_info_table);
 
 uint64_t
-MapHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type, const VulkanObjectInfoTable& object_info_table);
+MapHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type, const CommonObjectInfoTable& object_info_table);
 
-template <typename T>
-static typename T::HandleType* MapHandleArray(HandlePointerDecoder<typename T::HandleType>* handles_pointer,
-                                              const VulkanObjectInfoTable&                  object_info_table,
-                                              const T* (VulkanObjectInfoTable::*GetInfoFunc)(format::HandleId) const)
-{
-    assert(handles_pointer != nullptr);
-
-    typename T::HandleType* handles = nullptr;
-
-    if (!handles_pointer->IsNull())
-    {
-        size_t                  len = handles_pointer->GetLength();
-        const format::HandleId* ids = handles_pointer->GetPointer();
-
-        handles_pointer->SetHandleLength(len);
-
-        handles = handles_pointer->GetHandlePointer();
-
-        for (size_t i = 0; i < len; ++i)
-        {
-            if (ids[i] != format::kNullHandleId)
-            {
-                const T* info = (object_info_table.*GetInfoFunc)(ids[i]);
-                if (info != nullptr)
-                {
-                    handles[i] = info->handle;
-
-                    if constexpr (has_handle_future_v<T>)
-                    {
-                        if (info->handle == VK_NULL_HANDLE && info->future.valid())
-                        {
-                            const auto& [result, async_handles] = info->future.get();
-                            handles[i]                          = async_handles[info->future_handle_index];
-                        }
-                    }
-                }
-                else
-                {
-                    handles[i] = VK_NULL_HANDLE;
-                    GFXRECON_LOG_WARNING("Failed to map handle for object id %" PRIu64, ids[i]);
-                }
-            }
-        }
-    }
-
-    return handles;
-}
-
-template <typename T>
-static void AddHandle(format::HandleId             parent_id,
-                      format::HandleId             id,
-                      const typename T::HandleType handle,
-                      T&&                          initial_info,
-                      VulkanObjectInfoTable*       object_info_table,
-                      void (VulkanObjectInfoTable::*AddFunc)(T&&))
-{
-    assert(object_info_table != nullptr);
-
-    initial_info.handle     = handle;
-    initial_info.capture_id = id;
-    initial_info.parent_id  = parent_id;
-    (object_info_table->*AddFunc)(std::forward<T>(initial_info));
-}
-
-template <typename T>
-static void AddHandle(format::HandleId       parent_id,
-                      format::HandleId       id,
-                      typename T::HandleType handle,
-                      VulkanObjectInfoTable* object_info_table,
-                      void (VulkanObjectInfoTable::*AddFunc)(T&&))
-{
-    assert(object_info_table != nullptr);
-
-    T info;
-    info.handle     = handle;
-    info.capture_id = id;
-    info.parent_id  = parent_id;
-    (object_info_table->*AddFunc)(std::move(info));
-}
-
-template <typename T>
+template <typename S, typename T>
 static void AddHandleArray(format::HandleId              parent_id,
+                           format::HandleId              pool_id,
                            const format::HandleId*       ids,
                            size_t                        ids_len,
                            const typename T::HandleType* handles,
                            size_t                        handles_len,
                            std::vector<T>&&              initial_infos,
-                           VulkanObjectInfoTable*        object_info_table,
-                           void (VulkanObjectInfoTable::*AddFunc)(T&&))
+                           CommonObjectInfoTable*        object_info_table,
+                           void (CommonObjectInfoTable::*AddFunc)(T&&))
 {
     assert(object_info_table != nullptr);
 
@@ -174,23 +58,30 @@ static void AddHandleArray(format::HandleId              parent_id,
 
         for (size_t i = 0; i < len; ++i)
         {
-            auto info_iter        = std::next(initial_infos.begin(), i);
-            info_iter->handle     = handles[i];
-            info_iter->capture_id = ids[i];
-            info_iter->parent_id  = parent_id;
-            (object_info_table->*AddFunc)(std::move(*info_iter));
+            // Prevent the the ID from being added to the pool's child list if it would be rejectd by AddFunc due to a
+            // null handle ID or null handle.
+            if ((ids[i] != format::kNullHandleId) && (handles[i] != 0))
+            {
+                auto info_iter        = std::next(initial_infos.begin(), i);
+                info_iter->handle     = handles[i];
+                info_iter->capture_id = ids[i];
+                info_iter->parent_id  = parent_id;
+                info_iter->pool_id    = pool_id;
+                (object_info_table->*AddFunc)(std::move(*info_iter));
+            }
         }
     }
 }
 
-template <typename T>
+template <typename S, typename T>
 static void AddHandleArray(format::HandleId              parent_id,
+                           format::HandleId              pool_id,
                            const format::HandleId*       ids,
                            size_t                        ids_len,
                            const typename T::HandleType* handles,
                            size_t                        handles_len,
-                           VulkanObjectInfoTable*        object_info_table,
-                           void (VulkanObjectInfoTable::*AddFunc)(T&&))
+                           CommonObjectInfoTable*        object_info_table,
+                           void (CommonObjectInfoTable::*AddFunc)(T&&))
 {
     assert(object_info_table != nullptr);
 
@@ -199,66 +90,17 @@ static void AddHandleArray(format::HandleId              parent_id,
         size_t len = std::min(ids_len, handles_len);
         for (size_t i = 0; i < len; ++i)
         {
-            T info;
-            info.handle     = handles[i];
-            info.capture_id = ids[i];
-            info.parent_id  = parent_id;
-            (object_info_table->*AddFunc)(std::move(info));
-        }
-    }
-}
-
-template <typename T>
-static void AddHandleArrayAsync(format::HandleId        parent_id,
-                                const format::HandleId* ids,
-                                size_t                  ids_len,
-                                VulkanObjectInfoTable*  object_info_table,
-                                void (VulkanObjectInfoTable::*AddFunc)(T&&),
-                                std::shared_future<handle_create_result_t<typename T::HandleType>> future)
-{
-    static_assert(has_handle_future_v<T>, "handle-type does not support asynchronous creation");
-    assert(object_info_table != nullptr);
-
-    if (ids != nullptr)
-    {
-        for (size_t i = 0; i < ids_len; ++i)
-        {
-            T info;
-            info.handle              = VK_NULL_HANDLE; // handle does not yet exist
-            info.capture_id          = ids[i];
-            info.parent_id           = parent_id;
-            info.future              = future;
-            info.future_handle_index = i;
-            (object_info_table->*AddFunc)(std::move(info));
-        }
-    }
-}
-
-template <typename T>
-static void AddHandleArrayAsync(format::HandleId        parent_id,
-                                const format::HandleId* ids,
-                                size_t                  ids_len,
-                                VulkanObjectInfoTable*  object_info_table,
-                                std::vector<T>&&        initial_infos,
-                                void (VulkanObjectInfoTable::*AddFunc)(T&&),
-                                std::shared_future<handle_create_result_t<typename T::HandleType>> future)
-{
-    static_assert(has_handle_future_v<T>, "handle-type does not support asynchronous creation");
-    assert(object_info_table != nullptr);
-
-    if (ids != nullptr)
-    {
-        assert(ids_len <= initial_infos.size());
-
-        for (size_t i = 0; i < ids_len; ++i)
-        {
-            auto info_iter                 = std::next(initial_infos.begin(), i);
-            info_iter->handle              = VK_NULL_HANDLE; // handle does not yet exist
-            info_iter->capture_id          = ids[i];
-            info_iter->parent_id           = parent_id;
-            info_iter->future              = future;
-            info_iter->future_handle_index = i;
-            (object_info_table->*AddFunc)(std::move(*info_iter));
+            // Prevent the the ID from being added to the pool's child list if it would be rejectd by AddFunc due to a
+            // null handle ID or null handle.
+            if ((ids[i] != format::kNullHandleId) && (handles[i] != 0))
+            {
+                T info;
+                info.handle     = handles[i];
+                info.capture_id = ids[i];
+                info.parent_id  = parent_id;
+                info.pool_id    = pool_id;
+                (object_info_table->*AddFunc)(std::move(info));
+            }
         }
     }
 }
@@ -271,9 +113,9 @@ static void AddHandleArray(format::HandleId              parent_id,
                            const typename T::HandleType* handles,
                            size_t                        handles_len,
                            std::vector<T>&&              initial_infos,
-                           VulkanObjectInfoTable*        object_info_table,
-                           S* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
-                           void (VulkanObjectInfoTable::*AddFunc)(T&&))
+                           CommonObjectInfoTable*        object_info_table,
+                           S* (CommonObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                           void (CommonObjectInfoTable::*AddFunc)(T&&))
 {
     assert(object_info_table != nullptr);
 
@@ -314,9 +156,9 @@ static void AddHandleArray(format::HandleId              parent_id,
                            size_t                        ids_len,
                            const typename T::HandleType* handles,
                            size_t                        handles_len,
-                           VulkanObjectInfoTable*        object_info_table,
-                           S* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
-                           void (VulkanObjectInfoTable::*AddFunc)(T&&))
+                           CommonObjectInfoTable*        object_info_table,
+                           S* (CommonObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                           void (CommonObjectInfoTable::*AddFunc)(T&&))
 {
     assert(object_info_table != nullptr);
 
@@ -347,25 +189,13 @@ static void AddHandleArray(format::HandleId              parent_id,
     }
 }
 
-inline void RemoveHandle(format::HandleId       id,
-                         VulkanObjectInfoTable* object_info_table,
-                         void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId))
-{
-    assert(object_info_table != nullptr);
-
-    if (id != format::kNullHandleId)
-    {
-        (object_info_table->*RemoveFunc)(id);
-    }
-}
-
 // Special case removal of pool objects, which require removal of objects allocated from the pool.
 template <typename T>
 void RemovePoolHandle(format::HandleId       id,
-                      VulkanObjectInfoTable* object_info_table,
-                      T* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
-                      void (VulkanObjectInfoTable::*RemovePoolFunc)(format::HandleId),
-                      void (VulkanObjectInfoTable::*RemoveObjectFunc)(format::HandleId))
+                      CommonObjectInfoTable* object_info_table,
+                      T* (CommonObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                      void (CommonObjectInfoTable::*RemovePoolFunc)(format::HandleId),
+                      void (CommonObjectInfoTable::*RemoveObjectFunc)(format::HandleId))
 {
     assert(object_info_table != nullptr);
 
@@ -385,9 +215,9 @@ void RemovePoolHandle(format::HandleId       id,
 template <typename S, typename T>
 void RemoveHandleArray(format::HandleId                                    pool_id,
                        const HandlePointerDecoder<typename T::HandleType>* handles_pointer,
-                       VulkanObjectInfoTable*                              object_info_table,
-                       S* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
-                       void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId))
+                       CommonObjectInfoTable*                              object_info_table,
+                       S* (CommonObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                       void (CommonObjectInfoTable::*RemoveFunc)(format::HandleId))
 {
     assert((handles_pointer != nullptr) && (object_info_table != nullptr));
 

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -46,8 +46,9 @@ void AddChildObject(std::unordered_map<format::HandleId, std::unordered_map<type
 
 // ImageInfo specialization to filter swapchain images from the list of VkImage objects to destroy.
 template <>
-void AddChildObject<ImageInfo>(
-    std::unordered_map<format::HandleId, std::unordered_map<VkImage, const ImageInfo*>>* objects, const ImageInfo* info)
+void AddChildObject<VulkanImageInfo>(
+    std::unordered_map<format::HandleId, std::unordered_map<VkImage, const VulkanImageInfo*>>* objects,
+    const VulkanImageInfo*                                                                     info)
 {
     assert(objects != nullptr);
 
@@ -158,144 +159,144 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
                         std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table,
                         VulkanSwapchain*                                               swapchain)
 {
-    FreeChildObjects<DeviceInfo, EventInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanEventInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkEvent),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitEventInfo,
-        &VulkanObjectInfoTable::RemoveEventInfo,
-        [&](const DeviceInfo* parent_info, const EventInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkEventInfo,
+        &VulkanObjectInfoTable::RemoveVkEventInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanEventInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyEvent(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, FenceInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanFenceInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkFence),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitFenceInfo,
-        &VulkanObjectInfoTable::RemoveFenceInfo,
-        [&](const DeviceInfo* parent_info, const FenceInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkFenceInfo,
+        &VulkanObjectInfoTable::RemoveVkFenceInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanFenceInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyFence(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, SemaphoreInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanSemaphoreInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkSemaphore),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitSemaphoreInfo,
-        &VulkanObjectInfoTable::RemoveSemaphoreInfo,
-        [&](const DeviceInfo* parent_info, const SemaphoreInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkSemaphoreInfo,
+        &VulkanObjectInfoTable::RemoveVkSemaphoreInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanSemaphoreInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroySemaphore(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, QueryPoolInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanQueryPoolInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkQueryPool),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitQueryPoolInfo,
-        &VulkanObjectInfoTable::RemoveQueryPoolInfo,
-        [&](const DeviceInfo* parent_info, const QueryPoolInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkQueryPoolInfo,
+        &VulkanObjectInfoTable::RemoveVkQueryPoolInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanQueryPoolInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyQueryPool(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, RenderPassInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanRenderPassInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkRenderPass),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitRenderPassInfo,
-        &VulkanObjectInfoTable::RemoveRenderPassInfo,
-        [&](const DeviceInfo* parent_info, const RenderPassInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkRenderPassInfo,
+        &VulkanObjectInfoTable::RemoveVkRenderPassInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanRenderPassInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyRenderPass(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, SamplerInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanSamplerInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkSampler),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitSamplerInfo,
-        &VulkanObjectInfoTable::RemoveSamplerInfo,
-        [&](const DeviceInfo* parent_info, const SamplerInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkSamplerInfo,
+        &VulkanObjectInfoTable::RemoveVkSamplerInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanSamplerInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroySampler(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, SamplerYcbcrConversionInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanSamplerYcbcrConversionInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkSamplerYcbcrConversion),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitSamplerYcbcrConversionInfo,
-        &VulkanObjectInfoTable::RemoveSamplerYcbcrConversionInfo,
-        [&](const DeviceInfo* parent_info, const SamplerYcbcrConversionInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkSamplerYcbcrConversionInfo,
+        &VulkanObjectInfoTable::RemoveVkSamplerYcbcrConversionInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanSamplerYcbcrConversionInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroySamplerYcbcrConversion(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, FramebufferInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanFramebufferInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkFramebuffer),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitFramebufferInfo,
-        &VulkanObjectInfoTable::RemoveFramebufferInfo,
-        [&](const DeviceInfo* parent_info, const FramebufferInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkFramebufferInfo,
+        &VulkanObjectInfoTable::RemoveVkFramebufferInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanFramebufferInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyFramebuffer(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, ImageViewInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanImageViewInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkImageView),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitImageViewInfo,
-        &VulkanObjectInfoTable::RemoveImageViewInfo,
-        [&](const DeviceInfo* parent_info, const ImageViewInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkImageViewInfo,
+        &VulkanObjectInfoTable::RemoveVkImageViewInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanImageViewInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyImageView(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, ImageInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanImageInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkImage),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitImageInfo,
-        &VulkanObjectInfoTable::RemoveImageInfo,
-        [&](const DeviceInfo* parent_info, const ImageInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkImageInfo,
+        &VulkanObjectInfoTable::RemoveVkImageInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanImageInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
 
             auto allocator = parent_info->allocator.get();
@@ -304,30 +305,30 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
             allocator->DestroyImage(object_info->handle, nullptr, object_info->allocator_data);
         });
 
-    FreeChildObjects<DeviceInfo, BufferViewInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanBufferViewInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkBufferView),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitBufferViewInfo,
-        &VulkanObjectInfoTable::RemoveBufferViewInfo,
-        [&](const DeviceInfo* parent_info, const BufferViewInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkBufferViewInfo,
+        &VulkanObjectInfoTable::RemoveVkBufferViewInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanBufferViewInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyBufferView(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, BufferInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanBufferInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkBuffer),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitBufferInfo,
-        &VulkanObjectInfoTable::RemoveBufferInfo,
-        [&](const DeviceInfo* parent_info, const BufferInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkBufferInfo,
+        &VulkanObjectInfoTable::RemoveVkBufferInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanBufferInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
 
             auto allocator = parent_info->allocator.get();
@@ -336,16 +337,16 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
             allocator->DestroyBuffer(object_info->handle, nullptr, object_info->allocator_data);
         });
 
-    FreeChildObjects<DeviceInfo, DeviceMemoryInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanDeviceMemoryInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkDeviceMemory),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitDeviceMemoryInfo,
-        &VulkanObjectInfoTable::RemoveDeviceMemoryInfo,
-        [&](const DeviceInfo* parent_info, const DeviceMemoryInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkDeviceMemoryInfo,
+        &VulkanObjectInfoTable::RemoveVkDeviceMemoryInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanDeviceMemoryInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
 
             auto allocator = parent_info->allocator.get();
@@ -354,240 +355,240 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
             allocator->FreeMemory(object_info->handle, nullptr, object_info->allocator_data);
         });
 
-    FreeChildObjects<DeviceInfo, PipelineCacheInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanPipelineCacheInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkPipelineCache),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitPipelineCacheInfo,
-        &VulkanObjectInfoTable::RemovePipelineCacheInfo,
-        [&](const DeviceInfo* parent_info, const PipelineCacheInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkPipelineCacheInfo,
+        &VulkanObjectInfoTable::RemoveVkPipelineCacheInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanPipelineCacheInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyPipelineCache(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, PipelineInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanPipelineInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkPipeline),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitPipelineInfo,
-        &VulkanObjectInfoTable::RemovePipelineInfo,
-        [&](const DeviceInfo* parent_info, const PipelineInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkPipelineInfo,
+        &VulkanObjectInfoTable::RemoveVkPipelineInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanPipelineInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyPipeline(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, PipelineLayoutInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanPipelineLayoutInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkPipelineLayout),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitPipelineLayoutInfo,
-        &VulkanObjectInfoTable::RemovePipelineLayoutInfo,
-        [&](const DeviceInfo* parent_info, const PipelineLayoutInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkPipelineLayoutInfo,
+        &VulkanObjectInfoTable::RemoveVkPipelineLayoutInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanPipelineLayoutInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyPipelineLayout(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, ShaderModuleInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanShaderModuleInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkShaderModule),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitShaderModuleInfo,
-        &VulkanObjectInfoTable::RemoveShaderModuleInfo,
-        [&](const DeviceInfo* parent_info, const ShaderModuleInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkShaderModuleInfo,
+        &VulkanObjectInfoTable::RemoveVkShaderModuleInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanShaderModuleInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyShaderModule(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, DescriptorSetLayoutInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanDescriptorSetLayoutInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkDescriptorSetLayout),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitDescriptorSetLayoutInfo,
-        &VulkanObjectInfoTable::RemoveDescriptorSetLayoutInfo,
-        [&](const DeviceInfo* parent_info, const DescriptorSetLayoutInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkDescriptorSetLayoutInfo,
+        &VulkanObjectInfoTable::RemoveVkDescriptorSetLayoutInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanDescriptorSetLayoutInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyDescriptorSetLayout(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, DescriptorUpdateTemplateInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanDescriptorUpdateTemplateInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkDescriptorUpdateTemplate),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitDescriptorUpdateTemplateInfo,
-        &VulkanObjectInfoTable::RemoveDescriptorUpdateTemplateInfo,
-        [&](const DeviceInfo* parent_info, const DescriptorUpdateTemplateInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkDescriptorUpdateTemplateInfo,
+        &VulkanObjectInfoTable::RemoveVkDescriptorUpdateTemplateInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanDescriptorUpdateTemplateInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyDescriptorUpdateTemplate(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, CommandPoolInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanCommandPoolInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkCommandPool),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitCommandPoolInfo,
-        &VulkanObjectInfoTable::RemoveCommandPoolInfo,
-        [&](const DeviceInfo* parent_info, const CommandPoolInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkCommandPoolInfo,
+        &VulkanObjectInfoTable::RemoveVkCommandPoolInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanCommandPoolInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyCommandPool(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, IndirectCommandsLayoutNVInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanIndirectCommandsLayoutNVInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkIndirectCommandsLayoutNV),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitIndirectCommandsLayoutNVInfo,
-        &VulkanObjectInfoTable::RemoveIndirectCommandsLayoutNVInfo,
-        [&](const DeviceInfo* parent_info, const IndirectCommandsLayoutNVInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkIndirectCommandsLayoutNVInfo,
+        &VulkanObjectInfoTable::RemoveVkIndirectCommandsLayoutNVInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanIndirectCommandsLayoutNVInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyIndirectCommandsLayoutNV(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, ValidationCacheEXTInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanValidationCacheEXTInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkValidationCacheEXT),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitValidationCacheEXTInfo,
-        &VulkanObjectInfoTable::RemoveValidationCacheEXTInfo,
-        [&](const DeviceInfo* parent_info, const ValidationCacheEXTInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkValidationCacheEXTInfo,
+        &VulkanObjectInfoTable::RemoveVkValidationCacheEXTInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanValidationCacheEXTInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyValidationCacheEXT(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, AccelerationStructureKHRInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanAccelerationStructureKHRInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkAccelerationStructureKHR),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitAccelerationStructureKHRInfo,
-        &VulkanObjectInfoTable::RemoveAccelerationStructureKHRInfo,
-        [&](const DeviceInfo* parent_info, const AccelerationStructureKHRInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkAccelerationStructureKHRInfo,
+        &VulkanObjectInfoTable::RemoveVkAccelerationStructureKHRInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanAccelerationStructureKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyAccelerationStructureKHR(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, AccelerationStructureNVInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanAccelerationStructureNVInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkAccelerationStructureNV),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitAccelerationStructureNVInfo,
-        &VulkanObjectInfoTable::RemoveAccelerationStructureNVInfo,
-        [&](const DeviceInfo* parent_info, const AccelerationStructureNVInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkAccelerationStructureNVInfo,
+        &VulkanObjectInfoTable::RemoveVkAccelerationStructureNVInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanAccelerationStructureNVInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyAccelerationStructureNV(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, PerformanceConfigurationINTELInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanPerformanceConfigurationINTELInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkPerformanceConfigurationINTEL),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitPerformanceConfigurationINTELInfo,
-        &VulkanObjectInfoTable::RemovePerformanceConfigurationINTELInfo,
-        [&](const DeviceInfo* parent_info, const PerformanceConfigurationINTELInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkPerformanceConfigurationINTELInfo,
+        &VulkanObjectInfoTable::RemoveVkPerformanceConfigurationINTELInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanPerformanceConfigurationINTELInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->ReleasePerformanceConfigurationINTEL(parent_info->handle, object_info->handle);
         });
 
-    FreeChildObjects<DeviceInfo, DeferredOperationKHRInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanDeferredOperationKHRInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkDeferredOperationKHR),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitDeferredOperationKHRInfo,
-        &VulkanObjectInfoTable::RemoveDeferredOperationKHRInfo,
-        [&](const DeviceInfo* parent_info, const DeferredOperationKHRInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkDeferredOperationKHRInfo,
+        &VulkanObjectInfoTable::RemoveVkDeferredOperationKHRInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanDeferredOperationKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyDeferredOperationKHR(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, PrivateDataSlotInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanPrivateDataSlotInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkPrivateDataSlotEXT),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitPrivateDataSlotInfo,
-        &VulkanObjectInfoTable::RemovePrivateDataSlotInfo,
-        [&](const DeviceInfo* parent_info, const PrivateDataSlotInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkPrivateDataSlotInfo,
+        &VulkanObjectInfoTable::RemoveVkPrivateDataSlotInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanPrivateDataSlotInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
                 ->DestroyPrivateDataSlot(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<InstanceInfo, DebugReportCallbackEXTInfo>(
+    FreeChildObjects<VulkanInstanceInfo, VulkanDebugReportCallbackEXTInfo>(
         table,
         GFXRECON_STR(VkInstance),
         GFXRECON_STR(VkDebugReportCallbackEXT),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetInstanceInfo,
-        &VulkanObjectInfoTable::VisitDebugReportCallbackEXTInfo,
-        &VulkanObjectInfoTable::RemoveDebugReportCallbackEXTInfo,
-        [&](const InstanceInfo* parent_info, const DebugReportCallbackEXTInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkInstanceInfo,
+        &VulkanObjectInfoTable::VisitVkDebugReportCallbackEXTInfo,
+        &VulkanObjectInfoTable::RemoveVkDebugReportCallbackEXTInfo,
+        [&](const VulkanInstanceInfo* parent_info, const VulkanDebugReportCallbackEXTInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_instance_table(parent_info->handle)
                 ->DestroyDebugReportCallbackEXT(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<InstanceInfo, DebugUtilsMessengerEXTInfo>(
+    FreeChildObjects<VulkanInstanceInfo, VulkanDebugUtilsMessengerEXTInfo>(
         table,
         GFXRECON_STR(VkInstance),
         GFXRECON_STR(VkDebugUtilsMessengerEXT),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetInstanceInfo,
-        &VulkanObjectInfoTable::VisitDebugUtilsMessengerEXTInfo,
-        &VulkanObjectInfoTable::RemoveDebugUtilsMessengerEXTInfo,
-        [&](const InstanceInfo* parent_info, const DebugUtilsMessengerEXTInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkInstanceInfo,
+        &VulkanObjectInfoTable::VisitVkDebugUtilsMessengerEXTInfo,
+        &VulkanObjectInfoTable::RemoveVkDebugUtilsMessengerEXTInfo,
+        [&](const VulkanInstanceInfo* parent_info, const VulkanDebugUtilsMessengerEXTInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_instance_table(parent_info->handle)
                 ->DestroyDebugUtilsMessengerEXT(parent_info->handle, object_info->handle, nullptr);
@@ -595,16 +596,16 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
 
     // VKDescriptorPool objects have a special destroy function to destroy any retired descriptor pool objects that ran
     // out of memory during replay.
-    FreeChildObjects<DeviceInfo, DescriptorPoolInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanDescriptorPoolInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkDescriptorPool),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitDescriptorPoolInfo,
-        &VulkanObjectInfoTable::RemoveDescriptorPoolInfo,
-        [&](const DeviceInfo* parent_info, const DescriptorPoolInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkDescriptorPoolInfo,
+        &VulkanObjectInfoTable::RemoveVkDescriptorPoolInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanDescriptorPoolInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
 
             for (auto retired_pool : object_info->retired_pools)
@@ -619,16 +620,16 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
 
     // VkSwapchainKHR objects have a special destroy function to ignore the object when it has a null surface handle.
     // A valid swapchain object was not created in this case.
-    FreeChildObjects<DeviceInfo, SwapchainKHRInfo>(
+    FreeChildObjects<VulkanDeviceInfo, VulkanSwapchainKHRInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkSwapchainKHR),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitSwapchainKHRInfo,
-        &VulkanObjectInfoTable::RemoveSwapchainKHRInfo,
-        [&](const DeviceInfo* parent_info, const SwapchainKHRInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkDeviceInfo,
+        &VulkanObjectInfoTable::VisitVkSwapchainKHRInfo,
+        &VulkanObjectInfoTable::RemoveVkSwapchainKHRInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanSwapchainKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             if (object_info->surface != VK_NULL_HANDLE)
             {
@@ -641,7 +642,7 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
                 auto allocator = parent_info->allocator.get();
                 assert(allocator != nullptr);
 
-                for (const ImageInfo& image_info : object_info->image_infos)
+                for (const VulkanImageInfo& image_info : object_info->image_infos)
                 {
                     allocator->DestroyImageDirect(image_info.handle, nullptr, image_info.allocator_data);
                     allocator->FreeMemoryDirect(image_info.memory, nullptr, image_info.memory_allocator_data);
@@ -651,31 +652,31 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
 
     // VkSurfaceKHR objects have a special destroy function to destroy the object through the Window object that
     // initially created it.
-    FreeChildObjects<InstanceInfo, SurfaceKHRInfo>(
+    FreeChildObjects<VulkanInstanceInfo, VulkanSurfaceKHRInfo>(
         table,
         GFXRECON_STR(VkInstance),
         GFXRECON_STR(VkSurfaceKHR),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetInstanceInfo,
-        &VulkanObjectInfoTable::VisitSurfaceKHRInfo,
-        &VulkanObjectInfoTable::RemoveSurfaceKHRInfo,
-        [&](const InstanceInfo* parent_info, const SurfaceKHRInfo* object_info) {
+        &VulkanObjectInfoTable::GetVkInstanceInfo,
+        &VulkanObjectInfoTable::VisitVkSurfaceKHRInfo,
+        &VulkanObjectInfoTable::RemoveVkSurfaceKHRInfo,
+        [&](const VulkanInstanceInfo* parent_info, const VulkanSurfaceKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             auto table  = get_instance_table(parent_info->handle);
             swapchain->DestroySurface(table->DestroySurfaceKHR, parent_info, object_info, nullptr);
         });
 
-    FreeParentObjects<DeviceInfo>(table,
-                                  remove_entries,
-                                  &VulkanObjectInfoTable::VisitDeviceInfo,
-                                  &VulkanObjectInfoTable::RemoveDeviceInfo,
-                                  [&](const DeviceInfo* object_info) {
-                                      assert(object_info != nullptr);
-                                      object_info->allocator->Destroy();
-                                      auto table = get_device_table(object_info->handle);
-                                      table->DestroyDevice(object_info->handle, nullptr);
-                                  });
+    FreeParentObjects<VulkanDeviceInfo>(table,
+                                        remove_entries,
+                                        &VulkanObjectInfoTable::VisitVkDeviceInfo,
+                                        &VulkanObjectInfoTable::RemoveVkDeviceInfo,
+                                        [&](const VulkanDeviceInfo* object_info) {
+                                            assert(object_info != nullptr);
+                                            object_info->allocator->Destroy();
+                                            auto table = get_device_table(object_info->handle);
+                                            table->DestroyDevice(object_info->handle, nullptr);
+                                        });
 
     // Remove the objects that are not destroyed from the table.
     if (remove_entries)
@@ -692,20 +693,24 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         //   VkDescriptorSet
         //   VkImage objects that were retrieved from a VkSwapchainKHR object
 
-        ClearObjects<PhysicalDeviceInfo>(
-            table, &VulkanObjectInfoTable::VisitPhysicalDeviceInfo, &VulkanObjectInfoTable::RemovePhysicalDeviceInfo);
-        ClearObjects<QueueInfo>(table, &VulkanObjectInfoTable::VisitQueueInfo, &VulkanObjectInfoTable::RemoveQueueInfo);
-        ClearObjects<DisplayKHRInfo>(
-            table, &VulkanObjectInfoTable::VisitDisplayKHRInfo, &VulkanObjectInfoTable::RemoveDisplayKHRInfo);
-        ClearObjects<DisplayModeKHRInfo>(
-            table, &VulkanObjectInfoTable::VisitDisplayModeKHRInfo, &VulkanObjectInfoTable::RemoveDisplayModeKHRInfo);
-        ClearObjects<CommandBufferInfo>(
-            table, &VulkanObjectInfoTable::VisitCommandBufferInfo, &VulkanObjectInfoTable::RemoveCommandBufferInfo);
-        ClearObjects<DescriptorSetInfo>(
-            table, &VulkanObjectInfoTable::VisitDescriptorSetInfo, &VulkanObjectInfoTable::RemoveDescriptorSetInfo);
+        ClearObjects<VulkanPhysicalDeviceInfo>(table,
+                                               &VulkanObjectInfoTable::VisitVkPhysicalDeviceInfo,
+                                               &VulkanObjectInfoTable::RemoveVkPhysicalDeviceInfo);
+        ClearObjects<VulkanQueueInfo>(
+            table, &VulkanObjectInfoTable::VisitVkQueueInfo, &VulkanObjectInfoTable::RemoveVkQueueInfo);
+        ClearObjects<VulkanDisplayKHRInfo>(
+            table, &VulkanObjectInfoTable::VisitVkDisplayKHRInfo, &VulkanObjectInfoTable::RemoveVkDisplayKHRInfo);
+        ClearObjects<VulkanDisplayModeKHRInfo>(table,
+                                               &VulkanObjectInfoTable::VisitVkDisplayModeKHRInfo,
+                                               &VulkanObjectInfoTable::RemoveVkDisplayModeKHRInfo);
+        ClearObjects<VulkanCommandBufferInfo>(
+            table, &VulkanObjectInfoTable::VisitVkCommandBufferInfo, &VulkanObjectInfoTable::RemoveVkCommandBufferInfo);
+        ClearObjects<VulkanDescriptorSetInfo>(
+            table, &VulkanObjectInfoTable::VisitVkDescriptorSetInfo, &VulkanObjectInfoTable::RemoveVkDescriptorSetInfo);
 
         // Clear the remaining swap chain images.
-        ClearObjects<ImageInfo>(table, &VulkanObjectInfoTable::VisitImageInfo, &VulkanObjectInfoTable::RemoveImageInfo);
+        ClearObjects<VulkanImageInfo>(
+            table, &VulkanObjectInfoTable::VisitVkImageInfo, &VulkanObjectInfoTable::RemoveVkImageInfo);
     }
 }
 
@@ -715,15 +720,15 @@ void FreeAllLiveInstances(VulkanObjectInfoTable*                                
                           std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
                           std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table)
 {
-    FreeParentObjects<InstanceInfo>(table,
-                                    remove_entries,
-                                    &VulkanObjectInfoTable::VisitInstanceInfo,
-                                    &VulkanObjectInfoTable::RemoveInstanceInfo,
-                                    [&](const InstanceInfo* object_info) {
-                                        assert(object_info != nullptr);
-                                        auto table = get_instance_table(object_info->handle);
-                                        table->DestroyInstance(object_info->handle, nullptr);
-                                    });
+    FreeParentObjects<VulkanInstanceInfo>(table,
+                                          remove_entries,
+                                          &VulkanObjectInfoTable::VisitVkInstanceInfo,
+                                          &VulkanObjectInfoTable::RemoveVkInstanceInfo,
+                                          [&](const VulkanInstanceInfo* object_info) {
+                                              assert(object_info != nullptr);
+                                              auto table = get_instance_table(object_info->handle);
+                                              table->DestroyInstance(object_info->handle, nullptr);
+                                          });
 }
 
 GFXRECON_END_NAMESPACE(object_cleanup)

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -59,14 +59,14 @@ void AddChildObject<VulkanImageInfo>(
 }
 
 template <typename S, typename T>
-void FreeChildObjects(VulkanObjectInfoTable* table,
+void FreeChildObjects(CommonObjectInfoTable* table,
                       const std::string&     parent_type_name,
                       const std::string&     object_type_name,
                       bool                   remove_entries,
                       bool                   report_leaks,
-                      S* (VulkanObjectInfoTable::*GetParentInfoFunc)(format::HandleId),
-                      void (VulkanObjectInfoTable::*VisitFunc)(std::function<void(const T*)>) const,
-                      void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId),
+                      S* (CommonObjectInfoTable::*GetParentInfoFunc)(format::HandleId),
+                      void (CommonObjectInfoTable::*VisitFunc)(std::function<void(const T*)>) const,
+                      void (CommonObjectInfoTable::*RemoveFunc)(format::HandleId),
                       std::function<void(const S*, const T*)> destroy_func)
 {
     assert(table != nullptr);
@@ -107,10 +107,10 @@ void FreeChildObjects(VulkanObjectInfoTable* table,
 }
 
 template <typename T>
-void FreeParentObjects(VulkanObjectInfoTable* table,
+void FreeParentObjects(CommonObjectInfoTable* table,
                        bool                   remove_entries,
-                       void (VulkanObjectInfoTable::*VisitFunc)(std::function<void(const T*)>) const,
-                       void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId),
+                       void (CommonObjectInfoTable::*VisitFunc)(std::function<void(const T*)>) const,
+                       void (CommonObjectInfoTable::*RemoveFunc)(format::HandleId),
                        std::function<void(const T*)> destroy_func)
 {
     assert(table != nullptr);
@@ -133,9 +133,9 @@ void FreeParentObjects(VulkanObjectInfoTable* table,
 }
 
 template <typename T>
-void ClearObjects(VulkanObjectInfoTable* table,
-                  void (VulkanObjectInfoTable::*VisitFunc)(std::function<void(const T*)>) const,
-                  void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId))
+void ClearObjects(CommonObjectInfoTable* table,
+                  void (CommonObjectInfoTable::*VisitFunc)(std::function<void(const T*)>) const,
+                  void (CommonObjectInfoTable::*RemoveFunc)(format::HandleId))
 {
     assert(table != nullptr);
 
@@ -152,7 +152,7 @@ void ClearObjects(VulkanObjectInfoTable* table,
     }
 }
 
-void FreeAllLiveObjects(VulkanObjectInfoTable*                                         table,
+void FreeAllLiveObjects(CommonObjectInfoTable*                                         table,
                         bool                                                           remove_entries,
                         bool                                                           report_leaks,
                         std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
@@ -165,9 +165,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkEvent),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkEventInfo,
-        &VulkanObjectInfoTable::RemoveVkEventInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkEventInfo,
+        &CommonObjectInfoTable::RemoveVkEventInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanEventInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyEvent(parent_info->handle, object_info->handle, nullptr);
@@ -179,9 +179,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkFence),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkFenceInfo,
-        &VulkanObjectInfoTable::RemoveVkFenceInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkFenceInfo,
+        &CommonObjectInfoTable::RemoveVkFenceInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanFenceInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyFence(parent_info->handle, object_info->handle, nullptr);
@@ -193,9 +193,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkSemaphore),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkSemaphoreInfo,
-        &VulkanObjectInfoTable::RemoveVkSemaphoreInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkSemaphoreInfo,
+        &CommonObjectInfoTable::RemoveVkSemaphoreInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanSemaphoreInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroySemaphore(parent_info->handle, object_info->handle, nullptr);
@@ -207,9 +207,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkQueryPool),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkQueryPoolInfo,
-        &VulkanObjectInfoTable::RemoveVkQueryPoolInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkQueryPoolInfo,
+        &CommonObjectInfoTable::RemoveVkQueryPoolInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanQueryPoolInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyQueryPool(parent_info->handle, object_info->handle, nullptr);
@@ -221,9 +221,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkRenderPass),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkRenderPassInfo,
-        &VulkanObjectInfoTable::RemoveVkRenderPassInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkRenderPassInfo,
+        &CommonObjectInfoTable::RemoveVkRenderPassInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanRenderPassInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyRenderPass(parent_info->handle, object_info->handle, nullptr);
@@ -235,9 +235,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkSampler),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkSamplerInfo,
-        &VulkanObjectInfoTable::RemoveVkSamplerInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkSamplerInfo,
+        &CommonObjectInfoTable::RemoveVkSamplerInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanSamplerInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroySampler(parent_info->handle, object_info->handle, nullptr);
@@ -249,9 +249,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkSamplerYcbcrConversion),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkSamplerYcbcrConversionInfo,
-        &VulkanObjectInfoTable::RemoveVkSamplerYcbcrConversionInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkSamplerYcbcrConversionInfo,
+        &CommonObjectInfoTable::RemoveVkSamplerYcbcrConversionInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanSamplerYcbcrConversionInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -264,9 +264,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkFramebuffer),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkFramebufferInfo,
-        &VulkanObjectInfoTable::RemoveVkFramebufferInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkFramebufferInfo,
+        &CommonObjectInfoTable::RemoveVkFramebufferInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanFramebufferInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -279,9 +279,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkImageView),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkImageViewInfo,
-        &VulkanObjectInfoTable::RemoveVkImageViewInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkImageViewInfo,
+        &CommonObjectInfoTable::RemoveVkImageViewInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanImageViewInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyImageView(parent_info->handle, object_info->handle, nullptr);
@@ -293,9 +293,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkImage),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkImageInfo,
-        &VulkanObjectInfoTable::RemoveVkImageInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkImageInfo,
+        &CommonObjectInfoTable::RemoveVkImageInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanImageInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
 
@@ -311,9 +311,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkBufferView),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkBufferViewInfo,
-        &VulkanObjectInfoTable::RemoveVkBufferViewInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkBufferViewInfo,
+        &CommonObjectInfoTable::RemoveVkBufferViewInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanBufferViewInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyBufferView(parent_info->handle, object_info->handle, nullptr);
@@ -325,9 +325,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkBuffer),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkBufferInfo,
-        &VulkanObjectInfoTable::RemoveVkBufferInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkBufferInfo,
+        &CommonObjectInfoTable::RemoveVkBufferInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanBufferInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
 
@@ -343,9 +343,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkDeviceMemory),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkDeviceMemoryInfo,
-        &VulkanObjectInfoTable::RemoveVkDeviceMemoryInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkDeviceMemoryInfo,
+        &CommonObjectInfoTable::RemoveVkDeviceMemoryInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanDeviceMemoryInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
 
@@ -361,9 +361,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkPipelineCache),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkPipelineCacheInfo,
-        &VulkanObjectInfoTable::RemoveVkPipelineCacheInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkPipelineCacheInfo,
+        &CommonObjectInfoTable::RemoveVkPipelineCacheInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPipelineCacheInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -376,9 +376,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkPipeline),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkPipelineInfo,
-        &VulkanObjectInfoTable::RemoveVkPipelineInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkPipelineInfo,
+        &CommonObjectInfoTable::RemoveVkPipelineInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPipelineInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)->DestroyPipeline(parent_info->handle, object_info->handle, nullptr);
@@ -390,9 +390,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkPipelineLayout),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkPipelineLayoutInfo,
-        &VulkanObjectInfoTable::RemoveVkPipelineLayoutInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkPipelineLayoutInfo,
+        &CommonObjectInfoTable::RemoveVkPipelineLayoutInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPipelineLayoutInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -405,9 +405,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkShaderModule),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkShaderModuleInfo,
-        &VulkanObjectInfoTable::RemoveVkShaderModuleInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkShaderModuleInfo,
+        &CommonObjectInfoTable::RemoveVkShaderModuleInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanShaderModuleInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -420,9 +420,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkDescriptorSetLayout),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkDescriptorSetLayoutInfo,
-        &VulkanObjectInfoTable::RemoveVkDescriptorSetLayoutInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkDescriptorSetLayoutInfo,
+        &CommonObjectInfoTable::RemoveVkDescriptorSetLayoutInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanDescriptorSetLayoutInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -435,9 +435,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkDescriptorUpdateTemplate),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkDescriptorUpdateTemplateInfo,
-        &VulkanObjectInfoTable::RemoveVkDescriptorUpdateTemplateInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkDescriptorUpdateTemplateInfo,
+        &CommonObjectInfoTable::RemoveVkDescriptorUpdateTemplateInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanDescriptorUpdateTemplateInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -450,9 +450,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkCommandPool),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkCommandPoolInfo,
-        &VulkanObjectInfoTable::RemoveVkCommandPoolInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkCommandPoolInfo,
+        &CommonObjectInfoTable::RemoveVkCommandPoolInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanCommandPoolInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -465,9 +465,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkIndirectCommandsLayoutNV),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkIndirectCommandsLayoutNVInfo,
-        &VulkanObjectInfoTable::RemoveVkIndirectCommandsLayoutNVInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkIndirectCommandsLayoutNVInfo,
+        &CommonObjectInfoTable::RemoveVkIndirectCommandsLayoutNVInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanIndirectCommandsLayoutNVInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -480,9 +480,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkValidationCacheEXT),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkValidationCacheEXTInfo,
-        &VulkanObjectInfoTable::RemoveVkValidationCacheEXTInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkValidationCacheEXTInfo,
+        &CommonObjectInfoTable::RemoveVkValidationCacheEXTInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanValidationCacheEXTInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -495,9 +495,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkAccelerationStructureKHR),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkAccelerationStructureKHRInfo,
-        &VulkanObjectInfoTable::RemoveVkAccelerationStructureKHRInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkAccelerationStructureKHRInfo,
+        &CommonObjectInfoTable::RemoveVkAccelerationStructureKHRInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanAccelerationStructureKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -510,9 +510,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkAccelerationStructureNV),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkAccelerationStructureNVInfo,
-        &VulkanObjectInfoTable::RemoveVkAccelerationStructureNVInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkAccelerationStructureNVInfo,
+        &CommonObjectInfoTable::RemoveVkAccelerationStructureNVInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanAccelerationStructureNVInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -525,9 +525,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkPerformanceConfigurationINTEL),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkPerformanceConfigurationINTELInfo,
-        &VulkanObjectInfoTable::RemoveVkPerformanceConfigurationINTELInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkPerformanceConfigurationINTELInfo,
+        &CommonObjectInfoTable::RemoveVkPerformanceConfigurationINTELInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPerformanceConfigurationINTELInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -540,9 +540,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkDeferredOperationKHR),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkDeferredOperationKHRInfo,
-        &VulkanObjectInfoTable::RemoveVkDeferredOperationKHRInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkDeferredOperationKHRInfo,
+        &CommonObjectInfoTable::RemoveVkDeferredOperationKHRInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanDeferredOperationKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -555,9 +555,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkPrivateDataSlotEXT),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkPrivateDataSlotInfo,
-        &VulkanObjectInfoTable::RemoveVkPrivateDataSlotInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkPrivateDataSlotInfo,
+        &CommonObjectInfoTable::RemoveVkPrivateDataSlotInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPrivateDataSlotInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
@@ -570,9 +570,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkDebugReportCallbackEXT),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkInstanceInfo,
-        &VulkanObjectInfoTable::VisitVkDebugReportCallbackEXTInfo,
-        &VulkanObjectInfoTable::RemoveVkDebugReportCallbackEXTInfo,
+        &CommonObjectInfoTable::GetVkInstanceInfo,
+        &CommonObjectInfoTable::VisitVkDebugReportCallbackEXTInfo,
+        &CommonObjectInfoTable::RemoveVkDebugReportCallbackEXTInfo,
         [&](const VulkanInstanceInfo* parent_info, const VulkanDebugReportCallbackEXTInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_instance_table(parent_info->handle)
@@ -585,9 +585,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkDebugUtilsMessengerEXT),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkInstanceInfo,
-        &VulkanObjectInfoTable::VisitVkDebugUtilsMessengerEXTInfo,
-        &VulkanObjectInfoTable::RemoveVkDebugUtilsMessengerEXTInfo,
+        &CommonObjectInfoTable::GetVkInstanceInfo,
+        &CommonObjectInfoTable::VisitVkDebugUtilsMessengerEXTInfo,
+        &CommonObjectInfoTable::RemoveVkDebugUtilsMessengerEXTInfo,
         [&](const VulkanInstanceInfo* parent_info, const VulkanDebugUtilsMessengerEXTInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_instance_table(parent_info->handle)
@@ -602,9 +602,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkDescriptorPool),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkDescriptorPoolInfo,
-        &VulkanObjectInfoTable::RemoveVkDescriptorPoolInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkDescriptorPoolInfo,
+        &CommonObjectInfoTable::RemoveVkDescriptorPoolInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanDescriptorPoolInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
 
@@ -626,9 +626,9 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkSwapchainKHR),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkDeviceInfo,
-        &VulkanObjectInfoTable::VisitVkSwapchainKHRInfo,
-        &VulkanObjectInfoTable::RemoveVkSwapchainKHRInfo,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkSwapchainKHRInfo,
+        &CommonObjectInfoTable::RemoveVkSwapchainKHRInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanSwapchainKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             if (object_info->surface != VK_NULL_HANDLE)
@@ -658,19 +658,19 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         GFXRECON_STR(VkSurfaceKHR),
         remove_entries,
         report_leaks,
-        &VulkanObjectInfoTable::GetVkInstanceInfo,
-        &VulkanObjectInfoTable::VisitVkSurfaceKHRInfo,
-        &VulkanObjectInfoTable::RemoveVkSurfaceKHRInfo,
+        &CommonObjectInfoTable::GetVkInstanceInfo,
+        &CommonObjectInfoTable::VisitVkSurfaceKHRInfo,
+        &CommonObjectInfoTable::RemoveVkSurfaceKHRInfo,
         [&](const VulkanInstanceInfo* parent_info, const VulkanSurfaceKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            auto table  = get_instance_table(parent_info->handle);
+            auto table = get_instance_table(parent_info->handle);
             swapchain->DestroySurface(table->DestroySurfaceKHR, parent_info, object_info, nullptr);
         });
 
     FreeParentObjects<VulkanDeviceInfo>(table,
                                         remove_entries,
-                                        &VulkanObjectInfoTable::VisitVkDeviceInfo,
-                                        &VulkanObjectInfoTable::RemoveVkDeviceInfo,
+                                        &CommonObjectInfoTable::VisitVkDeviceInfo,
+                                        &CommonObjectInfoTable::RemoveVkDeviceInfo,
                                         [&](const VulkanDeviceInfo* object_info) {
                                             assert(object_info != nullptr);
                                             object_info->allocator->Destroy();
@@ -694,27 +694,27 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         //   VkImage objects that were retrieved from a VkSwapchainKHR object
 
         ClearObjects<VulkanPhysicalDeviceInfo>(table,
-                                               &VulkanObjectInfoTable::VisitVkPhysicalDeviceInfo,
-                                               &VulkanObjectInfoTable::RemoveVkPhysicalDeviceInfo);
+                                               &CommonObjectInfoTable::VisitVkPhysicalDeviceInfo,
+                                               &CommonObjectInfoTable::RemoveVkPhysicalDeviceInfo);
         ClearObjects<VulkanQueueInfo>(
-            table, &VulkanObjectInfoTable::VisitVkQueueInfo, &VulkanObjectInfoTable::RemoveVkQueueInfo);
+            table, &CommonObjectInfoTable::VisitVkQueueInfo, &CommonObjectInfoTable::RemoveVkQueueInfo);
         ClearObjects<VulkanDisplayKHRInfo>(
-            table, &VulkanObjectInfoTable::VisitVkDisplayKHRInfo, &VulkanObjectInfoTable::RemoveVkDisplayKHRInfo);
+            table, &CommonObjectInfoTable::VisitVkDisplayKHRInfo, &CommonObjectInfoTable::RemoveVkDisplayKHRInfo);
         ClearObjects<VulkanDisplayModeKHRInfo>(table,
-                                               &VulkanObjectInfoTable::VisitVkDisplayModeKHRInfo,
-                                               &VulkanObjectInfoTable::RemoveVkDisplayModeKHRInfo);
+                                               &CommonObjectInfoTable::VisitVkDisplayModeKHRInfo,
+                                               &CommonObjectInfoTable::RemoveVkDisplayModeKHRInfo);
         ClearObjects<VulkanCommandBufferInfo>(
-            table, &VulkanObjectInfoTable::VisitVkCommandBufferInfo, &VulkanObjectInfoTable::RemoveVkCommandBufferInfo);
+            table, &CommonObjectInfoTable::VisitVkCommandBufferInfo, &CommonObjectInfoTable::RemoveVkCommandBufferInfo);
         ClearObjects<VulkanDescriptorSetInfo>(
-            table, &VulkanObjectInfoTable::VisitVkDescriptorSetInfo, &VulkanObjectInfoTable::RemoveVkDescriptorSetInfo);
+            table, &CommonObjectInfoTable::VisitVkDescriptorSetInfo, &CommonObjectInfoTable::RemoveVkDescriptorSetInfo);
 
         // Clear the remaining swap chain images.
         ClearObjects<VulkanImageInfo>(
-            table, &VulkanObjectInfoTable::VisitVkImageInfo, &VulkanObjectInfoTable::RemoveVkImageInfo);
+            table, &CommonObjectInfoTable::VisitVkImageInfo, &CommonObjectInfoTable::RemoveVkImageInfo);
     }
 }
 
-void FreeAllLiveInstances(VulkanObjectInfoTable*                                         table,
+void FreeAllLiveInstances(CommonObjectInfoTable*                                         table,
                           bool                                                           remove_entries,
                           bool                                                           report_leaks,
                           std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
@@ -722,8 +722,8 @@ void FreeAllLiveInstances(VulkanObjectInfoTable*                                
 {
     FreeParentObjects<VulkanInstanceInfo>(table,
                                           remove_entries,
-                                          &VulkanObjectInfoTable::VisitVkInstanceInfo,
-                                          &VulkanObjectInfoTable::RemoveVkInstanceInfo,
+                                          &CommonObjectInfoTable::VisitVkInstanceInfo,
+                                          &CommonObjectInfoTable::RemoveVkInstanceInfo,
                                           [&](const VulkanInstanceInfo* object_info) {
                                               assert(object_info != nullptr);
                                               auto table = get_instance_table(object_info->handle);

--- a/framework/decode/vulkan_object_cleanup_util.h
+++ b/framework/decode/vulkan_object_cleanup_util.h
@@ -24,7 +24,7 @@
 #define GFXRECON_DECODE_VULKAN_OBJECT_CLEANUP_UTIL_H
 
 #include "decode/vulkan_swapchain.h"
-#include "decode/vulkan_object_info_table.h"
+#include "decode/common_object_info_table.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "util/defines.h"
 
@@ -34,14 +34,14 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 GFXRECON_BEGIN_NAMESPACE(object_cleanup)
 
-void FreeAllLiveObjects(VulkanObjectInfoTable*                                         table,
+void FreeAllLiveObjects(CommonObjectInfoTable*                                         table,
                         bool                                                           remove_entries,
                         bool                                                           report_leaks,
                         std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
                         std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table,
                         VulkanSwapchain*                                               swapchain);
 
-void FreeAllLiveInstances(VulkanObjectInfoTable*                                         table,
+void FreeAllLiveInstances(CommonObjectInfoTable*                                         table,
                           bool                                                           remove_entries,
                           bool                                                           report_leaks,
                           std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -159,7 +159,7 @@ enum ValidationCacheEXTArrayIndices : uint32_t
 // Structures for storing Vulkan object info.
 //
 
-struct ReplayDeviceInfo
+struct VulkanReplayDeviceInfo
 {
     std::optional<VkPhysicalDeviceProperties>       properties;
     std::optional<VkPhysicalDeviceMemoryProperties> memory_properties;
@@ -260,7 +260,7 @@ struct VulkanInstanceInfo : public VulkanObjectInfo<VkInstance>
     std::vector<format::HandleId> capture_devices;
     std::vector<VkPhysicalDevice> replay_devices;
 
-    std::unordered_map<VkPhysicalDevice, ReplayDeviceInfo> replay_device_info;
+    std::unordered_map<VkPhysicalDevice, VulkanReplayDeviceInfo> replay_device_info;
 };
 
 struct VulkanPhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
@@ -287,7 +287,7 @@ struct VulkanPhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
     uint32_t shaderGroupHandleAlignment = 0;
 
     // Closest matching replay device.
-    ReplayDeviceInfo* replay_device_info{ nullptr };
+    VulkanReplayDeviceInfo* replay_device_info{ nullptr };
 };
 
 struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>
@@ -552,13 +552,13 @@ struct VulkanSwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
 
     // When replay is restricted to a specific surface, a dummy swapchain is created for the omitted surfaces, requiring
     // backing images.
-    uint32_t                  replay_image_count{ 0 };
+    uint32_t                     replay_image_count{ 0 };
     std::vector<VulkanImageInfo> image_infos;
-    VkSwapchainCreateFlagsKHR image_flags{ 0 };
-    VkFormat                  image_format{ VK_FORMAT_UNDEFINED };
-    uint32_t                  image_array_layers{ 0 };
-    VkImageUsageFlags         image_usage{ 0 };
-    VkSharingMode             image_sharing_mode{ VK_SHARING_MODE_EXCLUSIVE };
+    VkSwapchainCreateFlagsKHR    image_flags{ 0 };
+    VkFormat                     image_format{ VK_FORMAT_UNDEFINED };
+    uint32_t                     image_array_layers{ 0 };
+    VkImageUsageFlags            image_usage{ 0 };
+    VkSharingMode                image_sharing_mode{ VK_SHARING_MODE_EXCLUSIVE };
 };
 
 struct VulkanValidationCacheEXTInfo : public VulkanObjectInfo<VkValidationCacheEXT>
@@ -663,30 +663,30 @@ struct VulkanDescriptorSetLayoutInfo : public VulkanObjectInfo<VkDescriptorSetLa
 struct VulkanDescriptorTypeImageInfo
 {
     const VulkanImageViewInfo* image_view_info;
-    VkImageLayout        image_layout;
+    VkImageLayout              image_layout;
 };
 
 struct VulkanDescriptorTypeBufferInfo
 {
     const VulkanBufferInfo* buffer_info;
-    VkDeviceSize      offset;
-    VkDeviceSize      range;
+    VkDeviceSize            offset;
+    VkDeviceSize            range;
 };
 
 struct VulkanDescriptorSetBindingInfo
 {
-    VkDescriptorType                      desc_type{ VK_DESCRIPTOR_TYPE_MAX_ENUM };
+    VkDescriptorType                            desc_type{ VK_DESCRIPTOR_TYPE_MAX_ENUM };
     std::vector<VulkanDescriptorTypeImageInfo>  image_info;
     std::vector<VulkanDescriptorTypeBufferInfo> buffer_info;
     std::vector<const VulkanBufferViewInfo*>    texel_buffer_view_info;
-    std::vector<uint8_t>                  inline_uniform_block;
+    std::vector<uint8_t>                        inline_uniform_block;
 };
 
 struct VulkanDescriptorSetInfo : public VulkanPoolObjectInfo<VkDescriptorSet>
 {
     // One entry per binding
-    using DescriptorBindingsInfo = std::unordered_map<uint32_t, VulkanDescriptorSetBindingInfo>;
-    DescriptorBindingsInfo descriptors;
+    using VulkanDescriptorBindingsInfo = std::unordered_map<uint32_t, VulkanDescriptorSetBindingInfo>;
+    VulkanDescriptorBindingsInfo descriptors;
 };
 
 struct VulkanAccelerationStructureKHRInfo : public VulkanObjectInfo<VkAccelerationStructureKHR>

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -212,42 +212,44 @@ struct VulkanPoolObjectInfo : public VulkanObjectInfo<T>
 // Declarations for Vulkan objects without additional replay state info.
 //
 
-typedef VulkanObjectInfo<VkEvent>                         EventInfo;
-typedef VulkanObjectInfo<VkQueryPool>                     QueryPoolInfo;
-typedef VulkanObjectInfo<VkPipelineLayout>                PipelineLayoutInfo;
-typedef VulkanObjectInfo<VkPrivateDataSlot>               PrivateDataSlotInfo;
-typedef VulkanObjectInfo<VkSampler>                       SamplerInfo;
-typedef VulkanPoolInfo<VkCommandPool>                     CommandPoolInfo;
-typedef VulkanObjectInfo<VkSamplerYcbcrConversion>        SamplerYcbcrConversionInfo;
-typedef VulkanObjectInfo<VkDisplayModeKHR>                DisplayModeKHRInfo;
-typedef VulkanObjectInfo<VkDebugReportCallbackEXT>        DebugReportCallbackEXTInfo;
-typedef VulkanObjectInfo<VkIndirectCommandsLayoutNV>      IndirectCommandsLayoutNVInfo;
-typedef VulkanObjectInfo<VkDebugUtilsMessengerEXT>        DebugUtilsMessengerEXTInfo;
-typedef VulkanObjectInfo<VkAccelerationStructureNV>       AccelerationStructureNVInfo;
-typedef VulkanObjectInfo<VkPerformanceConfigurationINTEL> PerformanceConfigurationINTELInfo;
-typedef VulkanObjectInfo<VkMicromapEXT>                   MicromapEXTInfo;
-typedef VulkanObjectInfo<VkOpticalFlowSessionNV>          OpticalFlowSessionNVInfo;
-typedef VulkanObjectInfo<VkVideoSessionParametersKHR>                   VideoSessionParametersKHRInfo;
-typedef VulkanObjectInfo<VkPipelineBinaryKHR>                           PipelineBinaryKHRInfo;
-typedef VulkanObjectInfo<VkPipelineBinaryCreateInfoKHR>                 PipelineBinaryCreateInfoKHRInfo;
-typedef VulkanObjectInfo<VkPipelineBinaryDataInfoKHR>                   PipelineBinaryDataInfoKHRInfo;
-typedef VulkanObjectInfo<VkPipelineBinaryDataKHR>                       PipelineBinaryDataKHRInfo;
-typedef VulkanObjectInfo<VkPipelineBinaryHandlesInfoKHR>                PipelineBinaryHandlesInfoKHRInfo;
-typedef VulkanObjectInfo<VkPipelineBinaryKeyKHR>                        PipelineBinaryKeyKHRInfo;
-typedef VulkanObjectInfo<VkPipelineBinaryKeysAndDataKHR>                PipelineBinaryKeysAndDataKHRInfo;
-typedef VulkanObjectInfo<VkReleaseCapturedPipelineDataInfoKHR>          ReleaseCapturedPipelineDataInfoKHRInfo;
-typedef VulkanObjectInfo<VkDevicePipelineBinaryInternalCacheControlKHR> DevicePipelineBinaryInternalCacheControlKHRInfo;
-typedef VulkanObjectInfo<VkPipelineBinaryInfoKHR>                       PipelineBinaryInfoKHRInfo;
-typedef VulkanObjectInfo<VkPhysicalDevicePipelineBinaryFeaturesKHR>     PhysicalDevicePipelineBinaryFeaturesKHRInfo;
-typedef VulkanObjectInfo<VkPhysicalDevicePipelineBinaryPropertiesKHR>   PhysicalDevicePipelineBinaryPropertiesKHRInfo;
-typedef VulkanObjectInfo<VkIndirectCommandsLayoutEXT>                   IndirectCommandsLayoutEXTInfo;
-typedef VulkanObjectInfo<VkIndirectExecutionSetEXT>                     IndirectExecutionSetEXTInfo;
+typedef VulkanObjectInfo<VkEvent>                              VulkanEventInfo;
+typedef VulkanObjectInfo<VkQueryPool>                          VulkanQueryPoolInfo;
+typedef VulkanObjectInfo<VkPipelineLayout>                     VulkanPipelineLayoutInfo;
+typedef VulkanObjectInfo<VkPrivateDataSlot>                    VulkanPrivateDataSlotInfo;
+typedef VulkanObjectInfo<VkSampler>                            VulkanSamplerInfo;
+typedef VulkanPoolInfo<VkCommandPool>                          VulkanCommandPoolInfo;
+typedef VulkanObjectInfo<VkSamplerYcbcrConversion>             VulkanSamplerYcbcrConversionInfo;
+typedef VulkanObjectInfo<VkDisplayModeKHR>                     VulkanDisplayModeKHRInfo;
+typedef VulkanObjectInfo<VkDebugReportCallbackEXT>             VulkanDebugReportCallbackEXTInfo;
+typedef VulkanObjectInfo<VkIndirectCommandsLayoutNV>           VulkanIndirectCommandsLayoutNVInfo;
+typedef VulkanObjectInfo<VkDebugUtilsMessengerEXT>             VulkanDebugUtilsMessengerEXTInfo;
+typedef VulkanObjectInfo<VkAccelerationStructureNV>            VulkanAccelerationStructureNVInfo;
+typedef VulkanObjectInfo<VkPerformanceConfigurationINTEL>      VulkanPerformanceConfigurationINTELInfo;
+typedef VulkanObjectInfo<VkMicromapEXT>                        VulkanMicromapEXTInfo;
+typedef VulkanObjectInfo<VkOpticalFlowSessionNV>               VulkanOpticalFlowSessionNVInfo;
+typedef VulkanObjectInfo<VkVideoSessionParametersKHR>          VulkanVideoSessionParametersKHRInfo;
+typedef VulkanObjectInfo<VkPipelineBinaryKHR>                  VulkanPipelineBinaryKHRInfo;
+typedef VulkanObjectInfo<VkPipelineBinaryCreateInfoKHR>        VulkanPipelineBinaryCreateInfoKHRInfo;
+typedef VulkanObjectInfo<VkPipelineBinaryDataInfoKHR>          VulkanPipelineBinaryDataInfoKHRInfo;
+typedef VulkanObjectInfo<VkPipelineBinaryDataKHR>              VulkanPipelineBinaryDataKHRInfo;
+typedef VulkanObjectInfo<VkPipelineBinaryHandlesInfoKHR>       VulkanPipelineBinaryHandlesInfoKHRInfo;
+typedef VulkanObjectInfo<VkPipelineBinaryKeyKHR>               VulkanPipelineBinaryKeyKHRInfo;
+typedef VulkanObjectInfo<VkPipelineBinaryKeysAndDataKHR>       VulkanPipelineBinaryKeysAndDataKHRInfo;
+typedef VulkanObjectInfo<VkReleaseCapturedPipelineDataInfoKHR> VulkanReleaseCapturedPipelineDataInfoKHRInfo;
+typedef VulkanObjectInfo<VkDevicePipelineBinaryInternalCacheControlKHR>
+                                                  VulkanDevicePipelineBinaryInternalCacheControlKHRInfo;
+typedef VulkanObjectInfo<VkPipelineBinaryInfoKHR> VulkanPipelineBinaryInfoKHRInfo;
+typedef VulkanObjectInfo<VkPhysicalDevicePipelineBinaryFeaturesKHR> VulkanPhysicalDevicePipelineBinaryFeaturesKHRInfo;
+typedef VulkanObjectInfo<VkPhysicalDevicePipelineBinaryPropertiesKHR>
+                                                      VulkanPhysicalDevicePipelineBinaryPropertiesKHRInfo;
+typedef VulkanObjectInfo<VkIndirectCommandsLayoutEXT> VulkanIndirectCommandsLayoutEXTInfo;
+typedef VulkanObjectInfo<VkIndirectExecutionSetEXT>   VulkanIndirectExecutionSetEXTInfo;
 
 //
 // Declarations for Vulkan objects with additional replay state info.
 //
 
-struct InstanceInfo : public VulkanObjectInfo<VkInstance>
+struct VulkanInstanceInfo : public VulkanObjectInfo<VkInstance>
 {
     uint32_t                             api_version{ VK_MAKE_VERSION(1, 0, 0) };
     std::vector<std::string>             enabled_extensions;
@@ -261,7 +263,7 @@ struct InstanceInfo : public VulkanObjectInfo<VkInstance>
     std::unordered_map<VkPhysicalDevice, ReplayDeviceInfo> replay_device_info;
 };
 
-struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
+struct VulkanPhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 {
     VkInstance                           parent{ VK_NULL_HANDLE };
     uint32_t                             parent_api_version{ 0 };
@@ -288,7 +290,7 @@ struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
     ReplayDeviceInfo* replay_device_info{ nullptr };
 };
 
-struct DeviceInfo : public VulkanObjectInfo<VkDevice>
+struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>
 {
     VkPhysicalDevice                         parent{ VK_NULL_HANDLE };
     std::unique_ptr<VulkanResourceAllocator> allocator;
@@ -312,7 +314,7 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
     std::vector<VkPhysicalDevice> replay_device_group;
 };
 
-struct QueueInfo : public VulkanObjectInfo<VkQueue>
+struct VulkanQueueInfo : public VulkanObjectInfo<VkQueue>
 {
     VkDevice                             parent{ VK_NULL_HANDLE };
     std::unordered_map<uint32_t, size_t> array_counts;
@@ -320,7 +322,7 @@ struct QueueInfo : public VulkanObjectInfo<VkQueue>
     uint32_t                             queue_index;
 };
 
-struct SemaphoreInfo : public VulkanObjectInfo<VkSemaphore>
+struct VulkanSemaphoreInfo : public VulkanObjectInfo<VkSemaphore>
 {
     bool is_external{ false };
 
@@ -335,20 +337,20 @@ struct SemaphoreInfo : public VulkanObjectInfo<VkSemaphore>
     bool signaled{ false };
 };
 
-struct FenceInfo : public VulkanObjectInfo<VkFence>
+struct VulkanFenceInfo : public VulkanObjectInfo<VkFence>
 {
     // If a null-swapchain/surface interacts with a fence, replay needs to to shadow signal it until a future call waits
     // on it.
     bool shadow_signaled{ false };
 };
 
-struct DeviceMemoryInfo : public VulkanObjectInfo<VkDeviceMemory>
+struct VulkanDeviceMemoryInfo : public VulkanObjectInfo<VkDeviceMemory>
 {
     VulkanResourceAllocator*            allocator{ nullptr };
     VulkanResourceAllocator::MemoryData allocator_data{ 0 };
 };
 
-struct BufferInfo : public VulkanObjectInfo<VkBuffer>
+struct VulkanBufferInfo : public VulkanObjectInfo<VkBuffer>
 {
     // The following values are only used for memory portability.
     VulkanResourceAllocator::ResourceData allocator_data{ 0 };
@@ -363,12 +365,12 @@ struct BufferInfo : public VulkanObjectInfo<VkBuffer>
     uint32_t           queue_family_index{ 0 };
 };
 
-struct BufferViewInfo : public VulkanObjectInfo<VkBufferView>
+struct VulkanBufferViewInfo : public VulkanObjectInfo<VkBufferView>
 {
     format::HandleId buffer_id{ format::kNullHandleId };
 };
 
-struct ImageInfo : public VulkanObjectInfo<VkImage>
+struct VulkanImageInfo : public VulkanObjectInfo<VkImage>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
 
@@ -398,24 +400,24 @@ struct ImageInfo : public VulkanObjectInfo<VkImage>
     VkImageLayout intermediate_layout{ VK_IMAGE_LAYOUT_UNDEFINED };
 };
 
-typedef struct PipelineCacheData
+struct VulkanPipelineCacheData
 {
     std::vector<uint8_t> capture_cache_data;
     std::vector<uint8_t> replay_cache_data;
-} PipelineCacheData;
+};
 
-struct PipelineCacheInfo : public VulkanObjectInfo<VkPipelineCache>
+struct VulkanPipelineCacheInfo : public VulkanObjectInfo<VkPipelineCache>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
 
     // hash id of capture time pipeline cache data to capture and replay time pipeline cache data map;
-    std::unordered_map<uint32_t, std::vector<PipelineCacheData>> pipeline_cache_data;
+    std::unordered_map<uint32_t, std::vector<VulkanPipelineCacheData>> pipeline_cache_data;
 
     // cache was created using VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT flag.
     bool requires_external_synchronization = false;
 };
 
-struct ShaderModuleInfo : public VulkanObjectInfo<VkShaderModule>
+struct VulkanShaderModuleInfo : public VulkanObjectInfo<VkShaderModule>
 {
     // All information stored in ShaderModuleInfo is populated and used
     // by the dump resources feature
@@ -435,15 +437,15 @@ struct ShaderModuleInfo : public VulkanObjectInfo<VkShaderModule>
         bool             is_array;
     };
 
-    ShaderModuleInfo() = default;
-    ShaderModuleInfo(const ShaderModuleInfo& other)
+    VulkanShaderModuleInfo() = default;
+    VulkanShaderModuleInfo(const VulkanShaderModuleInfo& other)
     {
         handle                = other.handle;
         parent_id             = other.parent_id;
         capture_id            = other.capture_id;
         used_descriptors_info = other.used_descriptors_info;
     }
-    ShaderModuleInfo& operator=(const ShaderModuleInfo& other) = default;
+    VulkanShaderModuleInfo& operator=(const VulkanShaderModuleInfo& other) = default;
 
     // One entry per descriptor binding
     using ShaderDescriptorSetInfo = std::map<uint32_t, ShaderDescriptorInfo>;
@@ -454,13 +456,13 @@ struct ShaderModuleInfo : public VulkanObjectInfo<VkShaderModule>
     ShaderDescriptorSetsInfos used_descriptors_info;
 };
 
-struct PipelineInfo : public VulkanObjectInfoAsync<VkPipeline>
+struct VulkanPipelineInfo : public VulkanObjectInfoAsync<VkPipeline>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
 
     // The following information is populated and used only when the
     // dump resources feature is in use
-    std::unordered_map<VkShaderStageFlagBits, ShaderModuleInfo> shaders;
+    std::unordered_map<VkShaderStageFlagBits, VulkanShaderModuleInfo> shaders;
 
     struct InputBindingDescription
     {
@@ -493,7 +495,7 @@ struct PipelineInfo : public VulkanObjectInfoAsync<VkPipeline>
     std::unordered_map<graphics::shader_group_handle_t, graphics::shader_group_handle_t> shader_group_handle_map;
 };
 
-struct DescriptorPoolInfo : public VulkanPoolInfo<VkDescriptorPool>
+struct VulkanDescriptorPoolInfo : public VulkanPoolInfo<VkDescriptorPool>
 {
     VkDescriptorPoolCreateFlags       flags{};
     uint32_t                          max_sets{ 0 };
@@ -502,18 +504,18 @@ struct DescriptorPoolInfo : public VulkanPoolInfo<VkDescriptorPool>
     std::vector<VkDescriptorPool>     retired_pools;
 };
 
-struct DescriptorUpdateTemplateInfo : public VulkanObjectInfo<VkDescriptorUpdateTemplate>
+struct VulkanDescriptorUpdateTemplateInfo : public VulkanObjectInfo<VkDescriptorUpdateTemplate>
 {
     std::vector<VkDescriptorType>                descriptor_image_types;
     std::vector<VkDescriptorUpdateTemplateEntry> entries;
 };
 
-struct DisplayKHRInfo : public VulkanObjectInfo<VkDisplayKHR>
+struct VulkanDisplayKHRInfo : public VulkanObjectInfo<VkDisplayKHR>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
 };
 
-struct SurfaceKHRInfo : public VulkanObjectInfo<VkSurfaceKHR>
+struct VulkanSurfaceKHRInfo : public VulkanObjectInfo<VkSurfaceKHR>
 {
     Window*                              window{ nullptr };
     std::unordered_map<uint32_t, size_t> array_counts;
@@ -522,11 +524,11 @@ struct SurfaceKHRInfo : public VulkanObjectInfo<VkSurfaceKHR>
     std::unordered_map<VkPhysicalDevice, VkSurfaceCapabilitiesKHR> surface_capabilities;
 };
 
-struct SwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
+struct VulkanSwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
 {
     VkSurfaceKHR         surface{ VK_NULL_HANDLE };
     format::HandleId     surface_id{ format::kNullHandleId };
-    DeviceInfo*          device_info{ nullptr };
+    VulkanDeviceInfo*    device_info{ nullptr };
     uint32_t             width{ 0 };
     uint32_t             height{ 0 };
     VkFormat             format{ VK_FORMAT_UNDEFINED };
@@ -551,7 +553,7 @@ struct SwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
     // When replay is restricted to a specific surface, a dummy swapchain is created for the omitted surfaces, requiring
     // backing images.
     uint32_t                  replay_image_count{ 0 };
-    std::vector<ImageInfo>    image_infos;
+    std::vector<VulkanImageInfo> image_infos;
     VkSwapchainCreateFlagsKHR image_flags{ 0 };
     VkFormat                  image_format{ VK_FORMAT_UNDEFINED };
     uint32_t                  image_array_layers{ 0 };
@@ -559,24 +561,24 @@ struct SwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
     VkSharingMode             image_sharing_mode{ VK_SHARING_MODE_EXCLUSIVE };
 };
 
-struct ValidationCacheEXTInfo : public VulkanObjectInfo<VkValidationCacheEXT>
+struct VulkanValidationCacheEXTInfo : public VulkanObjectInfo<VkValidationCacheEXT>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
 };
 
-struct ImageViewInfo : public VulkanObjectInfo<VkImageView>
+struct VulkanImageViewInfo : public VulkanObjectInfo<VkImageView>
 {
     format::HandleId image_id{ format::kNullHandleId };
 };
 
-struct FramebufferInfo : public VulkanObjectInfo<VkFramebuffer>
+struct VulkanFramebufferInfo : public VulkanObjectInfo<VkFramebuffer>
 {
     VkFramebufferCreateFlags             framebuffer_flags{ 0 };
     std::unordered_map<uint32_t, size_t> array_counts;
     std::vector<format::HandleId>        attachment_image_view_ids;
 };
 
-struct DeferredOperationKHRInfo : public VulkanObjectInfo<VkDeferredOperationKHR>
+struct VulkanDeferredOperationKHRInfo : public VulkanObjectInfo<VkDeferredOperationKHR>
 {
     bool pending_state{ false };
 
@@ -587,7 +589,7 @@ struct DeferredOperationKHRInfo : public VulkanObjectInfo<VkDeferredOperationKHR
     std::vector<format::HandleId>                                  capturePipelines;
 };
 
-struct VideoSessionKHRInfo : VulkanObjectInfo<VkVideoSessionKHR>
+struct VulkanVideoSessionKHRInfo : VulkanObjectInfo<VkVideoSessionKHR>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
 
@@ -600,19 +602,19 @@ struct VideoSessionKHRInfo : VulkanObjectInfo<VkVideoSessionKHR>
     uint32_t queue_family_index{ 0 };
 };
 
-struct ShaderEXTInfo : VulkanObjectInfoAsync<VkShaderEXT>
+struct VulkanShaderEXTInfo : VulkanObjectInfoAsync<VkShaderEXT>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
 };
 
-struct CommandBufferInfo : public VulkanPoolObjectInfo<VkCommandBuffer>
+struct VulkanCommandBufferInfo : public VulkanPoolObjectInfo<VkCommandBuffer>
 {
     bool                                                is_frame_boundary{ false };
     std::vector<format::HandleId>                       frame_buffer_ids;
     std::unordered_map<format::HandleId, VkImageLayout> image_layout_barriers;
 };
 
-struct RenderPassInfo : public VulkanObjectInfo<VkRenderPass>
+struct VulkanRenderPassInfo : public VulkanObjectInfo<VkRenderPass>
 {
     std::vector<VkImageLayout>           attachment_description_final_layouts;
     std::vector<VkAttachmentDescription> attachment_descs;
@@ -646,7 +648,7 @@ struct RenderPassInfo : public VulkanObjectInfo<VkRenderPass>
     } multiview;
 };
 
-struct DescriptorSetLayoutInfo : public VulkanObjectInfo<VkDescriptorSetLayout>
+struct VulkanDescriptorSetLayoutInfo : public VulkanObjectInfo<VkDescriptorSetLayout>
 {
     struct DescriptorBindingLayout
     {
@@ -658,36 +660,36 @@ struct DescriptorSetLayoutInfo : public VulkanObjectInfo<VkDescriptorSetLayout>
     std::vector<DescriptorBindingLayout> bindings_layout;
 };
 
-struct DescriptorTypeImageInfo
+struct VulkanDescriptorTypeImageInfo
 {
-    const ImageViewInfo* image_view_info;
+    const VulkanImageViewInfo* image_view_info;
     VkImageLayout        image_layout;
 };
 
-struct DescriptorTypeBufferInfo
+struct VulkanDescriptorTypeBufferInfo
 {
-    const BufferInfo* buffer_info;
+    const VulkanBufferInfo* buffer_info;
     VkDeviceSize      offset;
     VkDeviceSize      range;
 };
 
-struct DescriptorSetBindingInfo
+struct VulkanDescriptorSetBindingInfo
 {
     VkDescriptorType                      desc_type{ VK_DESCRIPTOR_TYPE_MAX_ENUM };
-    std::vector<DescriptorTypeImageInfo>  image_info;
-    std::vector<DescriptorTypeBufferInfo> buffer_info;
-    std::vector<const BufferViewInfo*>    texel_buffer_view_info;
+    std::vector<VulkanDescriptorTypeImageInfo>  image_info;
+    std::vector<VulkanDescriptorTypeBufferInfo> buffer_info;
+    std::vector<const VulkanBufferViewInfo*>    texel_buffer_view_info;
     std::vector<uint8_t>                  inline_uniform_block;
 };
 
-struct DescriptorSetInfo : public VulkanPoolObjectInfo<VkDescriptorSet>
+struct VulkanDescriptorSetInfo : public VulkanPoolObjectInfo<VkDescriptorSet>
 {
     // One entry per binding
-    using DescriptorBindingsInfo = std::unordered_map<uint32_t, DescriptorSetBindingInfo>;
+    using DescriptorBindingsInfo = std::unordered_map<uint32_t, VulkanDescriptorSetBindingInfo>;
     DescriptorBindingsInfo descriptors;
 };
 
-struct AccelerationStructureKHRInfo : public VulkanObjectInfo<VkAccelerationStructureKHR>
+struct VulkanAccelerationStructureKHRInfo : public VulkanObjectInfo<VkAccelerationStructureKHR>
 {
     VkDeviceAddress capture_address = 0;
     VkDeviceAddress replay_address  = 0;
@@ -697,9 +699,9 @@ struct AccelerationStructureKHRInfo : public VulkanObjectInfo<VkAccelerationStru
 // Handle alias types for extension handle types that have been promoted to core types.
 //
 
-typedef SamplerYcbcrConversionInfo   SamplerYcbcrConversionKHRInfo;
-typedef DescriptorUpdateTemplateInfo DescriptorUpdateTemplateKHRInfo;
-typedef PrivateDataSlotInfo          PrivateDataSlotEXTInfo;
+typedef VulkanSamplerYcbcrConversionInfo   VulkanSamplerYcbcrConversionKHRInfo;
+typedef VulkanDescriptorUpdateTemplateInfo VulkanDescriptorUpdateTemplateKHRInfo;
+typedef VulkanPrivateDataSlotInfo          VulkanPrivateDataSlotEXTInfo;
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_object_info_table_base.h
+++ b/framework/decode/vulkan_object_info_table_base.h
@@ -102,13 +102,13 @@ class VulkanObjectInfoTableBase
     // Note: the "dummy" template parameter is here for the sole purpose of working around a gcc issue which does
     // not allow full specialization in non-namespace scope (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282)
     template <typename dummy>
-    void AddObjectInfo(SurfaceKHRInfo&& info, std::unordered_map<format::HandleId, SurfaceKHRInfo>* map)
+    void AddObjectInfo(VulkanSurfaceKHRInfo&& info, std::unordered_map<format::HandleId, VulkanSurfaceKHRInfo>* map)
     {
         assert(map != nullptr);
 
         if (info.capture_id != 0)
         {
-            auto result = map->emplace(info.capture_id, std::forward<SurfaceKHRInfo>(info));
+            auto result = map->emplace(info.capture_id, std::forward<VulkanSurfaceKHRInfo>(info));
 
             if (!result.second)
             {
@@ -123,7 +123,7 @@ class VulkanObjectInfoTableBase
                 auto iter = result.first;
                 if (iter->second.handle != info.handle)
                 {
-                    iter->second = std::forward<SurfaceKHRInfo>(info);
+                    iter->second = std::forward<VulkanSurfaceKHRInfo>(info);
                 }
             }
         }

--- a/framework/decode/vulkan_object_info_table_base.h
+++ b/framework/decode/vulkan_object_info_table_base.h
@@ -53,7 +53,7 @@ class VulkanObjectInfoTableBase
 {
   protected:
     template <typename T>
-    void AddObjectInfo(T&& info, std::unordered_map<format::HandleId, T>* map)
+    void AddVkObjectInfo(T&& info, std::unordered_map<format::HandleId, T>* map)
     {
         assert(map != nullptr);
 
@@ -102,7 +102,7 @@ class VulkanObjectInfoTableBase
     // Note: the "dummy" template parameter is here for the sole purpose of working around a gcc issue which does
     // not allow full specialization in non-namespace scope (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282)
     template <typename dummy>
-    void AddObjectInfo(VulkanSurfaceKHRInfo&& info, std::unordered_map<format::HandleId, VulkanSurfaceKHRInfo>* map)
+    void AddVkObjectInfo(VulkanSurfaceKHRInfo&& info, std::unordered_map<format::HandleId, VulkanSurfaceKHRInfo>* map)
     {
         assert(map != nullptr);
 
@@ -130,7 +130,7 @@ class VulkanObjectInfoTableBase
     }
 
     template <typename T>
-    const T* GetObjectInfo(format::HandleId id, const std::unordered_map<format::HandleId, T>* map) const
+    const T* GetVkObjectInfo(format::HandleId id, const std::unordered_map<format::HandleId, T>* map) const
     {
         assert(map != nullptr);
 
@@ -150,7 +150,7 @@ class VulkanObjectInfoTableBase
     }
 
     template <typename T>
-    T* GetObjectInfo(format::HandleId id, std::unordered_map<format::HandleId, T>* map)
+    T* GetVkObjectInfo(format::HandleId id, std::unordered_map<format::HandleId, T>* map)
     {
         assert(map != nullptr);
 

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -28,7 +28,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                            original_result,
-                                                 InstanceInfo*                       instance_info,
+                                                 VulkanInstanceInfo*                 instance_info,
                                                  const std::string&                  wsi_extension,
                                                  VkFlags                             flags,
                                                  HandlePointerDecoder<VkSurfaceKHR>* surface,
@@ -60,7 +60,7 @@ VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                       
     {
         if (surface != nullptr)
         {
-            auto surface_info                      = reinterpret_cast<SurfaceKHRInfo*>(surface->GetConsumerData(0));
+            auto surface_info = reinterpret_cast<VulkanSurfaceKHRInfo*>(surface->GetConsumerData(0));
             surface_info->surface_creation_skipped = true;
         }
 
@@ -74,14 +74,14 @@ VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                       
 }
 
 void VulkanOffscreenSwapchain::DestroySurface(PFN_vkDestroySurfaceKHR      func,
-                                              const InstanceInfo*          instance_info,
-                                              const SurfaceKHRInfo*        surface_info,
+                                              const VulkanInstanceInfo*    instance_info,
+                                              const VulkanSurfaceKHRInfo*  surface_info,
                                               const VkAllocationCallbacks* allocator)
 {}
 
 VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                              original_result,
                                                       PFN_vkCreateSwapchainKHR              func,
-                                                      const DeviceInfo*                     device_info,
+                                                      const VulkanDeviceInfo*               device_info,
                                                       const VkSwapchainCreateInfoKHR*       create_info,
                                                       const VkAllocationCallbacks*          allocator,
                                                       HandlePointerDecoder<VkSwapchainKHR>* swapchain,
@@ -125,10 +125,10 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
     return original_result;
 }
 
-void VulkanOffscreenSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
-                                                   const DeviceInfo*            device_info,
-                                                   const SwapchainKHRInfo*      swapchain_info,
-                                                   const VkAllocationCallbacks* allocator)
+void VulkanOffscreenSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
+                                                   const VulkanDeviceInfo*       device_info,
+                                                   const VulkanSwapchainKHRInfo* swapchain_info,
+                                                   const VkAllocationCallbacks*  allocator)
 {
     if ((device_info != nullptr) && (swapchain_info != nullptr))
     {
@@ -138,8 +138,8 @@ void VulkanOffscreenSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    
 
 VkResult VulkanOffscreenSwapchain::GetSwapchainImagesKHR(VkResult                    original_result,
                                                          PFN_vkGetSwapchainImagesKHR func,
-                                                         const DeviceInfo*           device_info,
-                                                         SwapchainKHRInfo*           swapchain_info,
+                                                         const VulkanDeviceInfo*     device_info,
+                                                         VulkanSwapchainKHRInfo*     swapchain_info,
                                                          uint32_t                    capture_image_count,
                                                          uint32_t*                   image_count,
                                                          VkImage*                    images)
@@ -167,8 +167,8 @@ VkResult VulkanOffscreenSwapchain::GetSwapchainImagesKHR(VkResult               
 
 VkResult VulkanOffscreenSwapchain::AcquireNextImageKHR(VkResult                  original_result,
                                                        PFN_vkAcquireNextImageKHR func,
-                                                       const DeviceInfo*         device_info,
-                                                       SwapchainKHRInfo*         swapchain_info,
+                                                       const VulkanDeviceInfo*   device_info,
+                                                       VulkanSwapchainKHRInfo*   swapchain_info,
                                                        uint64_t                  timeout,
                                                        VkSemaphore               semaphore,
                                                        VkFence                   fence,
@@ -204,8 +204,8 @@ VkResult VulkanOffscreenSwapchain::AcquireNextImageKHR(VkResult                 
 
 VkResult VulkanOffscreenSwapchain::AcquireNextImage2KHR(VkResult                         original_result,
                                                         PFN_vkAcquireNextImage2KHR       func,
-                                                        const DeviceInfo*                device_info,
-                                                        SwapchainKHRInfo*                swapchain_info,
+                                                        const VulkanDeviceInfo*          device_info,
+                                                        VulkanSwapchainKHRInfo*          swapchain_info,
                                                         const VkAcquireNextImageInfoKHR* acquire_info,
                                                         uint32_t                         capture_image_index,
                                                         uint32_t*                        image_index)
@@ -238,12 +238,12 @@ VkResult VulkanOffscreenSwapchain::AcquireNextImage2KHR(VkResult                
     return original_result;
 }
 
-VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                              original_result,
-                                                   PFN_vkQueuePresentKHR                 func,
-                                                   const std::vector<uint32_t>&          capture_image_indices,
-                                                   const std::vector<SwapchainKHRInfo*>& swapchain_infos,
-                                                   const QueueInfo*                      queue_info,
-                                                   const VkPresentInfoKHR*               present_info)
+VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                                    original_result,
+                                                   PFN_vkQueuePresentKHR                       func,
+                                                   const std::vector<uint32_t>&                capture_image_indices,
+                                                   const std::vector<VulkanSwapchainKHRInfo*>& swapchain_infos,
+                                                   const VulkanQueueInfo*                      queue_info,
+                                                   const VkPresentInfoKHR*                     present_info)
 {
     if (swapchain_options_.offscreen_swapchain_frame_boundary)
     {
@@ -293,12 +293,12 @@ VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                     
 
 // queue_info could be nullptr. It means it doesn't specify a VkQueue and use default_queue. Its purpose is to singal
 // semaphores or fence. All VkQueue should work.
-VkResult VulkanOffscreenSwapchain::SignalSemaphoresFence(const QueueInfo*   queue_info,
-                                                         uint32_t           wait_semaphore_count,
-                                                         const VkSemaphore* wait_semaphores,
-                                                         uint32_t           signal_semaphore_count,
-                                                         const VkSemaphore* signal_semaphores,
-                                                         VkFence            fence)
+VkResult VulkanOffscreenSwapchain::SignalSemaphoresFence(const VulkanQueueInfo* queue_info,
+                                                         uint32_t               wait_semaphore_count,
+                                                         const VkSemaphore*     wait_semaphores,
+                                                         uint32_t               signal_semaphore_count,
+                                                         const VkSemaphore*     signal_semaphores,
+                                                         VkFence                fence)
 {
     uint32_t queue_family_index = default_queue_family_index_;
     if (queue_info)

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -36,7 +36,7 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
     virtual ~VulkanOffscreenSwapchain() override {}
 
     virtual VkResult CreateSurface(VkResult                            original_result,
-                                   InstanceInfo*                       instance_info,
+                                   VulkanInstanceInfo*                 instance_info,
                                    const std::string&                  wsi_extension,
                                    VkFlags                             flags,
                                    HandlePointerDecoder<VkSurfaceKHR>* surface,
@@ -49,35 +49,35 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                    bool                                force_windowed = false) override;
 
     virtual void DestroySurface(PFN_vkDestroySurfaceKHR      func,
-                                const InstanceInfo*          instance_info,
-                                const SurfaceKHRInfo*        surface_info,
+                                const VulkanInstanceInfo*    instance_info,
+                                const VulkanSurfaceKHRInfo*  surface_info,
                                 const VkAllocationCallbacks* allocator) override;
 
     virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
                                         PFN_vkCreateSwapchainKHR              func,
-                                        const DeviceInfo*                     device_info,
+                                        const VulkanDeviceInfo*               device_info,
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
                                         const encode::VulkanDeviceTable*      device_table) override;
 
-    virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
-                                     const DeviceInfo*            device_info,
-                                     const SwapchainKHRInfo*      swapchain_info,
-                                     const VkAllocationCallbacks* allocator) override;
+    virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
+                                     const VulkanDeviceInfo*       device_info,
+                                     const VulkanSwapchainKHRInfo* swapchain_info,
+                                     const VkAllocationCallbacks*  allocator) override;
 
     virtual VkResult GetSwapchainImagesKHR(VkResult                    original_result,
                                            PFN_vkGetSwapchainImagesKHR func,
-                                           const DeviceInfo*           device_info,
-                                           SwapchainKHRInfo*           swapchain_info,
+                                           const VulkanDeviceInfo*     device_info,
+                                           VulkanSwapchainKHRInfo*     swapchain_info,
                                            uint32_t                    capture_image_count,
                                            uint32_t*                   image_count,
                                            VkImage*                    images) override;
 
     virtual VkResult AcquireNextImageKHR(VkResult                  original_result,
                                          PFN_vkAcquireNextImageKHR func,
-                                         const DeviceInfo*         device_info,
-                                         SwapchainKHRInfo*         swapchain_info,
+                                         const VulkanDeviceInfo*   device_info,
+                                         VulkanSwapchainKHRInfo*   swapchain_info,
                                          uint64_t                  timeout,
                                          VkSemaphore               semaphore,
                                          VkFence                   fence,
@@ -86,29 +86,29 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
 
     virtual VkResult AcquireNextImage2KHR(VkResult                         original_result,
                                           PFN_vkAcquireNextImage2KHR       func,
-                                          const DeviceInfo*                device_info,
-                                          SwapchainKHRInfo*                swapchain_info,
+                                          const VulkanDeviceInfo*          device_info,
+                                          VulkanSwapchainKHRInfo*          swapchain_info,
                                           const VkAcquireNextImageInfoKHR* acquire_info,
                                           uint32_t                         capture_image_index,
                                           uint32_t*                        image_index) override;
 
-    virtual VkResult QueuePresentKHR(VkResult                              original_result,
-                                     PFN_vkQueuePresentKHR                 func,
-                                     const std::vector<uint32_t>&          capture_image_indices,
-                                     const std::vector<SwapchainKHRInfo*>& swapchain_infos,
-                                     const QueueInfo*                      queue_info,
-                                     const VkPresentInfoKHR*               present_info) override;
+    virtual VkResult QueuePresentKHR(VkResult                                    original_result,
+                                     PFN_vkQueuePresentKHR                       func,
+                                     const std::vector<uint32_t>&                capture_image_indices,
+                                     const std::vector<VulkanSwapchainKHRInfo*>& swapchain_infos,
+                                     const VulkanQueueInfo*                      queue_info,
+                                     const VkPresentInfoKHR*                     present_info) override;
 
   private:
     const uint32_t default_queue_family_index_{ 0 };
     VkQueue        default_queue_{ VK_NULL_HANDLE }; // default_queue_family_index_,0
 
-    VkResult SignalSemaphoresFence(const QueueInfo*   queue_info,
-                                   uint32_t           wait_semaphore_count,
-                                   const VkSemaphore* wait_semaphores,
-                                   uint32_t           signal_semaphore_count,
-                                   const VkSemaphore* signal_semaphores,
-                                   VkFence            fence);
+    VkResult SignalSemaphoresFence(const VulkanQueueInfo* queue_info,
+                                   uint32_t               wait_semaphore_count,
+                                   const VkSemaphore*     wait_semaphores,
+                                   uint32_t               signal_semaphore_count,
+                                   const VkSemaphore*     signal_semaphores,
+                                   VkFence                fence);
 
     VkFrameBoundaryEXT frame_boundary_;
 };

--- a/framework/decode/vulkan_realign_allocator.cpp
+++ b/framework/decode/vulkan_realign_allocator.cpp
@@ -69,7 +69,7 @@ VkResult VulkanRealignAllocator::AllocateMemory(const VkMemoryAllocateInfo*  all
     if ((allocate_info != nullptr) && (allocator_data != nullptr))
     {
         // allocate new memory allocation size collected from first pass by resource tracking
-        auto                 tracked_memory_info   = tracked_object_table_->GetTrackedDeviceMemoryInfo(capture_id);
+        auto                 tracked_memory_info   = tracked_object_table_->GetTrackedVkDeviceMemoryInfo(capture_id);
         VkMemoryAllocateInfo realign_allocate_info = *allocate_info;
 
         VkDeviceSize realign_size = tracked_memory_info->GetReplayMemoryAllocationSize();
@@ -101,7 +101,7 @@ VkResult VulkanRealignAllocator::BindBufferMemory(VkBuffer               buffer,
     if (resource_info != nullptr)
     {
         // Update buffer to new binding offset from first pass data collected from resource tracking.
-        auto tracked_buffer_info = tracked_object_table_->GetTrackedResourceInfo(resource_info->capture_id);
+        auto tracked_buffer_info = tracked_object_table_->GetTrackedVkResourceInfo(resource_info->capture_id);
         if (tracked_buffer_info != nullptr)
         {
             realign_offset = tracked_buffer_info->GetReplayBindOffset();
@@ -132,7 +132,7 @@ VkResult VulkanRealignAllocator::BindBufferMemory2(uint32_t                     
             if (resource_info != nullptr)
             {
                 // Update buffer to new binding offset from first pass data collected from resource tracking.
-                auto tracked_buffer_info = tracked_object_table_->GetTrackedResourceInfo(resource_info->capture_id);
+                auto tracked_buffer_info = tracked_object_table_->GetTrackedVkResourceInfo(resource_info->capture_id);
                 if (tracked_buffer_info != nullptr)
                 {
                     realign_bind_infos[i].memoryOffset = tracked_buffer_info->GetReplayBindOffset();
@@ -161,7 +161,7 @@ VkResult VulkanRealignAllocator::BindImageMemory(VkImage                image,
     if (resource_info != nullptr)
     {
         // Update image to new binding offset from first pass data collected from resource tracking.
-        auto tracked_image_info = tracked_object_table_->GetTrackedResourceInfo(resource_info->capture_id);
+        auto tracked_image_info = tracked_object_table_->GetTrackedVkResourceInfo(resource_info->capture_id);
         if (tracked_image_info != nullptr)
         {
             realign_offset = tracked_image_info->GetReplayBindOffset();
@@ -192,7 +192,7 @@ VkResult VulkanRealignAllocator::BindImageMemory2(uint32_t                     b
             if (resource_info != nullptr)
             {
                 // Update image to new binding offset from first pass data collected from resource tracking.
-                auto tracked_image_info = tracked_object_table_->GetTrackedResourceInfo(resource_info->capture_id);
+                auto tracked_image_info = tracked_object_table_->GetTrackedVkResourceInfo(resource_info->capture_id);
                 if (tracked_image_info != nullptr)
                 {
                     realign_bind_infos[i].memoryOffset = tracked_image_info->GetReplayBindOffset();
@@ -229,7 +229,7 @@ VkResult VulkanRealignAllocator::BindVideoSessionMemory(VkVideoSessionKHR       
             if (resource_info != nullptr)
             {
                 // Update video seesion to new binding offset from first pass data collected from resource tracking.
-                auto tracked_session_info = tracked_object_table_->GetTrackedResourceInfo(resource_info->capture_id);
+                auto tracked_session_info = tracked_object_table_->GetTrackedVkResourceInfo(resource_info->capture_id);
                 if (tracked_session_info != nullptr)
                 {
                     realign_bind_infos[i].memoryOffset = tracked_session_info->GetReplayBindOffset();
@@ -259,7 +259,7 @@ VkResult VulkanRealignAllocator::MapMemory(VkDeviceMemory   memory,
     if (memory_info != nullptr)
     {
         // Update map memory size to new allocated memory size.
-        auto tracked_memory_info = tracked_object_table_->GetTrackedDeviceMemoryInfo(memory_info->capture_id);
+        auto tracked_memory_info = tracked_object_table_->GetTrackedVkDeviceMemoryInfo(memory_info->capture_id);
 
         // Update map memory size.
         auto map_memories_sizes_list = tracked_memory_info->GetMappedMemorySizesList();
@@ -320,8 +320,8 @@ VkResult VulkanRealignAllocator::WriteMappedMemoryRange(MemoryData     allocator
 }
 
 // Util function to find the matching offset with the resources offsets.
-VkDeviceSize VulkanRealignAllocator::FindMatchingResourceOffset(const TrackedDeviceMemoryInfo* tracked_memory_info,
-                                                                VkDeviceSize                   offset) const
+VkDeviceSize VulkanRealignAllocator::FindMatchingResourceOffset(const TrackedVkDeviceMemoryInfo* tracked_memory_info,
+                                                                VkDeviceSize                     offset) const
 {
     assert(tracked_memory_info != nullptr);
 
@@ -604,7 +604,7 @@ VkResult VulkanRealignAllocator::UpdateResourceData(
     format::HandleId capture_id, MemoryData allocator_data, uint64_t offset, uint64_t size, const uint8_t* data)
 {
     // Find the corresponding resources offset and update fill memory to new offset.
-    auto tracked_memory_info = tracked_object_table_->GetTrackedDeviceMemoryInfo(capture_id);
+    auto tracked_memory_info = tracked_object_table_->GetTrackedVkDeviceMemoryInfo(capture_id);
 
     auto         tracked_bound_resources = tracked_memory_info->GetBoundResourcesList();
     VkDeviceSize mapped_memory_offset    = offset;
@@ -702,9 +702,9 @@ VkResult VulkanRealignAllocator::UpdateResourceData(
 
             auto create_info = entry->GetImageCreateInfo();
             bool skip_update = false, update_data_without_change_memory_location = false;
-            auto tracked_device_info = tracked_object_table_->GetTrackedDeviceInfo(entry->GetCaptureDeviceId());
-            auto tracked_physical_device_info =
-                tracked_object_table_->GetTrackedPhysicalDeviceInfo(tracked_device_info->GetCapturePhysicalDeviceId());
+            auto tracked_device_info = tracked_object_table_->GetTrackedVkDeviceInfo(entry->GetCaptureDeviceId());
+            auto tracked_physical_device_info = tracked_object_table_->GetTrackedVkPhysicalDeviceInfo(
+                tracked_device_info->GetCapturePhysicalDeviceId());
 
             if (!tracked_physical_device_info->IsGpuDriverChanged())
             {
@@ -916,7 +916,7 @@ std::unique_ptr<VkMappedMemoryRange[]> VulkanRealignAllocator::UpdateMappedMemor
             if (memory_info != nullptr)
             {
                 // Update map memory size to new allocated memory size.
-                auto tracked_memory_info = tracked_object_table_->GetTrackedDeviceMemoryInfo(memory_info->capture_id);
+                auto tracked_memory_info = tracked_object_table_->GetTrackedVkDeviceMemoryInfo(memory_info->capture_id);
 
                 if (tracked_memory_info != nullptr)
                 {

--- a/framework/decode/vulkan_realign_allocator.h
+++ b/framework/decode/vulkan_realign_allocator.h
@@ -102,8 +102,8 @@ class VulkanRealignAllocator : public VulkanDefaultAllocator
 
   private:
     // Util function to find the matching offset with the resources offsets.
-    VkDeviceSize FindMatchingResourceOffset(const TrackedDeviceMemoryInfo* tracked_memory_info,
-                                            VkDeviceSize                   original_offset) const;
+    VkDeviceSize FindMatchingResourceOffset(const TrackedVkDeviceMemoryInfo* tracked_memory_info,
+                                            VkDeviceSize                     original_offset) const;
 
     // Util function to update the resource data (memcpy to mapped memory).
     VkResult UpdateResourceData(

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -223,7 +223,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     WaitDevicesIdle();
 
     // Cleanup screenshot resources before destroying device.
-    object_info_table_.VisitDeviceInfo([this](const DeviceInfo* info) {
+    object_info_table_.VisitVkDeviceInfo([this](const VulkanDeviceInfo* info) {
         assert(info != nullptr);
         VkDevice device = info->handle;
 
@@ -262,7 +262,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
 
 void VulkanReplayConsumerBase::WaitDevicesIdle()
 {
-    object_info_table_.VisitDeviceInfo([this](const DeviceInfo* info) {
+    object_info_table_.VisitVkDeviceInfo([this](const VulkanDeviceInfo* info) {
         assert(info != nullptr);
         VkDevice device = info->handle;
 
@@ -305,7 +305,7 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
     VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
     // We need to find the device memory associated with this ID, and then lookup its mapped pointer.
-    const DeviceMemoryInfo* memory_info = object_info_table_.GetDeviceMemoryInfo(memory_id);
+    const VulkanDeviceMemoryInfo* memory_info = object_info_table_.GetVkDeviceMemoryInfo(memory_id);
 
     if (memory_info != nullptr)
     {
@@ -400,7 +400,7 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
 void VulkanReplayConsumerBase::ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height)
 {
     // We need to find the surface associated with this ID, and then lookup its window.
-    const SurfaceKHRInfo* surface_info = object_info_table_.GetSurfaceKHRInfo(surface_id);
+    const VulkanSurfaceKHRInfo* surface_info = object_info_table_.GetVkSurfaceKHRInfo(surface_id);
 
     if (surface_info != nullptr)
     {
@@ -438,7 +438,7 @@ void VulkanReplayConsumerBase::ProcessResizeWindowCommand2(format::HandleId surf
                                                            uint32_t         pre_transform)
 {
     // We need to find the surface associated with this ID, and then lookup its window.
-    const SurfaceKHRInfo* surface_info = object_info_table_.GetSurfaceKHRInfo(surface_id);
+    const VulkanSurfaceKHRInfo* surface_info = object_info_table_.GetVkSurfaceKHRInfo(surface_id);
 
     if (surface_info != nullptr)
     {
@@ -636,7 +636,7 @@ void VulkanReplayConsumerBase::ProcessSetDevicePropertiesCommand(format::HandleI
                                                                  const uint8_t pipeline_cache_uuid[format::kUuidSize],
                                                                  const std::string& device_name)
 {
-    PhysicalDeviceInfo* physical_device_info = object_info_table_.GetPhysicalDeviceInfo(physical_device_id);
+    VulkanPhysicalDeviceInfo* physical_device_info = object_info_table_.GetVkPhysicalDeviceInfo(physical_device_id);
 
     if (physical_device_info != nullptr)
     {
@@ -659,7 +659,7 @@ void VulkanReplayConsumerBase::ProcessSetDeviceMemoryPropertiesCommand(
     const std::vector<format::DeviceMemoryType>& memory_types,
     const std::vector<format::DeviceMemoryHeap>& memory_heaps)
 {
-    PhysicalDeviceInfo* physical_device_info = object_info_table_.GetPhysicalDeviceInfo(physical_device_id);
+    VulkanPhysicalDeviceInfo* physical_device_info = object_info_table_.GetVkPhysicalDeviceInfo(physical_device_id);
 
     if (physical_device_info != nullptr)
     {
@@ -686,7 +686,7 @@ void VulkanReplayConsumerBase::ProcessSetOpaqueAddressCommand(format::HandleId d
                                                               format::HandleId object_id,
                                                               uint64_t         address)
 {
-    DeviceInfo* device_info = object_info_table_.GetDeviceInfo(device_id);
+    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(device_id);
 
     if (device_info != nullptr)
     {
@@ -700,7 +700,7 @@ void VulkanReplayConsumerBase::ProcessSetRayTracingShaderGroupHandlesCommand(for
                                                                              size_t           data_size,
                                                                              const uint8_t*   data)
 {
-    DeviceInfo* device_info = object_info_table_.GetDeviceInfo(device_id);
+    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(device_id);
     if (device_info != nullptr)
     {
         // There should only be one dataset per pipeline.
@@ -717,8 +717,8 @@ void VulkanReplayConsumerBase::ProcessSetSwapchainImageStateCommand(
     uint32_t                                            last_presented_image,
     const std::vector<format::SwapchainImageStateInfo>& image_info)
 {
-    const DeviceInfo* device_info    = object_info_table_.GetDeviceInfo(device_id);
-    SwapchainKHRInfo* swapchain_info = object_info_table_.GetSwapchainKHRInfo(swapchain_id);
+    const VulkanDeviceInfo* device_info    = object_info_table_.GetVkDeviceInfo(device_id);
+    VulkanSwapchainKHRInfo* swapchain_info = object_info_table_.GetVkSwapchainKHRInfo(swapchain_id);
 
     if ((device_info != nullptr) && (swapchain_info != nullptr))
     {
@@ -758,7 +758,7 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
 {
     GFXRECON_UNREFERENCED_PARAMETER(max_resource_size);
 
-    DeviceInfo* device_info = object_info_table_.GetDeviceInfo(device_id);
+    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(device_id);
 
     if (device_info != nullptr)
     {
@@ -801,7 +801,7 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
 
 void VulkanReplayConsumerBase::ProcessEndResourceInitCommand(format::HandleId device_id)
 {
-    DeviceInfo* device_info = object_info_table_.GetDeviceInfo(device_id);
+    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(device_id);
 
     if ((device_info != nullptr) && (device_info->resource_initializer != nullptr))
     {
@@ -814,8 +814,8 @@ void VulkanReplayConsumerBase::ProcessInitBufferCommand(format::HandleId device_
                                                         uint64_t         data_size,
                                                         const uint8_t*   data)
 {
-    DeviceInfo*       device_info = object_info_table_.GetDeviceInfo(device_id);
-    const BufferInfo* buffer_info = object_info_table_.GetBufferInfo(buffer_id);
+    VulkanDeviceInfo*       device_info = object_info_table_.GetVkDeviceInfo(device_id);
+    const VulkanBufferInfo* buffer_info = object_info_table_.GetVkBufferInfo(buffer_id);
 
     if ((device_info != nullptr) && (buffer_info != nullptr))
     {
@@ -891,8 +891,8 @@ void VulkanReplayConsumerBase::ProcessInitImageCommand(format::HandleId         
                                                        const std::vector<uint64_t>& level_sizes,
                                                        const uint8_t*               data)
 {
-    DeviceInfo*      device_info = object_info_table_.GetDeviceInfo(device_id);
-    const ImageInfo* image_info  = object_info_table_.GetImageInfo(image_id);
+    VulkanDeviceInfo*      device_info = object_info_table_.GetVkDeviceInfo(device_id);
+    const VulkanImageInfo* image_info  = object_info_table_.GetVkImageInfo(image_id);
 
     if ((device_info != nullptr) && (image_info != nullptr))
     {
@@ -1198,7 +1198,7 @@ void VulkanReplayConsumerBase::CheckResult(const char*                func_name,
     }
 }
 
-void VulkanReplayConsumerBase::SetInstancePhysicalDeviceEntries(InstanceInfo*           instance_info,
+void VulkanReplayConsumerBase::SetInstancePhysicalDeviceEntries(VulkanInstanceInfo*     instance_info,
                                                                 size_t                  capture_device_count,
                                                                 const format::HandleId* capture_devices,
                                                                 size_t                  replay_device_count,
@@ -1233,7 +1233,7 @@ void VulkanReplayConsumerBase::SetInstancePhysicalDeviceEntries(InstanceInfo*   
     }
 }
 
-void VulkanReplayConsumerBase::CheckReplayDeviceInfo(PhysicalDeviceInfo* physical_device_info)
+void VulkanReplayConsumerBase::CheckReplayDeviceInfo(VulkanPhysicalDeviceInfo* physical_device_info)
 {
     assert(physical_device_info != nullptr);
 
@@ -1242,7 +1242,7 @@ void VulkanReplayConsumerBase::CheckReplayDeviceInfo(PhysicalDeviceInfo* physica
         // A physical device handle was obtained without calling vkEnumeratePhysicalDevices or
         // vkEnumeratePhysicalDeviceGroups, so the physical device initialization that would have been performed when
         // replaying those calls will be performed here.
-        auto instance_info = object_info_table_.GetInstanceInfo(physical_device_info->parent_id);
+        auto instance_info = object_info_table_.GetVkInstanceInfo(physical_device_info->parent_id);
         if (instance_info != nullptr)
         {
             assert(physical_device_info->handle != VK_NULL_HANDLE);
@@ -1258,9 +1258,9 @@ void VulkanReplayConsumerBase::CheckReplayDeviceInfo(PhysicalDeviceInfo* physica
     }
 }
 
-void VulkanReplayConsumerBase::SetPhysicalDeviceInstanceInfo(InstanceInfo*       instance_info,
-                                                             PhysicalDeviceInfo* physical_device_info,
-                                                             VkPhysicalDevice    replay_device)
+void VulkanReplayConsumerBase::SetPhysicalDeviceInstanceInfo(VulkanInstanceInfo*       instance_info,
+                                                             VulkanPhysicalDeviceInfo* physical_device_info,
+                                                             VkPhysicalDevice          replay_device)
 {
     assert((instance_info != nullptr) && (physical_device_info != nullptr));
 
@@ -1270,7 +1270,7 @@ void VulkanReplayConsumerBase::SetPhysicalDeviceInstanceInfo(InstanceInfo*      
     physical_device_info->replay_device_info        = &instance_info->replay_device_info[replay_device];
 }
 
-void VulkanReplayConsumerBase::SetPhysicalDeviceProperties(PhysicalDeviceInfo*               physical_device_info,
+void VulkanReplayConsumerBase::SetPhysicalDeviceProperties(VulkanPhysicalDeviceInfo*         physical_device_info,
                                                            const VkPhysicalDeviceProperties* capture_properties,
                                                            const VkPhysicalDeviceProperties* replay_properties)
 {
@@ -1293,7 +1293,7 @@ void VulkanReplayConsumerBase::SetPhysicalDeviceProperties(PhysicalDeviceInfo*  
     replay_device_info->properties = *replay_properties;
 }
 
-void VulkanReplayConsumerBase::SetPhysicalDeviceProperties(PhysicalDeviceInfo*                physical_device_info,
+void VulkanReplayConsumerBase::SetPhysicalDeviceProperties(VulkanPhysicalDeviceInfo*          physical_device_info,
                                                            const VkPhysicalDeviceProperties2* capture_properties,
                                                            const VkPhysicalDeviceProperties2* replay_properties)
 {
@@ -1316,7 +1316,7 @@ void VulkanReplayConsumerBase::SetPhysicalDeviceProperties(PhysicalDeviceInfo*  
 }
 
 void VulkanReplayConsumerBase::SetPhysicalDeviceMemoryProperties(
-    PhysicalDeviceInfo*                     physical_device_info,
+    VulkanPhysicalDeviceInfo*               physical_device_info,
     const VkPhysicalDeviceMemoryProperties* capture_properties,
     const VkPhysicalDeviceMemoryProperties* replay_properties)
 {
@@ -1333,11 +1333,11 @@ void VulkanReplayConsumerBase::SetPhysicalDeviceMemoryProperties(
     replay_device_info->memory_properties = *replay_properties;
 }
 
-void VulkanReplayConsumerBase::SelectPhysicalDevice(PhysicalDeviceInfo* physical_device_info)
+void VulkanReplayConsumerBase::SelectPhysicalDevice(VulkanPhysicalDeviceInfo* physical_device_info)
 {
     assert((physical_device_info != nullptr) && (physical_device_info->parent_id != format::kNullHandleId));
 
-    InstanceInfo* instance_info = object_info_table_.GetInstanceInfo(physical_device_info->parent_id);
+    VulkanInstanceInfo* instance_info = object_info_table_.GetVkInstanceInfo(physical_device_info->parent_id);
 
     if (instance_info != nullptr)
     {
@@ -1366,13 +1366,13 @@ void VulkanReplayConsumerBase::SelectPhysicalDevice(PhysicalDeviceInfo* physical
     }
 }
 
-void VulkanReplayConsumerBase::SelectPhysicalDeviceGroup(PhysicalDeviceInfo*                  physical_device_info,
+void VulkanReplayConsumerBase::SelectPhysicalDeviceGroup(VulkanPhysicalDeviceInfo*            physical_device_info,
                                                          const std::vector<format::HandleId>& capture_device_group,
                                                          std::vector<VkPhysicalDevice>&       replay_device_group)
 {
     assert((physical_device_info != nullptr) && (physical_device_info->parent_id != format::kNullHandleId));
 
-    InstanceInfo* instance_info = object_info_table_.GetInstanceInfo(physical_device_info->parent_id);
+    VulkanInstanceInfo* instance_info = object_info_table_.GetVkInstanceInfo(physical_device_info->parent_id);
 
     if (instance_info != nullptr)
     {
@@ -1401,7 +1401,8 @@ void VulkanReplayConsumerBase::SelectPhysicalDeviceGroup(PhysicalDeviceInfo*    
     }
 }
 
-bool VulkanReplayConsumerBase::GetOverrideDevice(InstanceInfo* instance_info, PhysicalDeviceInfo* physical_device_info)
+bool VulkanReplayConsumerBase::GetOverrideDevice(VulkanInstanceInfo*       instance_info,
+                                                 VulkanPhysicalDeviceInfo* physical_device_info)
 {
     const auto& replay_devices      = instance_info->replay_devices;
     int32_t     replay_devices_size = static_cast<int32_t>(replay_devices.size());
@@ -1463,8 +1464,8 @@ bool VulkanReplayConsumerBase::GetOverrideDevice(InstanceInfo* instance_info, Ph
     return true;
 }
 
-bool VulkanReplayConsumerBase::GetOverrideDeviceGroup(InstanceInfo*                  instance_info,
-                                                      PhysicalDeviceInfo*            physical_device_info,
+bool VulkanReplayConsumerBase::GetOverrideDeviceGroup(VulkanInstanceInfo*            instance_info,
+                                                      VulkanPhysicalDeviceInfo*      physical_device_info,
                                                       std::vector<VkPhysicalDevice>& replay_device_group)
 {
     VkInstance instance               = instance_info->handle;
@@ -1559,7 +1560,8 @@ bool VulkanReplayConsumerBase::GetOverrideDeviceGroup(InstanceInfo*             
     return true;
 }
 
-void VulkanReplayConsumerBase::GetMatchingDevice(InstanceInfo* instance_info, PhysicalDeviceInfo* physical_device_info)
+void VulkanReplayConsumerBase::GetMatchingDevice(VulkanInstanceInfo*       instance_info,
+                                                 VulkanPhysicalDeviceInfo* physical_device_info)
 {
     // Dispatch table for retrieving physical device properties, if necessary.
     auto table = GetInstanceTable(physical_device_info->handle);
@@ -1614,14 +1616,14 @@ void VulkanReplayConsumerBase::GetMatchingDevice(InstanceInfo* instance_info, Ph
     }
 }
 
-void VulkanReplayConsumerBase::GetMatchingDeviceGroup(InstanceInfo*                        instance_info,
-                                                      PhysicalDeviceInfo*                  physical_device_info,
+void VulkanReplayConsumerBase::GetMatchingDeviceGroup(VulkanInstanceInfo*                  instance_info,
+                                                      VulkanPhysicalDeviceInfo*            physical_device_info,
                                                       const std::vector<format::HandleId>& capture_device_group,
                                                       std::vector<VkPhysicalDevice>&       replay_device_group)
 {
     for (auto handle_id : capture_device_group)
     {
-        auto physical_device_info = GetObjectInfoTable().GetPhysicalDeviceInfo(handle_id);
+        auto physical_device_info = GetObjectInfoTable().GetVkPhysicalDeviceInfo(handle_id);
         GetMatchingDevice(instance_info, physical_device_info);
         replay_device_group.emplace_back(physical_device_info->handle);
     }
@@ -1687,7 +1689,7 @@ void VulkanReplayConsumerBase::GetMatchingDeviceGroup(InstanceInfo*             
     }
 }
 
-void VulkanReplayConsumerBase::CheckPhysicalDeviceCompatibility(PhysicalDeviceInfo* physical_device_info)
+void VulkanReplayConsumerBase::CheckPhysicalDeviceCompatibility(VulkanPhysicalDeviceInfo* physical_device_info)
 {
     CheckReplayDeviceInfo(physical_device_info);
     auto replay_device_info = physical_device_info->replay_device_info;
@@ -1714,7 +1716,7 @@ void VulkanReplayConsumerBase::CheckPhysicalDeviceCompatibility(PhysicalDeviceIn
 }
 
 void VulkanReplayConsumerBase::CheckPhysicalDeviceGroupCompatibility(
-    InstanceInfo*                        instance_info,
+    VulkanInstanceInfo*                  instance_info,
     const std::vector<format::HandleId>& capture_device_group,
     const std::vector<VkPhysicalDevice>& replay_device_group)
 {
@@ -1730,7 +1732,7 @@ void VulkanReplayConsumerBase::CheckPhysicalDeviceGroupCompatibility(
     {
         for (size_t i = 0; i < capture_size; ++i)
         {
-            auto capture_info = GetObjectInfoTable().GetPhysicalDeviceInfo(capture_device_group[i]);
+            auto capture_info = GetObjectInfoTable().GetVkPhysicalDeviceInfo(capture_device_group[i]);
             if (i < replay_size)
             {
                 auto*       replay_device_info = &instance_info->replay_device_info[replay_device_group[i]];
@@ -1755,7 +1757,7 @@ void VulkanReplayConsumerBase::CheckPhysicalDeviceGroupCompatibility(
 
         for (size_t i = 0; i < capture_size; ++i)
         {
-            auto capture_info = GetObjectInfoTable().GetPhysicalDeviceInfo(capture_device_group[i]);
+            auto capture_info = GetObjectInfoTable().GetVkPhysicalDeviceInfo(capture_device_group[i]);
 
             std::ostringstream string_stream;
             string_stream << "[vendorID = " << capture_info->capture_vendor_id
@@ -1818,7 +1820,7 @@ bool VulkanReplayConsumerBase::CheckTrimDeviceExtensions(VkPhysicalDevice       
     return have_extensions;
 }
 
-void VulkanReplayConsumerBase::InitializeResourceAllocator(const PhysicalDeviceInfo*       physical_device_info,
+void VulkanReplayConsumerBase::InitializeResourceAllocator(const VulkanPhysicalDeviceInfo* physical_device_info,
                                                            VkDevice                        device,
                                                            const std::vector<std::string>& enabled_device_extensions,
                                                            VulkanResourceAllocator*        allocator)
@@ -1958,7 +1960,7 @@ void VulkanReplayConsumerBase::ProcessSwapchainFullScreenExclusiveInfo(
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
         // Get the surface info from the Decoded_VkSwapchainCreateInfoKHR handle id.
         HMONITOR   hmonitor     = nullptr;
-        const auto surface_info = object_info_table_.GetSurfaceKHRInfo(swapchain_info->surface);
+        const auto surface_info = object_info_table_.GetVkSurfaceKHRInfo(swapchain_info->surface);
 
         if ((surface_info != nullptr) && (surface_info->window != nullptr))
         {
@@ -2049,7 +2051,7 @@ void VulkanReplayConsumerBase::SetSwapchainWindowSize(const Decoded_VkSwapchainC
     const auto create_info = swapchain_info->decoded_value;
     if (create_info != nullptr)
     {
-        const auto surface_info = object_info_table_.GetSurfaceKHRInfo(swapchain_info->surface);
+        const auto surface_info = object_info_table_.GetVkSurfaceKHRInfo(swapchain_info->surface);
         if (surface_info && (surface_info->window != nullptr))
         {
             uint32_t pre_transform = 0;
@@ -2126,7 +2128,7 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
 
         for (uint32_t i = 0; i < present_info->swapchainCount; ++i)
         {
-            auto swapchain_info = object_info_table_.GetSwapchainKHRInfo(swapchain_ids[i]);
+            auto swapchain_info = object_info_table_.GetVkSwapchainKHRInfo(swapchain_ids[i]);
             if ((swapchain_info != nullptr) && (swapchain_info->device_info != nullptr) &&
                 (swapchain_info->images.size() > 0))
             {
@@ -2179,14 +2181,15 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
     }
 }
 
-bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(const CommandBufferInfo* command_buffer_info)
+bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
+    const VulkanCommandBufferInfo* command_buffer_info)
 {
     GFXRECON_ASSERT(command_buffer_info != nullptr);
     if (command_buffer_info->is_frame_boundary)
     {
         if (screenshot_handler_->IsScreenshotFrame())
         {
-            DeviceInfo* device_info = object_info_table_.GetDeviceInfo(command_buffer_info->parent_id);
+            VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(command_buffer_info->parent_id);
 
             auto instance_table = GetInstanceTable(device_info->parent);
             GFXRECON_ASSERT(instance_table != nullptr);
@@ -2197,13 +2200,14 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(const Comm
 
             for (size_t i = 0; i < command_buffer_info->frame_buffer_ids.size(); ++i)
             {
-                auto framebuffer_info = object_info_table_.GetFramebufferInfo(command_buffer_info->frame_buffer_ids[i]);
+                auto framebuffer_info =
+                    object_info_table_.GetVkFramebufferInfo(command_buffer_info->frame_buffer_ids[i]);
 
                 for (size_t j = 0; j < framebuffer_info->attachment_image_view_ids.size(); ++j)
                 {
                     auto image_view_id   = framebuffer_info->attachment_image_view_ids[j];
-                    auto image_view_info = object_info_table_.GetImageViewInfo(image_view_id);
-                    auto image_info      = object_info_table_.GetImageInfo(image_view_info->image_id);
+                    auto image_view_info = object_info_table_.GetVkImageViewInfo(image_view_id);
+                    auto image_info      = object_info_table_.GetVkImageInfo(image_view_info->image_id);
 
                     // Only screenshot images that are color attachments.
                     if ((image_info->usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) !=
@@ -2260,7 +2264,8 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(const Comm
     return false;
 }
 
-bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const DeviceInfo* device_info, const PNextNode* pnext)
+bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDeviceInfo* device_info,
+                                                               const PNextNode*        pnext)
 {
     const auto* frame_boundary = GetPNextMetaStruct<Decoded_VkFrameBoundaryEXT>(pnext);
     if (frame_boundary == nullptr ||
@@ -2283,7 +2288,7 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const DeviceInfo*
                 screenshot_file_prefix_ + "_frame_" + std::to_string(screenshot_handler_->GetCurrentFrame());
 
             const format::HandleId handleId   = frame_boundary->pImages.GetPointer()[i];
-            const ImageInfo*       image_info = GetObjectInfoTable().GetImageInfo(handleId);
+            const VulkanImageInfo* image_info = GetObjectInfoTable().GetVkImageInfo(handleId);
 
             const uint32_t screenshot_width =
                 options_.screenshot_scale
@@ -2524,7 +2529,7 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
 
         if (modified_create_info.pApplicationInfo != nullptr)
         {
-            auto instance_info = reinterpret_cast<InstanceInfo*>(pInstance->GetConsumerData(0));
+            auto instance_info = reinterpret_cast<VulkanInstanceInfo*>(pInstance->GetConsumerData(0));
             assert(instance_info != nullptr);
 
             instance_info->api_version = modified_create_info.pApplicationInfo->apiVersion;
@@ -2538,8 +2543,8 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
 }
 
 VkResult
-VulkanReplayConsumerBase::OverrideCreateDevice(VkResult            original_result,
-                                               PhysicalDeviceInfo* physical_device_info,
+VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  original_result,
+                                               VulkanPhysicalDeviceInfo* physical_device_info,
                                                const StructPointerDecoder<Decoded_VkDeviceCreateInfo>*    pCreateInfo,
                                                const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                                HandlePointerDecoder<VkDevice>*                            pDevice)
@@ -2709,7 +2714,7 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult            original_resu
 
     AddDeviceTable(*replay_device, get_device_proc_addr);
 
-    auto device_info = reinterpret_cast<DeviceInfo*>(pDevice->GetConsumerData(0));
+    auto device_info = reinterpret_cast<VulkanDeviceInfo*>(pDevice->GetConsumerData(0));
     assert(device_info != nullptr);
 
     device_info->replay_device_group = std::move(replay_device_group);
@@ -2772,7 +2777,7 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult            original_resu
 
 void VulkanReplayConsumerBase::OverrideDestroyDevice(
     PFN_vkDestroyDevice                                        func,
-    const DeviceInfo*                                          device_info,
+    const VulkanDeviceInfo*                                    device_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     VkDevice device = VK_NULL_HANDLE;
@@ -2795,7 +2800,7 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
 VkResult
 VulkanReplayConsumerBase::OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysicalDevices          func,
                                                            VkResult                                original_result,
-                                                           InstanceInfo*                           instance_info,
+                                                           VulkanInstanceInfo*                     instance_info,
                                                            PointerDecoder<uint32_t>*               pPhysicalDeviceCount,
                                                            HandlePointerDecoder<VkPhysicalDevice>* pPhysicalDevices)
 {
@@ -2823,7 +2828,8 @@ VulkanReplayConsumerBase::OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysic
 
         for (uint32_t i = 0; i < replay_device_count; ++i)
         {
-            auto physical_device_info = reinterpret_cast<PhysicalDeviceInfo*>(pPhysicalDevices->GetConsumerData(i));
+            auto physical_device_info =
+                reinterpret_cast<VulkanPhysicalDeviceInfo*>(pPhysicalDevices->GetConsumerData(i));
             assert(physical_device_info != nullptr);
 
             SetPhysicalDeviceInstanceInfo(instance_info, physical_device_info, replay_devices[i]);
@@ -2838,14 +2844,14 @@ VulkanReplayConsumerBase::OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysic
 
             for (uint32_t i = replay_device_count; i < capture_device_count; ++i)
             {
-                PhysicalDeviceInfo overflow_info;
+                VulkanPhysicalDeviceInfo overflow_info;
 
                 overflow_info.handle     = overflow_device;
                 overflow_info.capture_id = capture_devices[i];
                 overflow_info.parent_id  = instance_info->capture_id;
                 SetPhysicalDeviceInstanceInfo(instance_info, &overflow_info, overflow_device);
 
-                object_info_table_.AddPhysicalDeviceInfo(std::move(overflow_info));
+                object_info_table_.AddVkPhysicalDeviceInfo(std::move(overflow_info));
             }
         }
     }
@@ -2856,7 +2862,7 @@ VulkanReplayConsumerBase::OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysic
 VkResult VulkanReplayConsumerBase::OverrideEnumeratePhysicalDeviceGroups(
     PFN_vkEnumeratePhysicalDeviceGroups                            func,
     VkResult                                                       original_result,
-    InstanceInfo*                                                  instance_info,
+    VulkanInstanceInfo*                                            instance_info,
     PointerDecoder<uint32_t>*                                      pPhysicalDeviceGroupCount,
     StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties)
 {
@@ -2953,14 +2959,14 @@ VkResult VulkanReplayConsumerBase::OverrideEnumeratePhysicalDeviceGroups(
                 // There is currently no way to provide pre-initialized info data for a newly created handle that is a
                 // member of a struct, so we insert the handle here.  The generated code will also perform a handle
                 // insertion, which will be ignored.
-                PhysicalDeviceInfo physical_device_info;
+                VulkanPhysicalDeviceInfo physical_device_info;
 
                 physical_device_info.handle     = entry.second;
                 physical_device_info.capture_id = entry.first;
                 physical_device_info.parent_id  = instance_info->capture_id;
                 SetPhysicalDeviceInstanceInfo(instance_info, &physical_device_info, entry.second);
 
-                object_info_table_.AddPhysicalDeviceInfo(std::move(physical_device_info));
+                object_info_table_.AddVkPhysicalDeviceInfo(std::move(physical_device_info));
             }
         }
 
@@ -2981,14 +2987,14 @@ VkResult VulkanReplayConsumerBase::OverrideEnumeratePhysicalDeviceGroups(
 
             for (size_t i = replay_devices.size(); i < capture_devices.size(); ++i)
             {
-                PhysicalDeviceInfo overflow_info;
+                VulkanPhysicalDeviceInfo overflow_info;
 
                 overflow_info.handle     = overflow_device;
                 overflow_info.capture_id = capture_devices[i];
                 overflow_info.parent_id  = instance_info->capture_id;
                 SetPhysicalDeviceInstanceInfo(instance_info, &overflow_info, overflow_device);
 
-                object_info_table_.AddPhysicalDeviceInfo(std::move(overflow_info));
+                object_info_table_.AddVkPhysicalDeviceInfo(std::move(overflow_info));
             }
         }
     }
@@ -2997,7 +3003,7 @@ VkResult VulkanReplayConsumerBase::OverrideEnumeratePhysicalDeviceGroups(
 }
 
 void VulkanReplayConsumerBase::OverrideGetDeviceQueue(PFN_vkGetDeviceQueue           func,
-                                                      DeviceInfo*                    device_info,
+                                                      VulkanDeviceInfo*              device_info,
                                                       uint32_t                       queueFamilyIndex,
                                                       uint32_t                       queueIndex,
                                                       HandlePointerDecoder<VkQueue>* pQueue)
@@ -3014,14 +3020,14 @@ void VulkanReplayConsumerBase::OverrideGetDeviceQueue(PFN_vkGetDeviceQueue      
     // Add tracking for which VkQueue objects are associated with what queue family and index.
     // This is necessary for the virtual swapchain to determine which command buffer to use when
     // Bliting the images on the Presenting Queue.
-    auto queue_info          = reinterpret_cast<QueueInfo*>(pQueue->GetConsumerData(0));
+    auto queue_info          = reinterpret_cast<VulkanQueueInfo*>(pQueue->GetConsumerData(0));
     queue_info->parent       = device;
     queue_info->family_index = queueFamilyIndex;
     queue_info->queue_index  = queueIndex;
 }
 
 void VulkanReplayConsumerBase::OverrideGetDeviceQueue2(PFN_vkGetDeviceQueue2                             func,
-                                                       DeviceInfo*                                       device_info,
+                                                       VulkanDeviceInfo*                                 device_info,
                                                        StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
                                                        HandlePointerDecoder<VkQueue>*                    pQueue)
 {
@@ -3038,7 +3044,7 @@ void VulkanReplayConsumerBase::OverrideGetDeviceQueue2(PFN_vkGetDeviceQueue2    
     // Add tracking for which VkQueue objects are associated with what queue family and index.
     // This is necessary for the virtual swapchain to determine which command buffer to use when
     // Bliting the images on the Presenting Queue.
-    auto queue_info          = reinterpret_cast<QueueInfo*>(pQueue->GetConsumerData(0));
+    auto queue_info          = reinterpret_cast<VulkanQueueInfo*>(pQueue->GetConsumerData(0));
     queue_info->parent       = device;
     queue_info->family_index = in_pQueueInfo->queueFamilyIndex;
     queue_info->queue_index  = in_pQueueInfo->queueIndex;
@@ -3046,7 +3052,7 @@ void VulkanReplayConsumerBase::OverrideGetDeviceQueue2(PFN_vkGetDeviceQueue2    
 
 void VulkanReplayConsumerBase::OverrideGetPhysicalDeviceProperties(
     PFN_vkGetPhysicalDeviceProperties                         func,
-    PhysicalDeviceInfo*                                       physical_device_info,
+    VulkanPhysicalDeviceInfo*                                 physical_device_info,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties)
 {
     assert((physical_device_info != nullptr) && (pProperties != nullptr) && !pProperties->IsNull() &&
@@ -3063,7 +3069,7 @@ void VulkanReplayConsumerBase::OverrideGetPhysicalDeviceProperties(
 
 void VulkanReplayConsumerBase::OverrideGetPhysicalDeviceProperties2(
     PFN_vkGetPhysicalDeviceProperties2                         func,
-    PhysicalDeviceInfo*                                        physical_device_info,
+    VulkanPhysicalDeviceInfo*                                  physical_device_info,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties)
 {
     assert((physical_device_info != nullptr) && (pProperties != nullptr) && !pProperties->IsNull() &&
@@ -3081,7 +3087,7 @@ void VulkanReplayConsumerBase::OverrideGetPhysicalDeviceProperties2(
 
 void VulkanReplayConsumerBase::OverrideGetPhysicalDeviceMemoryProperties(
     PFN_vkGetPhysicalDeviceMemoryProperties                         func,
-    PhysicalDeviceInfo*                                             physical_device_info,
+    VulkanPhysicalDeviceInfo*                                       physical_device_info,
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties>* pMemoryProperties)
 {
     assert((physical_device_info != nullptr) && (pMemoryProperties != nullptr) && !pMemoryProperties->IsNull() &&
@@ -3098,7 +3104,7 @@ void VulkanReplayConsumerBase::OverrideGetPhysicalDeviceMemoryProperties(
 
 void VulkanReplayConsumerBase::OverrideGetPhysicalDeviceMemoryProperties2(
     PFN_vkGetPhysicalDeviceMemoryProperties2                         func,
-    PhysicalDeviceInfo*                                              physical_device_info,
+    VulkanPhysicalDeviceInfo*                                        physical_device_info,
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties)
 {
     assert((physical_device_info != nullptr) && (pMemoryProperties != nullptr) && !pMemoryProperties->IsNull() &&
@@ -3118,8 +3124,8 @@ void VulkanReplayConsumerBase::OverrideGetPhysicalDeviceMemoryProperties2(
 VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceSurfaceCapabilitiesKHR(
     PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR           func,
     VkResult                                                original_result,
-    PhysicalDeviceInfo*                                     physical_device_info,
-    SurfaceKHRInfo*                                         surface_info,
+    VulkanPhysicalDeviceInfo*                               physical_device_info,
+    VulkanSurfaceKHRInfo*                                   surface_info,
     StructPointerDecoder<Decoded_VkSurfaceCapabilitiesKHR>* pSurfaceCapabilities)
 {
     assert((physical_device_info != nullptr) && (surface_info != nullptr) && (pSurfaceCapabilities != nullptr) &&
@@ -3140,7 +3146,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceSurfaceCapabilitiesK
 VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceSurfaceCapabilities2KHR(
     PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR                 func,
     VkResult                                                       original_result,
-    PhysicalDeviceInfo*                                            physical_device_info,
+    VulkanPhysicalDeviceInfo*                                      physical_device_info,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
     StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>*       pSurfaceCapabilities)
 {
@@ -3156,7 +3162,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceSurfaceCapabilities2
     if (result == VK_SUCCESS)
     {
         auto surface_id                                     = pSurfaceInfo->GetMetaStructPointer()->surface;
-        auto surface_info                                   = GetObjectInfoTable().GetSurfaceKHRInfo(surface_id);
+        auto surface_info                                   = GetObjectInfoTable().GetVkSurfaceKHRInfo(surface_id);
         surface_info->surface_capabilities[physical_device] = replay_surface_capabilities->surfaceCapabilities;
     }
     return result;
@@ -3164,7 +3170,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceSurfaceCapabilities2
 
 VkResult VulkanReplayConsumerBase::OverrideWaitForFences(PFN_vkWaitForFences                  func,
                                                          VkResult                             original_result,
-                                                         const DeviceInfo*                    device_info,
+                                                         const VulkanDeviceInfo*              device_info,
                                                          uint32_t                             fenceCount,
                                                          const HandlePointerDecoder<VkFence>* pFences,
                                                          VkBool32                             waitAll,
@@ -3205,7 +3211,7 @@ VkResult VulkanReplayConsumerBase::OverrideWaitForFences(PFN_vkWaitForFences    
         const format::HandleId* fence_handles = pFences->GetPointer();
         for (size_t i = 0; i < pFences->GetLength(); ++i)
         {
-            FenceInfo* fence_info = object_info_table_.GetFenceInfo(fence_handles[i]);
+            VulkanFenceInfo* fence_info = object_info_table_.GetVkFenceInfo(fence_handles[i]);
             if (fence_info != nullptr)
             {
                 VkFence fence_handle = fence_info->handle;
@@ -3256,10 +3262,10 @@ VkResult VulkanReplayConsumerBase::OverrideWaitForFences(PFN_vkWaitForFences    
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideGetFenceStatus(PFN_vkGetFenceStatus func,
-                                                          VkResult             original_result,
-                                                          const DeviceInfo*    device_info,
-                                                          const FenceInfo*     fence_info)
+VkResult VulkanReplayConsumerBase::OverrideGetFenceStatus(PFN_vkGetFenceStatus    func,
+                                                          VkResult                original_result,
+                                                          const VulkanDeviceInfo* device_info,
+                                                          const VulkanFenceInfo*  fence_info)
 {
     assert((device_info != nullptr) && (fence_info != nullptr));
 
@@ -3301,10 +3307,10 @@ VkResult VulkanReplayConsumerBase::OverrideGetFenceStatus(PFN_vkGetFenceStatus f
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideGetEventStatus(PFN_vkGetEventStatus func,
-                                                          VkResult             original_result,
-                                                          const DeviceInfo*    device_info,
-                                                          const EventInfo*     event_info)
+VkResult VulkanReplayConsumerBase::OverrideGetEventStatus(PFN_vkGetEventStatus    func,
+                                                          VkResult                original_result,
+                                                          const VulkanDeviceInfo* device_info,
+                                                          const VulkanEventInfo*  event_info)
 {
     assert((device_info != nullptr) && (event_info != nullptr));
 
@@ -3323,16 +3329,16 @@ VkResult VulkanReplayConsumerBase::OverrideGetEventStatus(PFN_vkGetEventStatus f
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideGetQueryPoolResults(PFN_vkGetQueryPoolResults func,
-                                                               VkResult                  original_result,
-                                                               const DeviceInfo*         device_info,
-                                                               const QueryPoolInfo*      query_pool_info,
-                                                               uint32_t                  firstQuery,
-                                                               uint32_t                  queryCount,
-                                                               size_t                    dataSize,
-                                                               PointerDecoder<uint8_t>*  pData,
-                                                               VkDeviceSize              stride,
-                                                               VkQueryResultFlags        flags)
+VkResult VulkanReplayConsumerBase::OverrideGetQueryPoolResults(PFN_vkGetQueryPoolResults  func,
+                                                               VkResult                   original_result,
+                                                               const VulkanDeviceInfo*    device_info,
+                                                               const VulkanQueryPoolInfo* query_pool_info,
+                                                               uint32_t                   firstQuery,
+                                                               uint32_t                   queryCount,
+                                                               size_t                     dataSize,
+                                                               PointerDecoder<uint8_t>*   pData,
+                                                               VkDeviceSize               stride,
+                                                               VkQueryResultFlags         flags)
 {
     assert((device_info != nullptr) && (query_pool_info != nullptr) && (pData != nullptr) &&
            (pData->GetOutputPointer() != nullptr));
@@ -3352,13 +3358,13 @@ VkResult VulkanReplayConsumerBase::OverrideGetQueryPoolResults(PFN_vkGetQueryPoo
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit func,
-                                                       uint64_t          index,
-                                                       VkResult          original_result,
-                                                       const QueueInfo*  queue_info,
-                                                       uint32_t          submitCount,
+VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit      func,
+                                                       uint64_t               index,
+                                                       VkResult               original_result,
+                                                       const VulkanQueueInfo* queue_info,
+                                                       uint32_t               submitCount,
                                                        const StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
-                                                       const FenceInfo*                                  fence_info)
+                                                       const VulkanFenceInfo*                            fence_info)
 {
     assert((queue_info != nullptr) && (pSubmits != nullptr));
 
@@ -3384,8 +3390,8 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit func,
     {
         // Check for imported semaphores in the current submission list, mapping the pSubmits array index to a vector of
         // imported semaphore info structures.
-        std::unordered_map<uint32_t, std::vector<const SemaphoreInfo*>> altered_submits;
-        std::vector<const SemaphoreInfo*>                               removed_semaphores;
+        std::unordered_map<uint32_t, std::vector<const VulkanSemaphoreInfo*>> altered_submits;
+        std::vector<const VulkanSemaphoreInfo*>                               removed_semaphores;
 
         if (submit_info_data != nullptr)
         {
@@ -3488,12 +3494,12 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit func,
 
     if (screenshot_handler_ != nullptr)
     {
-        CommandBufferInfo* frame_boundary_command_buffer_info = nullptr;
+        VulkanCommandBufferInfo* frame_boundary_command_buffer_info = nullptr;
         for (uint32_t i = 0; i < submitCount; ++i)
         {
             if (submit_info_data != nullptr)
             {
-                if (CheckPNextChainForFrameBoundary(object_info_table_.GetDeviceInfo(queue_info->parent_id),
+                if (CheckPNextChainForFrameBoundary(object_info_table_.GetVkDeviceInfo(queue_info->parent_id),
                                                     submit_info_data->pNext))
                 {
                     break;
@@ -3503,12 +3509,12 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit func,
                 const auto command_buffer_ids   = submit_info_data[i].pCommandBuffers.GetPointer();
                 for (uint32_t j = 0; j < command_buffer_count; ++j)
                 {
-                    auto command_buffer_info = GetObjectInfoTable().GetCommandBufferInfo(command_buffer_ids[j]);
+                    auto command_buffer_info = GetObjectInfoTable().GetVkCommandBufferInfo(command_buffer_ids[j]);
 
                     // Apply any layouts from submitted command lists.
                     for (auto image_layout : command_buffer_info->image_layout_barriers)
                     {
-                        auto image_info = GetObjectInfoTable().GetImageInfo(image_layout.first);
+                        auto image_info = GetObjectInfoTable().GetVkImageInfo(image_layout.first);
                         if (image_info != nullptr)
                         {
                             image_info->current_layout = image_layout.second;
@@ -3528,12 +3534,12 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit func,
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2 func,
-                                                        VkResult           original_result,
-                                                        const QueueInfo*   queue_info,
-                                                        uint32_t           submitCount,
+VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2     func,
+                                                        VkResult               original_result,
+                                                        const VulkanQueueInfo* queue_info,
+                                                        uint32_t               submitCount,
                                                         const StructPointerDecoder<Decoded_VkSubmitInfo2>* pSubmits,
-                                                        const FenceInfo*                                   fence_info)
+                                                        const VulkanFenceInfo*                             fence_info)
 {
     assert((queue_info != nullptr) && (pSubmits != nullptr));
 
@@ -3559,8 +3565,8 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2 func,
     {
         // Check for imported semaphores in the current submission list, mapping the pSubmits array index to a vector of
         // imported semaphore info structures.
-        std::unordered_map<uint32_t, std::vector<const SemaphoreInfo*>> altered_submits;
-        std::vector<const SemaphoreInfo*>                               removed_semaphores;
+        std::unordered_map<uint32_t, std::vector<const VulkanSemaphoreInfo*>> altered_submits;
+        std::vector<const VulkanSemaphoreInfo*>                               removed_semaphores;
 
         if (submit_info_data != nullptr)
         {
@@ -3668,7 +3674,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2 func,
         {
             if (submit_info_data != nullptr)
             {
-                if (CheckPNextChainForFrameBoundary(object_info_table_.GetDeviceInfo(queue_info->parent_id),
+                if (CheckPNextChainForFrameBoundary(object_info_table_.GetVkDeviceInfo(queue_info->parent_id),
                                                     submit_info_data->pNext))
                 {
                     break;
@@ -3679,7 +3685,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2 func,
                 for (uint32_t j = 0; j < command_buffer_count; ++j)
                 {
                     auto command_buffer_info =
-                        GetObjectInfoTable().GetCommandBufferInfo(command_buffer_infos[j].commandBuffer);
+                        GetObjectInfoTable().GetVkCommandBufferInfo(command_buffer_infos[j].commandBuffer);
                     if (CheckCommandBufferInfoForFrameBoundary(command_buffer_info))
                     {
                         break;
@@ -3695,10 +3701,10 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2 func,
 VkResult
 VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse                                 func,
                                                   VkResult                                              original_result,
-                                                  const QueueInfo*                                      queue_info,
+                                                  const VulkanQueueInfo*                                queue_info,
                                                   uint32_t                                              bindInfoCount,
                                                   const StructPointerDecoder<Decoded_VkBindSparseInfo>* pBindInfo,
-                                                  const FenceInfo*                                      fence_info)
+                                                  const VulkanFenceInfo*                                fence_info)
 {
     assert((queue_info != nullptr) && (pBindInfo != nullptr) && !pBindInfo->IsNull());
 
@@ -3722,8 +3728,8 @@ VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse         
     {
         // Check for imported semaphores in the current bind info list, mapping the pBindInfo array index to a vector of
         // imported semaphore info structures.
-        std::unordered_map<uint32_t, std::vector<const SemaphoreInfo*>> altered_submits;
-        std::vector<const SemaphoreInfo*>                               removed_semaphores;
+        std::unordered_map<uint32_t, std::vector<const VulkanSemaphoreInfo*>> altered_submits;
+        std::vector<const VulkanSemaphoreInfo*>                               removed_semaphores;
 
         auto bind_info_data = pBindInfo->GetMetaStructPointer();
         if (bind_info_data != nullptr)
@@ -3817,7 +3823,7 @@ VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse         
 VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorSetLayout(
     PFN_vkCreateDescriptorSetLayout                                func,
     VkResult                                                       original_result,
-    const DeviceInfo*                                              device_info,
+    const VulkanDeviceInfo*                                        device_info,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>*           pAllocator,
     HandlePointerDecoder<VkDescriptorSetLayout>*                   pSetLayout)
@@ -3832,7 +3838,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorSetLayout(
     // The information gathered here is only relevant to the dump resources feature
     if (result >= 0 && options_.dumping_resources)
     {
-        auto layout_info = reinterpret_cast<DescriptorSetLayoutInfo*>(pSetLayout->GetConsumerData(0));
+        auto layout_info = reinterpret_cast<VulkanDescriptorSetLayoutInfo*>(pSetLayout->GetConsumerData(0));
         assert(layout_info != nullptr);
 
         const auto create_info_meta = pCreateInfo->GetMetaStructPointer();
@@ -3859,7 +3865,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorSetLayout(
 VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorPool(
     PFN_vkCreateDescriptorPool                                      func,
     VkResult                                                        original_result,
-    const DeviceInfo*                                               device_info,
+    const VulkanDeviceInfo*                                         device_info,
     const StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*      pAllocator,
     HandlePointerDecoder<VkDescriptorPool>*                         pDescriptorPool)
@@ -3877,7 +3883,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorPool(
         // Due to capture and replay differences, it is possible for descriptor set allocation to fail with the
         // descriptor pool running out of memory.  To handle this case, replay will store the pool creation info so that
         // it can attempt to recover from an out of pool memory event by creating a new pool with the same properties.
-        auto pool_info = reinterpret_cast<DescriptorPoolInfo*>(pDescriptorPool->GetConsumerData(0));
+        auto pool_info = reinterpret_cast<VulkanDescriptorPoolInfo*>(pDescriptorPool->GetConsumerData(0));
         assert(pool_info != nullptr);
 
         pool_info->flags    = create_info->flags;
@@ -3913,8 +3919,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorPool(
 
 void VulkanReplayConsumerBase::OverrideDestroyDescriptorPool(
     PFN_vkDestroyDescriptorPool                                func,
-    const DeviceInfo*                                          device_info,
-    DescriptorPoolInfo*                                        descriptor_pool_info,
+    const VulkanDeviceInfo*                                    device_info,
+    VulkanDescriptorPoolInfo*                                  descriptor_pool_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     assert(device_info != nullptr);
@@ -3940,7 +3946,7 @@ void VulkanReplayConsumerBase::OverrideDestroyDescriptorPool(
 VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
     PFN_vkAllocateDescriptorSets                                     func,
     VkResult                                                         original_result,
-    const DeviceInfo*                                                device_info,
+    const VulkanDeviceInfo*                                          device_info,
     const StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
     HandlePointerDecoder<VkDescriptorSet>*                           pDescriptorSets)
 {
@@ -3959,7 +3965,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
             // descriptor pool and attempting the allocation a second time.
             VkDescriptorPool new_pool  = VK_NULL_HANDLE;
             auto             meta_info = pAllocateInfo->GetMetaStructPointer();
-            auto             pool_info = object_info_table_.GetDescriptorPoolInfo(meta_info->descriptorPool);
+            auto             pool_info = object_info_table_.GetVkDescriptorPoolInfo(meta_info->descriptorPool);
 
             VkDescriptorPoolCreateInfo create_info = { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
             create_info.pNext                      = nullptr;
@@ -4017,12 +4023,12 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
 
             for (uint32_t i = 0; i < desc_set_count; ++i)
             {
-                DescriptorSetInfo* desc_info =
-                    reinterpret_cast<DescriptorSetInfo*>(pDescriptorSets->GetConsumerData(i));
+                VulkanDescriptorSetInfo* desc_info =
+                    reinterpret_cast<VulkanDescriptorSetInfo*>(pDescriptorSets->GetConsumerData(i));
                 assert(desc_info != nullptr);
 
-                DescriptorSetLayoutInfo* set_layout_info =
-                    object_info_table_.GetDescriptorSetLayoutInfo(set_layout_ids[i]);
+                VulkanDescriptorSetLayoutInfo* set_layout_info =
+                    object_info_table_.GetVkDescriptorSetLayoutInfo(set_layout_ids[i]);
                 assert(set_layout_info != nullptr);
 
                 for (const auto& layout_binding : set_layout_info->bindings_layout)
@@ -4095,7 +4101,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
 VkResult VulkanReplayConsumerBase::OverrideAllocateCommandBuffers(
     PFN_vkAllocateCommandBuffers                                     func,
     VkResult                                                         original_result,
-    const DeviceInfo*                                                device_info,
+    const VulkanDeviceInfo*                                          device_info,
     const StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
     HandlePointerDecoder<VkCommandBuffer>*                           pCommandBuffers)
 {
@@ -4118,8 +4124,8 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateCommandBuffers(
 }
 
 void VulkanReplayConsumerBase::OverrideFreeCommandBuffers(PFN_vkFreeCommandBuffers               func,
-                                                          const DeviceInfo*                      device_info,
-                                                          CommandPoolInfo*                       command_pool_info,
+                                                          const VulkanDeviceInfo*                device_info,
+                                                          VulkanCommandPoolInfo*                 command_pool_info,
                                                           uint32_t                               command_buffer_count,
                                                           HandlePointerDecoder<VkCommandBuffer>* pCommandBuffers)
 {
@@ -4136,7 +4142,7 @@ void VulkanReplayConsumerBase::OverrideFreeCommandBuffers(PFN_vkFreeCommandBuffe
             {
                 if (options_.dumping_resources)
                 {
-                    CommandBufferInfo* cb_info = object_info_table_.GetCommandBufferInfo(*it);
+                    VulkanCommandBufferInfo* cb_info = object_info_table_.GetVkCommandBufferInfo(*it);
                     assert(cb_info != nullptr);
                     resource_dumper.ResetCommandBuffer(cb_info->handle);
                 }
@@ -4151,7 +4157,7 @@ void VulkanReplayConsumerBase::OverrideFreeCommandBuffers(PFN_vkFreeCommandBuffe
 VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
     PFN_vkAllocateMemory                                       func,
     VkResult                                                   original_result,
-    const DeviceInfo*                                          device_info,
+    const VulkanDeviceInfo*                                    device_info,
     const StructPointerDecoder<Decoded_VkMemoryAllocateInfo>*  pAllocateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDeviceMemory>*                      pMemory)
@@ -4277,7 +4283,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
         if ((result == VK_SUCCESS) && (replay_allocate_info != nullptr) && ((*replay_memory) != VK_NULL_HANDLE))
         {
-            auto memory_info = reinterpret_cast<DeviceMemoryInfo*>(pMemory->GetConsumerData(0));
+            auto memory_info = reinterpret_cast<VulkanDeviceMemoryInfo*>(pMemory->GetConsumerData(0));
             assert(memory_info != nullptr);
 
             memory_info->allocator      = allocator;
@@ -4305,14 +4311,14 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideMapMemory(PFN_vkMapMemory   func,
-                                                     VkResult          original_result,
-                                                     const DeviceInfo* device_info,
-                                                     DeviceMemoryInfo* memory_info,
-                                                     VkDeviceSize      offset,
-                                                     VkDeviceSize      size,
-                                                     VkMemoryMapFlags  flags,
-                                                     void**            ppData)
+VkResult VulkanReplayConsumerBase::OverrideMapMemory(PFN_vkMapMemory         func,
+                                                     VkResult                original_result,
+                                                     const VulkanDeviceInfo* device_info,
+                                                     VulkanDeviceMemoryInfo* memory_info,
+                                                     VkDeviceSize            offset,
+                                                     VkDeviceSize            size,
+                                                     VkMemoryMapFlags        flags,
+                                                     void**                  ppData)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
@@ -4325,9 +4331,9 @@ VkResult VulkanReplayConsumerBase::OverrideMapMemory(PFN_vkMapMemory   func,
     return allocator->MapMemory(memory_info->handle, offset, size, flags, ppData, memory_info->allocator_data);
 }
 
-void VulkanReplayConsumerBase::OverrideUnmapMemory(PFN_vkUnmapMemory func,
-                                                   const DeviceInfo* device_info,
-                                                   DeviceMemoryInfo* memory_info)
+void VulkanReplayConsumerBase::OverrideUnmapMemory(PFN_vkUnmapMemory       func,
+                                                   const VulkanDeviceInfo* device_info,
+                                                   VulkanDeviceMemoryInfo* memory_info)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
 
@@ -4342,7 +4348,7 @@ void VulkanReplayConsumerBase::OverrideUnmapMemory(PFN_vkUnmapMemory func,
 VkResult VulkanReplayConsumerBase::OverrideFlushMappedMemoryRanges(
     PFN_vkFlushMappedMemoryRanges                            func,
     VkResult                                                 original_result,
-    const DeviceInfo*                                        device_info,
+    const VulkanDeviceInfo*                                  device_info,
     uint32_t                                                 memoryRangeCount,
     const StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges)
 {
@@ -4357,7 +4363,7 @@ VkResult VulkanReplayConsumerBase::OverrideFlushMappedMemoryRanges(
 
     for (uint32_t i = 0; i < memoryRangeCount; ++i)
     {
-        auto memory_info = object_info_table_.GetDeviceMemoryInfo(replay_range_meta_datas[i].memory);
+        auto memory_info = object_info_table_.GetVkDeviceMemoryInfo(replay_range_meta_datas[i].memory);
 
         if (memory_info != nullptr)
         {
@@ -4374,7 +4380,7 @@ VkResult VulkanReplayConsumerBase::OverrideFlushMappedMemoryRanges(
 VkResult VulkanReplayConsumerBase::OverrideInvalidateMappedMemoryRanges(
     PFN_vkInvalidateMappedMemoryRanges                       func,
     VkResult                                                 original_result,
-    const DeviceInfo*                                        device_info,
+    const VulkanDeviceInfo*                                  device_info,
     uint32_t                                                 memoryRangeCount,
     const StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges)
 {
@@ -4389,7 +4395,7 @@ VkResult VulkanReplayConsumerBase::OverrideInvalidateMappedMemoryRanges(
 
     for (uint32_t i = 0; i < memoryRangeCount; ++i)
     {
-        auto memory_info = object_info_table_.GetDeviceMemoryInfo(replay_range_meta_datas[i].memory);
+        auto memory_info = object_info_table_.GetVkDeviceMemoryInfo(replay_range_meta_datas[i].memory);
 
         if (memory_info != nullptr)
         {
@@ -4404,9 +4410,9 @@ VkResult VulkanReplayConsumerBase::OverrideInvalidateMappedMemoryRanges(
         memoryRangeCount, pMemoryRanges->GetPointer(), allocator_datas.data());
 }
 
-void VulkanReplayConsumerBase::OverrideFreeMemory(PFN_vkFreeMemory  func,
-                                                  const DeviceInfo* device_info,
-                                                  DeviceMemoryInfo* memory_info,
+void VulkanReplayConsumerBase::OverrideFreeMemory(PFN_vkFreeMemory        func,
+                                                  const VulkanDeviceInfo* device_info,
+                                                  VulkanDeviceMemoryInfo* memory_info,
                                                   const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
@@ -4437,12 +4443,12 @@ void VulkanReplayConsumerBase::OverrideFreeMemory(PFN_vkFreeMemory  func,
     allocator->FreeMemory(memory, GetAllocationCallbacks(pAllocator), allocator_data);
 }
 
-VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory(PFN_vkBindBufferMemory func,
-                                                            VkResult               original_result,
-                                                            const DeviceInfo*      device_info,
-                                                            BufferInfo*            buffer_info,
-                                                            DeviceMemoryInfo*      memory_info,
-                                                            VkDeviceSize           memoryOffset)
+VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory(PFN_vkBindBufferMemory  func,
+                                                            VkResult                original_result,
+                                                            const VulkanDeviceInfo* device_info,
+                                                            VulkanBufferInfo*       buffer_info,
+                                                            VulkanDeviceMemoryInfo* memory_info,
+                                                            VkDeviceSize            memoryOffset)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
@@ -4496,7 +4502,7 @@ VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory(PFN_vkBindBufferMemo
 VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory2(
     PFN_vkBindBufferMemory2                                     func,
     VkResult                                                    original_result,
-    const DeviceInfo*                                           device_info,
+    const VulkanDeviceInfo*                                     device_info,
     uint32_t                                                    bindInfoCount,
     const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos)
 {
@@ -4509,8 +4515,8 @@ VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory2(
     auto replay_bind_meta_infos = pBindInfos->GetMetaStructPointer();
     assert((replay_bind_infos != nullptr) && (replay_bind_meta_infos != nullptr));
 
-    std::vector<BufferInfo*>                           buffer_infos;
-    std::vector<const DeviceMemoryInfo*>               memory_infos;
+    std::vector<VulkanBufferInfo*>                     buffer_infos;
+    std::vector<const VulkanDeviceMemoryInfo*>         memory_infos;
     std::vector<VulkanResourceAllocator::ResourceData> allocator_buffer_datas(bindInfoCount, 0);
     std::vector<VulkanResourceAllocator::MemoryData>   allocator_memory_datas(bindInfoCount, 0);
     std::vector<VkMemoryPropertyFlags>                 memory_property_flags(bindInfoCount, 0);
@@ -4519,8 +4525,8 @@ VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory2(
     {
         const Decoded_VkBindBufferMemoryInfo* bind_meta_info = &replay_bind_meta_infos[i];
 
-        auto buffer_info = object_info_table_.GetBufferInfo(bind_meta_info->buffer);
-        auto memory_info = object_info_table_.GetDeviceMemoryInfo(bind_meta_info->memory);
+        auto buffer_info = object_info_table_.GetVkBufferInfo(bind_meta_info->buffer);
+        auto memory_info = object_info_table_.GetVkDeviceMemoryInfo(bind_meta_info->memory);
 
         buffer_infos.push_back(buffer_info);
         memory_infos.push_back(memory_info);
@@ -4568,12 +4574,12 @@ VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory2(
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideBindImageMemory(PFN_vkBindImageMemory func,
-                                                           VkResult              original_result,
-                                                           const DeviceInfo*     device_info,
-                                                           ImageInfo*            image_info,
-                                                           DeviceMemoryInfo*     memory_info,
-                                                           VkDeviceSize          memoryOffset)
+VkResult VulkanReplayConsumerBase::OverrideBindImageMemory(PFN_vkBindImageMemory   func,
+                                                           VkResult                original_result,
+                                                           const VulkanDeviceInfo* device_info,
+                                                           VulkanImageInfo*        image_info,
+                                                           VulkanDeviceMemoryInfo* memory_info,
+                                                           VkDeviceSize            memoryOffset)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
@@ -4604,7 +4610,7 @@ VkResult VulkanReplayConsumerBase::OverrideBindImageMemory(PFN_vkBindImageMemory
 VkResult VulkanReplayConsumerBase::OverrideBindImageMemory2(
     PFN_vkBindImageMemory2                                     func,
     VkResult                                                   original_result,
-    const DeviceInfo*                                          device_info,
+    const VulkanDeviceInfo*                                    device_info,
     uint32_t                                                   bindInfoCount,
     const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos)
 {
@@ -4617,8 +4623,8 @@ VkResult VulkanReplayConsumerBase::OverrideBindImageMemory2(
     auto replay_bind_meta_infos = pBindInfos->GetMetaStructPointer();
     assert((replay_bind_infos != nullptr) && (replay_bind_meta_infos != nullptr));
 
-    std::vector<ImageInfo*>                            image_infos;
-    std::vector<const DeviceMemoryInfo*>               memory_infos;
+    std::vector<VulkanImageInfo*>                      image_infos;
+    std::vector<const VulkanDeviceMemoryInfo*>         memory_infos;
     std::vector<VulkanResourceAllocator::ResourceData> allocator_image_datas(bindInfoCount, 0);
     std::vector<VulkanResourceAllocator::MemoryData>   allocator_memory_datas(bindInfoCount, 0);
     std::vector<VkMemoryPropertyFlags>                 memory_property_flags(bindInfoCount, 0);
@@ -4627,8 +4633,8 @@ VkResult VulkanReplayConsumerBase::OverrideBindImageMemory2(
     {
         const Decoded_VkBindImageMemoryInfo* bind_meta_info = &replay_bind_meta_infos[i];
 
-        auto image_info  = object_info_table_.GetImageInfo(bind_meta_info->image);
-        auto memory_info = object_info_table_.GetDeviceMemoryInfo(bind_meta_info->memory);
+        auto image_info  = object_info_table_.GetVkImageInfo(bind_meta_info->image);
+        auto memory_info = object_info_table_.GetVkDeviceMemoryInfo(bind_meta_info->memory);
 
         image_infos.push_back(image_info);
         memory_infos.push_back(memory_info);
@@ -4680,8 +4686,8 @@ VkResult VulkanReplayConsumerBase::OverrideBindImageMemory2(
 VkResult VulkanReplayConsumerBase::OverrideBindVideoSessionMemoryKHR(
     PFN_vkBindVideoSessionMemoryKHR                                func,
     VkResult                                                       original_result,
-    const DeviceInfo*                                              device_info,
-    VideoSessionKHRInfo*                                           video_session_info,
+    const VulkanDeviceInfo*                                        device_info,
+    VulkanVideoSessionKHRInfo*                                     video_session_info,
     uint32_t                                                       bindSessionMemoryInfoCount,
     StructPointerDecoder<Decoded_VkBindVideoSessionMemoryInfoKHR>* pBindSessionMemoryInfos)
 {
@@ -4705,7 +4711,7 @@ VkResult VulkanReplayConsumerBase::OverrideBindVideoSessionMemoryKHR(
     GFXRECON_ASSERT((replay_bind_infos != nullptr) && (replay_bind_meta_infos != nullptr));
 
     uint32_t                                           session_mem_count = video_session_info->allocator_datas.size();
-    std::vector<const DeviceMemoryInfo*>               memory_infos;
+    std::vector<const VulkanDeviceMemoryInfo*>         memory_infos;
     std::vector<VulkanResourceAllocator::ResourceData> allocator_session_datas(session_mem_count, 0);
     std::vector<VulkanResourceAllocator::MemoryData>   allocator_memory_datas(session_mem_count, 0);
     std::vector<VkMemoryPropertyFlags>                 memory_property_flags(session_mem_count, 0);
@@ -4719,7 +4725,7 @@ VkResult VulkanReplayConsumerBase::OverrideBindVideoSessionMemoryKHR(
             const auto* bind_meta_info = &replay_bind_meta_infos[i];
             if (mem_index == bind_meta_info->decoded_value->memoryBindIndex)
             {
-                auto memory_info = object_info_table_.GetDeviceMemoryInfo(bind_meta_info->memory);
+                auto memory_info = object_info_table_.GetVkDeviceMemoryInfo(bind_meta_info->memory);
                 memory_infos.push_back(memory_info);
 
                 if (memory_info != nullptr)
@@ -4761,7 +4767,7 @@ VkResult VulkanReplayConsumerBase::OverrideBindVideoSessionMemoryKHR(
 VkResult
 VulkanReplayConsumerBase::OverrideCreateBuffer(PFN_vkCreateBuffer                                      func,
                                                VkResult                                                original_result,
-                                               const DeviceInfo*                                       device_info,
+                                               const VulkanDeviceInfo*                                 device_info,
                                                const StructPointerDecoder<Decoded_VkBufferCreateInfo>* pCreateInfo,
                                                const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                                HandlePointerDecoder<VkBuffer>*                            pBuffer)
@@ -4851,7 +4857,7 @@ VulkanReplayConsumerBase::OverrideCreateBuffer(PFN_vkCreateBuffer               
 
     if ((result == VK_SUCCESS) && (replay_create_info != nullptr) && ((*replay_buffer) != VK_NULL_HANDLE))
     {
-        auto buffer_info = reinterpret_cast<BufferInfo*>(pBuffer->GetConsumerData(0));
+        auto buffer_info = reinterpret_cast<VulkanBufferInfo*>(pBuffer->GetConsumerData(0));
         assert(buffer_info != nullptr);
 
         buffer_info->allocator_data = allocator_data;
@@ -4874,8 +4880,8 @@ VulkanReplayConsumerBase::OverrideCreateBuffer(PFN_vkCreateBuffer               
 
 void VulkanReplayConsumerBase::OverrideDestroyBuffer(
     PFN_vkDestroyBuffer                                        func,
-    const DeviceInfo*                                          device_info,
-    BufferInfo*                                                buffer_info,
+    const VulkanDeviceInfo*                                    device_info,
+    VulkanBufferInfo*                                          buffer_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
@@ -4905,7 +4911,7 @@ void VulkanReplayConsumerBase::OverrideDestroyBuffer(
 VkResult
 VulkanReplayConsumerBase::OverrideCreateImage(PFN_vkCreateImage                                      func,
                                               VkResult                                               original_result,
-                                              const DeviceInfo*                                      device_info,
+                                              const VulkanDeviceInfo*                                device_info,
                                               const StructPointerDecoder<Decoded_VkImageCreateInfo>* pCreateInfo,
                                               const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                               HandlePointerDecoder<VkImage>*                             pImage)
@@ -4941,7 +4947,7 @@ VulkanReplayConsumerBase::OverrideCreateImage(PFN_vkCreateImage                 
 
     if ((result == VK_SUCCESS) && (replay_create_info != nullptr) && ((*replay_image) != VK_NULL_HANDLE))
     {
-        auto image_info = reinterpret_cast<ImageInfo*>(pImage->GetConsumerData(0));
+        auto image_info = reinterpret_cast<VulkanImageInfo*>(pImage->GetConsumerData(0));
         assert(image_info != nullptr);
 
         image_info->allocator_data = allocator_data;
@@ -4973,8 +4979,8 @@ VulkanReplayConsumerBase::OverrideCreateImage(PFN_vkCreateImage                 
 
 void VulkanReplayConsumerBase::OverrideDestroyImage(
     PFN_vkDestroyImage                                         func,
-    const DeviceInfo*                                          device_info,
-    ImageInfo*                                                 image_info,
+    const VulkanDeviceInfo*                                    device_info,
+    VulkanImageInfo*                                           image_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
@@ -5001,7 +5007,7 @@ void VulkanReplayConsumerBase::OverrideDestroyImage(
 VkResult VulkanReplayConsumerBase::OverrideCreateVideoSessionKHR(
     PFN_vkCreateVideoSessionKHR                                      func,
     VkResult                                                         original_result,
-    const DeviceInfo*                                                device_info,
+    const VulkanDeviceInfo*                                          device_info,
     const StructPointerDecoder<Decoded_VkVideoSessionCreateInfoKHR>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
     HandlePointerDecoder<VkVideoSessionKHR>*                         pVideoSession)
@@ -5025,7 +5031,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateVideoSessionKHR(
 
     if ((result == VK_SUCCESS) && (replay_create_info != nullptr) && ((*replay_session) != VK_NULL_HANDLE))
     {
-        auto session_info = reinterpret_cast<VideoSessionKHRInfo*>(pVideoSession->GetConsumerData(0));
+        auto session_info = reinterpret_cast<VulkanVideoSessionKHRInfo*>(pVideoSession->GetConsumerData(0));
         GFXRECON_ASSERT(session_info != nullptr);
 
         session_info->allocator_datas    = allocator_datas;
@@ -5037,8 +5043,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateVideoSessionKHR(
 
 void VulkanReplayConsumerBase::OverrideDestroyVideoSessionKHR(
     PFN_vkDestroyVideoSessionKHR                               func,
-    const DeviceInfo*                                          device_info,
-    VideoSessionKHRInfo*                                       video_session_info,
+    const VulkanDeviceInfo*                                    device_info,
+    VulkanVideoSessionKHRInfo*                                 video_session_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
@@ -5064,8 +5070,8 @@ void VulkanReplayConsumerBase::OverrideDestroyVideoSessionKHR(
 
 void VulkanReplayConsumerBase::OverrideGetImageSubresourceLayout(
     PFN_vkGetImageSubresourceLayout                         func,
-    const DeviceInfo*                                       device_info,
-    const ImageInfo*                                        image_info,
+    const VulkanDeviceInfo*                                 device_info,
+    const VulkanImageInfo*                                  image_info,
     const StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
     StructPointerDecoder<Decoded_VkSubresourceLayout>*      pLayout)
 {
@@ -5094,7 +5100,7 @@ void StoreAttachmentDescriptionFinalLayouts(const T* pCreateInfo, HandlePointerD
     {
         GFXRECON_ASSERT(pCreateInfo->GetMetaStructPointer()->pAttachments != nullptr);
         const auto* attachment_descs = pCreateInfo->GetMetaStructPointer()->pAttachments->GetPointer();
-        auto        render_pass_info = reinterpret_cast<RenderPassInfo*>(pRenderPass->GetConsumerData(0));
+        auto        render_pass_info = reinterpret_cast<VulkanRenderPassInfo*>(pRenderPass->GetConsumerData(0));
         GFXRECON_ASSERT(render_pass_info != nullptr)
 
         // Save attachment descriptions to RenderPassInfo.
@@ -5109,7 +5115,7 @@ void StoreAttachmentDescriptionFinalLayouts(const T* pCreateInfo, HandlePointerD
 VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass(
     PFN_vkCreateRenderPass                                      func,
     VkResult                                                    original_result,
-    const DeviceInfo*                                           device_info,
+    const VulkanDeviceInfo*                                     device_info,
     const StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*  pAllocator,
     HandlePointerDecoder<VkRenderPass>*                         pRenderPass)
@@ -5130,7 +5136,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass(
     }
 
     const VkRenderPassCreateInfo* create_info      = pCreateInfo->GetPointer();
-    auto                          render_pass_info = reinterpret_cast<RenderPassInfo*>(pRenderPass->GetConsumerData(0));
+    auto render_pass_info = reinterpret_cast<VulkanRenderPassInfo*>(pRenderPass->GetConsumerData(0));
     assert(render_pass_info);
 
     // Copy attachments
@@ -5144,7 +5150,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass(
     render_pass_info->subpass_refs.reserve(create_info->subpassCount);
     for (uint32_t i = 0; i < create_info->subpassCount; ++i)
     {
-        struct RenderPassInfo::SubpassReferences sp_ref;
+        struct VulkanRenderPassInfo::SubpassReferences sp_ref;
 
         // Copy input attachment refs
         for (uint32_t s = 0; s < create_info->pSubpasses[i].inputAttachmentCount; ++s)
@@ -5249,7 +5255,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass(
 VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass2(
     PFN_vkCreateRenderPass2                                      func,
     VkResult                                                     original_result,
-    const DeviceInfo*                                            device_info,
+    const VulkanDeviceInfo*                                      device_info,
     const StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
     HandlePointerDecoder<VkRenderPass>*                          pRenderPass)
@@ -5269,7 +5275,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass2(
     }
 
     const VkRenderPassCreateInfo2* create_info = pCreateInfo->GetPointer();
-    auto render_pass_info                      = reinterpret_cast<RenderPassInfo*>(pRenderPass->GetConsumerData(0));
+    auto render_pass_info = reinterpret_cast<VulkanRenderPassInfo*>(pRenderPass->GetConsumerData(0));
     assert(render_pass_info);
 
     render_pass_info->attachment_descs.resize(create_info->attachmentCount);
@@ -5289,7 +5295,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass2(
     render_pass_info->subpass_refs.reserve(create_info->subpassCount);
     for (uint32_t i = 0; i < create_info->subpassCount; ++i)
     {
-        struct RenderPassInfo::SubpassReferences sp_ref;
+        struct VulkanRenderPassInfo::SubpassReferences sp_ref;
         sp_ref.color_att_refs.resize(create_info->pSubpasses[i].colorAttachmentCount);
         for (uint32_t s = 0; s < create_info->pSubpasses[i].colorAttachmentCount; ++s)
         {
@@ -5323,7 +5329,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass2(
 
 void VulkanReplayConsumerBase::OverrideCmdPipelineBarrier(
     PFN_vkCmdPipelineBarrier                                   func,
-    CommandBufferInfo*                                         command_buffer_info,
+    VulkanCommandBufferInfo*                                   command_buffer_info,
     VkPipelineStageFlags                                       srcStageMask,
     VkPipelineStageFlags                                       dstStageMask,
     VkDependencyFlags                                          dependencyFlags,
@@ -5350,7 +5356,7 @@ void VulkanReplayConsumerBase::OverrideCmdPipelineBarrier(
     {
         auto image_id                                        = pImageMemoryBarriers->GetMetaStructPointer()[i].image;
         command_buffer_info->image_layout_barriers[image_id] = pImageMemoryBarriers->GetPointer()[i].newLayout;
-        ImageInfo* img_info                                  = object_info_table_.GetImageInfo(image_id);
+        VulkanImageInfo* img_info                            = object_info_table_.GetVkImageInfo(image_id);
         assert(img_info != nullptr);
         img_info->intermediate_layout = pImageMemoryBarriers->GetPointer()[i].newLayout;
     }
@@ -5358,7 +5364,7 @@ void VulkanReplayConsumerBase::OverrideCmdPipelineBarrier(
 
 void VulkanReplayConsumerBase::OverrideCmdPipelineBarrier2(
     PFN_vkCmdPipelineBarrier2                       func,
-    CommandBufferInfo*                              command_buffer_info,
+    VulkanCommandBufferInfo*                        command_buffer_info,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
 {
     swapchain_->CmdPipelineBarrier2(func, command_buffer_info, pDependencyInfo->GetPointer());
@@ -5375,7 +5381,7 @@ void VulkanReplayConsumerBase::OverrideCmdPipelineBarrier2(
                 command_buffer_info->image_layout_barriers[image_id] =
                     dependency_info_meta->pImageMemoryBarriers->GetPointer()[i].newLayout;
 
-                ImageInfo* img_info           = object_info_table_.GetImageInfo(image_id);
+                VulkanImageInfo* img_info     = object_info_table_.GetVkImageInfo(image_id);
                 img_info->intermediate_layout = dependency_info_meta->pImageMemoryBarriers->GetPointer()[i].newLayout;
             }
         }
@@ -5384,7 +5390,7 @@ void VulkanReplayConsumerBase::OverrideCmdPipelineBarrier2(
 
 void VulkanReplayConsumerBase::OverrideCmdPipelineBarrier2KHR(
     PFN_vkCmdPipelineBarrier2                       func,
-    CommandBufferInfo*                              command_buffer_info,
+    VulkanCommandBufferInfo*                        command_buffer_info,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
 {
     OverrideCmdPipelineBarrier2(func, command_buffer_info, pDependencyInfo);
@@ -5393,7 +5399,7 @@ void VulkanReplayConsumerBase::OverrideCmdPipelineBarrier2KHR(
 VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorUpdateTemplate(
     PFN_vkCreateDescriptorUpdateTemplate                                      func,
     VkResult                                                                  original_result,
-    const DeviceInfo*                                                         device_info,
+    const VulkanDeviceInfo*                                                   device_info,
     const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*                pAllocator,
     HandlePointerDecoder<VkDescriptorUpdateTemplate>*                         pDescriptorUpdateTemplate)
@@ -5527,7 +5533,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorUpdateTemplate(
         if ((result == VK_SUCCESS) && ((*replay_template) != VK_NULL_HANDLE))
         {
             auto update_template_info =
-                reinterpret_cast<DescriptorUpdateTemplateInfo*>(pDescriptorUpdateTemplate->GetConsumerData(0));
+                reinterpret_cast<VulkanDescriptorUpdateTemplateInfo*>(pDescriptorUpdateTemplate->GetConsumerData(0));
             assert(update_template_info != nullptr);
 
             update_template_info->descriptor_image_types = std::move(image_types);
@@ -5547,8 +5553,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorUpdateTemplate(
 
 void VulkanReplayConsumerBase::OverrideDestroyDescriptorUpdateTemplate(
     PFN_vkDestroyDescriptorUpdateTemplate                      func,
-    const DeviceInfo*                                          device_info,
-    const DescriptorUpdateTemplateInfo*                        descriptor_update_template_info,
+    const VulkanDeviceInfo*                                    device_info,
+    const VulkanDescriptorUpdateTemplateInfo*                  descriptor_update_template_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     assert(device_info != nullptr);
@@ -5611,7 +5617,7 @@ static VkDescriptorType SpvReflectToVkDescriptorType(SpvReflectDescriptorType ty
     }
 }
 
-static bool SPIRVReflectPerformReflectionOnShaderModule(ShaderModuleInfo*             shader_info,
+static bool SPIRVReflectPerformReflectionOnShaderModule(VulkanShaderModuleInfo*       shader_info,
                                                         size_t                        spirv_size,
                                                         const uint32_t*               spirv_code,
                                                         const VkPhysicalDeviceLimits& phys_dev_limits)
@@ -5659,7 +5665,7 @@ static bool SPIRVReflectPerformReflectionOnShaderModule(ShaderModuleInfo*       
 
             shader_info->used_descriptors_info[binding->set].emplace(
                 binding->binding,
-                ShaderModuleInfo::ShaderDescriptorInfo(type, readonly, binding->accessed, count, is_array));
+                VulkanShaderModuleInfo::ShaderDescriptorInfo(type, readonly, binding->accessed, count, is_array));
         }
     }
 
@@ -5669,7 +5675,7 @@ static bool SPIRVReflectPerformReflectionOnShaderModule(ShaderModuleInfo*       
 VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
     PFN_vkCreateShaderModule                                      func,
     VkResult                                                      original_result,
-    const DeviceInfo*                                             device_info,
+    const VulkanDeviceInfo*                                       device_info,
     const StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*    pAllocator,
     HandlePointerDecoder<VkShaderModule>*                         pShaderModule)
@@ -5692,10 +5698,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
 
             if (options_.dumping_resources)
             {
-                ShaderModuleInfo* shader_info = reinterpret_cast<ShaderModuleInfo*>(pShaderModule->GetConsumerData(0));
+                VulkanShaderModuleInfo* shader_info =
+                    reinterpret_cast<VulkanShaderModuleInfo*>(pShaderModule->GetConsumerData(0));
                 assert(shader_info);
 
-                const PhysicalDeviceInfo* phys_dev = object_info_table_.GetPhysicalDeviceInfo(device_info->parent_id);
+                const VulkanPhysicalDeviceInfo* phys_dev =
+                    object_info_table_.GetVkPhysicalDeviceInfo(device_info->parent_id);
                 assert(phys_dev);
                 assert(phys_dev->replay_device_info);
 
@@ -5743,10 +5751,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
 
         if (vk_res == VK_SUCCESS && options_.dumping_resources)
         {
-            ShaderModuleInfo* shader_info = reinterpret_cast<ShaderModuleInfo*>(pShaderModule->GetConsumerData(0));
+            VulkanShaderModuleInfo* shader_info =
+                reinterpret_cast<VulkanShaderModuleInfo*>(pShaderModule->GetConsumerData(0));
             assert(shader_info);
 
-            const PhysicalDeviceInfo* phys_dev = object_info_table_.GetPhysicalDeviceInfo(device_info->parent_id);
+            const VulkanPhysicalDeviceInfo* phys_dev =
+                object_info_table_.GetVkPhysicalDeviceInfo(device_info->parent_id);
             assert(phys_dev);
             assert(phys_dev->replay_device_info);
 
@@ -5760,12 +5770,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
     return vk_res;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelineCacheData func,
-                                                                VkResult                   original_result,
-                                                                const DeviceInfo*          device_info,
-                                                                const PipelineCacheInfo*   pipeline_cache_info,
-                                                                PointerDecoder<size_t>*    pDataSize,
-                                                                PointerDecoder<uint8_t>*   pData)
+VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelineCacheData     func,
+                                                                VkResult                       original_result,
+                                                                const VulkanDeviceInfo*        device_info,
+                                                                const VulkanPipelineCacheInfo* pipeline_cache_info,
+                                                                PointerDecoder<size_t>*        pDataSize,
+                                                                PointerDecoder<uint8_t>*       pData)
 {
     if ((options_.omit_pipeline_cache_data) || (original_result != VK_SUCCESS) || pData->GetPointer() == nullptr)
     {
@@ -5813,7 +5823,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelin
                 // We found some existing pipeline cache data has same hash, so we continue to check if it's same with
                 // current pipeline cache data
 
-                const std::vector<PipelineCacheData>& cache_data = iterator->second;
+                const std::vector<VulkanPipelineCacheData>& cache_data = iterator->second;
 
                 for (auto& existing_cache_data : cache_data)
                 {
@@ -5835,10 +5845,11 @@ VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelin
 
             if (new_cache_data)
             {
-                std::vector<PipelineCacheData>& item = const_cast<PipelineCacheInfo*>(pipeline_cache_info)
-                                                           ->pipeline_cache_data[capture_pipeline_cache_data_hash];
+                std::vector<VulkanPipelineCacheData>& item =
+                    const_cast<VulkanPipelineCacheInfo*>(pipeline_cache_info)
+                        ->pipeline_cache_data[capture_pipeline_cache_data_hash];
                 auto              output_cache_data_size = *pDataSize->GetOutputPointer();
-                PipelineCacheData pipeline_cache_data;
+                VulkanPipelineCacheData pipeline_cache_data;
                 pipeline_cache_data.capture_cache_data.resize(cache_data_size);
                 memcpy(pipeline_cache_data.capture_cache_data.data(), pData->GetPointer(), cache_data_size);
                 pipeline_cache_data.replay_cache_data.resize(output_cache_data_size);
@@ -5853,7 +5864,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelin
 VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
     PFN_vkCreatePipelineCache                                      func,
     VkResult                                                       original_result,
-    const DeviceInfo*                                              device_info,
+    const VulkanDeviceInfo*                                        device_info,
     const StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*     pAllocator,
     HandlePointerDecoder<VkPipelineCache>*                         pPipelineCache)
@@ -5890,7 +5901,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
         if ((create_info.pInitialData != nullptr) && (create_info.initialDataSize != 0))
         {
             // keep track if external synchronization is required
-            auto handle_info = reinterpret_cast<PipelineCacheInfo*>(pPipelineCache->GetConsumerData(0));
+            auto handle_info = reinterpret_cast<VulkanPipelineCacheInfo*>(pPipelineCache->GetConsumerData(0));
             handle_info->requires_external_synchronization =
                 create_info.flags & VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT;
 
@@ -5903,7 +5914,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
             capture_pipeline_cache_data_      = const_cast<void*>(create_info.pInitialData);
             capture_pipeline_cache_data_size_ = create_info.initialDataSize;
 
-            object_info_table_.VisitPipelineCacheInfo([this](const PipelineCacheInfo* pipeline_cache_info) {
+            object_info_table_.VisitVkPipelineCacheInfo([this](const VulkanPipelineCacheInfo* pipeline_cache_info) {
                 GFXRECON_ASSERT(pipeline_cache_info != nullptr);
 
                 auto iterator = pipeline_cache_info->pipeline_cache_data.find(capture_pipeline_cache_data_hash_);
@@ -5967,8 +5978,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
 
 VkResult VulkanReplayConsumerBase::OverrideResetDescriptorPool(PFN_vkResetDescriptorPool  func,
                                                                VkResult                   original_result,
-                                                               const DeviceInfo*          device_info,
-                                                               DescriptorPoolInfo*        pool_info,
+                                                               const VulkanDeviceInfo*    device_info,
+                                                               VulkanDescriptorPoolInfo*  pool_info,
                                                                VkDescriptorPoolResetFlags flags)
 {
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
@@ -5978,7 +5989,7 @@ VkResult VulkanReplayConsumerBase::OverrideResetDescriptorPool(PFN_vkResetDescri
     // Descriptor sets allocated from the pool are implicitly freed and must be removed from the object info table.
     for (auto child_id : pool_info->child_ids)
     {
-        object_info_table_.RemoveDescriptorSetInfo(child_id);
+        object_info_table_.RemoveVkDescriptorSetInfo(child_id);
     }
 
     pool_info->child_ids.clear();
@@ -5989,7 +6000,7 @@ VkResult VulkanReplayConsumerBase::OverrideResetDescriptorPool(PFN_vkResetDescri
 VkResult VulkanReplayConsumerBase::OverrideCreateDebugReportCallbackEXT(
     PFN_vkCreateDebugReportCallbackEXT                                      func,
     VkResult                                                                original_result,
-    const InstanceInfo*                                                     instance_info,
+    const VulkanInstanceInfo*                                               instance_info,
     const StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*              pAllocator,
     HandlePointerDecoder<VkDebugReportCallbackEXT>*                         pCallback)
@@ -6020,7 +6031,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDebugReportCallbackEXT(
 VkResult VulkanReplayConsumerBase::OverrideCreateDebugUtilsMessengerEXT(
     PFN_vkCreateDebugUtilsMessengerEXT                                      func,
     VkResult                                                                original_result,
-    const InstanceInfo*                                                     instance_info,
+    const VulkanInstanceInfo*                                               instance_info,
     const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*              pAllocator,
     HandlePointerDecoder<VkDebugUtilsMessengerEXT>*                         pMessenger)
@@ -6050,7 +6061,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDebugUtilsMessengerEXT(
 VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
     PFN_vkCreateSwapchainKHR                                      func,
     VkResult                                                      original_result,
-    DeviceInfo*                                                   device_info,
+    VulkanDeviceInfo*                                             device_info,
     const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*    pAllocator,
     HandlePointerDecoder<VkSwapchainKHR>*                         pSwapchain)
@@ -6064,7 +6075,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
     auto     replay_create_info = pCreateInfo->GetPointer();
     GFXRECON_ASSERT(replay_create_info != nullptr);
     auto replay_swapchain = pSwapchain->GetHandlePointer();
-    auto swapchain_info   = reinterpret_cast<SwapchainKHRInfo*>(pSwapchain->GetConsumerData(0));
+    auto swapchain_info   = reinterpret_cast<VulkanSwapchainKHRInfo*>(pSwapchain->GetConsumerData(0));
     assert(swapchain_info != nullptr);
 
     // Ignore swapchain creation if surface creation was skipped when rendering is restricted to a specific surface.
@@ -6092,8 +6103,9 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
         }
 
         bool                colorspace_extension_used_unsupported = false;
-        PhysicalDeviceInfo* physical_device_info = object_info_table_.GetPhysicalDeviceInfo(device_info->parent_id);
-        InstanceInfo*       instance_info        = object_info_table_.GetInstanceInfo(physical_device_info->parent_id);
+        VulkanPhysicalDeviceInfo* physical_device_info =
+            object_info_table_.GetVkPhysicalDeviceInfo(device_info->parent_id);
+        VulkanInstanceInfo* instance_info = object_info_table_.GetVkInstanceInfo(physical_device_info->parent_id);
 
         auto colorspace_extension_map_iterator = kColorSpaceExtensionMap.find(replay_create_info->imageColorSpace);
         if (colorspace_extension_map_iterator != kColorSpaceExtensionMap.end())
@@ -6216,7 +6228,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
 VkResult VulkanReplayConsumerBase::OverrideCreateSharedSwapchainsKHR(
     PFN_vkCreateSharedSwapchainsKHR                               func,
     VkResult                                                      original_result,
-    DeviceInfo*                                                   device_info,
+    VulkanDeviceInfo*                                             device_info,
     uint32_t                                                      swapchainCount,
     const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfos,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*    pAllocator,
@@ -6233,8 +6245,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSharedSwapchainsKHR(
 
 void VulkanReplayConsumerBase::OverrideDestroySwapchainKHR(
     PFN_vkDestroySwapchainKHR                                  func,
-    DeviceInfo*                                                device_info,
-    SwapchainKHRInfo*                                          swapchain_info,
+    VulkanDeviceInfo*                                          device_info,
+    VulkanSwapchainKHRInfo*                                    swapchain_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     // Delete backed images of dummy swapchain.
@@ -6243,7 +6255,7 @@ void VulkanReplayConsumerBase::OverrideDestroySwapchainKHR(
         auto allocator = device_info->allocator.get();
         assert(allocator != nullptr);
 
-        for (const ImageInfo& image_info : swapchain_info->image_infos)
+        for (const VulkanImageInfo& image_info : swapchain_info->image_infos)
         {
             allocator->DestroyImageDirect(image_info.handle, nullptr, image_info.allocator_data);
             allocator->FreeMemoryDirect(image_info.memory, nullptr, image_info.memory_allocator_data);
@@ -6257,8 +6269,8 @@ void VulkanReplayConsumerBase::OverrideDestroySwapchainKHR(
 
 VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapchainImagesKHR    func,
                                                                  VkResult                       original_result,
-                                                                 const DeviceInfo*              device_info,
-                                                                 SwapchainKHRInfo*              swapchain_info,
+                                                                 const VulkanDeviceInfo*        device_info,
+                                                                 VulkanSwapchainKHRInfo*        swapchain_info,
                                                                  PointerDecoder<uint32_t>*      pSwapchainImageCount,
                                                                  HandlePointerDecoder<VkImage>* pSwapchainImages)
 {
@@ -6315,7 +6327,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapch
             for (uint32_t i = 0; i < capture_image_count; ++i)
             {
                 VkImage*   replay_image = &(replay_images[i]);
-                ImageInfo* image_info   = reinterpret_cast<ImageInfo*>(pSwapchainImages->GetConsumerData(i));
+                VulkanImageInfo* image_info = reinterpret_cast<VulkanImageInfo*>(pSwapchainImages->GetConsumerData(i));
                 assert(image_info != nullptr);
 
                 result = CreateSwapchainImage(device_info, &image_create_info, replay_image, image_info);
@@ -6363,7 +6375,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapch
 
             for (uint32_t i = 0; i < count; ++i)
             {
-                auto image_info = reinterpret_cast<ImageInfo*>(pSwapchainImages->GetConsumerData(i));
+                auto image_info = reinterpret_cast<VulkanImageInfo*>(pSwapchainImages->GetConsumerData(i));
                 assert(image_info != nullptr);
 
                 image_info->format             = swapchain_info->format;
@@ -6401,11 +6413,11 @@ VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapch
 
 VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNextImageKHR func,
                                                                VkResult                  original_result,
-                                                               const DeviceInfo*         device_info,
-                                                               SwapchainKHRInfo*         swapchain_info,
+                                                               const VulkanDeviceInfo*   device_info,
+                                                               VulkanSwapchainKHRInfo*   swapchain_info,
                                                                uint64_t                  timeout,
-                                                               SemaphoreInfo*            semaphore_info,
-                                                               FenceInfo*                fence_info,
+                                                               VulkanSemaphoreInfo*      semaphore_info,
+                                                               VulkanFenceInfo*          fence_info,
                                                                PointerDecoder<uint32_t>* pImageIndex)
 {
     assert(swapchain_info != nullptr);
@@ -6526,7 +6538,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
 VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
     PFN_vkAcquireNextImage2KHR                                     func,
     VkResult                                                       original_result,
-    const DeviceInfo*                                              device_info,
+    const VulkanDeviceInfo*                                        device_info,
     const StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
     PointerDecoder<uint32_t>*                                      pImageIndex)
 {
@@ -6534,7 +6546,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
 
     VkResult          result            = VK_SUCCESS;
     auto              acquire_meta_info = pAcquireInfo->GetMetaStructPointer();
-    SwapchainKHRInfo* swapchain_info    = object_info_table_.GetSwapchainKHRInfo(acquire_meta_info->swapchain);
+    VulkanSwapchainKHRInfo* swapchain_info    = object_info_table_.GetVkSwapchainKHRInfo(acquire_meta_info->swapchain);
     assert(swapchain_info != nullptr);
 
     // If image acquire failed at capture, there is nothing worth replaying as the fence and semaphore aren't processed
@@ -6598,7 +6610,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
 
             assert(replay_index != nullptr);
 
-            auto swapchain_info = object_info_table_.GetSwapchainKHRInfo(acquire_meta_info->swapchain);
+            auto swapchain_info = object_info_table_.GetVkSwapchainKHRInfo(acquire_meta_info->swapchain);
 
             // If expected result is VK_SUCCESS, ensure that vkAcquireNextImageKHR2 waits until the image is
             // available by using a timeout of UINT64_MAX.
@@ -6634,8 +6646,8 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
     {
         // Track semphore and fence objects as shadow objects so that they can be ignored when they would have been
         // unsignaled (waited on).
-        SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(acquire_meta_info->semaphore);
-        FenceInfo*     fence_info     = object_info_table_.GetFenceInfo(acquire_meta_info->fence);
+        VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(acquire_meta_info->semaphore);
+        VulkanFenceInfo*     fence_info     = object_info_table_.GetVkFenceInfo(acquire_meta_info->fence);
 
         if (semaphore_info != nullptr)
         {
@@ -6656,7 +6668,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
 VkResult
 VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR                                 func,
                                                   VkResult                                              original_result,
-                                                  const QueueInfo*                                      queue_info,
+                                                  const VulkanQueueInfo*                                queue_info,
                                                   const StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
 {
     assert((queue_info != nullptr) && (pPresentInfo != nullptr) && !pPresentInfo->IsNull());
@@ -6699,7 +6711,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
         {
             assert(swapchain_ids != nullptr);
 
-            const auto swapchain_info = object_info_table_.GetSwapchainKHRInfo(swapchain_ids[i]);
+            const auto swapchain_info = object_info_table_.GetVkSwapchainKHRInfo(swapchain_ids[i]);
             if ((swapchain_info != nullptr) && (swapchain_info->surface != VK_NULL_HANDLE))
             {
                 valid_swapchains_.emplace_back(swapchain_info->handle);
@@ -6868,7 +6880,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
         {
             assert(swapchain_ids != nullptr);
 
-            const auto swapchain_info = object_info_table_.GetSwapchainKHRInfo(swapchain_ids[i]);
+            const auto swapchain_info = object_info_table_.GetVkSwapchainKHRInfo(swapchain_ids[i]);
             if (swapchain_info != nullptr)
             {
                 swapchain_infos_[i] = swapchain_info;
@@ -6927,7 +6939,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
 
     if (options_.wait_before_present)
     {
-        VkDevice device = MapHandle<DeviceInfo>(queue_info->parent_id, &VulkanObjectInfoTable::GetDeviceInfo);
+        VkDevice device = MapHandle<VulkanDeviceInfo>(queue_info->parent_id, &VulkanObjectInfoTable::GetVkDeviceInfo);
         GetDeviceTable(device)->DeviceWaitIdle(device);
     }
 
@@ -7004,7 +7016,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                 size_t count = present_info_data->pWaitSemaphores.GetLength();
                 for (uint32_t i = 0; i < count; ++i)
                 {
-                    SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_ids[i]);
+                    VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_ids[i]);
                     if (semaphore_info)
                     {
                         semaphore_info->forward_progress = false;
@@ -7019,7 +7031,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
             for (uint32_t i = 0; i < pPresentInfo->GetPointer()->swapchainCount; ++i)
             {
                 format::HandleId fence      = present_fence_info->pFences.GetPointer()[i];
-                FenceInfo*       fence_info = object_info_table_.GetFenceInfo(fence);
+                VulkanFenceInfo* fence_info = object_info_table_.GetVkFenceInfo(fence);
                 if (fence_info)
                 {
                     fence_info->shadow_signaled = true;
@@ -7040,7 +7052,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
 VkResult VulkanReplayConsumerBase::OverrideImportSemaphoreFdKHR(
     PFN_vkImportSemaphoreFdKHR                                      func,
     VkResult                                                        original_result,
-    const DeviceInfo*                                               device_info,
+    const VulkanDeviceInfo*                                         device_info,
     const StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo)
 {
     // Skip external semaphore import.  There is no actual file descriptor backing it in replay.
@@ -7055,7 +7067,7 @@ VkResult VulkanReplayConsumerBase::OverrideImportSemaphoreFdKHR(
         auto info = pImportSemaphoreFdInfo->GetMetaStructPointer();
         assert(info != nullptr);
 
-        SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(info->semaphore);
+        VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(info->semaphore);
 
         if (semaphore_info != nullptr)
         {
@@ -7070,7 +7082,7 @@ VkResult VulkanReplayConsumerBase::OverrideImportSemaphoreFdKHR(
 VkResult VulkanReplayConsumerBase::OverrideGetSemaphoreFdKHR(
     PFN_vkGetSemaphoreFdKHR                                      func,
     VkResult                                                     original_result,
-    const DeviceInfo*                                            device_info,
+    const VulkanDeviceInfo*                                      device_info,
     const StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
     const PointerDecoder<int>*                                   pFd)
 {
@@ -7089,7 +7101,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetSemaphoreFdKHR(
 VkResult VulkanReplayConsumerBase::OverrideImportSemaphoreWin32HandleKHR(
     PFN_vkImportSemaphoreWin32HandleKHR                                      func,
     VkResult                                                                 original_result,
-    const DeviceInfo*                                                        device_info,
+    const VulkanDeviceInfo*                                                  device_info,
     const StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo)
 {
     // Skip external semaphore import.  There is no actual OS resource backing it in replay.
@@ -7104,7 +7116,7 @@ VkResult VulkanReplayConsumerBase::OverrideImportSemaphoreWin32HandleKHR(
         auto info = pImportSemaphoreWin32HandleInfo->GetMetaStructPointer();
         assert(info != nullptr);
 
-        SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(info->semaphore);
+        VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(info->semaphore);
 
         if (semaphore_info != nullptr)
         {
@@ -7119,7 +7131,7 @@ VkResult VulkanReplayConsumerBase::OverrideImportSemaphoreWin32HandleKHR(
 VkResult VulkanReplayConsumerBase::OverrideGetSemaphoreWin32HandleKHR(
     PFN_vkGetSemaphoreWin32HandleKHR                                      func,
     VkResult                                                              original_result,
-    const DeviceInfo*                                                     device_info,
+    const VulkanDeviceInfo*                                               device_info,
     const StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
     const PointerDecoder<uint64_t, void*>*                                pHandle)
 {
@@ -7136,7 +7148,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetSemaphoreWin32HandleKHR(
 
 VkResult VulkanReplayConsumerBase::OverrideGetRandROutputDisplayEXT(PFN_vkGetRandROutputDisplayEXT      func,
                                                                     VkResult                            original_result,
-                                                                    const PhysicalDeviceInfo*           physicalDevice,
+                                                                    const VulkanPhysicalDeviceInfo*     physicalDevice,
                                                                     Display*                            dpy,
                                                                     RROutput                            rrOutput,
                                                                     HandlePointerDecoder<VkDisplayKHR>* pDisplay)
@@ -7152,7 +7164,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetRandROutputDisplayEXT(PFN_vkGetRan
 VkResult VulkanReplayConsumerBase::OverrideCreateAndroidSurfaceKHR(
     PFN_vkCreateAndroidSurfaceKHR                                      func,
     VkResult                                                           original_result,
-    InstanceInfo*                                                      instance_info,
+    VulkanInstanceInfo*                                                instance_info,
     const StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*         pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*                                pSurface)
@@ -7184,7 +7196,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateAndroidSurfaceKHR(
 VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(
     PFN_vkCreateWin32SurfaceKHR                                      func,
     VkResult                                                         original_result,
-    InstanceInfo*                                                    instance_info,
+    VulkanInstanceInfo*                                              instance_info,
     const StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*                              pSurface)
@@ -7215,7 +7227,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWin32PresentationSupportKHR(
     PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR func,
-    const PhysicalDeviceInfo*                          physical_device_info,
+    const VulkanPhysicalDeviceInfo*                    physical_device_info,
     uint32_t                                           queueFamilyIndex)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
@@ -7234,7 +7246,7 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWin32PresentationSup
 VkResult VulkanReplayConsumerBase::OverrideCreateXcbSurfaceKHR(
     PFN_vkCreateXcbSurfaceKHR                                      func,
     VkResult                                                       original_result,
-    InstanceInfo*                                                  instance_info,
+    VulkanInstanceInfo*                                            instance_info,
     const StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*     pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*                            pSurface)
@@ -7265,7 +7277,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateXcbSurfaceKHR(
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXcbPresentationSupportKHR(
     PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR func,
-    const PhysicalDeviceInfo*                        physical_device_info,
+    const VulkanPhysicalDeviceInfo*                  physical_device_info,
     uint32_t                                         queueFamilyIndex,
     xcb_connection_t*                                connection,
     xcb_visualid_t                                   visual_id)
@@ -7288,7 +7300,7 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXcbPresentationSuppo
 VkResult VulkanReplayConsumerBase::OverrideCreateXlibSurfaceKHR(
     PFN_vkCreateXlibSurfaceKHR                                      func,
     VkResult                                                        original_result,
-    InstanceInfo*                                                   instance_info,
+    VulkanInstanceInfo*                                             instance_info,
     const StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*      pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*                             pSurface)
@@ -7319,7 +7331,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateXlibSurfaceKHR(
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXlibPresentationSupportKHR(
     PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR func,
-    const PhysicalDeviceInfo*                         physical_device_info,
+    const VulkanPhysicalDeviceInfo*                   physical_device_info,
     uint32_t                                          queueFamilyIndex,
     Display*                                          dpy,
     VisualID                                          visualID)
@@ -7342,7 +7354,7 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXlibPresentationSupp
 VkResult VulkanReplayConsumerBase::OverrideCreateWaylandSurfaceKHR(
     PFN_vkCreateWaylandSurfaceKHR                                      func,
     VkResult                                                           original_result,
-    InstanceInfo*                                                      instance_info,
+    VulkanInstanceInfo*                                                instance_info,
     const StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*         pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*                                pSurface)
@@ -7374,7 +7386,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateWaylandSurfaceKHR(
 VkResult VulkanReplayConsumerBase::OverrideCreateDisplayPlaneSurfaceKHR(
     PFN_vkCreateDisplayPlaneSurfaceKHR                                 func,
     VkResult                                                           original_result,
-    InstanceInfo*                                                      instance_info,
+    VulkanInstanceInfo*                                                instance_info,
     const StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*         pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*                                pSurface)
@@ -7406,7 +7418,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDisplayPlaneSurfaceKHR(
 VkResult VulkanReplayConsumerBase::OverrideCreateHeadlessSurfaceEXT(
     PFN_vkCreateHeadlessSurfaceEXT                                      func,
     VkResult                                                            original_result,
-    InstanceInfo*                                                       instance_info,
+    VulkanInstanceInfo*                                                 instance_info,
     const StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*          pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*                                 pSurface)
@@ -7437,7 +7449,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateHeadlessSurfaceEXT(
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWaylandPresentationSupportKHR(
     PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR func,
-    const PhysicalDeviceInfo*                            physical_device_info,
+    const VulkanPhysicalDeviceInfo*                      physical_device_info,
     uint32_t                                             queueFamilyIndex,
     struct wl_display*                                   display)
 {
@@ -7458,7 +7470,7 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWaylandPresentationS
 VkResult VulkanReplayConsumerBase::OverrideCreateMetalSurfaceEXT(
     PFN_vkCreateMetalSurfaceEXT                                      func,
     VkResult                                                         original_result,
-    InstanceInfo*                                                    instance_info,
+    VulkanInstanceInfo*                                              instance_info,
     const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*                              pSurface)
@@ -7489,8 +7501,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateMetalSurfaceEXT(
 
 void VulkanReplayConsumerBase::OverrideDestroySurfaceKHR(
     PFN_vkDestroySurfaceKHR                                    func,
-    InstanceInfo*                                              instance_info,
-    const SurfaceKHRInfo*                                      surface_info,
+    VulkanInstanceInfo*                                        instance_info,
+    const VulkanSurfaceKHRInfo*                                surface_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     swapchain_->DestroySurface(func, instance_info, surface_info, GetAllocationCallbacks(pAllocator));
@@ -7499,7 +7511,7 @@ void VulkanReplayConsumerBase::OverrideDestroySurfaceKHR(
 VkResult VulkanReplayConsumerBase::OverrideCreateAccelerationStructureKHR(
     PFN_vkCreateAccelerationStructureKHR                                      func,
     VkResult                                                                  original_result,
-    const DeviceInfo*                                                         device_info,
+    const VulkanDeviceInfo*                                                   device_info,
     const StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoKHR>* pCreateInfo,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*                pAllocator,
     HandlePointerDecoder<VkAccelerationStructureKHR>*                         pAccelerationStructureKHR)
@@ -7548,8 +7560,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateAccelerationStructureKHR(
 
 void VulkanReplayConsumerBase::OverrideDestroyAccelerationStructureKHR(
     PFN_vkDestroyAccelerationStructureKHR                func,
-    const DeviceInfo*                                    device_info,
-    const AccelerationStructureKHRInfo*                  acceleration_structure_info,
+    const VulkanDeviceInfo*                              device_info,
+    const VulkanAccelerationStructureKHRInfo*            acceleration_structure_info,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     GFXRECON_ASSERT(device_info != nullptr);
@@ -7572,12 +7584,12 @@ void VulkanReplayConsumerBase::OverrideDestroyAccelerationStructureKHR(
 
 void VulkanReplayConsumerBase::OverrideCmdBuildAccelerationStructuresKHR(
     PFN_vkCmdBuildAccelerationStructuresKHR                                    func,
-    CommandBufferInfo*                                                         command_buffer_info,
+    VulkanCommandBufferInfo*                                                   command_buffer_info,
     uint32_t                                                                   infoCount,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>*   ppBuildRangeInfos)
 {
-    DeviceInfo*     device_info    = object_info_table_.GetDeviceInfo(command_buffer_info->parent_id);
+    VulkanDeviceInfo* device_info    = object_info_table_.GetVkDeviceInfo(command_buffer_info->parent_id);
     VkCommandBuffer command_buffer = command_buffer_info->handle;
     VkAccelerationStructureBuildGeometryInfoKHR* build_geometry_infos = pInfos->GetPointer();
     VkAccelerationStructureBuildRangeInfoKHR**   build_range_infos    = ppBuildRangeInfos->GetPointer();
@@ -7642,10 +7654,10 @@ void VulkanReplayConsumerBase::OverrideCmdBuildAccelerationStructuresKHR(
 
 void VulkanReplayConsumerBase::OverrideCmdCopyAccelerationStructureKHR(
     PFN_vkCmdCopyAccelerationStructureKHR                             func,
-    CommandBufferInfo*                                                command_buffer_info,
+    VulkanCommandBufferInfo*                                          command_buffer_info,
     StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo)
 {
-    DeviceInfo* device_info = object_info_table_.GetDeviceInfo(command_buffer_info->parent_id);
+    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(command_buffer_info->parent_id);
     if (device_info->allocator->SupportsOpaqueDeviceAddresses())
     {
         VkCommandBuffer                     command_buffer = command_buffer_info->handle;
@@ -7660,14 +7672,14 @@ void VulkanReplayConsumerBase::OverrideCmdCopyAccelerationStructureKHR(
 
 void VulkanReplayConsumerBase::OverrideCmdWriteAccelerationStructuresPropertiesKHR(
     PFN_vkCmdWriteAccelerationStructuresPropertiesKHR func,
-    CommandBufferInfo*                                command_buffer_info,
+    VulkanCommandBufferInfo*                          command_buffer_info,
     uint32_t                                          count,
     HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructures,
     VkQueryType                                       queryType,
-    gfxrecon::decode::QueryPoolInfo*                  query_pool_info,
+    gfxrecon::decode::VulkanQueryPoolInfo*            query_pool_info,
     uint32_t                                          firstQuery)
 {
-    DeviceInfo* device_info = object_info_table_.GetDeviceInfo(command_buffer_info->parent_id);
+    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(command_buffer_info->parent_id);
     if (device_info->allocator->SupportsOpaqueDeviceAddresses())
     {
         VkCommandBuffer                   command_buffer       = command_buffer_info->handle;
@@ -7684,9 +7696,9 @@ void VulkanReplayConsumerBase::OverrideCmdWriteAccelerationStructuresPropertiesK
 VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
     PFN_vkCreateRayTracingPipelinesKHR                                     func,
     VkResult                                                               original_result,
-    const DeviceInfo*                                                      device_info,
-    DeferredOperationKHRInfo*                                              deferred_operation_info,
-    const PipelineCacheInfo*                                               pipeline_cache_info,
+    const VulkanDeviceInfo*                                                device_info,
+    VulkanDeferredOperationKHRInfo*                                        deferred_operation_info,
+    const VulkanPipelineCacheInfo*                                         pipeline_cache_info,
     uint32_t                                                               createInfoCount,
     const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
@@ -7881,7 +7893,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
 
         for (uint32_t i = 0; i < createInfoCount; ++i)
         {
-            PipelineInfo* pipeline_info = reinterpret_cast<PipelineInfo*>(pPipelines->GetConsumerData(i));
+            VulkanPipelineInfo* pipeline_info = reinterpret_cast<VulkanPipelineInfo*>(pPipelines->GetConsumerData(i));
 
             const Decoded_VkPipelineShaderStageCreateInfo* stages_info_meta =
                 create_info_meta[i].pStages->GetMetaStructPointer();
@@ -7889,7 +7901,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
 
             for (size_t s = 0; s < stages_count; ++s)
             {
-                ShaderModuleInfo* module_info = object_info_table_.GetShaderModuleInfo(stages_info_meta[s].module);
+                VulkanShaderModuleInfo* module_info =
+                    object_info_table_.GetVkShaderModuleInfo(stages_info_meta[s].module);
                 assert(module_info);
                 assert(pipeline_info);
 
@@ -7901,10 +7914,11 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperationJoinKHR func,
-                                                                    VkResult                       original_result,
-                                                                    const DeviceInfo*              device_info,
-                                                                    DeferredOperationKHRInfo* deferred_operation_info)
+VkResult
+VulkanReplayConsumerBase::OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperationJoinKHR  func,
+                                                           VkResult                        original_result,
+                                                           const VulkanDeviceInfo*         device_info,
+                                                           VulkanDeferredOperationKHRInfo* deferred_operation_info)
 {
     if (deferred_operation_info->pending_state == false)
     {
@@ -7946,12 +7960,12 @@ VkResult VulkanReplayConsumerBase::OverrideDeferredOperationJoinKHR(PFN_vkDeferr
         j.get();
     }
 
-    AddHandles<PipelineInfo>(device_info->capture_id,
-                             deferred_operation_info->capturePipelines.data(),
-                             deferred_operation_info->capturePipelines.size(),
-                             deferred_operation_info->replayPipelines.data(),
-                             deferred_operation_info->replayPipelines.size(),
-                             &VulkanObjectInfoTable::AddPipelineInfo);
+    AddHandles<VulkanPipelineInfo>(device_info->capture_id,
+                                   deferred_operation_info->capturePipelines.data(),
+                                   deferred_operation_info->capturePipelines.size(),
+                                   deferred_operation_info->replayPipelines.data(),
+                                   deferred_operation_info->replayPipelines.size(),
+                                   &VulkanObjectInfoTable::AddVkPipelineInfo);
 
     deferred_operation_info->pending_state = false;
     deferred_operation_info->record_modified_create_infos.clear();
@@ -7965,7 +7979,7 @@ VkResult VulkanReplayConsumerBase::OverrideDeferredOperationJoinKHR(PFN_vkDeferr
 VkDeviceAddress VulkanReplayConsumerBase::OverrideGetBufferDeviceAddress(
     PFN_vkGetBufferDeviceAddress                                   func,
     VkDeviceAddress                                                original_result,
-    const DeviceInfo*                                              device_info,
+    const VulkanDeviceInfo*                                        device_info,
     const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
 {
     assert((device_info != nullptr) && (pInfo != nullptr) && !pInfo->IsNull() && (pInfo->GetPointer() != nullptr));
@@ -7998,7 +8012,7 @@ VkDeviceAddress VulkanReplayConsumerBase::OverrideGetBufferDeviceAddress(
 
     // keep track of old/new addresses in any case
     format::HandleId buffer      = pInfo->GetMetaStructPointer()->buffer;
-    BufferInfo*      buffer_info = GetObjectInfoTable().GetBufferInfo(buffer);
+    VulkanBufferInfo* buffer_info = GetObjectInfoTable().GetVkBufferInfo(buffer);
     GFXRECON_ASSERT(buffer_info != nullptr);
     buffer_info->capture_address = original_result;
     buffer_info->replay_address  = replay_device_address;
@@ -8011,7 +8025,7 @@ VkDeviceAddress VulkanReplayConsumerBase::OverrideGetBufferDeviceAddress(
 void VulkanReplayConsumerBase::OverrideGetAccelerationStructureDeviceAddressKHR(
     PFN_vkGetAccelerationStructureDeviceAddressKHR                                   func,
     VkDeviceAddress                                                                  original_result,
-    const DeviceInfo*                                                                device_info,
+    const VulkanDeviceInfo*                                                          device_info,
     const StructPointerDecoder<Decoded_VkAccelerationStructureDeviceAddressInfoKHR>* pInfo)
 {
     assert((device_info != nullptr) && (pInfo != nullptr) && !pInfo->IsNull() && (pInfo->GetPointer() != nullptr));
@@ -8028,8 +8042,8 @@ void VulkanReplayConsumerBase::OverrideGetAccelerationStructureDeviceAddressKHR(
 
     VkDeviceAddress replay_address = func(device, address_info);
 
-    AccelerationStructureKHRInfo* acceleration_structure_info =
-        GetObjectInfoTable().GetAccelerationStructureKHRInfo(pInfo->GetMetaStructPointer()->accelerationStructure);
+    VulkanAccelerationStructureKHRInfo* acceleration_structure_info =
+        GetObjectInfoTable().GetVkAccelerationStructureKHRInfo(pInfo->GetMetaStructPointer()->accelerationStructure);
     GFXRECON_ASSERT(acceleration_structure_info != nullptr);
     acceleration_structure_info->capture_address = original_result;
     acceleration_structure_info->replay_address  = replay_address;
@@ -8052,13 +8066,13 @@ void VulkanReplayConsumerBase::OverrideGetAccelerationStructureDeviceAddressKHR(
 
 VkResult
 VulkanReplayConsumerBase::OverrideGetRayTracingShaderGroupHandlesKHR(PFN_vkGetRayTracingShaderGroupHandlesKHR func,
-                                                                     VkResult                 original_result,
-                                                                     const DeviceInfo*        device_info,
-                                                                     const PipelineInfo*      pipeline_info,
-                                                                     uint32_t                 firstGroup,
-                                                                     uint32_t                 groupCount,
-                                                                     size_t                   dataSize,
-                                                                     PointerDecoder<uint8_t>* pData)
+                                                                     VkResult                  original_result,
+                                                                     const VulkanDeviceInfo*   device_info,
+                                                                     const VulkanPipelineInfo* pipeline_info,
+                                                                     uint32_t                  firstGroup,
+                                                                     uint32_t                  groupCount,
+                                                                     size_t                    dataSize,
+                                                                     PointerDecoder<uint8_t>*  pData)
 {
     assert((device_info != nullptr) && (pipeline_info != nullptr) && (pData != nullptr) &&
            (pData->GetOutputPointer() != nullptr));
@@ -8079,7 +8093,7 @@ VulkanReplayConsumerBase::OverrideGetRayTracingShaderGroupHandlesKHR(PFN_vkGetRa
 
     if (result == VK_SUCCESS)
     {
-        auto physical_device_info = GetObjectInfoTable().GetPhysicalDeviceInfo(device_info->parent_id);
+        auto physical_device_info = GetObjectInfoTable().GetVkPhysicalDeviceInfo(device_info->parent_id);
 
         // in practice: always 32 bytes
         uint32_t capture_handle_size = physical_device_info->shaderGroupHandleSize;
@@ -8096,7 +8110,7 @@ VulkanReplayConsumerBase::OverrideGetRayTracingShaderGroupHandlesKHR(PFN_vkGetRa
             graphics::shader_group_handle_t replay_handle       = { replay_handle_begin, replay_handle_size };
 
             auto& shader_group_handle_map =
-                GetObjectInfoTable().GetPipelineInfo(pipeline_info->capture_id)->shader_group_handle_map;
+                GetObjectInfoTable().GetVkPipelineInfo(pipeline_info->capture_id)->shader_group_handle_map;
             shader_group_handle_map[capture_handle] = replay_handle;
         }
     }
@@ -8106,7 +8120,7 @@ VulkanReplayConsumerBase::OverrideGetRayTracingShaderGroupHandlesKHR(PFN_vkGetRa
 VkResult VulkanReplayConsumerBase::OverrideGetAndroidHardwareBufferPropertiesANDROID(
     PFN_vkGetAndroidHardwareBufferPropertiesANDROID                         func,
     VkResult                                                                original_result,
-    const DeviceInfo*                                                       device_info,
+    const VulkanDeviceInfo*                                                 device_info,
     const struct AHardwareBuffer*                                           hardware_buffer,
     StructPointerDecoder<Decoded_VkAndroidHardwareBufferPropertiesANDROID>* pProperties)
 {
@@ -8137,7 +8151,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetAndroidHardwareBufferPropertiesAND
     }
 }
 
-void VulkanReplayConsumerBase::ClearCommandBufferInfo(CommandBufferInfo* command_buffer_info)
+void VulkanReplayConsumerBase::ClearCommandBufferInfo(VulkanCommandBufferInfo* command_buffer_info)
 {
     command_buffer_info->is_frame_boundary = false;
     command_buffer_info->frame_buffer_ids.clear();
@@ -8147,7 +8161,7 @@ VkResult VulkanReplayConsumerBase::OverrideBeginCommandBuffer(
     PFN_vkBeginCommandBuffer                                func,
     uint64_t                                                index,
     VkResult                                                original_result,
-    CommandBufferInfo*                                      command_buffer_info,
+    VulkanCommandBufferInfo*                                command_buffer_info,
     StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* begin_info_decoder)
 {
     ClearCommandBufferInfo(command_buffer_info);
@@ -8158,7 +8172,7 @@ VkResult VulkanReplayConsumerBase::OverrideBeginCommandBuffer(
     VkResult res = VK_SUCCESS;
     if (options_.dumping_resources && resource_dumper.DumpingBeginCommandBufferIndex(index))
     {
-        const DeviceInfo* device = GetObjectInfoTable().GetDeviceInfo(command_buffer_info->parent_id);
+        const VulkanDeviceInfo* device = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
 
         res = resource_dumper.CloneCommandBuffer(
             index, command_buffer_info, GetDeviceTable(device->handle), GetInstanceTable(device->parent));
@@ -8174,7 +8188,7 @@ VkResult VulkanReplayConsumerBase::OverrideBeginCommandBuffer(
 
 VkResult VulkanReplayConsumerBase::OverrideResetCommandBuffer(PFN_vkResetCommandBuffer  func,
                                                               VkResult                  original_result,
-                                                              CommandBufferInfo*        command_buffer_info,
+                                                              VulkanCommandBufferInfo*  command_buffer_info,
                                                               VkCommandBufferResetFlags flags)
 {
     ClearCommandBufferInfo(command_buffer_info);
@@ -8191,8 +8205,8 @@ VkResult VulkanReplayConsumerBase::OverrideResetCommandBuffer(PFN_vkResetCommand
 
 VkResult VulkanReplayConsumerBase::OverrideResetCommandPool(PFN_vkResetCommandPool  func,
                                                             VkResult                original_result,
-                                                            const DeviceInfo*       device_info,
-                                                            CommandPoolInfo*        pool_info,
+                                                            const VulkanDeviceInfo* device_info,
+                                                            VulkanCommandPoolInfo*  pool_info,
                                                             VkCommandPoolResetFlags flags)
 {
     assert(device_info != nullptr && pool_info != nullptr);
@@ -8201,7 +8215,7 @@ VkResult VulkanReplayConsumerBase::OverrideResetCommandPool(PFN_vkResetCommandPo
     {
         for (auto& cb_id : pool_info->child_ids)
         {
-            CommandBufferInfo* cb_info = object_info_table_.GetCommandBufferInfo(cb_id);
+            VulkanCommandBufferInfo* cb_info = object_info_table_.GetVkCommandBufferInfo(cb_id);
             assert(cb_info != nullptr);
 
             resource_dumper.ResetCommandBuffer(cb_info->handle);
@@ -8214,8 +8228,8 @@ VkResult VulkanReplayConsumerBase::OverrideResetCommandPool(PFN_vkResetCommandPo
 
 void VulkanReplayConsumerBase::OverrideDestroyCommandPool(
     PFN_vkDestroyCommandPool                             func,
-    const DeviceInfo*                                    device_info,
-    CommandPoolInfo*                                     pool_info,
+    const VulkanDeviceInfo*                              device_info,
+    VulkanCommandPoolInfo*                               pool_info,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     assert(device_info != nullptr);
@@ -8225,7 +8239,7 @@ void VulkanReplayConsumerBase::OverrideDestroyCommandPool(
     {
         for (auto& cb_id : pool_info->child_ids)
         {
-            CommandBufferInfo* cb_info = object_info_table_.GetCommandBufferInfo(cb_id);
+            VulkanCommandBufferInfo* cb_info = object_info_table_.GetVkCommandBufferInfo(cb_id);
             assert(cb_info != nullptr);
 
             resource_dumper.ResetCommandBuffer(cb_info->handle);
@@ -8238,7 +8252,7 @@ void VulkanReplayConsumerBase::OverrideDestroyCommandPool(
 
 void VulkanReplayConsumerBase::OverrideCmdDebugMarkerInsertEXT(
     PFN_vkCmdDebugMarkerInsertEXT                             func,
-    CommandBufferInfo*                                        command_buffer_info,
+    VulkanCommandBufferInfo*                                  command_buffer_info,
     StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* marker_info_decoder)
 {
     const VkDebugMarkerMarkerInfoEXT* marker_info = marker_info_decoder->GetPointer();
@@ -8253,7 +8267,7 @@ void VulkanReplayConsumerBase::OverrideCmdDebugMarkerInsertEXT(
 
 void VulkanReplayConsumerBase::OverrideCmdInsertDebugUtilsLabelEXT(
     PFN_vkCmdInsertDebugUtilsLabelEXT                   func,
-    CommandBufferInfo*                                  command_buffer_info,
+    VulkanCommandBufferInfo*                            command_buffer_info,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* label_info_decoder)
 {
     const VkDebugUtilsLabelEXT* label_info = label_info_decoder->GetPointer();
@@ -8268,7 +8282,7 @@ void VulkanReplayConsumerBase::OverrideCmdInsertDebugUtilsLabelEXT(
 
 void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
     PFN_vkCmdBeginRenderPass                             func,
-    CommandBufferInfo*                                   command_buffer_info,
+    VulkanCommandBufferInfo*                             command_buffer_info,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
     VkSubpassContents                                    contents)
 {
@@ -8277,8 +8291,8 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
     auto       render_pass_id        = render_pass_info_meta->renderPass;
     command_buffer_info->frame_buffer_ids.push_back(framebuffer_id);
 
-    auto framebuffer_info = object_info_table_.GetFramebufferInfo(framebuffer_id);
-    auto render_pass_info = object_info_table_.GetRenderPassInfo(render_pass_id);
+    auto framebuffer_info = object_info_table_.GetVkFramebufferInfo(framebuffer_id);
+    auto render_pass_info = object_info_table_.GetVkRenderPassInfo(render_pass_id);
     if ((render_pass_info != nullptr) && (framebuffer_info != nullptr))
     {
         const format::HandleId* attachment_image_view_ids = nullptr;
@@ -8304,13 +8318,13 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
         for (size_t i = 0; i < render_pass_info->attachment_description_final_layouts.size(); ++i)
         {
             auto image_view_id   = attachment_image_view_ids[i];
-            auto image_view_info = object_info_table_.GetImageViewInfo(image_view_id);
+            auto image_view_info = object_info_table_.GetVkImageViewInfo(image_view_id);
             command_buffer_info->image_layout_barriers[image_view_info->image_id] =
                 render_pass_info->attachment_description_final_layouts[i];
 
-            const ImageViewInfo* img_view_info = object_info_table_.GetImageViewInfo(image_view_id);
+            const VulkanImageViewInfo* img_view_info = object_info_table_.GetVkImageViewInfo(image_view_id);
             assert(image_view_info != nullptr);
-            ImageInfo* img_info = object_info_table_.GetImageInfo(img_view_info->image_id);
+            VulkanImageInfo* img_info = object_info_table_.GetVkImageInfo(img_view_info->image_id);
             assert(img_info);
             img_info->intermediate_layout = render_pass_info->attachment_description_final_layouts[i];
         }
@@ -8323,7 +8337,7 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
 
 void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
     PFN_vkCmdBeginRenderPass2                            func,
-    CommandBufferInfo*                                   command_buffer_info,
+    VulkanCommandBufferInfo*                             command_buffer_info,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>*    subpass_begin_info_decode)
 {
@@ -8332,8 +8346,8 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
     auto       render_pass_id        = render_pass_info_meta->renderPass;
     command_buffer_info->frame_buffer_ids.push_back(framebuffer_id);
 
-    auto framebuffer_info = object_info_table_.GetFramebufferInfo(framebuffer_id);
-    auto render_pass_info = object_info_table_.GetRenderPassInfo(render_pass_id);
+    auto framebuffer_info = object_info_table_.GetVkFramebufferInfo(framebuffer_id);
+    auto render_pass_info = object_info_table_.GetVkRenderPassInfo(render_pass_id);
     if ((render_pass_info != nullptr) && (framebuffer_info != nullptr))
     {
         GFXRECON_ASSERT(framebuffer_info->attachment_image_view_ids.size() ==
@@ -8342,13 +8356,13 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
         for (size_t i = 0; i < render_pass_info->attachment_description_final_layouts.size(); ++i)
         {
             auto image_view_id   = framebuffer_info->attachment_image_view_ids[i];
-            auto image_view_info = object_info_table_.GetImageViewInfo(image_view_id);
+            auto image_view_info = object_info_table_.GetVkImageViewInfo(image_view_id);
             command_buffer_info->image_layout_barriers[image_view_info->image_id] =
                 render_pass_info->attachment_description_final_layouts[i];
 
-            const ImageViewInfo* img_view_info = object_info_table_.GetImageViewInfo(image_view_id);
+            const VulkanImageViewInfo* img_view_info = object_info_table_.GetVkImageViewInfo(image_view_id);
             assert(image_view_info != nullptr);
-            ImageInfo* img_info = object_info_table_.GetImageInfo(img_view_info->image_id);
+            VulkanImageInfo* img_info = object_info_table_.GetVkImageInfo(img_view_info->image_id);
             assert(img_info);
             img_info->intermediate_layout = render_pass_info->attachment_description_final_layouts[i];
         }
@@ -8361,7 +8375,7 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
 
 void VulkanReplayConsumerBase::OverrideCmdTraceRaysKHR(
     PFN_vkCmdTraceRaysKHR                                          func,
-    CommandBufferInfo*                                             command_buffer_info,
+    VulkanCommandBufferInfo*                                       command_buffer_info,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pHitShaderBindingTable,
@@ -8379,7 +8393,7 @@ void VulkanReplayConsumerBase::OverrideCmdTraceRaysKHR(
         VkStridedDeviceAddressRegionKHR* in_pCallableShaderBindingTable = pCallableShaderBindingTable->GetPointer();
 
         // identify buffer(s) by their device-address
-        const DeviceInfo* device_info     = GetObjectInfoTable().GetDeviceInfo(command_buffer_info->parent_id);
+        const VulkanDeviceInfo* device_info     = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
         const auto&       address_tracker = GetDeviceAddressTracker(device_info->handle);
 
         auto address_remap = [&address_tracker](VkStridedDeviceAddressRegionKHR* address_region) {
@@ -8408,8 +8422,8 @@ void VulkanReplayConsumerBase::OverrideCmdTraceRaysKHR(
         address_remap(in_pHitShaderBindingTable);
         address_remap(in_pCallableShaderBindingTable);
 
-        const PhysicalDeviceInfo* physical_device_info =
-            GetObjectInfoTable().GetPhysicalDeviceInfo(device_info->parent_id);
+        const VulkanPhysicalDeviceInfo* physical_device_info =
+            GetObjectInfoTable().GetVkPhysicalDeviceInfo(device_info->parent_id);
 
         if (physical_device_info && physical_device_info->replay_device_info->raytracing_properties)
         {
@@ -8439,7 +8453,7 @@ void VulkanReplayConsumerBase::OverrideCmdTraceRaysKHR(
 VkResult VulkanReplayConsumerBase::OverrideCreateImageView(
     PFN_vkCreateImageView                                func,
     VkResult                                             original_result,
-    const DeviceInfo*                                    device_info,
+    const VulkanDeviceInfo*                              device_info,
     StructPointerDecoder<Decoded_VkImageViewCreateInfo>* create_info_decoder,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* allocator_decoder,
     HandlePointerDecoder<VkImageView>*                   view_decoder)
@@ -8453,7 +8467,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateImageView(
 
     if ((result == VK_SUCCESS) && ((*out_view) != VK_NULL_HANDLE))
     {
-        auto image_view_info = reinterpret_cast<ImageViewInfo*>(view_decoder->GetConsumerData(0));
+        auto image_view_info = reinterpret_cast<VulkanImageViewInfo*>(view_decoder->GetConsumerData(0));
         GFXRECON_ASSERT(image_view_info != nullptr);
 
         image_view_info->image_id = create_info_decoder->GetMetaStructPointer()->image;
@@ -8465,7 +8479,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateImageView(
 VkResult VulkanReplayConsumerBase::OverrideCreateFramebuffer(
     PFN_vkCreateFramebuffer                                func,
     VkResult                                               original_result,
-    const DeviceInfo*                                      device_info,
+    const VulkanDeviceInfo*                                device_info,
     StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* create_info_decoder,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>*   allocator_decoder,
     HandlePointerDecoder<VkFramebuffer>*                   frame_buffer_decoder)
@@ -8479,7 +8493,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateFramebuffer(
 
     if ((result == VK_SUCCESS) && ((*out_framebuffer) != VK_NULL_HANDLE))
     {
-        auto framebuffer_info = reinterpret_cast<FramebufferInfo*>(frame_buffer_decoder->GetConsumerData(0));
+        auto framebuffer_info = reinterpret_cast<VulkanFramebufferInfo*>(frame_buffer_decoder->GetConsumerData(0));
         GFXRECON_ASSERT(framebuffer_info != nullptr);
 
         framebuffer_info->framebuffer_flags = create_info->flags;
@@ -8499,9 +8513,9 @@ VkResult VulkanReplayConsumerBase::OverrideCreateFramebuffer(
 }
 
 void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryANDROID func,
-                                                            const DeviceInfo*          device_info,
-                                                            const SemaphoreInfo*       semaphore_info,
-                                                            const ImageInfo*           image_info)
+                                                            const VulkanDeviceInfo*    device_info,
+                                                            const VulkanSemaphoreInfo* semaphore_info,
+                                                            const VulkanImageInfo*     image_info)
 {
     GFXRECON_ASSERT((device_info != nullptr));
 
@@ -8559,7 +8573,7 @@ void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryA
 VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceToolProperties(
     PFN_vkGetPhysicalDeviceToolProperties                         func,
     VkResult                                                      original_result,
-    const PhysicalDeviceInfo*                                     physical_device_info,
+    const VulkanPhysicalDeviceInfo*                               physical_device_info,
     PointerDecoder<uint32_t>*                                     pToolCount,
     StructPointerDecoder<Decoded_VkPhysicalDeviceToolProperties>* pToolProperties)
 {
@@ -8580,9 +8594,9 @@ VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceToolProperties(
 }
 
 VkResult
-VulkanReplayConsumerBase::OverrideWaitSemaphores(PFN_vkWaitSemaphores func,
-                                                 VkResult             original_result,
-                                                 const DeviceInfo*    device_info,
+VulkanReplayConsumerBase::OverrideWaitSemaphores(PFN_vkWaitSemaphores    func,
+                                                 VkResult                original_result,
+                                                 const VulkanDeviceInfo* device_info,
                                                  const StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pInfo,
                                                  uint64_t                                                 timeout)
 {
@@ -8610,7 +8624,7 @@ VulkanReplayConsumerBase::OverrideWaitSemaphores(PFN_vkWaitSemaphores func,
 VkResult VulkanReplayConsumerBase::OverrideAcquireProfilingLockKHR(
     PFN_vkAcquireProfilingLockKHR                                      func,
     VkResult                                                           original_result,
-    const DeviceInfo*                                                  device_info,
+    const VulkanDeviceInfo*                                            device_info,
     const StructPointerDecoder<Decoded_VkAcquireProfilingLockInfoKHR>* pInfo)
 {
     assert((device_info != nullptr) && (pInfo != nullptr) && !pInfo->IsNull() && (pInfo->GetPointer() != nullptr));
@@ -8637,8 +8651,8 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireProfilingLockKHR(
 
 VkResult VulkanReplayConsumerBase::OverrideWaitForPresentKHR(PFN_vkWaitForPresentKHR func,
                                                              VkResult                original_result,
-                                                             const DeviceInfo*       device_info,
-                                                             SwapchainKHRInfo*       swapchain_info,
+                                                             const VulkanDeviceInfo* device_info,
+                                                             VulkanSwapchainKHRInfo* swapchain_info,
                                                              uint64_t                presentid,
                                                              uint64_t                timeout)
 {
@@ -8664,7 +8678,7 @@ VkResult VulkanReplayConsumerBase::OverrideWaitForPresentKHR(PFN_vkWaitForPresen
 }
 
 void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
-    const DescriptorUpdateTemplateInfo* update_template_info, DescriptorUpdateTemplateDecoder* decoder)
+    const VulkanDescriptorUpdateTemplateInfo* update_template_info, DescriptorUpdateTemplateDecoder* decoder)
 {
     assert(decoder != nullptr);
 
@@ -8710,7 +8724,7 @@ void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
 
         for (size_t i = 0; i < texel_buffer_view_count; ++i)
         {
-            auto texel_buffer_view_info = object_info_table_.GetBufferViewInfo(texel_buffer_view_ids[i]);
+            auto texel_buffer_view_info = object_info_table_.GetVkBufferViewInfo(texel_buffer_view_ids[i]);
 
             if (texel_buffer_view_info != nullptr)
             {
@@ -8730,7 +8744,7 @@ void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
 
         for (size_t i = 0; i < accel_struct_count; ++i)
         {
-            auto accel_struct_info = object_info_table_.GetAccelerationStructureKHRInfo(accel_struct_ids[i]);
+            auto accel_struct_info = object_info_table_.GetVkAccelerationStructureKHRInfo(accel_struct_ids[i]);
 
             if (accel_struct_info != nullptr)
             {
@@ -8745,7 +8759,7 @@ void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
 }
 
 void VulkanReplayConsumerBase::GetImportedSemaphores(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
-                                                     std::vector<const SemaphoreInfo*>*       imported_semaphores)
+                                                     std::vector<const VulkanSemaphoreInfo*>* imported_semaphores)
 {
     assert(imported_semaphores != nullptr);
 
@@ -8756,7 +8770,7 @@ void VulkanReplayConsumerBase::GetImportedSemaphores(const HandlePointerDecoder<
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            const SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_ids[i]);
+            const VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_ids[i]);
             if ((semaphore_info != nullptr) && semaphore_info->is_external)
             {
                 imported_semaphores->push_back(semaphore_info);
@@ -8767,7 +8781,7 @@ void VulkanReplayConsumerBase::GetImportedSemaphores(const HandlePointerDecoder<
 
 void VulkanReplayConsumerBase::GetImportedSemaphores(
     const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
-    std::vector<const SemaphoreInfo*>*                         imported_semaphores)
+    std::vector<const VulkanSemaphoreInfo*>*                   imported_semaphores)
 {
     assert(imported_semaphores != nullptr);
 
@@ -8778,7 +8792,8 @@ void VulkanReplayConsumerBase::GetImportedSemaphores(
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            const SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_infos[i].semaphore);
+            const VulkanSemaphoreInfo* semaphore_info =
+                object_info_table_.GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
             if ((semaphore_info != nullptr) && semaphore_info->is_external)
             {
                 imported_semaphores->push_back(semaphore_info);
@@ -8787,8 +8802,8 @@ void VulkanReplayConsumerBase::GetImportedSemaphores(
     }
 }
 
-void VulkanReplayConsumerBase::SignalShadowSemaphore(SemaphoreInfo*                     semaphore_info,
-                                                     std::vector<const SemaphoreInfo*>* shadow_semaphores)
+void VulkanReplayConsumerBase::SignalShadowSemaphore(VulkanSemaphoreInfo*                     semaphore_info,
+                                                     std::vector<const VulkanSemaphoreInfo*>* shadow_semaphores)
 {
     if (semaphore_info->shadow_signaled == true)
     {
@@ -8806,7 +8821,7 @@ void VulkanReplayConsumerBase::SignalShadowSemaphore(SemaphoreInfo*             
 }
 
 void VulkanReplayConsumerBase::GetShadowSemaphores(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
-                                                   std::vector<const SemaphoreInfo*>*       shadow_semaphores)
+                                                   std::vector<const VulkanSemaphoreInfo*>* shadow_semaphores)
 {
     assert(shadow_semaphores != nullptr);
 
@@ -8817,7 +8832,7 @@ void VulkanReplayConsumerBase::GetShadowSemaphores(const HandlePointerDecoder<Vk
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_ids[i]);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_ids[i]);
             if (semaphore_info != nullptr)
             {
                 SignalShadowSemaphore(semaphore_info, shadow_semaphores);
@@ -8828,7 +8843,7 @@ void VulkanReplayConsumerBase::GetShadowSemaphores(const HandlePointerDecoder<Vk
 
 void VulkanReplayConsumerBase::GetShadowSemaphores(
     const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
-    std::vector<const SemaphoreInfo*>*                         shadow_semaphores)
+    std::vector<const VulkanSemaphoreInfo*>*                   shadow_semaphores)
 {
     assert(shadow_semaphores != nullptr);
 
@@ -8839,7 +8854,7 @@ void VulkanReplayConsumerBase::GetShadowSemaphores(
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_infos[i].semaphore);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
             if (semaphore_info != nullptr)
             {
                 SignalShadowSemaphore(semaphore_info, shadow_semaphores);
@@ -8848,8 +8863,9 @@ void VulkanReplayConsumerBase::GetShadowSemaphores(
     }
 }
 
-void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
-                                                             std::vector<const SemaphoreInfo*>* removed_semaphores)
+void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(
+    const HandlePointerDecoder<VkSemaphore>& semaphore_data,
+    std::vector<const VulkanSemaphoreInfo*>* removed_semaphores)
 {
     assert(removed_semaphores != nullptr);
 
@@ -8860,13 +8876,13 @@ void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(const HandlePointer
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_ids[i]);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_ids[i]);
             if (semaphore_info != nullptr)
             {
                 VkSemaphore semaphore = semaphore_info->handle;
                 // Need to ignore if removed.
                 bool removed = false;
-                for (const SemaphoreInfo* remove_semaphore : *removed_semaphores)
+                for (const VulkanSemaphoreInfo* remove_semaphore : *removed_semaphores)
                 {
                     if (semaphore == remove_semaphore->handle)
                     {
@@ -8888,7 +8904,7 @@ void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(const HandlePointer
 
 void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(
     const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
-    std::vector<const SemaphoreInfo*>*                         removed_semaphores)
+    std::vector<const VulkanSemaphoreInfo*>*                   removed_semaphores)
 {
     assert(removed_semaphores != nullptr);
 
@@ -8899,13 +8915,13 @@ void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_infos[i].semaphore);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
             if (semaphore_info != nullptr)
             {
                 VkSemaphore semaphore = semaphore_info->handle;
                 // Need to ignore if removed.
                 bool removed = false;
-                for (const SemaphoreInfo* remove_semaphore : *removed_semaphores)
+                for (const VulkanSemaphoreInfo* remove_semaphore : *removed_semaphores)
                 {
                     if (semaphore == remove_semaphore->handle)
                     {
@@ -8925,8 +8941,9 @@ void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(
     }
 }
 
-void VulkanReplayConsumerBase::GetNonForwardProgress(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
-                                                     std::vector<const SemaphoreInfo*>* non_forward_progress_semaphores)
+void VulkanReplayConsumerBase::GetNonForwardProgress(
+    const HandlePointerDecoder<VkSemaphore>& semaphore_data,
+    std::vector<const VulkanSemaphoreInfo*>* non_forward_progress_semaphores)
 {
     assert(non_forward_progress_semaphores != nullptr);
 
@@ -8937,7 +8954,7 @@ void VulkanReplayConsumerBase::GetNonForwardProgress(const HandlePointerDecoder<
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_ids[i]);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_ids[i]);
             if ((semaphore_info != nullptr) && (semaphore_info->forward_progress == false))
             {
                 if (semaphore_info->signaled == false)
@@ -8955,7 +8972,7 @@ void VulkanReplayConsumerBase::GetNonForwardProgress(const HandlePointerDecoder<
 
 void VulkanReplayConsumerBase::GetNonForwardProgress(
     const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
-    std::vector<const SemaphoreInfo*>*                         non_forward_progress_semaphores)
+    std::vector<const VulkanSemaphoreInfo*>*                   non_forward_progress_semaphores)
 {
     assert(non_forward_progress_semaphores != nullptr);
 
@@ -8966,7 +8983,7 @@ void VulkanReplayConsumerBase::GetNonForwardProgress(
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_infos[i].semaphore);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
             if ((semaphore_info != nullptr) && (semaphore_info->forward_progress == false))
             {
                 if (semaphore_info->signaled == false)
@@ -8982,10 +8999,10 @@ void VulkanReplayConsumerBase::GetNonForwardProgress(
     }
 }
 
-VkResult VulkanReplayConsumerBase::CreateSwapchainImage(const DeviceInfo*        device_info,
+VkResult VulkanReplayConsumerBase::CreateSwapchainImage(const VulkanDeviceInfo*  device_info,
                                                         const VkImageCreateInfo* image_create_info,
                                                         VkImage*                 image,
-                                                        ImageInfo*               image_info)
+                                                        VulkanImageInfo*         image_info)
 {
     // TODO - Rename/repurpose CreateStagingImage to be more allow single place to create image resources.
     VulkanResourceAllocator* allocator = device_info->allocator.get();
@@ -9056,9 +9073,10 @@ VkResult VulkanReplayConsumerBase::CreateSwapchainImage(const DeviceInfo*       
     return result;
 }
 
-void VulkanReplayConsumerBase::UpdateDescriptorSetInfoWithTemplate(DescriptorSetInfo*                     desc_set_info,
-                                                                   const DescriptorUpdateTemplateInfo*    template_info,
-                                                                   const DescriptorUpdateTemplateDecoder* decoder) const
+void VulkanReplayConsumerBase::UpdateDescriptorSetInfoWithTemplate(
+    VulkanDescriptorSetInfo*                  desc_set_info,
+    const VulkanDescriptorUpdateTemplateInfo* template_info,
+    const DescriptorUpdateTemplateDecoder*    decoder) const
 {
     if (desc_set_info != nullptr)
     {
@@ -9093,8 +9111,8 @@ void VulkanReplayConsumerBase::UpdateDescriptorSetInfoWithTemplate(DescriptorSet
 
                     for (uint32_t i = 0; i < count; ++i)
                     {
-                        const ImageViewInfo* img_view_info =
-                            object_info_table_.GetImageViewInfo(img_desc_info[image_info_count].imageView);
+                        const VulkanImageViewInfo* img_view_info =
+                            object_info_table_.GetVkImageViewInfo(img_desc_info[image_info_count].imageView);
                         desc_set_info->descriptors[binding_index].image_info[i] = {
                             img_view_info, img_desc_info[image_info_count].decoded_value->imageLayout
                         };
@@ -9131,8 +9149,8 @@ void VulkanReplayConsumerBase::UpdateDescriptorSetInfoWithTemplate(DescriptorSet
 
                     for (uint32_t i = 0; i < count; ++i)
                     {
-                        const BufferInfo* buf_info =
-                            object_info_table_.GetBufferInfo(buf_desc_info[buffer_info_count].buffer);
+                        const VulkanBufferInfo* buf_info =
+                            object_info_table_.GetVkBufferInfo(buf_desc_info[buffer_info_count].buffer);
                         assert(buf_info != nullptr);
 
                         desc_set_info->descriptors[binding_index].buffer_info[i] = {
@@ -9160,8 +9178,8 @@ void VulkanReplayConsumerBase::UpdateDescriptorSetInfoWithTemplate(DescriptorSet
 
                     for (uint32_t i = 0; i < count; ++i)
                     {
-                        const BufferViewInfo* buf_view_info =
-                            object_info_table_.GetBufferViewInfo(buffer_view_ids[texel_buffer_view_count]);
+                        const VulkanBufferViewInfo* buf_view_info =
+                            object_info_table_.GetVkBufferViewInfo(buffer_view_ids[texel_buffer_view_count]);
                         assert(buf_view_info != nullptr);
 
                         desc_set_info->descriptors[binding_index].texel_buffer_view_info[i] = buf_view_info;
@@ -9214,11 +9232,11 @@ void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(const A
 {
     assert(pData != nullptr);
 
-    VkDevice        in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
+    VkDevice        in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
     VkDescriptorSet in_descriptorSet =
-        MapHandle<DescriptorSetInfo>(descriptorSet, &VulkanObjectInfoTable::GetDescriptorSetInfo);
+        MapHandle<VulkanDescriptorSetInfo>(descriptorSet, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
     VkDescriptorUpdateTemplate in_descriptorUpdateTemplate = VK_NULL_HANDLE;
-    auto update_template_info = object_info_table_.GetDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
+    auto update_template_info = object_info_table_.GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
 
     MapDescriptorUpdateTemplateHandles(update_template_info, pData);
 
@@ -9229,7 +9247,7 @@ void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(const A
 
     if (options_.dumping_resources)
     {
-        DescriptorSetInfo* desc_set_info = object_info_table_.GetDescriptorSetInfo(descriptorSet);
+        VulkanDescriptorSetInfo* desc_set_info = object_info_table_.GetVkDescriptorSetInfo(descriptorSet);
         UpdateDescriptorSetInfoWithTemplate(desc_set_info, update_template_info, pData);
     }
 
@@ -9247,10 +9265,11 @@ void VulkanReplayConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(con
     assert(pData != nullptr);
 
     VkCommandBuffer in_commandBuffer =
-        MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
+        MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
     VkDescriptorUpdateTemplate in_descriptorUpdateTemplate = VK_NULL_HANDLE;
-    VkPipelineLayout in_layout = MapHandle<PipelineLayoutInfo>(layout, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
-    auto update_template_info  = object_info_table_.GetDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
+    VkPipelineLayout           in_layout =
+        MapHandle<VulkanPipelineLayoutInfo>(layout, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+    auto update_template_info = object_info_table_.GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
 
     MapDescriptorUpdateTemplateHandles(update_template_info, pData);
 
@@ -9284,12 +9303,13 @@ void VulkanReplayConsumerBase::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
     Decoded_VkPushDescriptorSetWithTemplateInfoKHR* in_info =
         pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer();
     VkPushDescriptorSetWithTemplateInfoKHR* value = in_info->decoded_value;
-    DescriptorUpdateTemplateInfo*           update_template_info =
-        object_info_table_.GetDescriptorUpdateTemplateInfo(in_info->descriptorUpdateTemplate);
+    VulkanDescriptorUpdateTemplateInfo*     update_template_info =
+        object_info_table_.GetVkDescriptorUpdateTemplateInfo(in_info->descriptorUpdateTemplate);
 
     VkCommandBuffer in_commandBuffer =
-        MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
-    value->layout = MapHandle<PipelineLayoutInfo>(in_info->layout, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    value->layout =
+        MapHandle<VulkanPipelineLayoutInfo>(in_info->layout, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
 
     MapDescriptorUpdateTemplateHandles(update_template_info, &in_info->pData);
     value->pData = in_info->pData.GetPointer();
@@ -9316,11 +9336,11 @@ void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(cons
 {
     assert(pData != nullptr);
 
-    VkDevice        in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
+    VkDevice        in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
     VkDescriptorSet in_descriptorSet =
-        MapHandle<DescriptorSetInfo>(descriptorSet, &VulkanObjectInfoTable::GetDescriptorSetInfo);
+        MapHandle<VulkanDescriptorSetInfo>(descriptorSet, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
     VkDescriptorUpdateTemplate in_descriptorUpdateTemplate = VK_NULL_HANDLE;
-    auto update_template_info = object_info_table_.GetDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
+    auto update_template_info = object_info_table_.GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
 
     MapDescriptorUpdateTemplateHandles(update_template_info, pData);
 
@@ -9331,7 +9351,7 @@ void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(cons
 
     if (options_.dumping_resources)
     {
-        DescriptorSetInfo* desc_set_info = object_info_table_.GetDescriptorSetInfo(descriptorSet);
+        VulkanDescriptorSetInfo* desc_set_info = object_info_table_.GetVkDescriptorSetInfo(descriptorSet);
         UpdateDescriptorSetInfoWithTemplate(desc_set_info, update_template_info, pData);
     }
 
@@ -9350,9 +9370,9 @@ void VulkanReplayConsumerBase::Process_vkCreateRayTracingPipelinesKHR(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
     HandlePointerDecoder<VkPipeline>*                                pPipelines)
 {
-    auto in_device            = GetObjectInfoTable().GetDeviceInfo(device);
-    auto in_deferredOperation = GetObjectInfoTable().GetDeferredOperationKHRInfo(deferredOperation);
-    auto in_pipelineCache     = GetObjectInfoTable().GetPipelineCacheInfo(pipelineCache);
+    auto in_device            = GetObjectInfoTable().GetVkDeviceInfo(device);
+    auto in_deferredOperation = GetObjectInfoTable().GetVkDeferredOperationKHRInfo(deferredOperation);
+    auto in_pipelineCache     = GetObjectInfoTable().GetVkPipelineCacheInfo(pipelineCache);
     MapStructArrayHandles(pCreateInfos->GetMetaStructPointer(), pCreateInfos->GetLength(), GetObjectInfoTable());
 
     if (!pPipelines->IsNull())
@@ -9360,7 +9380,7 @@ void VulkanReplayConsumerBase::Process_vkCreateRayTracingPipelinesKHR(
         pPipelines->SetHandleLength(createInfoCount);
     }
 
-    std::vector<PipelineInfo> handle_info(createInfoCount);
+    std::vector<VulkanPipelineInfo> handle_info(createInfoCount);
 
     for (size_t i = 0; i < createInfoCount; ++i)
     {
@@ -9382,20 +9402,20 @@ void VulkanReplayConsumerBase::Process_vkCreateRayTracingPipelinesKHR(
     if ((replay_result == VK_SUCCESS) || (replay_result == VK_OPERATION_NOT_DEFERRED_KHR) ||
         (replay_result == VK_PIPELINE_COMPILE_REQUIRED_EXT))
     {
-        AddHandles<PipelineInfo>(device,
-                                 pPipelines->GetPointer(),
-                                 pPipelines->GetLength(),
-                                 pPipelines->GetHandlePointer(),
-                                 createInfoCount,
-                                 std::move(handle_info),
-                                 &VulkanObjectInfoTable::AddPipelineInfo);
+        AddHandles<VulkanPipelineInfo>(device,
+                                       pPipelines->GetPointer(),
+                                       pPipelines->GetLength(),
+                                       pPipelines->GetHandlePointer(),
+                                       createInfoCount,
+                                       std::move(handle_info),
+                                       &VulkanObjectInfoTable::AddVkPipelineInfo);
     }
 }
 
 void VulkanReplayConsumerBase::ProcessCopyVulkanAccelerationStructuresMetaCommand(
     format::HandleId device, StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* copy_infos)
 {
-    DeviceInfo* device_info = GetObjectInfoTable().GetDeviceInfo(device);
+    VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(device);
     GFXRECON_ASSERT(device_info != nullptr);
 
     auto allocator = device_info->allocator.get();
@@ -9420,7 +9440,7 @@ void VulkanReplayConsumerBase::ProcessBuildVulkanAccelerationStructuresMetaComma
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>*   ppRangeInfos,
     std::vector<std::vector<VkAccelerationStructureInstanceKHR>>&              instance_buffers_data)
 {
-    DeviceInfo* device_info = GetObjectInfoTable().GetDeviceInfo(device);
+    VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(device);
     GFXRECON_ASSERT(device_info != nullptr);
 
     auto allocator = device_info->allocator.get();
@@ -9441,7 +9461,7 @@ void VulkanReplayConsumerBase::ProcessBuildVulkanAccelerationStructuresMetaComma
 void VulkanReplayConsumerBase::ProcessVulkanAccelerationStructuresWritePropertiesMetaCommand(
     format::HandleId device_id, VkQueryType query_type, format::HandleId acceleration_structure_id)
 {
-    DeviceInfo* device_info = GetObjectInfoTable().GetDeviceInfo(device_id);
+    VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(device_id);
     GFXRECON_ASSERT(device_info != nullptr);
 
     auto allocator = device_info->allocator.get();
@@ -9452,8 +9472,8 @@ void VulkanReplayConsumerBase::ProcessVulkanAccelerationStructuresWritePropertie
         return;
     }
 
-    VkAccelerationStructureKHR acceleration_structure = MapHandle<AccelerationStructureKHRInfo>(
-        acceleration_structure_id, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+    VkAccelerationStructureKHR acceleration_structure = MapHandle<VulkanAccelerationStructureKHRInfo>(
+        acceleration_structure_id, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
 
     // TODO: implement
     //    acceleration_structure_builders_[device_id]->ProcessVulkanAccelerationStructuresWritePropertiesMetaCommand(
@@ -9462,7 +9482,7 @@ void VulkanReplayConsumerBase::ProcessVulkanAccelerationStructuresWritePropertie
 
 void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
     PFN_vkUpdateDescriptorSets                          func,
-    const DeviceInfo*                                   device_info,
+    const VulkanDeviceInfo*                             device_info,
     uint32_t                                            descriptor_write_count,
     StructPointerDecoder<Decoded_VkWriteDescriptorSet>* p_descriptor_writes,
     uint32_t                                            descriptor_copy_count,
@@ -9480,7 +9500,7 @@ void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
         const auto* writes_meta = p_descriptor_writes->GetMetaStructPointer();
         for (uint32_t s = 0; s < descriptor_write_count; ++s)
         {
-            DescriptorSetInfo* desc_set_info = GetObjectInfoTable().GetDescriptorSetInfo(writes_meta[s].dstSet);
+            VulkanDescriptorSetInfo* desc_set_info = GetObjectInfoTable().GetVkDescriptorSetInfo(writes_meta[s].dstSet);
 
             assert(desc_set_info != nullptr);
 
@@ -9510,7 +9530,7 @@ void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
                             desc_set_info->descriptors[binding].image_info[arr_idx].image_layout =
                                 in_pDescriptorWrites[s].pImageInfo[b].imageLayout;
                             desc_set_info->descriptors[binding].image_info[arr_idx].image_view_info =
-                                object_info_table_.GetImageViewInfo(
+                                object_info_table_.GetVkImageViewInfo(
                                     writes_meta[s].pImageInfo->GetMetaStructPointer()[b].imageView);
                         }
                     }
@@ -9528,7 +9548,7 @@ void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
                         {
                             const uint32_t arr_idx = write->dstArrayElement + i;
                             desc_set_info->descriptors[binding].buffer_info[arr_idx].buffer_info =
-                                object_info_table_.GetBufferInfo(
+                                object_info_table_.GetVkBufferInfo(
                                     writes_meta[s].pBufferInfo->GetMetaStructPointer()[b].buffer);
                             desc_set_info->descriptors[binding].buffer_info[arr_idx].offset =
                                 in_pDescriptorWrites[s].pBufferInfo[b].offset;
@@ -9548,7 +9568,7 @@ void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
                         {
                             const uint32_t arr_idx = write->dstArrayElement + i;
                             desc_set_info->descriptors[binding].texel_buffer_view_info[arr_idx] =
-                                object_info_table_.GetBufferViewInfo(writes_meta[s].pTexelBufferView.GetPointer()[b]);
+                                object_info_table_.GetVkBufferViewInfo(writes_meta[s].pTexelBufferView.GetPointer()[b]);
                         }
                     }
                     break;
@@ -9643,8 +9663,8 @@ void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
 VkResult VulkanReplayConsumerBase::OverrideCreateGraphicsPipelines(
     PFN_vkCreateGraphicsPipelines                                     func,
     VkResult                                                          original_result,
-    const DeviceInfo*                                                 device_info,
-    const PipelineCacheInfo*                                          pipeline_cache_info,
+    const VulkanDeviceInfo*                                           device_info,
+    const VulkanPipelineCacheInfo*                                    pipeline_cache_info,
     uint32_t                                                          create_info_count,
     const StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*        pAllocator,
@@ -9699,8 +9719,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateGraphicsPipelines(
 VkResult VulkanReplayConsumerBase::OverrideCreateComputePipelines(
     PFN_vkCreateComputePipelines                                     func,
     VkResult                                                         original_result,
-    const DeviceInfo*                                                device_info,
-    const PipelineCacheInfo*                                         pipeline_cache_info,
+    const VulkanDeviceInfo*                                          device_info,
+    const VulkanPipelineCacheInfo*                                   pipeline_cache_info,
     uint32_t                                                         create_info_count,
     const StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfos,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
@@ -9728,10 +9748,11 @@ VkResult VulkanReplayConsumerBase::OverrideCreateComputePipelines(
         for (uint32_t i = 0; i < create_info_count; ++i)
         {
             assert(create_info_meta[i].stage);
-            ShaderModuleInfo* module_info = object_info_table_.GetShaderModuleInfo(create_info_meta[i].stage->module);
+            VulkanShaderModuleInfo* module_info =
+                object_info_table_.GetVkShaderModuleInfo(create_info_meta[i].stage->module);
             assert(module_info);
 
-            PipelineInfo* pipeline_info = reinterpret_cast<PipelineInfo*>(pPipelines->GetConsumerData(i));
+            VulkanPipelineInfo* pipeline_info = reinterpret_cast<VulkanPipelineInfo*>(pPipelines->GetConsumerData(i));
             assert(pipeline_info);
 
             pipeline_info->shaders.insert({ VK_SHADER_STAGE_COMPUTE_BIT, *module_info });
@@ -9777,7 +9798,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateComputePipelines(
 VkResult VulkanReplayConsumerBase::OverrideCreateShadersEXT(
     PFN_vkCreateShadersEXT                                     func,
     VkResult                                                   original_result,
-    const DeviceInfo*                                          device_info,
+    const VulkanDeviceInfo*                                    device_info,
     uint32_t                                                   create_info_count,
     const StructPointerDecoder<Decoded_VkShaderCreateInfoEXT>* pCreateInfos,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
@@ -9827,8 +9848,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShadersEXT(
 
 void VulkanReplayConsumerBase::OverrideDestroyPipeline(
     PFN_vkDestroyPipeline                                      func,
-    const DeviceInfo*                                          device_info,
-    PipelineInfo*                                              pipeline_info,
+    const VulkanDeviceInfo*                                    device_info,
+    VulkanPipelineInfo*                                        pipeline_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     GFXRECON_ASSERT(device_info != nullptr);
@@ -9838,7 +9859,8 @@ void VulkanReplayConsumerBase::OverrideDestroyPipeline(
 
     if (pipeline_info != nullptr)
     {
-        in_pipeline = MapHandle<PipelineInfo>(pipeline_info->capture_id, &VulkanObjectInfoTable::GetPipelineInfo);
+        in_pipeline =
+            MapHandle<VulkanPipelineInfo>(pipeline_info->capture_id, &VulkanObjectInfoTable::GetVkPipelineInfo);
 
         if (IsUsedByAsyncTask(pipeline_info->capture_id))
         {
@@ -9854,8 +9876,8 @@ void VulkanReplayConsumerBase::OverrideDestroyPipeline(
 
 void VulkanReplayConsumerBase::OverrideDestroyRenderPass(
     PFN_vkDestroyRenderPass                                    func,
-    const DeviceInfo*                                          device_info,
-    RenderPassInfo*                                            renderpass_info,
+    const VulkanDeviceInfo*                                    device_info,
+    VulkanRenderPassInfo*                                      renderpass_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     VkDevice                     in_device     = device_info->handle;
@@ -9880,8 +9902,8 @@ void VulkanReplayConsumerBase::OverrideDestroyRenderPass(
 
 void VulkanReplayConsumerBase::OverrideDestroyShaderModule(
     PFN_vkDestroyShaderModule                                  func,
-    const DeviceInfo*                                          device_info,
-    ShaderModuleInfo*                                          shader_module_info,
+    const VulkanDeviceInfo*                                    device_info,
+    VulkanShaderModuleInfo*                                    shader_module_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     VkDevice                     in_device        = device_info->handle;
@@ -9907,8 +9929,8 @@ void VulkanReplayConsumerBase::OverrideDestroyShaderModule(
 std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::AsyncCreateGraphicsPipelines(
     const ApiCallInfo&                                          call_info,
     VkResult                                                    returnValue,
-    const DeviceInfo*                                           device_info,
-    const PipelineCacheInfo*                                    pipeline_cache_info,
+    const VulkanDeviceInfo*                                     device_info,
+    const VulkanPipelineCacheInfo*                              pipeline_cache_info,
     uint32_t                                                    createInfoCount,
     StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>*        pAllocator,
@@ -9945,7 +9967,7 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
         std::copy_n(pPipelines->GetPointer(), createInfoCount, pipelines.begin());
 
         sync_fn = [this, parent_id = pPipelines->GetPointer()[0]]() {
-            MapHandle<PipelineInfo>(parent_id, &VulkanObjectInfoTable::GetPipelineInfo);
+            MapHandle<VulkanPipelineInfo>(parent_id, &VulkanObjectInfoTable::GetVkPipelineInfo);
         };
     }
     TrackAsyncHandles(handle_deps, sync_fn);
@@ -9990,8 +10012,8 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
 std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::AsyncCreateComputePipelines(
     const ApiCallInfo&                                         call_info,
     VkResult                                                   returnValue,
-    const DeviceInfo*                                          device_info,
-    const PipelineCacheInfo*                                   pipeline_cache_info,
+    const VulkanDeviceInfo*                                    device_info,
+    const VulkanPipelineCacheInfo*                             pipeline_cache_info,
     uint32_t                                                   createInfoCount,
     StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfos,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
@@ -10020,7 +10042,7 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
     if (pPipelines != nullptr && createInfoCount > 0)
     {
         sync_fn = [this, parent_id = pPipelines->GetPointer()[0]]() {
-            MapHandle<PipelineInfo>(parent_id, &VulkanObjectInfoTable::GetPipelineInfo);
+            MapHandle<VulkanPipelineInfo>(parent_id, &VulkanObjectInfoTable::GetVkPipelineInfo);
         };
     }
     TrackAsyncHandles(handle_deps, sync_fn);
@@ -10057,7 +10079,7 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
 std::function<handle_create_result_t<VkShaderEXT>()>
 VulkanReplayConsumerBase::AsyncCreateShadersEXT(const ApiCallInfo&                                   call_info,
                                                 VkResult                                             returnValue,
-                                                const DeviceInfo*                                    device_info,
+                                                const VulkanDeviceInfo*                              device_info,
                                                 uint32_t                                             createInfoCount,
                                                 StructPointerDecoder<Decoded_VkShaderCreateInfoEXT>* pCreateInfos,
                                                 StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
@@ -10081,7 +10103,7 @@ VulkanReplayConsumerBase::AsyncCreateShadersEXT(const ApiCallInfo&              
         std::copy_n(pShaders->GetPointer(), createInfoCount, shaders.begin());
 
         sync_fn = [this, parent_id = pShaders->GetPointer()[0]]() {
-            MapHandle<ShaderEXTInfo>(parent_id, &VulkanObjectInfoTable::GetShaderEXTInfo);
+            MapHandle<VulkanShaderEXTInfo>(parent_id, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
         };
     }
     TrackAsyncHandles(handle_deps, sync_fn);

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -170,11 +170,17 @@ static uint32_t GetHardwareBufferFormatBpp(uint32_t format)
 
 VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::Application> application,
                                                    const VulkanReplayOptions&                options) :
-    resource_dumper_(options, object_info_table_),
-    loader_handle_(nullptr), get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr),
-    application_(application), options_(options), loading_trim_state_(false), replaying_trimmed_capture_(false),
-    have_imported_semaphores_(false), fps_info_(nullptr), omitted_pipeline_cache_data_(false)
+    loader_handle_(nullptr),
+    get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr), application_(application), options_(options),
+    loading_trim_state_(false), replaying_trimmed_capture_(false), have_imported_semaphores_(false), fps_info_(nullptr),
+    omitted_pipeline_cache_data_(false)
 {
+    object_info_table_ = CommonObjectInfoTable::GetSingleton();
+    assert(object_info_table_);
+
+    resource_dumper_ = new VulkanReplayDumpResources(options, object_info_table_);
+    assert(resource_dumper_);
+
     assert(application_ != nullptr);
     assert(options.create_resource_allocator != nullptr);
 
@@ -223,7 +229,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     WaitDevicesIdle();
 
     // Cleanup screenshot resources before destroying device.
-    object_info_table_.VisitVkDeviceInfo([this](const VulkanDeviceInfo* info) {
+    object_info_table_->VisitVkDeviceInfo([this](const VulkanDeviceInfo* info) {
         assert(info != nullptr);
         VkDevice device = info->handle;
 
@@ -237,7 +243,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     });
 
     object_cleanup::FreeAllLiveObjects(
-        &object_info_table_,
+        object_info_table_,
         false,
         true,
         [this](const void* handle) { return GetInstanceTable(handle); },
@@ -248,7 +254,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
 
     // Finally destroy vkInstances
     object_cleanup::FreeAllLiveInstances(
-        &object_info_table_,
+        object_info_table_,
         false,
         true,
         [this](const void* handle) { return GetInstanceTable(handle); },
@@ -258,11 +264,17 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     {
         graphics::ReleaseLoader(loader_handle_);
     }
+
+    delete resource_dumper_;
+    resource_dumper_ = nullptr;
+
+    CommonObjectInfoTable::ReleaseSingleton();
+    object_info_table_ = nullptr;
 }
 
 void VulkanReplayConsumerBase::WaitDevicesIdle()
 {
-    object_info_table_.VisitVkDeviceInfo([this](const VulkanDeviceInfo* info) {
+    object_info_table_->VisitVkDeviceInfo([this](const VulkanDeviceInfo* info) {
         assert(info != nullptr);
         VkDevice device = info->handle;
 
@@ -305,7 +317,7 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
     VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
     // We need to find the device memory associated with this ID, and then lookup its mapped pointer.
-    const VulkanDeviceMemoryInfo* memory_info = object_info_table_.GetVkDeviceMemoryInfo(memory_id);
+    const VulkanDeviceMemoryInfo* memory_info = object_info_table_->GetVkDeviceMemoryInfo(memory_id);
 
     if (memory_info != nullptr)
     {
@@ -400,7 +412,7 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
 void VulkanReplayConsumerBase::ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height)
 {
     // We need to find the surface associated with this ID, and then lookup its window.
-    const VulkanSurfaceKHRInfo* surface_info = object_info_table_.GetVkSurfaceKHRInfo(surface_id);
+    const VulkanSurfaceKHRInfo* surface_info = object_info_table_->GetVkSurfaceKHRInfo(surface_id);
 
     if (surface_info != nullptr)
     {
@@ -438,7 +450,7 @@ void VulkanReplayConsumerBase::ProcessResizeWindowCommand2(format::HandleId surf
                                                            uint32_t         pre_transform)
 {
     // We need to find the surface associated with this ID, and then lookup its window.
-    const VulkanSurfaceKHRInfo* surface_info = object_info_table_.GetVkSurfaceKHRInfo(surface_id);
+    const VulkanSurfaceKHRInfo* surface_info = object_info_table_->GetVkSurfaceKHRInfo(surface_id);
 
     if (surface_info != nullptr)
     {
@@ -636,7 +648,7 @@ void VulkanReplayConsumerBase::ProcessSetDevicePropertiesCommand(format::HandleI
                                                                  const uint8_t pipeline_cache_uuid[format::kUuidSize],
                                                                  const std::string& device_name)
 {
-    VulkanPhysicalDeviceInfo* physical_device_info = object_info_table_.GetVkPhysicalDeviceInfo(physical_device_id);
+    VulkanPhysicalDeviceInfo* physical_device_info = object_info_table_->GetVkPhysicalDeviceInfo(physical_device_id);
 
     if (physical_device_info != nullptr)
     {
@@ -659,7 +671,7 @@ void VulkanReplayConsumerBase::ProcessSetDeviceMemoryPropertiesCommand(
     const std::vector<format::DeviceMemoryType>& memory_types,
     const std::vector<format::DeviceMemoryHeap>& memory_heaps)
 {
-    VulkanPhysicalDeviceInfo* physical_device_info = object_info_table_.GetVkPhysicalDeviceInfo(physical_device_id);
+    VulkanPhysicalDeviceInfo* physical_device_info = object_info_table_->GetVkPhysicalDeviceInfo(physical_device_id);
 
     if (physical_device_info != nullptr)
     {
@@ -686,7 +698,7 @@ void VulkanReplayConsumerBase::ProcessSetOpaqueAddressCommand(format::HandleId d
                                                               format::HandleId object_id,
                                                               uint64_t         address)
 {
-    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(device_id);
+    VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(device_id);
 
     if (device_info != nullptr)
     {
@@ -700,7 +712,7 @@ void VulkanReplayConsumerBase::ProcessSetRayTracingShaderGroupHandlesCommand(for
                                                                              size_t           data_size,
                                                                              const uint8_t*   data)
 {
-    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(device_id);
+    VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(device_id);
     if (device_info != nullptr)
     {
         // There should only be one dataset per pipeline.
@@ -717,8 +729,8 @@ void VulkanReplayConsumerBase::ProcessSetSwapchainImageStateCommand(
     uint32_t                                            last_presented_image,
     const std::vector<format::SwapchainImageStateInfo>& image_info)
 {
-    const VulkanDeviceInfo* device_info    = object_info_table_.GetVkDeviceInfo(device_id);
-    VulkanSwapchainKHRInfo* swapchain_info = object_info_table_.GetVkSwapchainKHRInfo(swapchain_id);
+    const VulkanDeviceInfo* device_info    = object_info_table_->GetVkDeviceInfo(device_id);
+    VulkanSwapchainKHRInfo* swapchain_info = object_info_table_->GetVkSwapchainKHRInfo(swapchain_id);
 
     if ((device_info != nullptr) && (swapchain_info != nullptr))
     {
@@ -727,7 +739,7 @@ void VulkanReplayConsumerBase::ProcessSetSwapchainImageStateCommand(
                                                          swapchain_info,
                                                          last_presented_image,
                                                          image_info,
-                                                         object_info_table_,
+                                                         *object_info_table_,
                                                          swapchain_image_tracker_);
     }
     else
@@ -758,7 +770,7 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
 {
     GFXRECON_UNREFERENCED_PARAMETER(max_resource_size);
 
-    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(device_id);
+    VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(device_id);
 
     if (device_info != nullptr)
     {
@@ -801,7 +813,7 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
 
 void VulkanReplayConsumerBase::ProcessEndResourceInitCommand(format::HandleId device_id)
 {
-    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(device_id);
+    VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(device_id);
 
     if ((device_info != nullptr) && (device_info->resource_initializer != nullptr))
     {
@@ -814,8 +826,8 @@ void VulkanReplayConsumerBase::ProcessInitBufferCommand(format::HandleId device_
                                                         uint64_t         data_size,
                                                         const uint8_t*   data)
 {
-    VulkanDeviceInfo*       device_info = object_info_table_.GetVkDeviceInfo(device_id);
-    const VulkanBufferInfo* buffer_info = object_info_table_.GetVkBufferInfo(buffer_id);
+    VulkanDeviceInfo*       device_info = object_info_table_->GetVkDeviceInfo(device_id);
+    const VulkanBufferInfo* buffer_info = object_info_table_->GetVkBufferInfo(buffer_id);
 
     if ((device_info != nullptr) && (buffer_info != nullptr))
     {
@@ -891,8 +903,8 @@ void VulkanReplayConsumerBase::ProcessInitImageCommand(format::HandleId         
                                                        const std::vector<uint64_t>& level_sizes,
                                                        const uint8_t*               data)
 {
-    VulkanDeviceInfo*      device_info = object_info_table_.GetVkDeviceInfo(device_id);
-    const VulkanImageInfo* image_info  = object_info_table_.GetVkImageInfo(image_id);
+    VulkanDeviceInfo*      device_info = object_info_table_->GetVkDeviceInfo(device_id);
+    const VulkanImageInfo* image_info  = object_info_table_->GetVkImageInfo(image_id);
 
     if ((device_info != nullptr) && (image_info != nullptr))
     {
@@ -1242,7 +1254,7 @@ void VulkanReplayConsumerBase::CheckReplayDeviceInfo(VulkanPhysicalDeviceInfo* p
         // A physical device handle was obtained without calling vkEnumeratePhysicalDevices or
         // vkEnumeratePhysicalDeviceGroups, so the physical device initialization that would have been performed when
         // replaying those calls will be performed here.
-        auto instance_info = object_info_table_.GetVkInstanceInfo(physical_device_info->parent_id);
+        auto instance_info = object_info_table_->GetVkInstanceInfo(physical_device_info->parent_id);
         if (instance_info != nullptr)
         {
             assert(physical_device_info->handle != VK_NULL_HANDLE);
@@ -1337,7 +1349,7 @@ void VulkanReplayConsumerBase::SelectPhysicalDevice(VulkanPhysicalDeviceInfo* ph
 {
     assert((physical_device_info != nullptr) && (physical_device_info->parent_id != format::kNullHandleId));
 
-    VulkanInstanceInfo* instance_info = object_info_table_.GetVkInstanceInfo(physical_device_info->parent_id);
+    VulkanInstanceInfo* instance_info = object_info_table_->GetVkInstanceInfo(physical_device_info->parent_id);
 
     if (instance_info != nullptr)
     {
@@ -1372,7 +1384,7 @@ void VulkanReplayConsumerBase::SelectPhysicalDeviceGroup(VulkanPhysicalDeviceInf
 {
     assert((physical_device_info != nullptr) && (physical_device_info->parent_id != format::kNullHandleId));
 
-    VulkanInstanceInfo* instance_info = object_info_table_.GetVkInstanceInfo(physical_device_info->parent_id);
+    VulkanInstanceInfo* instance_info = object_info_table_->GetVkInstanceInfo(physical_device_info->parent_id);
 
     if (instance_info != nullptr)
     {
@@ -1960,7 +1972,7 @@ void VulkanReplayConsumerBase::ProcessSwapchainFullScreenExclusiveInfo(
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
         // Get the surface info from the Decoded_VkSwapchainCreateInfoKHR handle id.
         HMONITOR   hmonitor     = nullptr;
-        const auto surface_info = object_info_table_.GetVkSurfaceKHRInfo(swapchain_info->surface);
+        const auto surface_info = object_info_table_->GetVkSurfaceKHRInfo(swapchain_info->surface);
 
         if ((surface_info != nullptr) && (surface_info->window != nullptr))
         {
@@ -2051,7 +2063,7 @@ void VulkanReplayConsumerBase::SetSwapchainWindowSize(const Decoded_VkSwapchainC
     const auto create_info = swapchain_info->decoded_value;
     if (create_info != nullptr)
     {
-        const auto surface_info = object_info_table_.GetVkSurfaceKHRInfo(swapchain_info->surface);
+        const auto surface_info = object_info_table_->GetVkSurfaceKHRInfo(swapchain_info->surface);
         if (surface_info && (surface_info->window != nullptr))
         {
             uint32_t pre_transform = 0;
@@ -2128,7 +2140,7 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
 
         for (uint32_t i = 0; i < present_info->swapchainCount; ++i)
         {
-            auto swapchain_info = object_info_table_.GetVkSwapchainKHRInfo(swapchain_ids[i]);
+            auto swapchain_info = object_info_table_->GetVkSwapchainKHRInfo(swapchain_ids[i]);
             if ((swapchain_info != nullptr) && (swapchain_info->device_info != nullptr) &&
                 (swapchain_info->images.size() > 0))
             {
@@ -2190,7 +2202,7 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
     {
         if (screenshot_handler_->IsScreenshotFrame())
         {
-            VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(command_buffer_info->parent_id);
+            VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(command_buffer_info->parent_id);
 
             auto instance_table = GetInstanceTable(device_info->parent);
             GFXRECON_ASSERT(instance_table != nullptr);
@@ -2203,13 +2215,13 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
             for (size_t i = 0; i < command_buffer_info->frame_buffer_ids.size(); ++i)
             {
                 auto framebuffer_info =
-                    object_info_table_.GetVkFramebufferInfo(command_buffer_info->frame_buffer_ids[i]);
+                    object_info_table_->GetVkFramebufferInfo(command_buffer_info->frame_buffer_ids[i]);
 
                 for (size_t j = 0; j < framebuffer_info->attachment_image_view_ids.size(); ++j)
                 {
                     auto image_view_id   = framebuffer_info->attachment_image_view_ids[j];
-                    auto image_view_info = object_info_table_.GetVkImageViewInfo(image_view_id);
-                    auto image_info      = object_info_table_.GetVkImageInfo(image_view_info->image_id);
+                    auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
+                    auto image_info      = object_info_table_->GetVkImageInfo(image_view_info->image_id);
 
                     // Only screenshot images that are color attachments.
                     if ((image_info->usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) !=
@@ -2853,7 +2865,7 @@ VulkanReplayConsumerBase::OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysic
                 overflow_info.parent_id  = instance_info->capture_id;
                 SetPhysicalDeviceInstanceInfo(instance_info, &overflow_info, overflow_device);
 
-                object_info_table_.AddVkPhysicalDeviceInfo(std::move(overflow_info));
+                object_info_table_->AddVkPhysicalDeviceInfo(std::move(overflow_info));
             }
         }
     }
@@ -2968,7 +2980,7 @@ VkResult VulkanReplayConsumerBase::OverrideEnumeratePhysicalDeviceGroups(
                 physical_device_info.parent_id  = instance_info->capture_id;
                 SetPhysicalDeviceInstanceInfo(instance_info, &physical_device_info, entry.second);
 
-                object_info_table_.AddVkPhysicalDeviceInfo(std::move(physical_device_info));
+                object_info_table_->AddVkPhysicalDeviceInfo(std::move(physical_device_info));
             }
         }
 
@@ -2996,7 +3008,7 @@ VkResult VulkanReplayConsumerBase::OverrideEnumeratePhysicalDeviceGroups(
                 overflow_info.parent_id  = instance_info->capture_id;
                 SetPhysicalDeviceInstanceInfo(instance_info, &overflow_info, overflow_device);
 
-                object_info_table_.AddVkPhysicalDeviceInfo(std::move(overflow_info));
+                object_info_table_->AddVkPhysicalDeviceInfo(std::move(overflow_info));
             }
         }
     }
@@ -3213,7 +3225,7 @@ VkResult VulkanReplayConsumerBase::OverrideWaitForFences(PFN_vkWaitForFences    
         const format::HandleId* fence_handles = pFences->GetPointer();
         for (size_t i = 0; i < pFences->GetLength(); ++i)
         {
-            VulkanFenceInfo* fence_info = object_info_table_.GetVkFenceInfo(fence_handles[i]);
+            VulkanFenceInfo* fence_info = object_info_table_->GetVkFenceInfo(fence_handles[i]);
             if (fence_info != nullptr)
             {
                 VkFence fence_handle = fence_info->handle;
@@ -3474,9 +3486,9 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit      fu
             }
 
             if (submit_info_data != nullptr && (options_.dumping_resources) &&
-                resource_dumper_.MustDumpQueueSubmitIndex(index))
+                resource_dumper_->MustDumpQueueSubmitIndex(index))
             {
-                resource_dumper_.QueueSubmit(
+                resource_dumper_->QueueSubmit(
                     modified_submit_infos, *GetDeviceTable(queue_info->handle), queue_info->handle, fence, index);
             }
             else
@@ -3501,7 +3513,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit      fu
         {
             if (submit_info_data != nullptr)
             {
-                if (CheckPNextChainForFrameBoundary(object_info_table_.GetVkDeviceInfo(queue_info->parent_id),
+                if (CheckPNextChainForFrameBoundary(object_info_table_->GetVkDeviceInfo(queue_info->parent_id),
                                                     submit_info_data->pNext))
                 {
                     break;
@@ -3676,7 +3688,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2     f
         {
             if (submit_info_data != nullptr)
             {
-                if (CheckPNextChainForFrameBoundary(object_info_table_.GetVkDeviceInfo(queue_info->parent_id),
+                if (CheckPNextChainForFrameBoundary(object_info_table_->GetVkDeviceInfo(queue_info->parent_id),
                                                     submit_info_data->pNext))
                 {
                     break;
@@ -3967,7 +3979,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
             // descriptor pool and attempting the allocation a second time.
             VkDescriptorPool new_pool  = VK_NULL_HANDLE;
             auto             meta_info = pAllocateInfo->GetMetaStructPointer();
-            auto             pool_info = object_info_table_.GetVkDescriptorPoolInfo(meta_info->descriptorPool);
+            auto             pool_info = object_info_table_->GetVkDescriptorPoolInfo(meta_info->descriptorPool);
 
             VkDescriptorPoolCreateInfo create_info = { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
             create_info.pNext                      = nullptr;
@@ -4030,7 +4042,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
                 assert(desc_info != nullptr);
 
                 VulkanDescriptorSetLayoutInfo* set_layout_info =
-                    object_info_table_.GetVkDescriptorSetLayoutInfo(set_layout_ids[i]);
+                    object_info_table_->GetVkDescriptorSetLayoutInfo(set_layout_ids[i]);
                 assert(set_layout_info != nullptr);
 
                 for (const auto& layout_binding : set_layout_info->bindings_layout)
@@ -4144,9 +4156,9 @@ void VulkanReplayConsumerBase::OverrideFreeCommandBuffers(PFN_vkFreeCommandBuffe
             {
                 if (options_.dumping_resources)
                 {
-                    VulkanCommandBufferInfo* cb_info = object_info_table_.GetVkCommandBufferInfo(*it);
+                    VulkanCommandBufferInfo* cb_info = object_info_table_->GetVkCommandBufferInfo(*it);
                     assert(cb_info != nullptr);
-                    resource_dumper_.ResetCommandBuffer(cb_info->handle);
+                    resource_dumper_->ResetCommandBuffer(cb_info->handle);
                 }
             }
         }
@@ -4365,7 +4377,7 @@ VkResult VulkanReplayConsumerBase::OverrideFlushMappedMemoryRanges(
 
     for (uint32_t i = 0; i < memoryRangeCount; ++i)
     {
-        auto memory_info = object_info_table_.GetVkDeviceMemoryInfo(replay_range_meta_datas[i].memory);
+        auto memory_info = object_info_table_->GetVkDeviceMemoryInfo(replay_range_meta_datas[i].memory);
 
         if (memory_info != nullptr)
         {
@@ -4397,7 +4409,7 @@ VkResult VulkanReplayConsumerBase::OverrideInvalidateMappedMemoryRanges(
 
     for (uint32_t i = 0; i < memoryRangeCount; ++i)
     {
-        auto memory_info = object_info_table_.GetVkDeviceMemoryInfo(replay_range_meta_datas[i].memory);
+        auto memory_info = object_info_table_->GetVkDeviceMemoryInfo(replay_range_meta_datas[i].memory);
 
         if (memory_info != nullptr)
         {
@@ -4527,8 +4539,8 @@ VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory2(
     {
         const Decoded_VkBindBufferMemoryInfo* bind_meta_info = &replay_bind_meta_infos[i];
 
-        auto buffer_info = object_info_table_.GetVkBufferInfo(bind_meta_info->buffer);
-        auto memory_info = object_info_table_.GetVkDeviceMemoryInfo(bind_meta_info->memory);
+        auto buffer_info = object_info_table_->GetVkBufferInfo(bind_meta_info->buffer);
+        auto memory_info = object_info_table_->GetVkDeviceMemoryInfo(bind_meta_info->memory);
 
         buffer_infos.push_back(buffer_info);
         memory_infos.push_back(memory_info);
@@ -4635,8 +4647,8 @@ VkResult VulkanReplayConsumerBase::OverrideBindImageMemory2(
     {
         const Decoded_VkBindImageMemoryInfo* bind_meta_info = &replay_bind_meta_infos[i];
 
-        auto image_info  = object_info_table_.GetVkImageInfo(bind_meta_info->image);
-        auto memory_info = object_info_table_.GetVkDeviceMemoryInfo(bind_meta_info->memory);
+        auto image_info  = object_info_table_->GetVkImageInfo(bind_meta_info->image);
+        auto memory_info = object_info_table_->GetVkDeviceMemoryInfo(bind_meta_info->memory);
 
         image_infos.push_back(image_info);
         memory_infos.push_back(memory_info);
@@ -4727,7 +4739,7 @@ VkResult VulkanReplayConsumerBase::OverrideBindVideoSessionMemoryKHR(
             const auto* bind_meta_info = &replay_bind_meta_infos[i];
             if (mem_index == bind_meta_info->decoded_value->memoryBindIndex)
             {
-                auto memory_info = object_info_table_.GetVkDeviceMemoryInfo(bind_meta_info->memory);
+                auto memory_info = object_info_table_->GetVkDeviceMemoryInfo(bind_meta_info->memory);
                 memory_infos.push_back(memory_info);
 
                 if (memory_info != nullptr)
@@ -5358,7 +5370,7 @@ void VulkanReplayConsumerBase::OverrideCmdPipelineBarrier(
     {
         auto image_id                                        = pImageMemoryBarriers->GetMetaStructPointer()[i].image;
         command_buffer_info->image_layout_barriers[image_id] = pImageMemoryBarriers->GetPointer()[i].newLayout;
-        VulkanImageInfo* img_info                            = object_info_table_.GetVkImageInfo(image_id);
+        VulkanImageInfo* img_info                            = object_info_table_->GetVkImageInfo(image_id);
         assert(img_info != nullptr);
         img_info->intermediate_layout = pImageMemoryBarriers->GetPointer()[i].newLayout;
     }
@@ -5383,7 +5395,7 @@ void VulkanReplayConsumerBase::OverrideCmdPipelineBarrier2(
                 command_buffer_info->image_layout_barriers[image_id] =
                     dependency_info_meta->pImageMemoryBarriers->GetPointer()[i].newLayout;
 
-                VulkanImageInfo* img_info     = object_info_table_.GetVkImageInfo(image_id);
+                VulkanImageInfo* img_info     = object_info_table_->GetVkImageInfo(image_id);
                 img_info->intermediate_layout = dependency_info_meta->pImageMemoryBarriers->GetPointer()[i].newLayout;
             }
         }
@@ -5705,7 +5717,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
                 assert(shader_info);
 
                 const VulkanPhysicalDeviceInfo* phys_dev =
-                    object_info_table_.GetVkPhysicalDeviceInfo(device_info->parent_id);
+                    object_info_table_->GetVkPhysicalDeviceInfo(device_info->parent_id);
                 assert(phys_dev);
                 assert(phys_dev->replay_device_info);
 
@@ -5758,7 +5770,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
             assert(shader_info);
 
             const VulkanPhysicalDeviceInfo* phys_dev =
-                object_info_table_.GetVkPhysicalDeviceInfo(device_info->parent_id);
+                object_info_table_->GetVkPhysicalDeviceInfo(device_info->parent_id);
             assert(phys_dev);
             assert(phys_dev->replay_device_info);
 
@@ -5916,7 +5928,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
             capture_pipeline_cache_data_      = const_cast<void*>(create_info.pInitialData);
             capture_pipeline_cache_data_size_ = create_info.initialDataSize;
 
-            object_info_table_.VisitVkPipelineCacheInfo([this](const VulkanPipelineCacheInfo* pipeline_cache_info) {
+            object_info_table_->VisitVkPipelineCacheInfo([this](const VulkanPipelineCacheInfo* pipeline_cache_info) {
                 GFXRECON_ASSERT(pipeline_cache_info != nullptr);
 
                 auto iterator = pipeline_cache_info->pipeline_cache_data.find(capture_pipeline_cache_data_hash_);
@@ -5993,7 +6005,7 @@ VkResult VulkanReplayConsumerBase::OverrideResetDescriptorPool(PFN_vkResetDescri
     // Descriptor sets allocated from the pool are implicitly freed and must be removed from the object info table.
     for (auto child_id : pool_info->child_ids)
     {
-        object_info_table_.RemoveVkDescriptorSetInfo(child_id);
+        object_info_table_->RemoveVkDescriptorSetInfo(child_id);
     }
 
     pool_info->child_ids.clear();
@@ -6108,8 +6120,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
 
         bool                      colorspace_extension_used_unsupported = false;
         VulkanPhysicalDeviceInfo* physical_device_info =
-            object_info_table_.GetVkPhysicalDeviceInfo(device_info->parent_id);
-        VulkanInstanceInfo* instance_info = object_info_table_.GetVkInstanceInfo(physical_device_info->parent_id);
+            object_info_table_->GetVkPhysicalDeviceInfo(device_info->parent_id);
+        VulkanInstanceInfo* instance_info = object_info_table_->GetVkInstanceInfo(physical_device_info->parent_id);
 
         auto colorspace_extension_map_iterator = kColorSpaceExtensionMap.find(replay_create_info->imageColorSpace);
         if (colorspace_extension_map_iterator != kColorSpaceExtensionMap.end())
@@ -6466,7 +6478,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
                 // TODO: This should be processed at a higher level where the original handle IDs are available, so that
                 // the swap can be performed with the original handle ID and the semaphore can be guaranteed not to be
                 // used after destroy.
-                object_info_table_.ReplaceSemaphore(semaphore, preacquire_semaphore);
+                object_info_table_->ReplaceSemaphore(semaphore, preacquire_semaphore);
                 preacquire_semaphore = semaphore;
             }
 
@@ -6475,7 +6487,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
                 // TODO: This should be processed at a higher level where the original handle IDs are available, so that
                 // the swap can be performed with the original handle ID and the fence can be guaranteed not to be used
                 // after destroy.
-                object_info_table_.ReplaceFence(fence, preacquire_fence);
+                object_info_table_->ReplaceFence(fence, preacquire_fence);
                 preacquire_fence = fence;
             }
 
@@ -6550,7 +6562,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
 
     VkResult                result            = VK_SUCCESS;
     auto                    acquire_meta_info = pAcquireInfo->GetMetaStructPointer();
-    VulkanSwapchainKHRInfo* swapchain_info    = object_info_table_.GetVkSwapchainKHRInfo(acquire_meta_info->swapchain);
+    VulkanSwapchainKHRInfo* swapchain_info    = object_info_table_->GetVkSwapchainKHRInfo(acquire_meta_info->swapchain);
     assert(swapchain_info != nullptr);
 
     // If image acquire failed at capture, there is nothing worth replaying as the fence and semaphore aren't processed
@@ -6592,7 +6604,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
                 // TODO: This should be processed at a higher level where the original handle IDs are available, so that
                 // the swap can be performed with the original handle ID and the semaphore can be guaranteed not to be
                 // used after destroy.
-                object_info_table_.ReplaceSemaphore(replay_acquire_info->semaphore, preacquire_semaphore);
+                object_info_table_->ReplaceSemaphore(replay_acquire_info->semaphore, preacquire_semaphore);
                 preacquire_semaphore = replay_acquire_info->semaphore;
             }
 
@@ -6601,7 +6613,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
                 // TODO: This should be processed at a higher level where the original handle IDs are available, so that
                 // the swap can be performed with the original handle ID and the fence can be guaranteed not to be used
                 // after destroy.
-                object_info_table_.ReplaceFence(replay_acquire_info->fence, preacquire_fence);
+                object_info_table_->ReplaceFence(replay_acquire_info->fence, preacquire_fence);
                 preacquire_fence = replay_acquire_info->fence;
             }
 
@@ -6614,7 +6626,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
 
             assert(replay_index != nullptr);
 
-            auto swapchain_info = object_info_table_.GetVkSwapchainKHRInfo(acquire_meta_info->swapchain);
+            auto swapchain_info = object_info_table_->GetVkSwapchainKHRInfo(acquire_meta_info->swapchain);
 
             // If expected result is VK_SUCCESS, ensure that vkAcquireNextImageKHR2 waits until the image is
             // available by using a timeout of UINT64_MAX.
@@ -6650,8 +6662,8 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
     {
         // Track semphore and fence objects as shadow objects so that they can be ignored when they would have been
         // unsignaled (waited on).
-        VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(acquire_meta_info->semaphore);
-        VulkanFenceInfo*     fence_info     = object_info_table_.GetVkFenceInfo(acquire_meta_info->fence);
+        VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(acquire_meta_info->semaphore);
+        VulkanFenceInfo*     fence_info     = object_info_table_->GetVkFenceInfo(acquire_meta_info->fence);
 
         if (semaphore_info != nullptr)
         {
@@ -6715,7 +6727,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
         {
             assert(swapchain_ids != nullptr);
 
-            const auto swapchain_info = object_info_table_.GetVkSwapchainKHRInfo(swapchain_ids[i]);
+            const auto swapchain_info = object_info_table_->GetVkSwapchainKHRInfo(swapchain_ids[i]);
             if ((swapchain_info != nullptr) && (swapchain_info->surface != VK_NULL_HANDLE))
             {
                 valid_swapchains_.emplace_back(swapchain_info->handle);
@@ -6884,7 +6896,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
         {
             assert(swapchain_ids != nullptr);
 
-            const auto swapchain_info = object_info_table_.GetVkSwapchainKHRInfo(swapchain_ids[i]);
+            const auto swapchain_info = object_info_table_->GetVkSwapchainKHRInfo(swapchain_ids[i]);
             if (swapchain_info != nullptr)
             {
                 swapchain_infos_[i] = swapchain_info;
@@ -7020,7 +7032,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                 size_t count = present_info_data->pWaitSemaphores.GetLength();
                 for (uint32_t i = 0; i < count; ++i)
                 {
-                    VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_ids[i]);
+                    VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(semaphore_ids[i]);
                     if (semaphore_info)
                     {
                         semaphore_info->forward_progress = false;
@@ -7035,7 +7047,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
             for (uint32_t i = 0; i < pPresentInfo->GetPointer()->swapchainCount; ++i)
             {
                 format::HandleId fence      = present_fence_info->pFences.GetPointer()[i];
-                VulkanFenceInfo* fence_info = object_info_table_.GetVkFenceInfo(fence);
+                VulkanFenceInfo* fence_info = object_info_table_->GetVkFenceInfo(fence);
                 if (fence_info)
                 {
                     fence_info->shadow_signaled = true;
@@ -7071,7 +7083,7 @@ VkResult VulkanReplayConsumerBase::OverrideImportSemaphoreFdKHR(
         auto info = pImportSemaphoreFdInfo->GetMetaStructPointer();
         assert(info != nullptr);
 
-        VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(info->semaphore);
+        VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(info->semaphore);
 
         if (semaphore_info != nullptr)
         {
@@ -7120,7 +7132,7 @@ VkResult VulkanReplayConsumerBase::OverrideImportSemaphoreWin32HandleKHR(
         auto info = pImportSemaphoreWin32HandleInfo->GetMetaStructPointer();
         assert(info != nullptr);
 
-        VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(info->semaphore);
+        VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(info->semaphore);
 
         if (semaphore_info != nullptr)
         {
@@ -7593,7 +7605,7 @@ void VulkanReplayConsumerBase::OverrideCmdBuildAccelerationStructuresKHR(
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>*   ppBuildRangeInfos)
 {
-    VulkanDeviceInfo* device_info    = object_info_table_.GetVkDeviceInfo(command_buffer_info->parent_id);
+    VulkanDeviceInfo* device_info    = object_info_table_->GetVkDeviceInfo(command_buffer_info->parent_id);
     VkCommandBuffer command_buffer = command_buffer_info->handle;
     VkAccelerationStructureBuildGeometryInfoKHR* build_geometry_infos = pInfos->GetPointer();
     VkAccelerationStructureBuildRangeInfoKHR**   build_range_infos    = ppBuildRangeInfos->GetPointer();
@@ -7661,7 +7673,7 @@ void VulkanReplayConsumerBase::OverrideCmdCopyAccelerationStructureKHR(
     VulkanCommandBufferInfo*                                          command_buffer_info,
     StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo)
 {
-    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(command_buffer_info->parent_id);
+    VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(command_buffer_info->parent_id);
     if (device_info->allocator->SupportsOpaqueDeviceAddresses())
     {
         VkCommandBuffer                     command_buffer = command_buffer_info->handle;
@@ -7683,7 +7695,7 @@ void VulkanReplayConsumerBase::OverrideCmdWriteAccelerationStructuresPropertiesK
     gfxrecon::decode::VulkanQueryPoolInfo*            query_pool_info,
     uint32_t                                          firstQuery)
 {
-    VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(command_buffer_info->parent_id);
+    VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(command_buffer_info->parent_id);
     if (device_info->allocator->SupportsOpaqueDeviceAddresses())
     {
         VkCommandBuffer                   command_buffer       = command_buffer_info->handle;
@@ -7906,7 +7918,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
             for (size_t s = 0; s < stages_count; ++s)
             {
                 VulkanShaderModuleInfo* module_info =
-                    object_info_table_.GetVkShaderModuleInfo(stages_info_meta[s].module);
+                    object_info_table_->GetVkShaderModuleInfo(stages_info_meta[s].module);
                 assert(module_info);
                 assert(pipeline_info);
 
@@ -8174,11 +8186,11 @@ VkResult VulkanReplayConsumerBase::OverrideBeginCommandBuffer(
     const VkCommandBufferBeginInfo* begin_info     = begin_info_decoder->GetPointer();
 
     VkResult res = VK_SUCCESS;
-    if (options_.dumping_resources && resource_dumper_.DumpingBeginCommandBufferIndex(index))
+    if (options_.dumping_resources && resource_dumper_->DumpingBeginCommandBufferIndex(index))
     {
         const VulkanDeviceInfo* device = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
 
-        res = resource_dumper_.CloneCommandBuffer(
+        res = resource_dumper_->CloneCommandBuffer(
             index, command_buffer_info, GetDeviceTable(device->handle), GetInstanceTable(device->parent));
     }
 
@@ -8201,7 +8213,7 @@ VkResult VulkanReplayConsumerBase::OverrideResetCommandBuffer(PFN_vkResetCommand
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.ResetCommandBuffer((command_buffer));
+        resource_dumper_->ResetCommandBuffer((command_buffer));
     }
 
     return func(command_buffer, flags);
@@ -8219,10 +8231,10 @@ VkResult VulkanReplayConsumerBase::OverrideResetCommandPool(PFN_vkResetCommandPo
     {
         for (auto& cb_id : pool_info->child_ids)
         {
-            VulkanCommandBufferInfo* cb_info = object_info_table_.GetVkCommandBufferInfo(cb_id);
+            VulkanCommandBufferInfo* cb_info = object_info_table_->GetVkCommandBufferInfo(cb_id);
             assert(cb_info != nullptr);
 
-            resource_dumper_.ResetCommandBuffer(cb_info->handle);
+            resource_dumper_->ResetCommandBuffer(cb_info->handle);
         }
     }
 
@@ -8243,10 +8255,10 @@ void VulkanReplayConsumerBase::OverrideDestroyCommandPool(
     {
         for (auto& cb_id : pool_info->child_ids)
         {
-            VulkanCommandBufferInfo* cb_info = object_info_table_.GetVkCommandBufferInfo(cb_id);
+            VulkanCommandBufferInfo* cb_info = object_info_table_->GetVkCommandBufferInfo(cb_id);
             assert(cb_info != nullptr);
 
-            resource_dumper_.ResetCommandBuffer(cb_info->handle);
+            resource_dumper_->ResetCommandBuffer(cb_info->handle);
         }
     }
 
@@ -8295,8 +8307,8 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
     auto       render_pass_id        = render_pass_info_meta->renderPass;
     command_buffer_info->frame_buffer_ids.push_back(framebuffer_id);
 
-    auto framebuffer_info = object_info_table_.GetVkFramebufferInfo(framebuffer_id);
-    auto render_pass_info = object_info_table_.GetVkRenderPassInfo(render_pass_id);
+    auto framebuffer_info = object_info_table_->GetVkFramebufferInfo(framebuffer_id);
+    auto render_pass_info = object_info_table_->GetVkRenderPassInfo(render_pass_id);
     if ((render_pass_info != nullptr) && (framebuffer_info != nullptr))
     {
         const format::HandleId* attachment_image_view_ids = nullptr;
@@ -8322,13 +8334,13 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
         for (size_t i = 0; i < render_pass_info->attachment_description_final_layouts.size(); ++i)
         {
             auto image_view_id   = attachment_image_view_ids[i];
-            auto image_view_info = object_info_table_.GetVkImageViewInfo(image_view_id);
+            auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
             command_buffer_info->image_layout_barriers[image_view_info->image_id] =
                 render_pass_info->attachment_description_final_layouts[i];
 
-            const VulkanImageViewInfo* img_view_info = object_info_table_.GetVkImageViewInfo(image_view_id);
+            const VulkanImageViewInfo* img_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
             assert(image_view_info != nullptr);
-            VulkanImageInfo* img_info = object_info_table_.GetVkImageInfo(img_view_info->image_id);
+            VulkanImageInfo* img_info = object_info_table_->GetVkImageInfo(img_view_info->image_id);
             assert(img_info);
             img_info->intermediate_layout = render_pass_info->attachment_description_final_layouts[i];
         }
@@ -8350,8 +8362,8 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
     auto       render_pass_id        = render_pass_info_meta->renderPass;
     command_buffer_info->frame_buffer_ids.push_back(framebuffer_id);
 
-    auto framebuffer_info = object_info_table_.GetVkFramebufferInfo(framebuffer_id);
-    auto render_pass_info = object_info_table_.GetVkRenderPassInfo(render_pass_id);
+    auto framebuffer_info = object_info_table_->GetVkFramebufferInfo(framebuffer_id);
+    auto render_pass_info = object_info_table_->GetVkRenderPassInfo(render_pass_id);
     if ((render_pass_info != nullptr) && (framebuffer_info != nullptr))
     {
         GFXRECON_ASSERT(framebuffer_info->attachment_image_view_ids.size() ==
@@ -8360,13 +8372,13 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
         for (size_t i = 0; i < render_pass_info->attachment_description_final_layouts.size(); ++i)
         {
             auto image_view_id   = framebuffer_info->attachment_image_view_ids[i];
-            auto image_view_info = object_info_table_.GetVkImageViewInfo(image_view_id);
+            auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
             command_buffer_info->image_layout_barriers[image_view_info->image_id] =
                 render_pass_info->attachment_description_final_layouts[i];
 
-            const VulkanImageViewInfo* img_view_info = object_info_table_.GetVkImageViewInfo(image_view_id);
+            const VulkanImageViewInfo* img_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
             assert(image_view_info != nullptr);
-            VulkanImageInfo* img_info = object_info_table_.GetVkImageInfo(img_view_info->image_id);
+            VulkanImageInfo* img_info = object_info_table_->GetVkImageInfo(img_view_info->image_id);
             assert(img_info);
             img_info->intermediate_layout = render_pass_info->attachment_description_final_layouts[i];
         }
@@ -8700,7 +8712,7 @@ void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
             Decoded_VkDescriptorImageInfo* structs = decoder->GetImageInfoMetaStructPointer();
             for (size_t i = 0; i < image_info_count; ++i)
             {
-                MapStructHandles(update_template_info->descriptor_image_types[i], &structs[i], object_info_table_);
+                MapStructHandles(update_template_info->descriptor_image_types[i], &structs[i], *object_info_table_);
             }
         }
         else
@@ -8711,14 +8723,14 @@ void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
             Decoded_VkDescriptorImageInfo* structs = decoder->GetImageInfoMetaStructPointer();
             for (size_t i = 0; i < image_info_count; ++i)
             {
-                MapStructHandles(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, &structs[i], object_info_table_);
+                MapStructHandles(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, &structs[i], *object_info_table_);
             }
         }
     }
 
     if (buffer_info_count > 0)
     {
-        MapStructArrayHandles(decoder->GetBufferInfoMetaStructPointer(), buffer_info_count, object_info_table_);
+        MapStructArrayHandles(decoder->GetBufferInfoMetaStructPointer(), buffer_info_count, *object_info_table_);
     }
 
     if (texel_buffer_view_count > 0)
@@ -8728,7 +8740,7 @@ void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
 
         for (size_t i = 0; i < texel_buffer_view_count; ++i)
         {
-            auto texel_buffer_view_info = object_info_table_.GetVkBufferViewInfo(texel_buffer_view_ids[i]);
+            auto texel_buffer_view_info = object_info_table_->GetVkBufferViewInfo(texel_buffer_view_ids[i]);
 
             if (texel_buffer_view_info != nullptr)
             {
@@ -8748,7 +8760,7 @@ void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
 
         for (size_t i = 0; i < accel_struct_count; ++i)
         {
-            auto accel_struct_info = object_info_table_.GetVkAccelerationStructureKHRInfo(accel_struct_ids[i]);
+            auto accel_struct_info = object_info_table_->GetVkAccelerationStructureKHRInfo(accel_struct_ids[i]);
 
             if (accel_struct_info != nullptr)
             {
@@ -8774,7 +8786,7 @@ void VulkanReplayConsumerBase::GetImportedSemaphores(const HandlePointerDecoder<
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            const VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_ids[i]);
+            const VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(semaphore_ids[i]);
             if ((semaphore_info != nullptr) && semaphore_info->is_external)
             {
                 imported_semaphores->push_back(semaphore_info);
@@ -8797,7 +8809,7 @@ void VulkanReplayConsumerBase::GetImportedSemaphores(
         for (uint32_t i = 0; i < count; ++i)
         {
             const VulkanSemaphoreInfo* semaphore_info =
-                object_info_table_.GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
+                object_info_table_->GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
             if ((semaphore_info != nullptr) && semaphore_info->is_external)
             {
                 imported_semaphores->push_back(semaphore_info);
@@ -8836,7 +8848,7 @@ void VulkanReplayConsumerBase::GetShadowSemaphores(const HandlePointerDecoder<Vk
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_ids[i]);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(semaphore_ids[i]);
             if (semaphore_info != nullptr)
             {
                 SignalShadowSemaphore(semaphore_info, shadow_semaphores);
@@ -8858,7 +8870,7 @@ void VulkanReplayConsumerBase::GetShadowSemaphores(
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
             if (semaphore_info != nullptr)
             {
                 SignalShadowSemaphore(semaphore_info, shadow_semaphores);
@@ -8880,7 +8892,7 @@ void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_ids[i]);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(semaphore_ids[i]);
             if (semaphore_info != nullptr)
             {
                 VkSemaphore semaphore = semaphore_info->handle;
@@ -8919,7 +8931,7 @@ void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
             if (semaphore_info != nullptr)
             {
                 VkSemaphore semaphore = semaphore_info->handle;
@@ -8958,7 +8970,7 @@ void VulkanReplayConsumerBase::GetNonForwardProgress(
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_ids[i]);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(semaphore_ids[i]);
             if ((semaphore_info != nullptr) && (semaphore_info->forward_progress == false))
             {
                 if (semaphore_info->signaled == false)
@@ -8987,7 +8999,7 @@ void VulkanReplayConsumerBase::GetNonForwardProgress(
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            VulkanSemaphoreInfo* semaphore_info = object_info_table_.GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
+            VulkanSemaphoreInfo* semaphore_info = object_info_table_->GetVkSemaphoreInfo(semaphore_infos[i].semaphore);
             if ((semaphore_info != nullptr) && (semaphore_info->forward_progress == false))
             {
                 if (semaphore_info->signaled == false)
@@ -9116,7 +9128,7 @@ void VulkanReplayConsumerBase::UpdateDescriptorSetInfoWithTemplate(
                     for (uint32_t i = 0; i < count; ++i)
                     {
                         const VulkanImageViewInfo* img_view_info =
-                            object_info_table_.GetVkImageViewInfo(img_desc_info[image_info_count].imageView);
+                            object_info_table_->GetVkImageViewInfo(img_desc_info[image_info_count].imageView);
                         desc_set_info->descriptors[binding_index].image_info[i] = {
                             img_view_info, img_desc_info[image_info_count].decoded_value->imageLayout
                         };
@@ -9154,7 +9166,7 @@ void VulkanReplayConsumerBase::UpdateDescriptorSetInfoWithTemplate(
                     for (uint32_t i = 0; i < count; ++i)
                     {
                         const VulkanBufferInfo* buf_info =
-                            object_info_table_.GetVkBufferInfo(buf_desc_info[buffer_info_count].buffer);
+                            object_info_table_->GetVkBufferInfo(buf_desc_info[buffer_info_count].buffer);
                         assert(buf_info != nullptr);
 
                         desc_set_info->descriptors[binding_index].buffer_info[i] = {
@@ -9183,7 +9195,7 @@ void VulkanReplayConsumerBase::UpdateDescriptorSetInfoWithTemplate(
                     for (uint32_t i = 0; i < count; ++i)
                     {
                         const VulkanBufferViewInfo* buf_view_info =
-                            object_info_table_.GetVkBufferViewInfo(buffer_view_ids[texel_buffer_view_count]);
+                            object_info_table_->GetVkBufferViewInfo(buffer_view_ids[texel_buffer_view_count]);
                         assert(buf_view_info != nullptr);
 
                         desc_set_info->descriptors[binding_index].texel_buffer_view_info[i] = buf_view_info;
@@ -9222,7 +9234,7 @@ VulkanDeviceAddressTracker& VulkanReplayConsumerBase::GetDeviceAddressTracker(Vk
     if (it == _device_address_trackers.end())
     {
         auto [new_it, success] =
-            _device_address_trackers.insert({ device, VulkanDeviceAddressTracker(object_info_table_) });
+            _device_address_trackers.insert({ device, VulkanDeviceAddressTracker(*object_info_table_) });
         return new_it->second;
     }
     return it->second;
@@ -9240,7 +9252,7 @@ void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(const A
     VkDescriptorSet in_descriptorSet =
         MapHandle<VulkanDescriptorSetInfo>(descriptorSet, &CommonObjectInfoTable::GetVkDescriptorSetInfo);
     VkDescriptorUpdateTemplate in_descriptorUpdateTemplate = VK_NULL_HANDLE;
-    auto update_template_info = object_info_table_.GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
+    auto update_template_info = object_info_table_->GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
 
     MapDescriptorUpdateTemplateHandles(update_template_info, pData);
 
@@ -9251,7 +9263,7 @@ void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(const A
 
     if (options_.dumping_resources)
     {
-        VulkanDescriptorSetInfo* desc_set_info = object_info_table_.GetVkDescriptorSetInfo(descriptorSet);
+        VulkanDescriptorSetInfo* desc_set_info = object_info_table_->GetVkDescriptorSetInfo(descriptorSet);
         UpdateDescriptorSetInfoWithTemplate(desc_set_info, update_template_info, pData);
     }
 
@@ -9273,7 +9285,7 @@ void VulkanReplayConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(con
     VkDescriptorUpdateTemplate in_descriptorUpdateTemplate = VK_NULL_HANDLE;
     VkPipelineLayout           in_layout =
         MapHandle<VulkanPipelineLayoutInfo>(layout, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
-    auto update_template_info = object_info_table_.GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
+    auto update_template_info = object_info_table_->GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
 
     MapDescriptorUpdateTemplateHandles(update_template_info, pData);
 
@@ -9288,7 +9300,7 @@ void VulkanReplayConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(con
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPushDescriptorSetWithTemplateKHR(
+        resource_dumper_->Process_vkCmdPushDescriptorSetWithTemplateKHR(
             call_info,
             GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSetWithTemplateKHR,
             in_commandBuffer,
@@ -9308,7 +9320,7 @@ void VulkanReplayConsumerBase::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
         pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer();
     VkPushDescriptorSetWithTemplateInfoKHR* value = in_info->decoded_value;
     VulkanDescriptorUpdateTemplateInfo*     update_template_info =
-        object_info_table_.GetVkDescriptorUpdateTemplateInfo(in_info->descriptorUpdateTemplate);
+        object_info_table_->GetVkDescriptorUpdateTemplateInfo(in_info->descriptorUpdateTemplate);
 
     VkCommandBuffer in_commandBuffer =
         MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
@@ -9327,7 +9339,7 @@ void VulkanReplayConsumerBase::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPushDescriptorSetWithTemplate2KHR(
+        resource_dumper_->Process_vkCmdPushDescriptorSetWithTemplate2KHR(
             call_info, GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSetWithTemplate2KHR, in_commandBuffer, value);
     }
 }
@@ -9344,7 +9356,7 @@ void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(cons
     VkDescriptorSet in_descriptorSet =
         MapHandle<VulkanDescriptorSetInfo>(descriptorSet, &CommonObjectInfoTable::GetVkDescriptorSetInfo);
     VkDescriptorUpdateTemplate in_descriptorUpdateTemplate = VK_NULL_HANDLE;
-    auto update_template_info = object_info_table_.GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
+    auto update_template_info = object_info_table_->GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
 
     MapDescriptorUpdateTemplateHandles(update_template_info, pData);
 
@@ -9355,7 +9367,7 @@ void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(cons
 
     if (options_.dumping_resources)
     {
-        VulkanDescriptorSetInfo* desc_set_info = object_info_table_.GetVkDescriptorSetInfo(descriptorSet);
+        VulkanDescriptorSetInfo* desc_set_info = object_info_table_->GetVkDescriptorSetInfo(descriptorSet);
         UpdateDescriptorSetInfoWithTemplate(desc_set_info, update_template_info, pData);
     }
 
@@ -9534,7 +9546,7 @@ void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
                             desc_set_info->descriptors[binding].image_info[arr_idx].image_layout =
                                 in_pDescriptorWrites[s].pImageInfo[b].imageLayout;
                             desc_set_info->descriptors[binding].image_info[arr_idx].image_view_info =
-                                object_info_table_.GetVkImageViewInfo(
+                                object_info_table_->GetVkImageViewInfo(
                                     writes_meta[s].pImageInfo->GetMetaStructPointer()[b].imageView);
                         }
                     }
@@ -9552,7 +9564,7 @@ void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
                         {
                             const uint32_t arr_idx = write->dstArrayElement + i;
                             desc_set_info->descriptors[binding].buffer_info[arr_idx].buffer_info =
-                                object_info_table_.GetVkBufferInfo(
+                                object_info_table_->GetVkBufferInfo(
                                     writes_meta[s].pBufferInfo->GetMetaStructPointer()[b].buffer);
                             desc_set_info->descriptors[binding].buffer_info[arr_idx].offset =
                                 in_pDescriptorWrites[s].pBufferInfo[b].offset;
@@ -9572,7 +9584,8 @@ void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
                         {
                             const uint32_t arr_idx = write->dstArrayElement + i;
                             desc_set_info->descriptors[binding].texel_buffer_view_info[arr_idx] =
-                                object_info_table_.GetVkBufferViewInfo(writes_meta[s].pTexelBufferView.GetPointer()[b]);
+                                object_info_table_->GetVkBufferViewInfo(
+                                    writes_meta[s].pTexelBufferView.GetPointer()[b]);
                         }
                     }
                     break;
@@ -9711,7 +9724,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateGraphicsPipelines(
     {
         if (options_.dumping_resources)
         {
-            resource_dumper_.DumpGraphicsPipelineInfos(pCreateInfos, create_info_count, pPipelines);
+            resource_dumper_->DumpGraphicsPipelineInfos(pCreateInfos, create_info_count, pPipelines);
         }
 
         // check potentially inlined spirv
@@ -9753,7 +9766,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateComputePipelines(
         {
             assert(create_info_meta[i].stage);
             VulkanShaderModuleInfo* module_info =
-                object_info_table_.GetVkShaderModuleInfo(create_info_meta[i].stage->module);
+                object_info_table_->GetVkShaderModuleInfo(create_info_meta[i].stage->module);
             assert(module_info);
 
             VulkanPipelineInfo* pipeline_info = reinterpret_cast<VulkanPipelineInfo*>(pPipelines->GetConsumerData(i));
@@ -9954,7 +9967,7 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
     // Information is stored in the created PipelineInfos only when the dumping resources feature is in use
     if (returnValue == VK_SUCCESS && options_.dumping_resources)
     {
-        resource_dumper_.DumpGraphicsPipelineInfos(pCreateInfos, createInfoCount, pPipelines);
+        resource_dumper_->DumpGraphicsPipelineInfos(pCreateInfos, createInfoCount, pPipelines);
     }
 
     // replace with deep-copy of create-info array

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -32,7 +32,7 @@
 #include "decode/vulkan_device_address_tracker.h"
 #include "decode/vulkan_handle_mapping_util.h"
 #include "decode/vulkan_object_info.h"
-#include "decode/vulkan_object_info_table.h"
+#include "decode/common_object_info_table.h"
 #include "decode/vulkan_replay_options.h"
 #include "decode/vulkan_resource_allocator.h"
 #include "decode/vulkan_resource_tracking_consumer.h"
@@ -226,10 +226,21 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         }
     };
 
-  protected:
-    const VulkanObjectInfoTable& GetObjectInfoTable() const { return object_info_table_; }
+    // Xr Support requires this minimal set of remapping information
 
-    VulkanObjectInfoTable& GetObjectInfoTable() { return object_info_table_; }
+    VkInstance MapInstance(format::HandleId capture_id)
+    {
+        return MapHandle<VulkanInstanceInfo>(capture_id, &CommonObjectInfoTable::GetVkInstanceInfo);
+    }
+    VkDevice MapDevice(format::HandleId capture_id)
+    {
+        return MapHandle<VulkanDeviceInfo>(capture_id, &CommonObjectInfoTable::GetVkDeviceInfo);
+    }
+
+  protected:
+    const CommonObjectInfoTable& GetObjectInfoTable() const { return object_info_table_; }
+
+    CommonObjectInfoTable& GetObjectInfoTable() { return object_info_table_; }
 
     const encode::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
 
@@ -247,7 +258,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     template <typename T>
     typename T::HandleType MapHandle(format::HandleId id,
-                                     const T* (VulkanObjectInfoTable::*MapFunc)(format::HandleId) const) const
+                                     const T* (CommonObjectInfoTable::*MapFunc)(format::HandleId) const) const
     {
         return handle_mapping::MapHandle(id, object_info_table_, MapFunc);
     }
@@ -265,7 +276,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     template <typename T>
     typename T::HandleType* MapHandles(HandlePointerDecoder<typename T::HandleType>* handles_pointer,
                                        size_t                                        handles_len,
-                                       const T* (VulkanObjectInfoTable::*MapFunc)(format::HandleId) const) const
+                                       const T* (CommonObjectInfoTable::*MapFunc)(format::HandleId) const) const
     {
         // This parameter is only referenced by debug builds.
         GFXRECON_UNREFERENCED_PARAMETER(handles_len);
@@ -288,7 +299,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                    const format::HandleId*       id,
                    const typename T::HandleType* handle,
                    T&&                           initial_info,
-                   void (VulkanObjectInfoTable::*AddFunc)(T&&))
+                   void (CommonObjectInfoTable::*AddFunc)(T&&))
     {
         if ((id != nullptr) && (handle != nullptr))
         {
@@ -301,7 +312,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void AddHandle(format::HandleId              parent_id,
                    const format::HandleId*       id,
                    const typename T::HandleType* handle,
-                   void (VulkanObjectInfoTable::*AddFunc)(T&&))
+                   void (CommonObjectInfoTable::*AddFunc)(T&&))
     {
         if ((id != nullptr) && (handle != nullptr))
         {
@@ -316,7 +327,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                     const typename T::HandleType* handles,
                     size_t                        handles_len,
                     std::vector<T>&&              initial_infos,
-                    void (VulkanObjectInfoTable::*AddFunc)(T&&))
+                    void (CommonObjectInfoTable::*AddFunc)(T&&))
     {
         handle_mapping::AddHandleArray(
             parent_id, ids, ids_len, handles, handles_len, std::move(initial_infos), &object_info_table_, AddFunc);
@@ -328,7 +339,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                     size_t                        ids_len,
                     const typename T::HandleType* handles,
                     size_t                        handles_len,
-                    void (VulkanObjectInfoTable::*AddFunc)(T&&))
+                    void (CommonObjectInfoTable::*AddFunc)(T&&))
     {
         handle_mapping::AddHandleArray(parent_id, ids, ids_len, handles, handles_len, &object_info_table_, AddFunc);
     }
@@ -407,8 +418,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                         const typename T::HandleType* handles,
                         size_t                        handles_len,
                         std::vector<T>&&              initial_infos,
-                        S* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
-                        void (VulkanObjectInfoTable::*AddFunc)(T&&))
+                        S* (CommonObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                        void (CommonObjectInfoTable::*AddFunc)(T&&))
     {
         handle_mapping::AddHandleArray(parent_id,
                                        pool_id,
@@ -429,23 +440,23 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                         size_t                        ids_len,
                         const typename T::HandleType* handles,
                         size_t                        handles_len,
-                        S* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
-                        void (VulkanObjectInfoTable::*AddFunc)(T&&))
+                        S* (CommonObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                        void (CommonObjectInfoTable::*AddFunc)(T&&))
     {
         handle_mapping::AddHandleArray(
             parent_id, pool_id, ids, ids_len, handles, handles_len, &object_info_table_, GetPoolInfoFunc, AddFunc);
     }
 
-    void RemoveHandle(format::HandleId id, void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId))
+    void RemoveHandle(format::HandleId id, void (CommonObjectInfoTable::*RemoveFunc)(format::HandleId))
     {
         handle_mapping::RemoveHandle(id, &object_info_table_, RemoveFunc);
     }
 
     template <typename T>
     void RemovePoolHandle(format::HandleId id,
-                          T* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
-                          void (VulkanObjectInfoTable::*RemovePoolFunc)(format::HandleId),
-                          void (VulkanObjectInfoTable::*RemoveObjectFunc)(format::HandleId))
+                          T* (CommonObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                          void (CommonObjectInfoTable::*RemovePoolFunc)(format::HandleId),
+                          void (CommonObjectInfoTable::*RemoveObjectFunc)(format::HandleId))
     {
         handle_mapping::RemovePoolHandle(id, &object_info_table_, GetPoolInfoFunc, RemovePoolFunc, RemoveObjectFunc);
     }
@@ -454,8 +465,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void RemovePoolHandles(format::HandleId                                    pool_id,
                            const HandlePointerDecoder<typename T::HandleType>* handles_pointer,
                            size_t                                              handles_len,
-                           S* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
-                           void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId))
+                           S* (CommonObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                           void (CommonObjectInfoTable::*RemoveFunc)(format::HandleId))
     {
         // This parameter is only referenced by debug builds.
         GFXRECON_UNREFERENCED_PARAMETER(handles_len);
@@ -473,7 +484,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void SetOutputArrayCount(format::HandleId handle_id,
                              uint32_t         index,
                              size_t           count,
-                             HandleInfoT* (VulkanObjectInfoTable::*HandleInfoFunc)(format::HandleId))
+                             HandleInfoT* (CommonObjectInfoTable::*HandleInfoFunc)(format::HandleId))
     {
         HandleInfoT* info = (object_info_table_.*HandleInfoFunc)(handle_id);
         if (info != nullptr)
@@ -489,7 +500,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                uint32_t                      index,
                                const PointerDecoder<CountT>* original_count,
                                const ArrayT*                 original_array,
-                               const HandleInfoT* (VulkanObjectInfoTable::*HandleInfoFunc)(format::HandleId) const)
+                               const HandleInfoT* (CommonObjectInfoTable::*HandleInfoFunc)(format::HandleId) const)
     {
         assert((original_count != nullptr) && (original_array != nullptr));
 
@@ -1321,7 +1332,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     const VulkanReplayOptions options_;
 
-    VulkanReplayDumpResources resource_dumper;
+    VulkanReplayDumpResources resource_dumper_;
 
   private:
     void RaiseFatalError(const char* message) const;
@@ -1495,7 +1506,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unordered_map<encode::VulkanDispatchKey, encode::VulkanDeviceTable>   device_tables_;
     std::function<void(const char*)>                                           fatal_error_handler_;
     std::shared_ptr<application::Application>                                  application_;
-    VulkanObjectInfoTable                                                      object_info_table_;
+    CommonObjectInfoTable                                                      object_info_table_;
     bool                                                                       loading_trim_state_;
     bool                                                                       replaying_trimmed_capture_;
     SwapchainImageTracker                                                      swapchain_image_tracker_;
@@ -1541,14 +1552,14 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unordered_map<VkDeviceMemory, std::pair<void*, size_t>> external_memory_;
 
     // Temporary data used by OverrideQueuePresentKHR
-    std::vector<VkSwapchainKHR>       valid_swapchains_;
-    std::vector<uint32_t>             modified_image_indices_;
-    std::vector<uint32_t>             modified_device_masks_;
-    std::vector<VkPresentRegionKHR>   modified_regions_;
-    std::vector<VkPresentTimeGOOGLE>  modified_times_;
+    std::vector<VkSwapchainKHR>             valid_swapchains_;
+    std::vector<uint32_t>                   modified_image_indices_;
+    std::vector<uint32_t>                   modified_device_masks_;
+    std::vector<VkPresentRegionKHR>         modified_regions_;
+    std::vector<VkPresentTimeGOOGLE>        modified_times_;
     std::vector<const VulkanSemaphoreInfo*> removed_semaphores_;
-    std::unordered_set<uint32_t>      removed_swapchain_indices_;
-    std::vector<uint32_t>             capture_image_indices_;
+    std::unordered_set<uint32_t>            removed_swapchain_indices_;
+    std::vector<uint32_t>                   capture_image_indices_;
     std::vector<VulkanSwapchainKHRInfo*>    swapchain_infos_;
 
   protected:

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -535,296 +535,298 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                     HandlePointerDecoder<VkInstance>*                          pInstance);
 
     VkResult OverrideCreateDevice(VkResult                                                   original_result,
-                                  PhysicalDeviceInfo*                                        physical_device_info,
+                                  VulkanPhysicalDeviceInfo*                                  physical_device_info,
                                   const StructPointerDecoder<Decoded_VkDeviceCreateInfo>*    pCreateInfo,
                                   const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                   HandlePointerDecoder<VkDevice>*                            pDevice);
 
     void OverrideDestroyDevice(PFN_vkDestroyDevice                                        func,
-                               const DeviceInfo*                                          device_info,
+                               const VulkanDeviceInfo*                                    device_info,
                                const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     VkResult OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysicalDevices          func,
                                               VkResult                                original_result,
-                                              InstanceInfo*                           instance_info,
+                                              VulkanInstanceInfo*                     instance_info,
                                               PointerDecoder<uint32_t>*               pPhysicalDeviceCount,
                                               HandlePointerDecoder<VkPhysicalDevice>* pPhysicalDevices);
 
     VkResult OverrideEnumeratePhysicalDeviceGroups(
         PFN_vkEnumeratePhysicalDeviceGroups                            func,
         VkResult                                                       original_result,
-        InstanceInfo*                                                  instance_info,
+        VulkanInstanceInfo*                                            instance_info,
         PointerDecoder<uint32_t>*                                      pPhysicalDeviceGroupCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties);
 
     void OverrideGetPhysicalDeviceProperties(PFN_vkGetPhysicalDeviceProperties func,
-                                             PhysicalDeviceInfo*               physical_device_info,
+                                             VulkanPhysicalDeviceInfo*         physical_device_info,
                                              StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties);
 
     void OverrideGetPhysicalDeviceProperties2(PFN_vkGetPhysicalDeviceProperties2 func,
-                                              PhysicalDeviceInfo*                physical_device_info,
+                                              VulkanPhysicalDeviceInfo*          physical_device_info,
                                               StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties);
 
     void OverrideGetPhysicalDeviceMemoryProperties(
         PFN_vkGetPhysicalDeviceMemoryProperties                         func,
-        PhysicalDeviceInfo*                                             physical_device_info,
+        VulkanPhysicalDeviceInfo*                                       physical_device_info,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties>* pMemoryProperties);
 
     void OverrideGetPhysicalDeviceMemoryProperties2(
         PFN_vkGetPhysicalDeviceMemoryProperties2                         func,
-        PhysicalDeviceInfo*                                              physical_device_info,
+        VulkanPhysicalDeviceInfo*                                        physical_device_info,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties);
 
     VkResult OverrideGetPhysicalDeviceSurfaceCapabilitiesKHR(
         PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR           func,
         VkResult                                                original_result,
-        PhysicalDeviceInfo*                                     physical_device_info,
-        SurfaceKHRInfo*                                         surface_info,
+        VulkanPhysicalDeviceInfo*                               physical_device_info,
+        VulkanSurfaceKHRInfo*                                   surface_info,
         StructPointerDecoder<Decoded_VkSurfaceCapabilitiesKHR>* pSurfaceCapabilities);
 
     VkResult OverrideGetPhysicalDeviceSurfaceCapabilities2KHR(
         PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR                 func,
         VkResult                                                       original_result,
-        PhysicalDeviceInfo*                                            physical_device_info,
+        VulkanPhysicalDeviceInfo*                                      physical_device_info,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>*       pSurfaceCapabilities);
 
     VkResult OverrideGetPhysicalDeviceToolProperties(
         PFN_vkGetPhysicalDeviceToolProperties                         func,
         VkResult                                                      original_result,
-        const PhysicalDeviceInfo*                                     physical_device_info,
+        const VulkanPhysicalDeviceInfo*                               physical_device_info,
         PointerDecoder<uint32_t>*                                     pToolCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceToolProperties>* pToolProperties);
 
     void OverrideGetDeviceQueue(PFN_vkGetDeviceQueue           func,
-                                DeviceInfo*                    device_info,
+                                VulkanDeviceInfo*              device_info,
                                 uint32_t                       queueFamilyIndex,
                                 uint32_t                       queueIndex,
                                 HandlePointerDecoder<VkQueue>* pQueue);
     void OverrideGetDeviceQueue2(PFN_vkGetDeviceQueue2                             func,
-                                 DeviceInfo*                                       device_info,
+                                 VulkanDeviceInfo*                                 device_info,
                                  StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
                                  HandlePointerDecoder<VkQueue>*                    pQueue);
 
     VkResult OverrideWaitForFences(PFN_vkWaitForFences                  func,
                                    VkResult                             original_result,
-                                   const DeviceInfo*                    device_info,
+                                   const VulkanDeviceInfo*              device_info,
                                    uint32_t                             fenceCount,
                                    const HandlePointerDecoder<VkFence>* pFences,
                                    VkBool32                             waitAll,
                                    uint64_t                             timeout);
 
-    VkResult OverrideGetFenceStatus(PFN_vkGetFenceStatus func,
-                                    VkResult             original_result,
-                                    const DeviceInfo*    device_info,
-                                    const FenceInfo*     fence_info);
+    VkResult OverrideGetFenceStatus(PFN_vkGetFenceStatus    func,
+                                    VkResult                original_result,
+                                    const VulkanDeviceInfo* device_info,
+                                    const VulkanFenceInfo*  fence_info);
 
-    VkResult OverrideGetEventStatus(PFN_vkGetEventStatus func,
-                                    VkResult             original_result,
-                                    const DeviceInfo*    device_info,
-                                    const EventInfo*     event_info);
+    VkResult OverrideGetEventStatus(PFN_vkGetEventStatus    func,
+                                    VkResult                original_result,
+                                    const VulkanDeviceInfo* device_info,
+                                    const VulkanEventInfo*  event_info);
 
-    VkResult OverrideGetQueryPoolResults(PFN_vkGetQueryPoolResults func,
-                                         VkResult                  original_result,
-                                         const DeviceInfo*         device_info,
-                                         const QueryPoolInfo*      query_pool_info,
-                                         uint32_t                  firstQuery,
-                                         uint32_t                  queryCount,
-                                         size_t                    dataSize,
-                                         PointerDecoder<uint8_t>*  pData,
-                                         VkDeviceSize              stride,
-                                         VkQueryResultFlags        flags);
+    VkResult OverrideGetQueryPoolResults(PFN_vkGetQueryPoolResults  func,
+                                         VkResult                   original_result,
+                                         const VulkanDeviceInfo*    device_info,
+                                         const VulkanQueryPoolInfo* query_pool_info,
+                                         uint32_t                   firstQuery,
+                                         uint32_t                   queryCount,
+                                         size_t                     dataSize,
+                                         PointerDecoder<uint8_t>*   pData,
+                                         VkDeviceSize               stride,
+                                         VkQueryResultFlags         flags);
 
     VkResult OverrideQueueSubmit(PFN_vkQueueSubmit                                 func,
                                  uint64_t                                          index,
                                  VkResult                                          original_result,
-                                 const QueueInfo*                                  queue_info,
+                                 const VulkanQueueInfo*                            queue_info,
                                  uint32_t                                          submitCount,
                                  const StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
-                                 const FenceInfo*                                  fence_info);
+                                 const VulkanFenceInfo*                            fence_info);
 
     VkResult OverrideQueueSubmit2(PFN_vkQueueSubmit2                                 func,
                                   VkResult                                           original_result,
-                                  const QueueInfo*                                   queue_info,
+                                  const VulkanQueueInfo*                             queue_info,
                                   uint32_t                                           submitCount,
                                   const StructPointerDecoder<Decoded_VkSubmitInfo2>* pSubmits,
-                                  const FenceInfo*                                   fence_info);
+                                  const VulkanFenceInfo*                             fence_info);
 
     VkResult OverrideQueueBindSparse(PFN_vkQueueBindSparse                                 func,
                                      VkResult                                              original_result,
-                                     const QueueInfo*                                      queue_info,
+                                     const VulkanQueueInfo*                                queue_info,
                                      uint32_t                                              bindInfoCount,
                                      const StructPointerDecoder<Decoded_VkBindSparseInfo>* pBindInfo,
-                                     const FenceInfo*                                      fence_info);
+                                     const VulkanFenceInfo*                                fence_info);
 
     VkResult
     OverrideCreateDescriptorSetLayout(PFN_vkCreateDescriptorSetLayout                                func,
                                       VkResult                                                       original_result,
-                                      const DeviceInfo*                                              device_info,
+                                      const VulkanDeviceInfo*                                        device_info,
                                       StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
                                       StructPointerDecoder<Decoded_VkAllocationCallbacks>*           pAllocator,
                                       HandlePointerDecoder<VkDescriptorSetLayout>*                   pSetLayout);
 
     VkResult OverrideCreateDescriptorPool(PFN_vkCreateDescriptorPool func,
                                           VkResult                   original_result,
-                                          const DeviceInfo*          device_info,
+                                          const VulkanDeviceInfo*    device_info,
                                           const StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
                                           const StructPointerDecoder<Decoded_VkAllocationCallbacks>*      pAllocator,
                                           HandlePointerDecoder<VkDescriptorPool>* pDescriptorPool);
 
     void OverrideDestroyDescriptorPool(PFN_vkDestroyDescriptorPool                                func,
-                                       const DeviceInfo*                                          device_info,
-                                       DescriptorPoolInfo*                                        descriptor_pool_info,
+                                       const VulkanDeviceInfo*                                    device_info,
+                                       VulkanDescriptorPoolInfo*                                  descriptor_pool_info,
                                        const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     VkResult
     OverrideAllocateDescriptorSets(PFN_vkAllocateDescriptorSets                                     func,
                                    VkResult                                                         original_result,
-                                   const DeviceInfo*                                                device_info,
+                                   const VulkanDeviceInfo*                                          device_info,
                                    const StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
                                    HandlePointerDecoder<VkDescriptorSet>*                           pDescriptorSets);
 
     VkResult
     OverrideAllocateCommandBuffers(PFN_vkAllocateCommandBuffers                                     func,
                                    VkResult                                                         original_result,
-                                   const DeviceInfo*                                                device_info,
+                                   const VulkanDeviceInfo*                                          device_info,
                                    const StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
                                    HandlePointerDecoder<VkCommandBuffer>*                           pCommandBuffers);
 
     void OverrideFreeCommandBuffers(PFN_vkFreeCommandBuffers               func,
-                                    const DeviceInfo*                      device_info,
-                                    CommandPoolInfo*                       command_pool_info,
+                                    const VulkanDeviceInfo*                device_info,
+                                    VulkanCommandPoolInfo*                 command_pool_info,
                                     uint32_t                               command_buffer_count,
                                     HandlePointerDecoder<VkCommandBuffer>* pCommandBuffers);
 
     VkResult OverrideAllocateMemory(PFN_vkAllocateMemory                                       func,
                                     VkResult                                                   original_result,
-                                    const DeviceInfo*                                          device_info,
+                                    const VulkanDeviceInfo*                                    device_info,
                                     const StructPointerDecoder<Decoded_VkMemoryAllocateInfo>*  pAllocateInfo,
                                     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                     HandlePointerDecoder<VkDeviceMemory>*                      pMemory);
 
-    VkResult OverrideMapMemory(PFN_vkMapMemory   func,
-                               VkResult          original_result,
-                               const DeviceInfo* device_info,
-                               DeviceMemoryInfo* memory_info,
-                               VkDeviceSize      offset,
-                               VkDeviceSize      size,
-                               VkMemoryMapFlags  flags,
-                               void**            ppData);
+    VkResult OverrideMapMemory(PFN_vkMapMemory         func,
+                               VkResult                original_result,
+                               const VulkanDeviceInfo* device_info,
+                               VulkanDeviceMemoryInfo* memory_info,
+                               VkDeviceSize            offset,
+                               VkDeviceSize            size,
+                               VkMemoryMapFlags        flags,
+                               void**                  ppData);
 
-    void OverrideUnmapMemory(PFN_vkUnmapMemory func, const DeviceInfo* device_info, DeviceMemoryInfo* memory_info);
+    void OverrideUnmapMemory(PFN_vkUnmapMemory       func,
+                             const VulkanDeviceInfo* device_info,
+                             VulkanDeviceMemoryInfo* memory_info);
 
     VkResult OverrideFlushMappedMemoryRanges(PFN_vkFlushMappedMemoryRanges                            func,
                                              VkResult                                                 original_result,
-                                             const DeviceInfo*                                        device_info,
+                                             const VulkanDeviceInfo*                                  device_info,
                                              uint32_t                                                 memoryRangeCount,
                                              const StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges);
 
     VkResult
     OverrideInvalidateMappedMemoryRanges(PFN_vkInvalidateMappedMemoryRanges                       func,
                                          VkResult                                                 original_result,
-                                         const DeviceInfo*                                        device_info,
+                                         const VulkanDeviceInfo*                                  device_info,
                                          uint32_t                                                 memoryRangeCount,
                                          const StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges);
 
     void OverrideFreeMemory(PFN_vkFreeMemory                                           func,
-                            const DeviceInfo*                                          device_info,
-                            DeviceMemoryInfo*                                          memory_info,
+                            const VulkanDeviceInfo*                                    device_info,
+                            VulkanDeviceMemoryInfo*                                    memory_info,
                             const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
-    VkResult OverrideBindBufferMemory(PFN_vkBindBufferMemory func,
-                                      VkResult               original_result,
-                                      const DeviceInfo*      device_info,
-                                      BufferInfo*            buffer_info,
-                                      DeviceMemoryInfo*      memory_info,
-                                      VkDeviceSize           memoryOffset);
+    VkResult OverrideBindBufferMemory(PFN_vkBindBufferMemory  func,
+                                      VkResult                original_result,
+                                      const VulkanDeviceInfo* device_info,
+                                      VulkanBufferInfo*       buffer_info,
+                                      VulkanDeviceMemoryInfo* memory_info,
+                                      VkDeviceSize            memoryOffset);
 
     VkResult OverrideBindBufferMemory2(PFN_vkBindBufferMemory2                                     func,
                                        VkResult                                                    original_result,
-                                       const DeviceInfo*                                           device_info,
+                                       const VulkanDeviceInfo*                                     device_info,
                                        uint32_t                                                    bindInfoCount,
                                        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos);
 
-    VkResult OverrideBindImageMemory(PFN_vkBindImageMemory func,
-                                     VkResult              original_result,
-                                     const DeviceInfo*     device_info,
-                                     ImageInfo*            image_info,
-                                     DeviceMemoryInfo*     memory_info,
-                                     VkDeviceSize          memoryOffset);
+    VkResult OverrideBindImageMemory(PFN_vkBindImageMemory   func,
+                                     VkResult                original_result,
+                                     const VulkanDeviceInfo* device_info,
+                                     VulkanImageInfo*        image_info,
+                                     VulkanDeviceMemoryInfo* memory_info,
+                                     VkDeviceSize            memoryOffset);
 
     VkResult OverrideBindImageMemory2(PFN_vkBindImageMemory2                                     func,
                                       VkResult                                                   original_result,
-                                      const DeviceInfo*                                          device_info,
+                                      const VulkanDeviceInfo*                                    device_info,
                                       uint32_t                                                   bindInfoCount,
                                       const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos);
 
     VkResult OverrideBindVideoSessionMemoryKHR(
         PFN_vkBindVideoSessionMemoryKHR                                func,
         VkResult                                                       original_result,
-        const DeviceInfo*                                              device_info,
-        VideoSessionKHRInfo*                                           video_session_info,
+        const VulkanDeviceInfo*                                        device_info,
+        VulkanVideoSessionKHRInfo*                                     video_session_info,
         uint32_t                                                       bindSessionMemoryInfoCount,
         StructPointerDecoder<Decoded_VkBindVideoSessionMemoryInfoKHR>* pBindSessionMemoryInfos);
 
     VkResult OverrideCreateBuffer(PFN_vkCreateBuffer                                         func,
                                   VkResult                                                   original_result,
-                                  const DeviceInfo*                                          device_info,
+                                  const VulkanDeviceInfo*                                    device_info,
                                   const StructPointerDecoder<Decoded_VkBufferCreateInfo>*    pCreateInfo,
                                   const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                   HandlePointerDecoder<VkBuffer>*                            pBuffer);
 
     void OverrideDestroyBuffer(PFN_vkDestroyBuffer                                        func,
-                               const DeviceInfo*                                          device_info,
-                               BufferInfo*                                                buffer_info,
+                               const VulkanDeviceInfo*                                    device_info,
+                               VulkanBufferInfo*                                          buffer_info,
                                const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     VkResult OverrideCreateImage(PFN_vkCreateImage                                          func,
                                  VkResult                                                   original_result,
-                                 const DeviceInfo*                                          device_info,
+                                 const VulkanDeviceInfo*                                    device_info,
                                  const StructPointerDecoder<Decoded_VkImageCreateInfo>*     pCreateInfo,
                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                  HandlePointerDecoder<VkImage>*                             pImage);
 
     void OverrideDestroyImage(PFN_vkDestroyImage                                         func,
-                              const DeviceInfo*                                          device_info,
-                              ImageInfo*                                                 image_info,
+                              const VulkanDeviceInfo*                                    device_info,
+                              VulkanImageInfo*                                           image_info,
                               const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     VkResult OverrideCreateVideoSessionKHR(PFN_vkCreateVideoSessionKHR func,
                                            VkResult                    original_result,
-                                           const DeviceInfo*           device_info,
+                                           const VulkanDeviceInfo*     device_info,
                                            const StructPointerDecoder<Decoded_VkVideoSessionCreateInfoKHR>* pCreateInfo,
                                            const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
                                            HandlePointerDecoder<VkVideoSessionKHR>* pVideoSession);
 
     void OverrideDestroyVideoSessionKHR(PFN_vkDestroyVideoSessionKHR                               func,
-                                        const DeviceInfo*                                          device_info,
-                                        VideoSessionKHRInfo*                                       video_session_info,
+                                        const VulkanDeviceInfo*                                    device_info,
+                                        VulkanVideoSessionKHRInfo*                                 video_session_info,
                                         const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     void OverrideGetImageSubresourceLayout(PFN_vkGetImageSubresourceLayout                         func,
-                                           const DeviceInfo*                                       device_info,
-                                           const ImageInfo*                                        image_info,
+                                           const VulkanDeviceInfo*                                 device_info,
+                                           const VulkanImageInfo*                                  image_info,
                                            const StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
                                            StructPointerDecoder<Decoded_VkSubresourceLayout>*      pLayout);
 
     VkResult OverrideCreateRenderPass(PFN_vkCreateRenderPass                                      func,
                                       VkResult                                                    original_result,
-                                      const DeviceInfo*                                           device_info,
+                                      const VulkanDeviceInfo*                                     device_info,
                                       const StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
                                       const StructPointerDecoder<Decoded_VkAllocationCallbacks>*  pAllocator,
                                       HandlePointerDecoder<VkRenderPass>*                         pRenderPass);
 
     VkResult OverrideCreateRenderPass2(PFN_vkCreateRenderPass2                                      func,
                                        VkResult                                                     original_result,
-                                       const DeviceInfo*                                            device_info,
+                                       const VulkanDeviceInfo*                                      device_info,
                                        const StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
                                        const StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
                                        HandlePointerDecoder<VkRenderPass>*                          pRenderPass);
 
     void OverrideCmdPipelineBarrier(PFN_vkCmdPipelineBarrier                                   func,
-                                    CommandBufferInfo*                                         command_buffer_info,
+                                    VulkanCommandBufferInfo*                                   command_buffer_info,
                                     VkPipelineStageFlags                                       srcStageMask,
                                     VkPipelineStageFlags                                       dstStageMask,
                                     VkDependencyFlags                                          dependencyFlags,
@@ -836,57 +838,58 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                     const StructPointerDecoder<Decoded_VkImageMemoryBarrier>*  pImageMemoryBarriers);
 
     void OverrideCmdPipelineBarrier2(PFN_vkCmdPipelineBarrier2                       func,
-                                     CommandBufferInfo*                              command_buffer_info,
+                                     VulkanCommandBufferInfo*                        command_buffer_info,
                                      StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo);
 
     void OverrideCmdPipelineBarrier2KHR(PFN_vkCmdPipelineBarrier2                       func,
-                                        CommandBufferInfo*                              command_buffer_info,
+                                        VulkanCommandBufferInfo*                        command_buffer_info,
                                         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo);
 
     VkResult OverrideCreateDescriptorUpdateTemplate(
         PFN_vkCreateDescriptorUpdateTemplate                                      func,
         VkResult                                                                  original_result,
-        const DeviceInfo*                                                         device_info,
+        const VulkanDeviceInfo*                                                   device_info,
         const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*                pAllocator,
         HandlePointerDecoder<VkDescriptorUpdateTemplate>*                         pDescriptorUpdateTemplate);
 
-    void OverrideDestroyDescriptorUpdateTemplate(PFN_vkDestroyDescriptorUpdateTemplate func,
-                                                 const DeviceInfo*                     device_info,
-                                                 const DescriptorUpdateTemplateInfo*   descriptor_update_template_info,
-                                                 const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
+    void
+    OverrideDestroyDescriptorUpdateTemplate(PFN_vkDestroyDescriptorUpdateTemplate     func,
+                                            const VulkanDeviceInfo*                   device_info,
+                                            const VulkanDescriptorUpdateTemplateInfo* descriptor_update_template_info,
+                                            const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     VkResult OverrideCreateShaderModule(PFN_vkCreateShaderModule                                      func,
                                         VkResult                                                      original_result,
-                                        const DeviceInfo*                                             device_info,
+                                        const VulkanDeviceInfo*                                       device_info,
                                         const StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
                                         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*    pAllocator,
                                         HandlePointerDecoder<VkShaderModule>*                         pShaderModule);
 
-    VkResult OverrideGetPipelineCacheData(PFN_vkGetPipelineCacheData func,
-                                          VkResult                   original_result,
-                                          const DeviceInfo*          device_info,
-                                          const PipelineCacheInfo*   pipeline_cache_info,
-                                          PointerDecoder<size_t>*    pDataSize,
-                                          PointerDecoder<uint8_t>*   pData);
+    VkResult OverrideGetPipelineCacheData(PFN_vkGetPipelineCacheData     func,
+                                          VkResult                       original_result,
+                                          const VulkanDeviceInfo*        device_info,
+                                          const VulkanPipelineCacheInfo* pipeline_cache_info,
+                                          PointerDecoder<size_t>*        pDataSize,
+                                          PointerDecoder<uint8_t>*       pData);
 
     VkResult OverrideCreatePipelineCache(PFN_vkCreatePipelineCache                                      func,
                                          VkResult                                                       original_result,
-                                         const DeviceInfo*                                              device_info,
+                                         const VulkanDeviceInfo*                                        device_info,
                                          const StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
                                          const StructPointerDecoder<Decoded_VkAllocationCallbacks>*     pAllocator,
                                          HandlePointerDecoder<VkPipelineCache>*                         pPipelineCache);
 
     VkResult OverrideResetDescriptorPool(PFN_vkResetDescriptorPool  func,
                                          VkResult                   original_result,
-                                         const DeviceInfo*          device_info,
-                                         DescriptorPoolInfo*        pool_info,
+                                         const VulkanDeviceInfo*    device_info,
+                                         VulkanDescriptorPoolInfo*  pool_info,
                                          VkDescriptorPoolResetFlags flags);
 
     VkResult OverrideCreateDebugReportCallbackEXT(
         PFN_vkCreateDebugReportCallbackEXT                                      func,
         VkResult                                                                original_result,
-        const InstanceInfo*                                                     instance_info,
+        const VulkanInstanceInfo*                                               instance_info,
         const StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*              pAllocator,
         HandlePointerDecoder<VkDebugReportCallbackEXT>*                         pCallback);
@@ -894,14 +897,14 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult OverrideCreateDebugUtilsMessengerEXT(
         PFN_vkCreateDebugUtilsMessengerEXT                                      func,
         VkResult                                                                original_result,
-        const InstanceInfo*                                                     instance_info,
+        const VulkanInstanceInfo*                                               instance_info,
         const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*              pAllocator,
         HandlePointerDecoder<VkDebugUtilsMessengerEXT>*                         pMessenger);
 
     VkResult OverrideCreateSwapchainKHR(PFN_vkCreateSwapchainKHR                                      func,
                                         VkResult                                                      original_result,
-                                        DeviceInfo*                                                   device_info,
+                                        VulkanDeviceInfo*                                             device_info,
                                         const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
                                         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*    pAllocator,
                                         HandlePointerDecoder<VkSwapchainKHR>*                         pSwapchain);
@@ -909,72 +912,72 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult
     OverrideCreateSharedSwapchainsKHR(PFN_vkCreateSharedSwapchainsKHR                               func,
                                       VkResult                                                      original_result,
-                                      DeviceInfo*                                                   device_info,
+                                      VulkanDeviceInfo*                                             device_info,
                                       uint32_t                                                      swapchainCount,
                                       const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfos,
                                       const StructPointerDecoder<Decoded_VkAllocationCallbacks>*    pAllocator,
                                       HandlePointerDecoder<VkSwapchainKHR>*                         pSwapchains);
 
     void OverrideDestroySwapchainKHR(PFN_vkDestroySwapchainKHR                                  func,
-                                     DeviceInfo*                                                device_info,
-                                     SwapchainKHRInfo*                                          swapchain_info,
+                                     VulkanDeviceInfo*                                          device_info,
+                                     VulkanSwapchainKHRInfo*                                    swapchain_info,
                                      const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     VkResult OverrideGetSwapchainImagesKHR(PFN_vkGetSwapchainImagesKHR    func,
                                            VkResult                       original_result,
-                                           const DeviceInfo*              device_info,
-                                           SwapchainKHRInfo*              swapchain_info,
+                                           const VulkanDeviceInfo*        device_info,
+                                           VulkanSwapchainKHRInfo*        swapchain_info,
                                            PointerDecoder<uint32_t>*      pSwapchainImageCount,
                                            HandlePointerDecoder<VkImage>* pSwapchainImages);
 
     VkResult OverrideAcquireNextImageKHR(PFN_vkAcquireNextImageKHR func,
                                          VkResult                  original_result,
-                                         const DeviceInfo*         device_info,
-                                         SwapchainKHRInfo*         swapchain_info,
+                                         const VulkanDeviceInfo*   device_info,
+                                         VulkanSwapchainKHRInfo*   swapchain_info,
                                          uint64_t                  timeout,
-                                         SemaphoreInfo*            semaphore_info,
-                                         FenceInfo*                fence_info,
+                                         VulkanSemaphoreInfo*      semaphore_info,
+                                         VulkanFenceInfo*          fence_info,
                                          PointerDecoder<uint32_t>* pImageIndex);
 
     VkResult OverrideAcquireNextImage2KHR(PFN_vkAcquireNextImage2KHR func,
                                           VkResult                   original_result,
-                                          const DeviceInfo*          device_info,
+                                          const VulkanDeviceInfo*    device_info,
                                           const StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
                                           PointerDecoder<uint32_t>*                                      pImageIndex);
 
     VkResult OverrideQueuePresentKHR(PFN_vkQueuePresentKHR                                 func,
                                      VkResult                                              original_result,
-                                     const QueueInfo*                                      queue_info,
+                                     const VulkanQueueInfo*                                queue_info,
                                      const StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo);
 
     VkResult OverrideImportSemaphoreFdKHR(
         PFN_vkImportSemaphoreFdKHR                                      func,
         VkResult                                                        original_result,
-        const DeviceInfo*                                               device_info,
+        const VulkanDeviceInfo*                                         device_info,
         const StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo);
 
     VkResult OverrideGetSemaphoreFdKHR(PFN_vkGetSemaphoreFdKHR                                      func,
                                        VkResult                                                     original_result,
-                                       const DeviceInfo*                                            device_info,
+                                       const VulkanDeviceInfo*                                      device_info,
                                        const StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
                                        const PointerDecoder<int>*                                   pFd);
 
     VkResult OverrideImportSemaphoreWin32HandleKHR(
         PFN_vkImportSemaphoreWin32HandleKHR                                      func,
         VkResult                                                                 original_result,
-        const DeviceInfo*                                                        device_info,
+        const VulkanDeviceInfo*                                                  device_info,
         const StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo);
 
     VkResult OverrideGetSemaphoreWin32HandleKHR(
         PFN_vkGetSemaphoreWin32HandleKHR                                      func,
         VkResult                                                              original_result,
-        const DeviceInfo*                                                     device_info,
+        const VulkanDeviceInfo*                                               device_info,
         const StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         const PointerDecoder<uint64_t, void*>*                                pHandle);
 
     VkResult OverrideGetRandROutputDisplayEXT(PFN_vkGetRandROutputDisplayEXT      func,
                                               VkResult                            original_result,
-                                              const PhysicalDeviceInfo*           physicalDevice,
+                                              const VulkanPhysicalDeviceInfo*     physicalDevice,
                                               Display*                            dpy,
                                               RROutput                            rrOutput,
                                               HandlePointerDecoder<VkDisplayKHR>* pDisplay);
@@ -984,53 +987,53 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult
     OverrideCreateAndroidSurfaceKHR(PFN_vkCreateAndroidSurfaceKHR                                      func,
                                     VkResult                                                           original_result,
-                                    InstanceInfo*                                                      instance_info,
+                                    VulkanInstanceInfo*                                                instance_info,
                                     const StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
                                     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*         pAllocator,
                                     HandlePointerDecoder<VkSurfaceKHR>*                                pSurface);
 
     VkResult OverrideCreateWin32SurfaceKHR(PFN_vkCreateWin32SurfaceKHR func,
                                            VkResult                    original_result,
-                                           InstanceInfo*               instance_info,
+                                           VulkanInstanceInfo*         instance_info,
                                            const StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
                                            const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
                                            HandlePointerDecoder<VkSurfaceKHR>*                              pSurface);
 
     VkBool32
     OverrideGetPhysicalDeviceWin32PresentationSupportKHR(PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR func,
-                                                         const PhysicalDeviceInfo* physical_device_info,
-                                                         uint32_t                  queueFamilyIndex);
+                                                         const VulkanPhysicalDeviceInfo* physical_device_info,
+                                                         uint32_t                        queueFamilyIndex);
 
     VkResult OverrideCreateXcbSurfaceKHR(PFN_vkCreateXcbSurfaceKHR                                      func,
                                          VkResult                                                       original_result,
-                                         InstanceInfo*                                                  instance_info,
+                                         VulkanInstanceInfo*                                            instance_info,
                                          const StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
                                          const StructPointerDecoder<Decoded_VkAllocationCallbacks>*     pAllocator,
                                          HandlePointerDecoder<VkSurfaceKHR>*                            pSurface);
 
     VkBool32 OverrideGetPhysicalDeviceXcbPresentationSupportKHR(PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR func,
-                                                                const PhysicalDeviceInfo* physical_device_info,
-                                                                uint32_t                  queueFamilyIndex,
-                                                                xcb_connection_t*         connection,
-                                                                xcb_visualid_t            visual_id);
+                                                                const VulkanPhysicalDeviceInfo* physical_device_info,
+                                                                uint32_t                        queueFamilyIndex,
+                                                                xcb_connection_t*               connection,
+                                                                xcb_visualid_t                  visual_id);
 
     VkResult OverrideCreateXlibSurfaceKHR(PFN_vkCreateXlibSurfaceKHR func,
                                           VkResult                   original_result,
-                                          InstanceInfo*              instance_info,
+                                          VulkanInstanceInfo*        instance_info,
                                           const StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
                                           const StructPointerDecoder<Decoded_VkAllocationCallbacks>*      pAllocator,
                                           HandlePointerDecoder<VkSurfaceKHR>*                             pSurface);
 
     VkBool32 OverrideGetPhysicalDeviceXlibPresentationSupportKHR(PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR func,
-                                                                 const PhysicalDeviceInfo* physical_device_info,
-                                                                 uint32_t                  queueFamilyIndex,
-                                                                 Display*                  dpy,
-                                                                 VisualID                  visualID);
+                                                                 const VulkanPhysicalDeviceInfo* physical_device_info,
+                                                                 uint32_t                        queueFamilyIndex,
+                                                                 Display*                        dpy,
+                                                                 VisualID                        visualID);
 
     VkResult
     OverrideCreateWaylandSurfaceKHR(PFN_vkCreateWaylandSurfaceKHR                                      func,
                                     VkResult                                                           original_result,
-                                    InstanceInfo*                                                      instance_info,
+                                    VulkanInstanceInfo*                                                instance_info,
                                     const StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
                                     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*         pAllocator,
                                     HandlePointerDecoder<VkSurfaceKHR>*                                pSurface);
@@ -1038,7 +1041,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult
     OverrideCreateDisplayPlaneSurfaceKHR(PFN_vkCreateDisplayPlaneSurfaceKHR func,
                                          VkResult                           original_result,
-                                         InstanceInfo*                      instance_info,
+                                         VulkanInstanceInfo*                instance_info,
                                          const StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
                                          const StructPointerDecoder<Decoded_VkAllocationCallbacks>*         pAllocator,
                                          HandlePointerDecoder<VkSurfaceKHR>*                                pSurface);
@@ -1046,95 +1049,95 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult
     OverrideCreateHeadlessSurfaceEXT(PFN_vkCreateHeadlessSurfaceEXT func,
                                      VkResult                       original_result,
-                                     InstanceInfo*                  instance_info,
+                                     VulkanInstanceInfo*            instance_info,
                                      const StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
                                      const StructPointerDecoder<Decoded_VkAllocationCallbacks>*          pAllocator,
                                      HandlePointerDecoder<VkSurfaceKHR>*                                 pSurface);
 
     VkBool32
     OverrideGetPhysicalDeviceWaylandPresentationSupportKHR(PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR func,
-                                                           const PhysicalDeviceInfo* physical_device_info,
-                                                           uint32_t                  queueFamilyIndex,
-                                                           struct wl_display*        display);
+                                                           const VulkanPhysicalDeviceInfo* physical_device_info,
+                                                           uint32_t                        queueFamilyIndex,
+                                                           struct wl_display*              display);
 
     VkResult OverrideCreateMetalSurfaceEXT(PFN_vkCreateMetalSurfaceEXT func,
                                            VkResult                    original_result,
-                                           InstanceInfo*               instance_info,
+                                           VulkanInstanceInfo*         instance_info,
                                            const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
                                            const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
                                            HandlePointerDecoder<VkSurfaceKHR>*                              pSurface);
 
     void OverrideDestroySurfaceKHR(PFN_vkDestroySurfaceKHR                                    func,
-                                   InstanceInfo*                                              instance_info,
-                                   const SurfaceKHRInfo*                                      surface_info,
+                                   VulkanInstanceInfo*                                        instance_info,
+                                   const VulkanSurfaceKHRInfo*                                surface_info,
                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     VkResult OverrideCreateAccelerationStructureKHR(
         PFN_vkCreateAccelerationStructureKHR                                      func,
         VkResult                                                                  original_result,
-        const DeviceInfo*                                                         device_info,
+        const VulkanDeviceInfo*                                                   device_info,
         const StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoKHR>* pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*                pAllocator,
         HandlePointerDecoder<VkAccelerationStructureKHR>*                         pAccelerationStructureKHR);
 
-    void OverrideDestroyAccelerationStructureKHR(PFN_vkDestroyAccelerationStructureKHR func,
-                                                 const DeviceInfo*                     device_info,
-                                                 const AccelerationStructureKHRInfo*   acceleration_structure_info,
+    void OverrideDestroyAccelerationStructureKHR(PFN_vkDestroyAccelerationStructureKHR     func,
+                                                 const VulkanDeviceInfo*                   device_info,
+                                                 const VulkanAccelerationStructureKHRInfo* acceleration_structure_info,
                                                  StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     void OverrideCmdBuildAccelerationStructuresKHR(
         PFN_vkCmdBuildAccelerationStructuresKHR                                    func,
-        CommandBufferInfo*                                                         command_buffer_info,
+        VulkanCommandBufferInfo*                                                   command_buffer_info,
         uint32_t                                                                   infoCount,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>*   ppBuildRangeInfos);
 
     void
     OverrideCmdCopyAccelerationStructureKHR(PFN_vkCmdCopyAccelerationStructureKHR func,
-                                            CommandBufferInfo*                    command_buffer_info,
+                                            VulkanCommandBufferInfo*              command_buffer_info,
                                             StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo);
 
     void OverrideCmdWriteAccelerationStructuresPropertiesKHR(
         PFN_vkCmdWriteAccelerationStructuresPropertiesKHR func,
-        CommandBufferInfo*                                command_buffer_info,
+        VulkanCommandBufferInfo*                          command_buffer_info,
         uint32_t                                          count,
         HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructures,
         VkQueryType                                       queryType,
-        gfxrecon::decode::QueryPoolInfo*                  query_pool_info,
+        gfxrecon::decode::VulkanQueryPoolInfo*            query_pool_info,
         uint32_t                                          firstQuery);
 
     VkResult OverrideCreateRayTracingPipelinesKHR(
         PFN_vkCreateRayTracingPipelinesKHR                                     func,
         VkResult                                                               original_result,
-        const DeviceInfo*                                                      device_info,
-        DeferredOperationKHRInfo*                                              deferred_operation_info,
-        const PipelineCacheInfo*                                               pipeline_cache_info,
+        const VulkanDeviceInfo*                                                device_info,
+        VulkanDeferredOperationKHRInfo*                                        deferred_operation_info,
+        const VulkanPipelineCacheInfo*                                         pipeline_cache_info,
         uint32_t                                                               createInfoCount,
         const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
         HandlePointerDecoder<VkPipeline>*                                      pPipelines);
 
-    VkResult OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperationJoinKHR func,
-                                              VkResult                       original_result,
-                                              const DeviceInfo*              device_info,
-                                              DeferredOperationKHRInfo*      deferred_operation_info);
+    VkResult OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperationJoinKHR  func,
+                                              VkResult                        original_result,
+                                              const VulkanDeviceInfo*         device_info,
+                                              VulkanDeferredOperationKHRInfo* deferred_operation_info);
 
     VkDeviceAddress
     OverrideGetBufferDeviceAddress(PFN_vkGetBufferDeviceAddress                                   func,
                                    VkDeviceAddress                                                original_result,
-                                   const DeviceInfo*                                              device_info,
+                                   const VulkanDeviceInfo*                                        device_info,
                                    const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo);
 
     void OverrideGetAccelerationStructureDeviceAddressKHR(
         PFN_vkGetAccelerationStructureDeviceAddressKHR                                   func,
         VkDeviceAddress                                                                  original_result,
-        const DeviceInfo*                                                                device_info,
+        const VulkanDeviceInfo*                                                          device_info,
         const StructPointerDecoder<Decoded_VkAccelerationStructureDeviceAddressInfoKHR>* pInfo);
 
     VkResult OverrideGetRayTracingShaderGroupHandlesKHR(PFN_vkGetRayTracingShaderGroupHandlesKHR func,
                                                         VkResult                                 original_result,
-                                                        const DeviceInfo*                        device_info,
-                                                        const PipelineInfo*                      pipeline_info,
+                                                        const VulkanDeviceInfo*                  device_info,
+                                                        const VulkanPipelineInfo*                pipeline_info,
                                                         uint32_t                                 firstGroup,
                                                         uint32_t                                 groupCount,
                                                         size_t                                   dataSize,
@@ -1142,68 +1145,68 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult OverrideGetAndroidHardwareBufferPropertiesANDROID(
         PFN_vkGetAndroidHardwareBufferPropertiesANDROID                         func,
         VkResult                                                                original_result,
-        const DeviceInfo*                                                       device_info,
+        const VulkanDeviceInfo*                                                 device_info,
         const struct AHardwareBuffer*                                           hardware_buffer,
         StructPointerDecoder<Decoded_VkAndroidHardwareBufferPropertiesANDROID>* pProperties);
 
-    void ClearCommandBufferInfo(CommandBufferInfo* command_buffer_info);
+    void ClearCommandBufferInfo(VulkanCommandBufferInfo* command_buffer_info);
 
     VkResult OverrideBeginCommandBuffer(PFN_vkBeginCommandBuffer                                func,
                                         uint64_t                                                index,
                                         VkResult                                                original_result,
-                                        CommandBufferInfo*                                      command_buffer_info,
+                                        VulkanCommandBufferInfo*                                command_buffer_info,
                                         StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* begin_info_decoder);
 
     VkResult OverrideResetCommandBuffer(PFN_vkResetCommandBuffer  func,
                                         VkResult                  original_result,
-                                        CommandBufferInfo*        command_buffer_info,
+                                        VulkanCommandBufferInfo*  command_buffer_info,
                                         VkCommandBufferResetFlags flags);
 
     VkResult OverrideResetCommandPool(PFN_vkResetCommandPool  func,
                                       VkResult                original_result,
-                                      const DeviceInfo*       device_info,
-                                      CommandPoolInfo*        pool_info,
+                                      const VulkanDeviceInfo* device_info,
+                                      VulkanCommandPoolInfo*  pool_info,
                                       VkCommandPoolResetFlags flags);
 
     void OverrideDestroyCommandPool(PFN_vkDestroyCommandPool                             func,
-                                    const DeviceInfo*                                    device_info,
-                                    CommandPoolInfo*                                     pool_info,
+                                    const VulkanDeviceInfo*                              device_info,
+                                    VulkanCommandPoolInfo*                               pool_info,
                                     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     void OverrideCmdDebugMarkerInsertEXT(PFN_vkCmdDebugMarkerInsertEXT                             func,
-                                         CommandBufferInfo*                                        command_buffer_info,
+                                         VulkanCommandBufferInfo*                                  command_buffer_info,
                                          StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* marker_info_decoder);
 
     void OverrideCmdInsertDebugUtilsLabelEXT(PFN_vkCmdInsertDebugUtilsLabelEXT                   func,
-                                             CommandBufferInfo*                                  command_buffer_info,
+                                             VulkanCommandBufferInfo*                            command_buffer_info,
                                              StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* label_info_decoder);
 
     VkResult OverrideWaitSemaphores(PFN_vkWaitSemaphores                                     func,
                                     VkResult                                                 original_result,
-                                    const DeviceInfo*                                        device_info,
+                                    const VulkanDeviceInfo*                                  device_info,
                                     const StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pInfo,
                                     uint64_t                                                 timeout);
 
     VkResult OverrideAcquireProfilingLockKHR(PFN_vkAcquireProfilingLockKHR func,
                                              VkResult                      original_result,
-                                             const DeviceInfo*             device_info,
+                                             const VulkanDeviceInfo*       device_info,
                                              const StructPointerDecoder<Decoded_VkAcquireProfilingLockInfoKHR>* pInfo);
 
     VkResult OverrideWaitForPresentKHR(PFN_vkWaitForPresentKHR func,
                                        VkResult                original_result,
-                                       const DeviceInfo*       device_info,
-                                       SwapchainKHRInfo*       swapchain_info,
+                                       const VulkanDeviceInfo* device_info,
+                                       VulkanSwapchainKHRInfo* swapchain_info,
                                        uint64_t                presentid,
                                        uint64_t                timeout);
 
     void OverrideCmdBeginRenderPass(PFN_vkCmdBeginRenderPass                             func,
-                                    CommandBufferInfo*                                   command_buffer_info,
+                                    VulkanCommandBufferInfo*                             command_buffer_info,
                                     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
                                     VkSubpassContents                                    contents);
 
     void
     OverrideCmdTraceRaysKHR(PFN_vkCmdTraceRaysKHR                                          func,
-                            CommandBufferInfo*                                             command_buffer_info,
+                            VulkanCommandBufferInfo*                                       command_buffer_info,
                             StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
                             StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
                             StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pHitShaderBindingTable,
@@ -1214,42 +1217,42 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void
     OverrideCmdBeginRenderPass2(PFN_vkCmdBeginRenderPass2                            func,
-                                CommandBufferInfo*                                   command_buffer_info,
+                                VulkanCommandBufferInfo*                             command_buffer_info,
                                 StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
                                 StructPointerDecoder<Decoded_VkSubpassBeginInfo>*    subpass_begin_info_decode);
 
     VkResult OverrideCreateImageView(PFN_vkCreateImageView                                func,
                                      VkResult                                             original_result,
-                                     const DeviceInfo*                                    device_info,
+                                     const VulkanDeviceInfo*                              device_info,
                                      StructPointerDecoder<Decoded_VkImageViewCreateInfo>* create_info_decoder,
                                      StructPointerDecoder<Decoded_VkAllocationCallbacks>* allocator_decoder,
                                      HandlePointerDecoder<VkImageView>*                   view_decoder);
 
     VkResult OverrideCreateFramebuffer(PFN_vkCreateFramebuffer                                func,
                                        VkResult                                               original_result,
-                                       const DeviceInfo*                                      device_info,
+                                       const VulkanDeviceInfo*                                device_info,
                                        StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* create_info_decoder,
                                        StructPointerDecoder<Decoded_VkAllocationCallbacks>*   allocator_decoder,
                                        HandlePointerDecoder<VkFramebuffer>*                   frame_buffer_decoder);
 
     void OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryANDROID func,
-                                      const DeviceInfo*          device_info,
-                                      const SemaphoreInfo*       semaphore_info,
-                                      const ImageInfo*           image_info);
+                                      const VulkanDeviceInfo*    device_info,
+                                      const VulkanSemaphoreInfo* semaphore_info,
+                                      const VulkanImageInfo*     image_info);
 
     void OverrideUpdateDescriptorSets(PFN_vkUpdateDescriptorSets                          func,
-                                      const DeviceInfo*                                   device_info,
+                                      const VulkanDeviceInfo*                             device_info,
                                       uint32_t                                            descriptor_write_count,
                                       StructPointerDecoder<Decoded_VkWriteDescriptorSet>* p_descriptor_writes,
                                       uint32_t                                            descriptor_copy_count,
                                       StructPointerDecoder<Decoded_VkCopyDescriptorSet>*  p_pescriptor_copies);
 
     VkResult
-    OverrideCreateGraphicsPipelines(PFN_vkCreateGraphicsPipelines func,
-                                    VkResult                      original_result,
-                                    const DeviceInfo*             device_info,
-                                    const PipelineCacheInfo*      pipeline_cache_info,
-                                    uint32_t                      create_info_count,
+    OverrideCreateGraphicsPipelines(PFN_vkCreateGraphicsPipelines  func,
+                                    VkResult                       original_result,
+                                    const VulkanDeviceInfo*        device_info,
+                                    const VulkanPipelineCacheInfo* pipeline_cache_info,
+                                    uint32_t                       create_info_count,
                                     const StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
                                     const StructPointerDecoder<Decoded_VkAllocationCallbacks>*        pAllocator,
                                     HandlePointerDecoder<VkPipeline>*                                 pPipelines);
@@ -1257,8 +1260,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult
     OverrideCreateComputePipelines(PFN_vkCreateComputePipelines                                     func,
                                    VkResult                                                         original_result,
-                                   const DeviceInfo*                                                device_info,
-                                   const PipelineCacheInfo*                                         pipeline_cache_info,
+                                   const VulkanDeviceInfo*                                          device_info,
+                                   const VulkanPipelineCacheInfo*                                   pipeline_cache_info,
                                    uint32_t                                                         create_info_count,
                                    const StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfos,
                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
@@ -1266,32 +1269,32 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     VkResult OverrideCreateShadersEXT(PFN_vkCreateShadersEXT                                     func,
                                       VkResult                                                   original_result,
-                                      const DeviceInfo*                                          device_info,
+                                      const VulkanDeviceInfo*                                    device_info,
                                       uint32_t                                                   create_info_count,
                                       const StructPointerDecoder<Decoded_VkShaderCreateInfoEXT>* pCreateInfos,
                                       const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                       HandlePointerDecoder<VkShaderEXT>*                         pShaders);
 
     void OverrideDestroyPipeline(PFN_vkDestroyPipeline                                      func,
-                                 const DeviceInfo*                                          device_info,
-                                 PipelineInfo*                                              pipeline_info,
+                                 const VulkanDeviceInfo*                                    device_info,
+                                 VulkanPipelineInfo*                                        pipeline_info,
                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     void OverrideDestroyRenderPass(PFN_vkDestroyRenderPass                                    func,
-                                   const DeviceInfo*                                          device_info,
-                                   RenderPassInfo*                                            renderpass_info,
+                                   const VulkanDeviceInfo*                                    device_info,
+                                   VulkanRenderPassInfo*                                      renderpass_info,
                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     void OverrideDestroyShaderModule(PFN_vkDestroyShaderModule                                  func,
-                                     const DeviceInfo*                                          device_info,
-                                     ShaderModuleInfo*                                          shader_module_info,
+                                     const VulkanDeviceInfo*                                    device_info,
+                                     VulkanShaderModuleInfo*                                    shader_module_info,
                                      const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     std::function<handle_create_result_t<VkPipeline>()>
     AsyncCreateGraphicsPipelines(const ApiCallInfo&                                          call_info,
                                  VkResult                                                    returnValue,
-                                 const DeviceInfo*                                           device_info,
-                                 const PipelineCacheInfo*                                    pipeline_cache_info,
+                                 const VulkanDeviceInfo*                                     device_info,
+                                 const VulkanPipelineCacheInfo*                              pipeline_cache_info,
                                  uint32_t                                                    createInfoCount,
                                  StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
                                  StructPointerDecoder<Decoded_VkAllocationCallbacks>*        pAllocator,
@@ -1300,8 +1303,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::function<handle_create_result_t<VkPipeline>()>
     AsyncCreateComputePipelines(const ApiCallInfo&                                         call_info,
                                 VkResult                                                   returnValue,
-                                const DeviceInfo*                                          device_info,
-                                const PipelineCacheInfo*                                   pipeline_cache_info,
+                                const VulkanDeviceInfo*                                    device_info,
+                                const VulkanPipelineCacheInfo*                             pipeline_cache_info,
                                 uint32_t                                                   createInfoCount,
                                 StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfos,
                                 StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
@@ -1310,7 +1313,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::function<handle_create_result_t<VkShaderEXT>()>
     AsyncCreateShadersEXT(const ApiCallInfo&                                   call_info,
                           VkResult                                             returnValue,
-                          const DeviceInfo*                                    device_info,
+                          const VulkanDeviceInfo*                              device_info,
                           uint32_t                                             createInfoCount,
                           StructPointerDecoder<Decoded_VkShaderCreateInfoEXT>* pCreateInfos,
                           StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
@@ -1333,97 +1336,98 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     PFN_vkCreateDevice GetCreateDeviceProc(VkPhysicalDevice physical_device);
 
-    void SetInstancePhysicalDeviceEntries(InstanceInfo*           instance_info,
+    void SetInstancePhysicalDeviceEntries(VulkanInstanceInfo*     instance_info,
                                           size_t                  capture_device_count,
                                           const format::HandleId* capture_devices,
                                           size_t                  replay_device_count,
                                           const VkPhysicalDevice* replay_devices);
 
-    void CheckReplayDeviceInfo(PhysicalDeviceInfo* physical_device_info);
+    void CheckReplayDeviceInfo(VulkanPhysicalDeviceInfo* physical_device_info);
 
-    void SetPhysicalDeviceInstanceInfo(InstanceInfo*       instance_info,
-                                       PhysicalDeviceInfo* physical_device_info,
-                                       VkPhysicalDevice    replay_device);
+    void SetPhysicalDeviceInstanceInfo(VulkanInstanceInfo*       instance_info,
+                                       VulkanPhysicalDeviceInfo* physical_device_info,
+                                       VkPhysicalDevice          replay_device);
 
-    void SetPhysicalDeviceProperties(PhysicalDeviceInfo*               physical_device_info,
+    void SetPhysicalDeviceProperties(VulkanPhysicalDeviceInfo*         physical_device_info,
                                      const VkPhysicalDeviceProperties* capture_properties,
                                      const VkPhysicalDeviceProperties* replay_properties);
 
-    void SetPhysicalDeviceProperties(PhysicalDeviceInfo*                physical_device_info,
+    void SetPhysicalDeviceProperties(VulkanPhysicalDeviceInfo*          physical_device_info,
                                      const VkPhysicalDeviceProperties2* capture_properties,
                                      const VkPhysicalDeviceProperties2* replay_properties);
 
-    void SetPhysicalDeviceMemoryProperties(PhysicalDeviceInfo*                     physical_device_info,
+    void SetPhysicalDeviceMemoryProperties(VulkanPhysicalDeviceInfo*               physical_device_info,
                                            const VkPhysicalDeviceMemoryProperties* capture_properties,
                                            const VkPhysicalDeviceMemoryProperties* replay_properties);
 
     // Can override PhysicalDeviceInfo::handle and PhysicalDeviceInfo::replay_device_info based on comparison between
     // capture and replay physical device properties or GPU override settings.
-    void SelectPhysicalDevice(PhysicalDeviceInfo* physical_device_info);
+    void SelectPhysicalDevice(VulkanPhysicalDeviceInfo* physical_device_info);
 
-    void SelectPhysicalDeviceGroup(PhysicalDeviceInfo*                  physical_device_info,
+    void SelectPhysicalDeviceGroup(VulkanPhysicalDeviceInfo*            physical_device_info,
                                    const std::vector<format::HandleId>& capture_device_group,
                                    std::vector<VkPhysicalDevice>&       replay_device_group);
 
-    bool GetOverrideDevice(InstanceInfo* instance_info, PhysicalDeviceInfo* physical_device_info);
+    bool GetOverrideDevice(VulkanInstanceInfo* instance_info, VulkanPhysicalDeviceInfo* physical_device_info);
 
-    bool GetOverrideDeviceGroup(InstanceInfo*                  instance_info,
-                                PhysicalDeviceInfo*            physical_device_info,
+    bool GetOverrideDeviceGroup(VulkanInstanceInfo*            instance_info,
+                                VulkanPhysicalDeviceInfo*      physical_device_info,
                                 std::vector<VkPhysicalDevice>& replay_device_group);
 
-    void GetMatchingDevice(InstanceInfo* instance_info, PhysicalDeviceInfo* physical_device_info);
+    void GetMatchingDevice(VulkanInstanceInfo* instance_info, VulkanPhysicalDeviceInfo* physical_device_info);
 
-    void GetMatchingDeviceGroup(InstanceInfo*                        instance_info,
-                                PhysicalDeviceInfo*                  physical_device_info,
+    void GetMatchingDeviceGroup(VulkanInstanceInfo*                  instance_info,
+                                VulkanPhysicalDeviceInfo*            physical_device_info,
                                 const std::vector<format::HandleId>& capture_device_group,
                                 std::vector<VkPhysicalDevice>&       replay_device_group);
 
-    void CheckPhysicalDeviceCompatibility(PhysicalDeviceInfo* physical_device_info);
+    void CheckPhysicalDeviceCompatibility(VulkanPhysicalDeviceInfo* physical_device_info);
 
-    void CheckPhysicalDeviceGroupCompatibility(InstanceInfo*                        instance_info,
+    void CheckPhysicalDeviceGroupCompatibility(VulkanInstanceInfo*                  instance_info,
                                                const std::vector<format::HandleId>& capture_device_group,
                                                const std::vector<VkPhysicalDevice>& replay_device_group);
 
     bool CheckTrimDeviceExtensions(VkPhysicalDevice physical_device, std::vector<std::string>* extensions);
 
-    void InitializeResourceAllocator(const PhysicalDeviceInfo*       physical_device_info,
+    void InitializeResourceAllocator(const VulkanPhysicalDeviceInfo* physical_device_info,
                                      VkDevice                        device,
                                      const std::vector<std::string>& enabled_device_extensions,
                                      VulkanResourceAllocator*        allocator);
 
-    void MapDescriptorUpdateTemplateHandles(const DescriptorUpdateTemplateInfo* update_template_info,
-                                            DescriptorUpdateTemplateDecoder*    decoder);
+    void MapDescriptorUpdateTemplateHandles(const VulkanDescriptorUpdateTemplateInfo* update_template_info,
+                                            DescriptorUpdateTemplateDecoder*          decoder);
 
     void GetImportedSemaphores(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
-                               std::vector<const SemaphoreInfo*>*       imported_semaphores);
+                               std::vector<const VulkanSemaphoreInfo*>* imported_semaphores);
 
     void GetImportedSemaphores(const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
-                               std::vector<const SemaphoreInfo*>*                         imported_semaphores);
+                               std::vector<const VulkanSemaphoreInfo*>*                   imported_semaphores);
 
-    void SignalShadowSemaphore(SemaphoreInfo* semaphore_info, std::vector<const SemaphoreInfo*>* shadow_semaphores);
+    void SignalShadowSemaphore(VulkanSemaphoreInfo*                     semaphore_info,
+                               std::vector<const VulkanSemaphoreInfo*>* shadow_semaphores);
 
     void GetShadowSemaphores(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
-                             std::vector<const SemaphoreInfo*>*       shadow_semaphores);
+                             std::vector<const VulkanSemaphoreInfo*>* shadow_semaphores);
 
     void GetShadowSemaphores(const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
-                             std::vector<const SemaphoreInfo*>*                         shadow_semaphores);
+                             std::vector<const VulkanSemaphoreInfo*>*                   shadow_semaphores);
 
     void TrackSemaphoreForwardProgress(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
-                                       std::vector<const SemaphoreInfo*>*       removed_semaphores);
+                                       std::vector<const VulkanSemaphoreInfo*>* removed_semaphores);
 
     void TrackSemaphoreForwardProgress(const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
-                                       std::vector<const SemaphoreInfo*>*                         removed_semaphores);
+                                       std::vector<const VulkanSemaphoreInfo*>*                   removed_semaphores);
 
     void GetNonForwardProgress(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
-                               std::vector<const SemaphoreInfo*>*       non_forward_progress_semaphores);
+                               std::vector<const VulkanSemaphoreInfo*>* non_forward_progress_semaphores);
 
     void GetNonForwardProgress(const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
-                               std::vector<const SemaphoreInfo*>* non_forward_progress_semaphores);
+                               std::vector<const VulkanSemaphoreInfo*>* non_forward_progress_semaphores);
 
-    VkResult CreateSwapchainImage(const DeviceInfo*        device_info,
+    VkResult CreateSwapchainImage(const VulkanDeviceInfo*  device_info,
                                   const VkImageCreateInfo* image_create_info,
                                   VkImage*                 image,
-                                  ImageInfo*               image_info);
+                                  VulkanImageInfo*         image_info);
 
     void ProcessCreateInstanceDebugCallbackInfo(const Decoded_VkInstanceCreateInfo* instance_info);
 
@@ -1438,12 +1442,12 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void WriteScreenshots(const Decoded_VkPresentInfoKHR* meta_info) const;
 
-    bool CheckCommandBufferInfoForFrameBoundary(const CommandBufferInfo* command_buffer_info);
-    bool CheckPNextChainForFrameBoundary(const DeviceInfo* device_info, const PNextNode* pnext);
+    bool CheckCommandBufferInfoForFrameBoundary(const VulkanCommandBufferInfo* command_buffer_info);
+    bool CheckPNextChainForFrameBoundary(const VulkanDeviceInfo* device_info, const PNextNode* pnext);
 
-    void UpdateDescriptorSetInfoWithTemplate(DescriptorSetInfo*                     desc_set_info,
-                                             const DescriptorUpdateTemplateInfo*    template_info,
-                                             const DescriptorUpdateTemplateDecoder* decoder) const;
+    void UpdateDescriptorSetInfoWithTemplate(VulkanDescriptorSetInfo*                  desc_set_info,
+                                             const VulkanDescriptorUpdateTemplateInfo* template_info,
+                                             const DescriptorUpdateTemplateDecoder*    decoder) const;
 
     VulkanDeviceAddressTracker& GetDeviceAddressTracker(VkDevice device);
 
@@ -1542,10 +1546,10 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::vector<uint32_t>             modified_device_masks_;
     std::vector<VkPresentRegionKHR>   modified_regions_;
     std::vector<VkPresentTimeGOOGLE>  modified_times_;
-    std::vector<const SemaphoreInfo*> removed_semaphores_;
+    std::vector<const VulkanSemaphoreInfo*> removed_semaphores_;
     std::unordered_set<uint32_t>      removed_swapchain_indices_;
     std::vector<uint32_t>             capture_image_indices_;
-    std::vector<SwapchainKHRInfo*>    swapchain_infos_;
+    std::vector<VulkanSwapchainKHRInfo*>    swapchain_infos_;
 
   protected:
     // Used by pipeline cache handling, there are the following two cases for the flag to be set:

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -238,9 +238,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     }
 
   protected:
-    const CommonObjectInfoTable& GetObjectInfoTable() const { return object_info_table_; }
+    const CommonObjectInfoTable& GetObjectInfoTable() const { return *object_info_table_; }
 
-    CommonObjectInfoTable& GetObjectInfoTable() { return object_info_table_; }
+    CommonObjectInfoTable& GetObjectInfoTable() { return *object_info_table_; }
 
     const encode::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
 
@@ -260,17 +260,17 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     typename T::HandleType MapHandle(format::HandleId id,
                                      const T* (CommonObjectInfoTable::*MapFunc)(format::HandleId) const) const
     {
-        return handle_mapping::MapHandle(id, object_info_table_, MapFunc);
+        return handle_mapping::MapHandle(id, *object_info_table_, MapFunc);
     }
 
     uint64_t MapHandle(uint64_t object, VkObjectType object_type)
     {
-        return handle_mapping::MapHandle(object, object_type, object_info_table_);
+        return handle_mapping::MapHandle(object, object_type, *object_info_table_);
     }
 
     uint64_t MapHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type)
     {
-        return handle_mapping::MapHandle(object, object_type, object_info_table_);
+        return handle_mapping::MapHandle(object, object_type, *object_info_table_);
     }
 
     template <typename T>
@@ -288,7 +288,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
             // The handle and ID array sizes are expected to be the same for mapping operations.
             assert(handles_len == handles_pointer->GetLength());
 
-            handles = handle_mapping::MapHandleArray(handles_pointer, object_info_table_, MapFunc);
+            handles = handle_mapping::MapHandleArray(handles_pointer, *object_info_table_, MapFunc);
         }
 
         return handles;
@@ -304,7 +304,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         if ((id != nullptr) && (handle != nullptr))
         {
             handle_mapping::AddHandle(
-                parent_id, *id, *handle, std::forward<T>(initial_info), &object_info_table_, AddFunc);
+                parent_id, *id, *handle, std::forward<T>(initial_info), object_info_table_, AddFunc);
         }
     }
 
@@ -316,7 +316,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     {
         if ((id != nullptr) && (handle != nullptr))
         {
-            handle_mapping::AddHandle(parent_id, *id, *handle, &object_info_table_, AddFunc);
+            handle_mapping::AddHandle(parent_id, *id, *handle, object_info_table_, AddFunc);
         }
     }
 
@@ -330,7 +330,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                     void (CommonObjectInfoTable::*AddFunc)(T&&))
     {
         handle_mapping::AddHandleArray(
-            parent_id, ids, ids_len, handles, handles_len, std::move(initial_infos), &object_info_table_, AddFunc);
+            parent_id, ids, ids_len, handles, handles_len, std::move(initial_infos), object_info_table_, AddFunc);
     }
 
     template <typename T>
@@ -341,14 +341,14 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                     size_t                        handles_len,
                     void (CommonObjectInfoTable::*AddFunc)(T&&))
     {
-        handle_mapping::AddHandleArray(parent_id, ids, ids_len, handles, handles_len, &object_info_table_, AddFunc);
+        handle_mapping::AddHandleArray(parent_id, ids, ids_len, handles, handles_len, object_info_table_, AddFunc);
     }
 
     template <typename T>
     void AddHandlesAsync(format::HandleId        parent_id,
                          const format::HandleId* ids,
                          size_t                  ids_len,
-                         void (VulkanObjectInfoTable::*AddFunc)(T&&),
+                         void (CommonObjectInfoTable::*AddFunc)(T&&),
                          std::function<handle_create_result_t<typename T::HandleType>()> create_function)
     {
         if (create_function)
@@ -360,7 +360,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
             background_queue_.poll();
 
             handle_mapping::AddHandleArrayAsync(
-                parent_id, ids, ids_len, &object_info_table_, AddFunc, std::move(result_future));
+                parent_id, ids, ids_len, object_info_table_, AddFunc, std::move(result_future));
         }
     }
 
@@ -369,7 +369,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                          const format::HandleId* ids,
                          size_t                  ids_len,
                          std::vector<T>&&        initial_infos,
-                         void (VulkanObjectInfoTable::*AddFunc)(T&&),
+                         void (CommonObjectInfoTable::*AddFunc)(T&&),
                          std::function<handle_create_result_t<typename T::HandleType>()> create_function)
     {
         if (create_function)
@@ -383,7 +383,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
             handle_mapping::AddHandleArrayAsync(parent_id,
                                                 ids,
                                                 ids_len,
-                                                &object_info_table_,
+                                                object_info_table_,
                                                 std::move(initial_infos),
                                                 AddFunc,
                                                 std::move(result_future));
@@ -428,7 +428,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                        handles,
                                        handles_len,
                                        std::move(initial_infos),
-                                       &object_info_table_,
+                                       object_info_table_,
                                        GetPoolInfoFunc,
                                        AddFunc);
     }
@@ -444,12 +444,12 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                         void (CommonObjectInfoTable::*AddFunc)(T&&))
     {
         handle_mapping::AddHandleArray(
-            parent_id, pool_id, ids, ids_len, handles, handles_len, &object_info_table_, GetPoolInfoFunc, AddFunc);
+            parent_id, pool_id, ids, ids_len, handles, handles_len, object_info_table_, GetPoolInfoFunc, AddFunc);
     }
 
     void RemoveHandle(format::HandleId id, void (CommonObjectInfoTable::*RemoveFunc)(format::HandleId))
     {
-        handle_mapping::RemoveHandle(id, &object_info_table_, RemoveFunc);
+        handle_mapping::RemoveHandle(id, object_info_table_, RemoveFunc);
     }
 
     template <typename T>
@@ -458,7 +458,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                           void (CommonObjectInfoTable::*RemovePoolFunc)(format::HandleId),
                           void (CommonObjectInfoTable::*RemoveObjectFunc)(format::HandleId))
     {
-        handle_mapping::RemovePoolHandle(id, &object_info_table_, GetPoolInfoFunc, RemovePoolFunc, RemoveObjectFunc);
+        handle_mapping::RemovePoolHandle(id, object_info_table_, GetPoolInfoFunc, RemovePoolFunc, RemoveObjectFunc);
     }
 
     template <typename S, typename T>
@@ -476,7 +476,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
             // The handle and ID array sizes are expected to be the same for mapping operations.
             assert(handles_len == handles_pointer->GetLength());
             handle_mapping::RemoveHandleArray<S, T>(
-                pool_id, handles_pointer, &object_info_table_, GetPoolInfoFunc, RemoveFunc);
+                pool_id, handles_pointer, object_info_table_, GetPoolInfoFunc, RemoveFunc);
         }
     }
 
@@ -486,7 +486,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                              size_t           count,
                              HandleInfoT* (CommonObjectInfoTable::*HandleInfoFunc)(format::HandleId))
     {
-        HandleInfoT* info = (object_info_table_.*HandleInfoFunc)(handle_id);
+        HandleInfoT* info = (object_info_table_->*HandleInfoFunc)(handle_id);
         if (info != nullptr)
         {
             info->array_counts[index] = static_cast<size_t>(count);
@@ -516,7 +516,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
             // such as VK_INCOMPLETE, continue to be generated at replay.
             if (original_result == VK_SUCCESS)
             {
-                const HandleInfoT* info = (object_info_table_.*HandleInfoFunc)(handle_id);
+                const HandleInfoT* info = (object_info_table_->*HandleInfoFunc)(handle_id);
                 if (info != nullptr)
                 {
                     auto entry = info->array_counts.find(index);
@@ -1332,7 +1332,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     const VulkanReplayOptions options_;
 
-    VulkanReplayDumpResources resource_dumper_;
+    VulkanReplayDumpResources* resource_dumper_;
 
   private:
     void RaiseFatalError(const char* message) const;
@@ -1506,7 +1506,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unordered_map<encode::VulkanDispatchKey, encode::VulkanDeviceTable>   device_tables_;
     std::function<void(const char*)>                                           fatal_error_handler_;
     std::shared_ptr<application::Application>                                  application_;
-    CommonObjectInfoTable                                                      object_info_table_;
+    CommonObjectInfoTable*                                                     object_info_table_;
     bool                                                                       loading_trim_state_;
     bool                                                                       replaying_trimmed_capture_;
     SwapchainImageTracker                                                      swapchain_image_tracker_;

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -239,8 +239,8 @@ VulkanReplayDumpResourcesBase::FindDispatchRaysCommandBufferContext(VkCommandBuf
     return context;
 }
 
-VkResult VulkanReplayDumpResourcesBase::CloneCommandBuffer(uint64_t           bcb_index,
-                                                           CommandBufferInfo* original_command_buffer_info,
+VkResult VulkanReplayDumpResourcesBase::CloneCommandBuffer(uint64_t                 bcb_index,
+                                                           VulkanCommandBufferInfo* original_command_buffer_info,
                                                            const encode::VulkanDeviceTable*   device_table,
                                                            const encode::VulkanInstanceTable* inst_table)
 
@@ -389,13 +389,13 @@ void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndexed(const ApiCallInfo&   
     }
 }
 
-void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndirect(const ApiCallInfo&    call_info,
-                                                            PFN_vkCmdDrawIndirect func,
-                                                            VkCommandBuffer       original_command_buffer,
-                                                            const BufferInfo*     buffer_info,
-                                                            VkDeviceSize          offset,
-                                                            uint32_t              draw_count,
-                                                            uint32_t              stride)
+void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndirect(const ApiCallInfo&      call_info,
+                                                            PFN_vkCmdDrawIndirect   func,
+                                                            VkCommandBuffer         original_command_buffer,
+                                                            const VulkanBufferInfo* buffer_info,
+                                                            VkDeviceSize            offset,
+                                                            uint32_t                draw_count,
+                                                            uint32_t                stride)
 {
     assert(IsRecording(original_command_buffer));
 
@@ -445,7 +445,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndirect(const ApiCallInfo&  
 void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndexedIndirect(const ApiCallInfo&           call_info,
                                                                    PFN_vkCmdDrawIndexedIndirect func,
                                                                    VkCommandBuffer              original_command_buffer,
-                                                                   const BufferInfo*            buffer_info,
+                                                                   const VulkanBufferInfo*      buffer_info,
                                                                    VkDeviceSize                 offset,
                                                                    uint32_t                     draw_count,
                                                                    uint32_t                     stride)
@@ -497,9 +497,9 @@ void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndexedIndirect(const ApiCall
 void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndirectCount(const ApiCallInfo&         call_info,
                                                                  PFN_vkCmdDrawIndirectCount func,
                                                                  VkCommandBuffer            original_command_buffer,
-                                                                 const BufferInfo*          buffer_info,
+                                                                 const VulkanBufferInfo*    buffer_info,
                                                                  VkDeviceSize               offset,
-                                                                 const BufferInfo*          count_buffer_info,
+                                                                 const VulkanBufferInfo*    count_buffer_info,
                                                                  VkDeviceSize               count_buffer_offset,
                                                                  uint32_t                   max_draw_count,
                                                                  uint32_t                   stride)
@@ -557,13 +557,13 @@ void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndirectCount(const ApiCallIn
 
 void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndexedIndirectCount(const ApiCallInfo&                call_info,
                                                                         PFN_vkCmdDrawIndexedIndirectCount func,
-                                                                        VkCommandBuffer   original_command_buffer,
-                                                                        const BufferInfo* buffer_info,
-                                                                        VkDeviceSize      offset,
-                                                                        const BufferInfo* count_buffer_info,
-                                                                        VkDeviceSize      count_buffer_offset,
-                                                                        uint32_t          max_draw_count,
-                                                                        uint32_t          stride)
+                                                                        VkCommandBuffer         original_command_buffer,
+                                                                        const VulkanBufferInfo* buffer_info,
+                                                                        VkDeviceSize            offset,
+                                                                        const VulkanBufferInfo* count_buffer_info,
+                                                                        VkDeviceSize            count_buffer_offset,
+                                                                        uint32_t                max_draw_count,
+                                                                        uint32_t                stride)
 {
     assert(IsRecording(original_command_buffer));
 
@@ -618,13 +618,13 @@ void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndexedIndirectCount(const Ap
 
 void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndirectCountKHR(const ApiCallInfo&            call_info,
                                                                     PFN_vkCmdDrawIndirectCountKHR func,
-                                                                    VkCommandBuffer   original_command_buffer,
-                                                                    const BufferInfo* buffer_info,
-                                                                    VkDeviceSize      offset,
-                                                                    const BufferInfo* count_buffer_info,
-                                                                    VkDeviceSize      count_buffer_offset,
-                                                                    uint32_t          max_draw_count,
-                                                                    uint32_t          stride)
+                                                                    VkCommandBuffer         original_command_buffer,
+                                                                    const VulkanBufferInfo* buffer_info,
+                                                                    VkDeviceSize            offset,
+                                                                    const VulkanBufferInfo* count_buffer_info,
+                                                                    VkDeviceSize            count_buffer_offset,
+                                                                    uint32_t                max_draw_count,
+                                                                    uint32_t                stride)
 {
     assert(IsRecording(original_command_buffer));
 
@@ -679,13 +679,13 @@ void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndirectCountKHR(const ApiCal
 
 void VulkanReplayDumpResourcesBase::OverrideCmdDrawIndexedIndirectCountKHR(const ApiCallInfo& call_info,
                                                                            PFN_vkCmdDrawIndexedIndirectCountKHR func,
-                                                                           VkCommandBuffer   original_command_buffer,
-                                                                           const BufferInfo* buffer_info,
-                                                                           VkDeviceSize      offset,
-                                                                           const BufferInfo* count_buffer_info,
-                                                                           VkDeviceSize      count_buffer_offset,
-                                                                           uint32_t          max_draw_count,
-                                                                           uint32_t          stride)
+                                                                           VkCommandBuffer original_command_buffer,
+                                                                           const VulkanBufferInfo* buffer_info,
+                                                                           VkDeviceSize            offset,
+                                                                           const VulkanBufferInfo* count_buffer_info,
+                                                                           VkDeviceSize            count_buffer_offset,
+                                                                           uint32_t                max_draw_count,
+                                                                           uint32_t                stride)
 {
     assert(IsRecording(original_command_buffer));
 
@@ -754,10 +754,10 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRenderPass(
         auto       framebuffer_id        = render_pass_info_meta->framebuffer;
         auto       render_pass_id        = render_pass_info_meta->renderPass;
 
-        const FramebufferInfo* framebuffer_info = object_info_table_.GetFramebufferInfo(framebuffer_id);
+        const VulkanFramebufferInfo* framebuffer_info = object_info_table_.GetVkFramebufferInfo(framebuffer_id);
         assert(framebuffer_info);
 
-        const RenderPassInfo* render_pass_info = object_info_table_.GetRenderPassInfo(render_pass_id);
+        const VulkanRenderPassInfo* render_pass_info = object_info_table_.GetVkRenderPassInfo(render_pass_id);
         assert(render_pass_info);
 
         // Do not record vkCmdBeginRenderPass commands in current DrawCall context command buffers.
@@ -803,10 +803,10 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRenderPass2(
         auto       framebuffer_id        = render_pass_info_meta->framebuffer;
         auto       render_pass_id        = render_pass_info_meta->renderPass;
 
-        const FramebufferInfo* framebuffer_info = object_info_table_.GetFramebufferInfo(framebuffer_id);
+        const VulkanFramebufferInfo* framebuffer_info = object_info_table_.GetVkFramebufferInfo(framebuffer_id);
         assert(framebuffer_info);
 
-        const RenderPassInfo* render_pass_info = object_info_table_.GetRenderPassInfo(render_pass_id);
+        const VulkanRenderPassInfo* render_pass_info = object_info_table_.GetVkRenderPassInfo(render_pass_id);
         assert(render_pass_info);
 
         // Do not record vkCmdBeginRenderPass commands in current DrawCall context command buffers.
@@ -965,11 +965,11 @@ void VulkanReplayDumpResourcesBase::OverrideCmdEndRenderPass2(
     }
 }
 
-void VulkanReplayDumpResourcesBase::OverrideCmdBindPipeline(const ApiCallInfo&    call_info,
-                                                            PFN_vkCmdBindPipeline func,
-                                                            VkCommandBuffer       original_command_buffer,
-                                                            VkPipelineBindPoint   pipelineBindPoint,
-                                                            const PipelineInfo*   pipeline)
+void VulkanReplayDumpResourcesBase::OverrideCmdBindPipeline(const ApiCallInfo&        call_info,
+                                                            PFN_vkCmdBindPipeline     func,
+                                                            VkCommandBuffer           original_command_buffer,
+                                                            VkPipelineBindPoint       pipelineBindPoint,
+                                                            const VulkanPipelineInfo* pipeline)
 {
     assert(pipeline);
     assert(IsRecording(original_command_buffer));
@@ -1002,24 +1002,24 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindDescriptorSets(const ApiCallI
                                                                   PFN_vkCmdBindDescriptorSets func,
                                                                   VkCommandBuffer             original_command_buffer,
                                                                   VkPipelineBindPoint         pipeline_bind_point,
-                                                                  const PipelineLayoutInfo*   layout_info,
-                                                                  uint32_t                    first_set,
-                                                                  uint32_t                    descriptor_sets_count,
-                                                                  const format::HandleId*     descriptor_sets_ids,
-                                                                  uint32_t                    dynamicOffsetCount,
-                                                                  const uint32_t*             pDynamicOffsets)
+                                                                  const VulkanPipelineLayoutInfo* layout_info,
+                                                                  uint32_t                        first_set,
+                                                                  uint32_t                        descriptor_sets_count,
+                                                                  const format::HandleId*         descriptor_sets_ids,
+                                                                  uint32_t                        dynamicOffsetCount,
+                                                                  const uint32_t*                 pDynamicOffsets)
 {
     assert(IsRecording(original_command_buffer));
     assert(descriptor_sets_ids);
 
     PipelineBindPoints                    bind_point = VkPipelineBindPointToPipelineBindPoint(pipeline_bind_point);
     std::vector<VkDescriptorSet>          desc_set_handles(descriptor_sets_count, VK_NULL_HANDLE);
-    std::vector<const DescriptorSetInfo*> desc_set_infos(descriptor_sets_count, nullptr);
+    std::vector<const VulkanDescriptorSetInfo*> desc_set_infos(descriptor_sets_count, nullptr);
 
     for (uint32_t i = 0; i < descriptor_sets_count; ++i)
     {
-        const DescriptorSetInfo* desc_set_info;
-        desc_set_info       = object_info_table_.GetDescriptorSetInfo(descriptor_sets_ids[i]);
+        const VulkanDescriptorSetInfo* desc_set_info;
+        desc_set_info       = object_info_table_.GetVkDescriptorSetInfo(descriptor_sets_ids[i]);
         desc_set_infos[i]   = desc_set_info;
         desc_set_handles[i] = (desc_set_info != nullptr) ? desc_set_info->handle : VK_NULL_HANDLE;
     }
@@ -1069,7 +1069,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindDescriptorSets(const ApiCallI
 void VulkanReplayDumpResourcesBase::OverrideCmdBindIndexBuffer(const ApiCallInfo&       call_info,
                                                                PFN_vkCmdBindIndexBuffer func,
                                                                VkCommandBuffer          original_command_buffer,
-                                                               const BufferInfo*        buffer,
+                                                               const VulkanBufferInfo*  buffer,
                                                                VkDeviceSize             offset,
                                                                VkIndexType              indexType)
 {
@@ -1102,7 +1102,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindIndexBuffer(const ApiCallInfo
 void VulkanReplayDumpResourcesBase::OverrideCmdBindIndexBuffer2KHR(const ApiCallInfo&           call_info,
                                                                    PFN_vkCmdBindIndexBuffer2KHR func,
                                                                    VkCommandBuffer              original_command_buffer,
-                                                                   const BufferInfo*            buffer,
+                                                                   const VulkanBufferInfo*      buffer,
                                                                    VkDeviceSize                 offset,
                                                                    VkDeviceSize                 size,
                                                                    VkIndexType                  indexType)
@@ -1145,14 +1145,14 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindVertexBuffers(const ApiCallIn
     bool                  found = GetDrawCallActiveCommandBuffers(original_command_buffer, first, last);
     VkCommandBuffer       dispatch_rays_command_buffer = GetDispatchRaysCommandBuffer(original_command_buffer);
 
-    std::vector<const BufferInfo*> buffer_infos(bindingCount, nullptr);
+    std::vector<const VulkanBufferInfo*> buffer_infos(bindingCount, nullptr);
     std::vector<VkBuffer>          buffer_handles(bindingCount, VK_NULL_HANDLE);
     if (found || dispatch_rays_command_buffer != VK_NULL_HANDLE)
     {
         for (uint32_t i = 0; i < bindingCount; ++i)
         {
             // Buffer can be VK_NULL_HANDLE
-            const BufferInfo* buffer_info = object_info_table_.GetBufferInfo(buffer_ids[i]);
+            const VulkanBufferInfo* buffer_info = object_info_table_.GetVkBufferInfo(buffer_ids[i]);
 
             buffer_infos[i]   = buffer_info;
             buffer_handles[i] = buffer_info != nullptr ? buffer_info->handle : VK_NULL_HANDLE;
@@ -1242,7 +1242,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindVertexBuffers2(const ApiCallI
     {
         for (uint32_t i = 0; i < bindingCount; ++i)
         {
-            const BufferInfo* buffer_info = object_info_table_.GetBufferInfo(pBuffers_ids[i]);
+            const VulkanBufferInfo* buffer_info = object_info_table_.GetVkBufferInfo(pBuffers_ids[i]);
             buffer_handles[i]             = (buffer_info != nullptr) ? buffer_info->handle : VK_NULL_HANDLE;
         }
     }
@@ -1262,11 +1262,11 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindVertexBuffers2(const ApiCallI
             assert(pSizes);
             assert(pStrides);
 
-            std::vector<const BufferInfo*> buffer_infos(bindingCount);
+            std::vector<const VulkanBufferInfo*> buffer_infos(bindingCount);
 
             for (uint32_t i = 0; i < bindingCount; ++i)
             {
-                const BufferInfo* buffer_info = object_info_table_.GetBufferInfo(pBuffers_ids[i]);
+                const VulkanBufferInfo* buffer_info = object_info_table_.GetVkBufferInfo(pBuffers_ids[i]);
 
                 buffer_infos[i] = buffer_info;
             }
@@ -1342,7 +1342,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdDispatch(const ApiCallInfo& call_
 void VulkanReplayDumpResourcesBase::OverrideCmdDispatchIndirect(const ApiCallInfo&        call_info,
                                                                 PFN_vkCmdDispatchIndirect func,
                                                                 VkCommandBuffer           original_command_buffer,
-                                                                const BufferInfo*         buffer_info,
+                                                                const VulkanBufferInfo*   buffer_info,
                                                                 VkDeviceSize              offset)
 {
     assert(IsRecording(original_command_buffer));
@@ -1624,32 +1624,32 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRendering(
             const size_t n_color_attachments    = rendering_info_meta->pColorAttachments->GetLength();
             const auto   color_attachments_meta = rendering_info_meta->pColorAttachments->GetMetaStructPointer();
 
-            std::vector<ImageInfo*>    color_attachments(n_color_attachments);
+            std::vector<VulkanImageInfo*> color_attachments(n_color_attachments);
             std::vector<VkImageLayout> color_attachment_layouts(n_color_attachments);
             for (size_t i = 0; i < n_color_attachments; ++i)
             {
-                const ImageViewInfo* img_view_info =
-                    object_info_table_.GetImageViewInfo(color_attachments_meta[i].imageView);
+                const VulkanImageViewInfo* img_view_info =
+                    object_info_table_.GetVkImageViewInfo(color_attachments_meta[i].imageView);
                 assert(img_view_info != nullptr);
 
-                ImageInfo* img_info = object_info_table_.GetImageInfo(img_view_info->image_id);
+                VulkanImageInfo* img_info = object_info_table_.GetVkImageInfo(img_view_info->image_id);
                 assert(img_info != nullptr);
 
                 color_attachments[i]        = img_info;
                 color_attachment_layouts[i] = color_attachments_meta[i].decoded_value->imageLayout;
             }
 
-            ImageInfo*    depth_attachment;
+            VulkanImageInfo* depth_attachment;
             VkImageLayout depth_attachment_layout;
             if (rendering_info_meta->pDepthAttachment != nullptr &&
                 rendering_info_meta->pDepthAttachment->GetMetaStructPointer() != nullptr)
             {
                 const auto depth_attachment_meta = rendering_info_meta->pDepthAttachment->GetMetaStructPointer();
-                const ImageViewInfo* img_view_info =
-                    object_info_table_.GetImageViewInfo(depth_attachment_meta->imageView);
+                const VulkanImageViewInfo* img_view_info =
+                    object_info_table_.GetVkImageViewInfo(depth_attachment_meta->imageView);
                 assert(img_view_info != nullptr);
 
-                ImageInfo* img_info = object_info_table_.GetImageInfo(img_view_info->image_id);
+                VulkanImageInfo* img_info = object_info_table_.GetVkImageInfo(img_view_info->image_id);
                 assert(img_info != nullptr);
 
                 depth_attachment        = img_info;
@@ -2085,7 +2085,7 @@ void VulkanReplayDumpResourcesBase::DumpGraphicsPipelineInfos(
 
     for (uint32_t i = 0; i < createInfoCount; ++i)
     {
-        PipelineInfo* pipeline_info = reinterpret_cast<PipelineInfo*>(pPipelines->GetConsumerData(i));
+        VulkanPipelineInfo* pipeline_info = reinterpret_cast<VulkanPipelineInfo*>(pPipelines->GetConsumerData(i));
 
         // Copy shader stage information
         const Decoded_VkPipelineShaderStageCreateInfo* stages_info_meta =
@@ -2098,7 +2098,8 @@ void VulkanReplayDumpResourcesBase::DumpGraphicsPipelineInfos(
             {
                 if (stages_info_meta[s].module != format::kNullHandleId)
                 {
-                    ShaderModuleInfo* module_info = object_info_table_.GetShaderModuleInfo(stages_info_meta[s].module);
+                    VulkanShaderModuleInfo* module_info =
+                        object_info_table_.GetVkShaderModuleInfo(stages_info_meta[s].module);
                     assert(module_info);
                     assert(pipeline_info);
 
@@ -2113,7 +2114,7 @@ void VulkanReplayDumpResourcesBase::DumpGraphicsPipelineInfos(
             // Vertex binding info
             for (uint32_t vb = 0; vb < in_p_create_infos[i].pVertexInputState->vertexBindingDescriptionCount; ++vb)
             {
-                PipelineInfo::InputBindingDescription info{
+                VulkanPipelineInfo::InputBindingDescription info{
                     in_p_create_infos[i].pVertexInputState->pVertexBindingDescriptions[vb].stride,
                     in_p_create_infos[i].pVertexInputState->pVertexBindingDescriptions[vb].inputRate
                 };
@@ -2125,7 +2126,7 @@ void VulkanReplayDumpResourcesBase::DumpGraphicsPipelineInfos(
             // Vertex attribute info
             for (uint32_t va = 0; va < in_p_create_infos[i].pVertexInputState->vertexAttributeDescriptionCount; ++va)
             {
-                PipelineInfo::InputAttributeDescription info{
+                VulkanPipelineInfo::InputAttributeDescription info{
                     in_p_create_infos[i].pVertexInputState->pVertexAttributeDescriptions[va].binding,
                     in_p_create_infos[i].pVertexInputState->pVertexAttributeDescriptions[va].format,
                     in_p_create_infos[i].pVertexInputState->pVertexAttributeDescriptions[va].offset

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -45,7 +45,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 VulkanReplayDumpResourcesBase::VulkanReplayDumpResourcesBase(const VulkanReplayOptions& options,
-                                                             CommonObjectInfoTable&     object_info_table) :
+                                                             CommonObjectInfoTable*     object_info_table) :
     QueueSubmit_indices_(options.QueueSubmit_Indices),
     recording_(false), dump_resources_before_(options.dump_resources_before), object_info_table_(object_info_table),
     output_json_per_command(options.dump_resources_json_per_command), dump_json_(options)
@@ -73,7 +73,7 @@ VulkanReplayDumpResourcesBase::VulkanReplayDumpResourcesBase(const VulkanReplayO
             draw_call_contexts.emplace(bcb_index,
                                        DrawCallsDumpingContext(options.Draw_Indices[i],
                                                                options.RenderPass_Indices[i],
-                                                               object_info_table,
+                                                               *object_info_table,
                                                                options,
                                                                dump_json_,
                                                                capture_filename));
@@ -90,7 +90,7 @@ VulkanReplayDumpResourcesBase::VulkanReplayDumpResourcesBase(const VulkanReplayO
                                               (options.TraceRays_Indices.size() && options.TraceRays_Indices[i].size())
                                                   ? options.TraceRays_Indices[i]
                                                   : std::vector<uint64_t>(),
-                                              object_info_table_,
+                                              *object_info_table_,
                                               options,
                                               dump_json_,
                                               capture_filename));
@@ -754,10 +754,10 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRenderPass(
         auto       framebuffer_id        = render_pass_info_meta->framebuffer;
         auto       render_pass_id        = render_pass_info_meta->renderPass;
 
-        const VulkanFramebufferInfo* framebuffer_info = object_info_table_.GetVkFramebufferInfo(framebuffer_id);
+        const VulkanFramebufferInfo* framebuffer_info = object_info_table_->GetVkFramebufferInfo(framebuffer_id);
         assert(framebuffer_info);
 
-        const VulkanRenderPassInfo* render_pass_info = object_info_table_.GetVkRenderPassInfo(render_pass_id);
+        const VulkanRenderPassInfo* render_pass_info = object_info_table_->GetVkRenderPassInfo(render_pass_id);
         assert(render_pass_info);
 
         // Do not record vkCmdBeginRenderPass commands in current DrawCall context command buffers.
@@ -803,10 +803,10 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRenderPass2(
         auto       framebuffer_id        = render_pass_info_meta->framebuffer;
         auto       render_pass_id        = render_pass_info_meta->renderPass;
 
-        const VulkanFramebufferInfo* framebuffer_info = object_info_table_.GetVkFramebufferInfo(framebuffer_id);
+        const VulkanFramebufferInfo* framebuffer_info = object_info_table_->GetVkFramebufferInfo(framebuffer_id);
         assert(framebuffer_info);
 
-        const VulkanRenderPassInfo* render_pass_info = object_info_table_.GetVkRenderPassInfo(render_pass_id);
+        const VulkanRenderPassInfo* render_pass_info = object_info_table_->GetVkRenderPassInfo(render_pass_id);
         assert(render_pass_info);
 
         // Do not record vkCmdBeginRenderPass commands in current DrawCall context command buffers.
@@ -1019,7 +1019,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindDescriptorSets(const ApiCallI
     for (uint32_t i = 0; i < descriptor_sets_count; ++i)
     {
         const VulkanDescriptorSetInfo* desc_set_info =
-            object_info_table_.GetVkDescriptorSetInfo(descriptor_sets_ids[i]);
+            object_info_table_->GetVkDescriptorSetInfo(descriptor_sets_ids[i]);
         desc_set_infos[i]   = desc_set_info;
         desc_set_handles[i] = (desc_set_info != nullptr) ? desc_set_info->handle : VK_NULL_HANDLE;
     }
@@ -1152,7 +1152,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindVertexBuffers(const ApiCallIn
         for (uint32_t i = 0; i < bindingCount; ++i)
         {
             // Buffer can be VK_NULL_HANDLE
-            const VulkanBufferInfo* buffer_info = object_info_table_.GetVkBufferInfo(buffer_ids[i]);
+            const VulkanBufferInfo* buffer_info = object_info_table_->GetVkBufferInfo(buffer_ids[i]);
 
             buffer_infos[i]   = buffer_info;
             buffer_handles[i] = buffer_info != nullptr ? buffer_info->handle : VK_NULL_HANDLE;
@@ -1242,7 +1242,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindVertexBuffers2(const ApiCallI
     {
         for (uint32_t i = 0; i < bindingCount; ++i)
         {
-            const VulkanBufferInfo* buffer_info = object_info_table_.GetVkBufferInfo(pBuffers_ids[i]);
+            const VulkanBufferInfo* buffer_info = object_info_table_->GetVkBufferInfo(pBuffers_ids[i]);
             buffer_handles[i]                   = (buffer_info != nullptr) ? buffer_info->handle : VK_NULL_HANDLE;
         }
     }
@@ -1266,7 +1266,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindVertexBuffers2(const ApiCallI
 
             for (uint32_t i = 0; i < bindingCount; ++i)
             {
-                const VulkanBufferInfo* buffer_info = object_info_table_.GetVkBufferInfo(pBuffers_ids[i]);
+                const VulkanBufferInfo* buffer_info = object_info_table_->GetVkBufferInfo(pBuffers_ids[i]);
 
                 buffer_infos[i] = buffer_info;
             }
@@ -1629,10 +1629,10 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRendering(
             for (size_t i = 0; i < n_color_attachments; ++i)
             {
                 const VulkanImageViewInfo* img_view_info =
-                    object_info_table_.GetVkImageViewInfo(color_attachments_meta[i].imageView);
+                    object_info_table_->GetVkImageViewInfo(color_attachments_meta[i].imageView);
                 assert(img_view_info != nullptr);
 
-                VulkanImageInfo* img_info = object_info_table_.GetVkImageInfo(img_view_info->image_id);
+                VulkanImageInfo* img_info = object_info_table_->GetVkImageInfo(img_view_info->image_id);
                 assert(img_info != nullptr);
 
                 color_attachments[i]        = img_info;
@@ -1646,10 +1646,10 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRendering(
             {
                 const auto depth_attachment_meta = rendering_info_meta->pDepthAttachment->GetMetaStructPointer();
                 const VulkanImageViewInfo* img_view_info =
-                    object_info_table_.GetVkImageViewInfo(depth_attachment_meta->imageView);
+                    object_info_table_->GetVkImageViewInfo(depth_attachment_meta->imageView);
                 assert(img_view_info != nullptr);
 
-                VulkanImageInfo* img_info = object_info_table_.GetVkImageInfo(img_view_info->image_id);
+                VulkanImageInfo* img_info = object_info_table_->GetVkImageInfo(img_view_info->image_id);
                 assert(img_info != nullptr);
 
                 depth_attachment        = img_info;
@@ -2099,7 +2099,7 @@ void VulkanReplayDumpResourcesBase::DumpGraphicsPipelineInfos(
                 if (stages_info_meta[s].module != format::kNullHandleId)
                 {
                     VulkanShaderModuleInfo* module_info =
-                        object_info_table_.GetVkShaderModuleInfo(stages_info_meta[s].module);
+                        object_info_table_->GetVkShaderModuleInfo(stages_info_meta[s].module);
                     assert(module_info);
                     assert(pipeline_info);
 

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -45,7 +45,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 VulkanReplayDumpResourcesBase::VulkanReplayDumpResourcesBase(const VulkanReplayOptions& options,
-                                                             VulkanObjectInfoTable&     object_info_table) :
+                                                             CommonObjectInfoTable&     object_info_table) :
     QueueSubmit_indices_(options.QueueSubmit_Indices),
     recording_(false), dump_resources_before_(options.dump_resources_before), object_info_table_(object_info_table),
     output_json_per_command(options.dump_resources_json_per_command), dump_json_(options)
@@ -1012,14 +1012,14 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindDescriptorSets(const ApiCallI
     assert(IsRecording(original_command_buffer));
     assert(descriptor_sets_ids);
 
-    PipelineBindPoints                    bind_point = VkPipelineBindPointToPipelineBindPoint(pipeline_bind_point);
-    std::vector<VkDescriptorSet>          desc_set_handles(descriptor_sets_count, VK_NULL_HANDLE);
+    PipelineBindPoints           bind_point = VkPipelineBindPointToPipelineBindPoint(pipeline_bind_point);
+    std::vector<VkDescriptorSet> desc_set_handles(descriptor_sets_count, VK_NULL_HANDLE);
     std::vector<const VulkanDescriptorSetInfo*> desc_set_infos(descriptor_sets_count, nullptr);
 
     for (uint32_t i = 0; i < descriptor_sets_count; ++i)
     {
-        const VulkanDescriptorSetInfo* desc_set_info;
-        desc_set_info       = object_info_table_.GetVkDescriptorSetInfo(descriptor_sets_ids[i]);
+        const VulkanDescriptorSetInfo* desc_set_info =
+            object_info_table_.GetVkDescriptorSetInfo(descriptor_sets_ids[i]);
         desc_set_infos[i]   = desc_set_info;
         desc_set_handles[i] = (desc_set_info != nullptr) ? desc_set_info->handle : VK_NULL_HANDLE;
     }
@@ -1146,7 +1146,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindVertexBuffers(const ApiCallIn
     VkCommandBuffer       dispatch_rays_command_buffer = GetDispatchRaysCommandBuffer(original_command_buffer);
 
     std::vector<const VulkanBufferInfo*> buffer_infos(bindingCount, nullptr);
-    std::vector<VkBuffer>          buffer_handles(bindingCount, VK_NULL_HANDLE);
+    std::vector<VkBuffer>                buffer_handles(bindingCount, VK_NULL_HANDLE);
     if (found || dispatch_rays_command_buffer != VK_NULL_HANDLE)
     {
         for (uint32_t i = 0; i < bindingCount; ++i)
@@ -1243,7 +1243,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindVertexBuffers2(const ApiCallI
         for (uint32_t i = 0; i < bindingCount; ++i)
         {
             const VulkanBufferInfo* buffer_info = object_info_table_.GetVkBufferInfo(pBuffers_ids[i]);
-            buffer_handles[i]             = (buffer_info != nullptr) ? buffer_info->handle : VK_NULL_HANDLE;
+            buffer_handles[i]                   = (buffer_info != nullptr) ? buffer_info->handle : VK_NULL_HANDLE;
         }
     }
 
@@ -1625,7 +1625,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRendering(
             const auto   color_attachments_meta = rendering_info_meta->pColorAttachments->GetMetaStructPointer();
 
             std::vector<VulkanImageInfo*> color_attachments(n_color_attachments);
-            std::vector<VkImageLayout> color_attachment_layouts(n_color_attachments);
+            std::vector<VkImageLayout>    color_attachment_layouts(n_color_attachments);
             for (size_t i = 0; i < n_color_attachments; ++i)
             {
                 const VulkanImageViewInfo* img_view_info =

--- a/framework/decode/vulkan_replay_dump_resources.h
+++ b/framework/decode/vulkan_replay_dump_resources.h
@@ -55,7 +55,7 @@ class VulkanReplayDumpResourcesBase
     ~VulkanReplayDumpResourcesBase();
 
     VkResult CloneCommandBuffer(uint64_t                           bcb_index,
-                                CommandBufferInfo*                 original_command_buffer_info,
+                                VulkanCommandBufferInfo*           original_command_buffer_info,
                                 const encode::VulkanDeviceTable*   device_table,
                                 const encode::VulkanInstanceTable* inst_table);
 
@@ -76,18 +76,18 @@ class VulkanReplayDumpResourcesBase
                                 int32_t              vertex_offset,
                                 uint32_t             first_instance);
 
-    void OverrideCmdDrawIndirect(const ApiCallInfo&    call_info,
-                                 PFN_vkCmdDrawIndirect func,
-                                 VkCommandBuffer       original_command_buffer,
-                                 const BufferInfo*     buffer_info,
-                                 VkDeviceSize          offset,
-                                 uint32_t              draw_count,
-                                 uint32_t              stride);
+    void OverrideCmdDrawIndirect(const ApiCallInfo&      call_info,
+                                 PFN_vkCmdDrawIndirect   func,
+                                 VkCommandBuffer         original_command_buffer,
+                                 const VulkanBufferInfo* buffer_info,
+                                 VkDeviceSize            offset,
+                                 uint32_t                draw_count,
+                                 uint32_t                stride);
 
     void OverrideCmdDrawIndexedIndirect(const ApiCallInfo&           call_info,
                                         PFN_vkCmdDrawIndexedIndirect func,
                                         VkCommandBuffer              original_command_buffer,
-                                        const BufferInfo*            buffer_info,
+                                        const VulkanBufferInfo*      buffer_info,
                                         VkDeviceSize                 offset,
                                         uint32_t                     draw_count,
                                         uint32_t                     stride);
@@ -95,9 +95,9 @@ class VulkanReplayDumpResourcesBase
     void OverrideCmdDrawIndirectCount(const ApiCallInfo&         call_info,
                                       PFN_vkCmdDrawIndirectCount func,
                                       VkCommandBuffer            original_command_buffer,
-                                      const BufferInfo*          buffer_info,
+                                      const VulkanBufferInfo*    buffer_info,
                                       VkDeviceSize               offset,
-                                      const BufferInfo*          count_buffer_info,
+                                      const VulkanBufferInfo*    count_buffer_info,
                                       VkDeviceSize               count_buffer_offset,
                                       uint32_t                   max_draw_count,
                                       uint32_t                   stride);
@@ -105,9 +105,9 @@ class VulkanReplayDumpResourcesBase
     void OverrideCmdDrawIndexedIndirectCount(const ApiCallInfo&                call_info,
                                              PFN_vkCmdDrawIndexedIndirectCount func,
                                              VkCommandBuffer                   original_command_buffer,
-                                             const BufferInfo*                 buffer_info,
+                                             const VulkanBufferInfo*           buffer_info,
                                              VkDeviceSize                      offset,
-                                             const BufferInfo*                 count_buffer_info,
+                                             const VulkanBufferInfo*           count_buffer_info,
                                              VkDeviceSize                      count_buffer_offset,
                                              uint32_t                          max_draw_count,
                                              uint32_t                          stride);
@@ -115,9 +115,9 @@ class VulkanReplayDumpResourcesBase
     void OverrideCmdDrawIndirectCountKHR(const ApiCallInfo&            call_info,
                                          PFN_vkCmdDrawIndirectCountKHR func,
                                          VkCommandBuffer               original_command_buffer,
-                                         const BufferInfo*             buffer_info,
+                                         const VulkanBufferInfo*       buffer_info,
                                          VkDeviceSize                  offset,
-                                         const BufferInfo*             count_buffer_info,
+                                         const VulkanBufferInfo*       count_buffer_info,
                                          VkDeviceSize                  count_buffer_offset,
                                          uint32_t                      max_draw_count,
                                          uint32_t                      stride);
@@ -125,9 +125,9 @@ class VulkanReplayDumpResourcesBase
     void OverrideCmdDrawIndexedIndirectCountKHR(const ApiCallInfo&                   call_info,
                                                 PFN_vkCmdDrawIndexedIndirectCountKHR func,
                                                 VkCommandBuffer                      original_command_buffer,
-                                                const BufferInfo*                    buffer_info,
+                                                const VulkanBufferInfo*              buffer_info,
                                                 VkDeviceSize                         offset,
-                                                const BufferInfo*                    count_buffer_info,
+                                                const VulkanBufferInfo*              count_buffer_info,
                                                 VkDeviceSize                         count_buffer_offset,
                                                 uint32_t                             max_draw_count,
                                                 uint32_t                             stride);
@@ -164,11 +164,11 @@ class VulkanReplayDumpResourcesBase
                                  StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
                                  StructPointerDecoder<Decoded_VkSubpassEndInfo>*   pSubpassEndInfo);
 
-    void OverrideCmdBindPipeline(const ApiCallInfo&    call_info,
-                                 PFN_vkCmdBindPipeline func,
-                                 VkCommandBuffer       original_command_buffer,
-                                 VkPipelineBindPoint   pipelineBindPoint,
-                                 const PipelineInfo*   pipeline);
+    void OverrideCmdBindPipeline(const ApiCallInfo&        call_info,
+                                 PFN_vkCmdBindPipeline     func,
+                                 VkCommandBuffer           original_command_buffer,
+                                 VkPipelineBindPoint       pipelineBindPoint,
+                                 const VulkanPipelineInfo* pipeline);
 
     void OverrideCmdDispatch(const ApiCallInfo& call_info,
                              PFN_vkCmdDispatch  func,
@@ -180,7 +180,7 @@ class VulkanReplayDumpResourcesBase
     void OverrideCmdDispatchIndirect(const ApiCallInfo&        call_info,
                                      PFN_vkCmdDispatchIndirect func,
                                      VkCommandBuffer           original_command_buffer,
-                                     const BufferInfo*         buffer_info,
+                                     const VulkanBufferInfo*   buffer_info,
                                      VkDeviceSize              offset);
 
     void
@@ -210,21 +210,21 @@ class VulkanReplayDumpResourcesBase
                                           VkCommandBuffer                original_command_buffer,
                                           VkDeviceAddress                indirectDeviceAddress);
 
-    void OverrideCmdBindDescriptorSets(const ApiCallInfo&          call_info,
-                                       PFN_vkCmdBindDescriptorSets func,
-                                       VkCommandBuffer             original_command_buffer,
-                                       VkPipelineBindPoint         pipeline_bind_point,
-                                       const PipelineLayoutInfo*   layout_info,
-                                       uint32_t                    first_set,
-                                       uint32_t                    descriptor_sets_count,
-                                       const format::HandleId*     descriptor_sets_ids,
-                                       uint32_t                    dynamicOffsetCount,
-                                       const uint32_t*             pDynamicOffsets);
+    void OverrideCmdBindDescriptorSets(const ApiCallInfo&              call_info,
+                                       PFN_vkCmdBindDescriptorSets     func,
+                                       VkCommandBuffer                 original_command_buffer,
+                                       VkPipelineBindPoint             pipeline_bind_point,
+                                       const VulkanPipelineLayoutInfo* layout_info,
+                                       uint32_t                        first_set,
+                                       uint32_t                        descriptor_sets_count,
+                                       const format::HandleId*         descriptor_sets_ids,
+                                       uint32_t                        dynamicOffsetCount,
+                                       const uint32_t*                 pDynamicOffsets);
 
     void OverrideCmdBindIndexBuffer(const ApiCallInfo&       call_info,
                                     PFN_vkCmdBindIndexBuffer func,
                                     VkCommandBuffer          original_command_buffer,
-                                    const BufferInfo*        buffer,
+                                    const VulkanBufferInfo*  buffer,
                                     VkDeviceSize             offset,
                                     VkIndexType              indexType);
 
@@ -258,7 +258,7 @@ class VulkanReplayDumpResourcesBase
     void OverrideCmdBindIndexBuffer2KHR(const ApiCallInfo&           call_info,
                                         PFN_vkCmdBindIndexBuffer2KHR func,
                                         VkCommandBuffer              commandBuffer,
-                                        const BufferInfo*            buffer,
+                                        const VulkanBufferInfo*      buffer,
                                         VkDeviceSize                 offset,
                                         VkDeviceSize                 size,
                                         VkIndexType                  indexType);

--- a/framework/decode/vulkan_replay_dump_resources.h
+++ b/framework/decode/vulkan_replay_dump_resources.h
@@ -24,9 +24,9 @@
 #define GFXRECON_GENERATED_VULKAN_REPLAY_DUMP_RESOURCES_BASE_H
 
 #include "decode/api_decoder.h"
+#include "decode/common_object_info_table.h"
 #include "decode/vulkan_object_info.h"
 #include "decode/vulkan_replay_options.h"
-#include "decode/vulkan_object_info_table.h"
 #include "decode/struct_pointer_decoder.h"
 #include "decode/vulkan_replay_dump_resources_common.h"
 #include "decode/vulkan_replay_dump_resources_draw_calls.h"
@@ -50,7 +50,7 @@ class VulkanReplayDumpResourcesBase
   public:
     VulkanReplayDumpResourcesBase() = delete;
 
-    VulkanReplayDumpResourcesBase(const VulkanReplayOptions& options, VulkanObjectInfoTable& object_info_table);
+    VulkanReplayDumpResourcesBase(const VulkanReplayOptions& options, CommonObjectInfoTable& object_info_table);
 
     ~VulkanReplayDumpResourcesBase();
 
@@ -348,7 +348,7 @@ class VulkanReplayDumpResourcesBase
 
     bool                          recording_;
     bool                          dump_resources_before_;
-    VulkanObjectInfoTable&        object_info_table_;
+    CommonObjectInfoTable&        object_info_table_;
     VulkanReplayDumpResourcesJson dump_json_;
     bool                          output_json_per_command;
 

--- a/framework/decode/vulkan_replay_dump_resources.h
+++ b/framework/decode/vulkan_replay_dump_resources.h
@@ -50,7 +50,7 @@ class VulkanReplayDumpResourcesBase
   public:
     VulkanReplayDumpResourcesBase() = delete;
 
-    VulkanReplayDumpResourcesBase(const VulkanReplayOptions& options, CommonObjectInfoTable& object_info_table);
+    VulkanReplayDumpResourcesBase(const VulkanReplayOptions& options, CommonObjectInfoTable* object_info_table);
 
     ~VulkanReplayDumpResourcesBase();
 
@@ -348,7 +348,7 @@ class VulkanReplayDumpResourcesBase
 
     bool                          recording_;
     bool                          dump_resources_before_;
-    CommonObjectInfoTable&        object_info_table_;
+    CommonObjectInfoTable*        object_info_table_;
     VulkanReplayDumpResourcesJson dump_json_;
     bool                          output_json_per_command;
 

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -157,7 +157,7 @@ uint32_t GetMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_prope
     return memory_type_index;
 }
 
-VkResult CloneImage(VulkanObjectInfoTable&                  object_info_table,
+VkResult CloneImage(CommonObjectInfoTable&                  object_info_table,
                     const encode::VulkanDeviceTable*        device_table,
                     const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
                     const VulkanImageInfo*                  image_info,
@@ -182,7 +182,7 @@ VkResult CloneImage(VulkanObjectInfoTable&                  object_info_table,
     ci.initialLayout         = VK_IMAGE_LAYOUT_UNDEFINED;
 
     const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(image_info->parent_id);
-    VkDevice          device      = device_info->handle;
+    VkDevice                device      = device_info->handle;
 
     assert(device_table);
     assert(new_image);
@@ -228,7 +228,7 @@ VkResult CloneImage(VulkanObjectInfoTable&                  object_info_table,
     return VK_SUCCESS;
 }
 
-VkResult CloneBuffer(VulkanObjectInfoTable&                  object_info_table,
+VkResult CloneBuffer(CommonObjectInfoTable&                  object_info_table,
                      const encode::VulkanDeviceTable*        device_table,
                      const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
                      const VulkanBufferInfo*                 buffer_info,
@@ -252,7 +252,7 @@ VkResult CloneBuffer(VulkanObjectInfoTable&                  object_info_table,
     ci.pQueueFamilyIndices   = nullptr;
 
     const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(buffer_info->parent_id);
-    VkDevice          device      = device_info->handle;
+    VkDevice                device      = device_info->handle;
 
     VkResult res = device_table->CreateBuffer(device, &ci, nullptr, new_buffer);
     if (res != VK_SUCCESS)
@@ -439,7 +439,7 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
                          const VulkanDeviceInfo*            device_info,
                          const encode::VulkanDeviceTable*   device_table,
                          const encode::VulkanInstanceTable* instance_table,
-                         VulkanObjectInfoTable&             object_info_table,
+                         CommonObjectInfoTable&             object_info_table,
                          const std::vector<std::string>&    filenames,
                          float                              scale,
                          std::vector<bool>&                 scaling_supported,

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -160,7 +160,7 @@ uint32_t GetMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_prope
 VkResult CloneImage(VulkanObjectInfoTable&                  object_info_table,
                     const encode::VulkanDeviceTable*        device_table,
                     const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
-                    const ImageInfo*                        image_info,
+                    const VulkanImageInfo*                  image_info,
                     VkImage*                                new_image,
                     VkDeviceMemory*                         new_image_memory)
 {
@@ -181,7 +181,7 @@ VkResult CloneImage(VulkanObjectInfoTable&                  object_info_table,
     ci.pQueueFamilyIndices   = nullptr;
     ci.initialLayout         = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(image_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(image_info->parent_id);
     VkDevice          device      = device_info->handle;
 
     assert(device_table);
@@ -231,7 +231,7 @@ VkResult CloneImage(VulkanObjectInfoTable&                  object_info_table,
 VkResult CloneBuffer(VulkanObjectInfoTable&                  object_info_table,
                      const encode::VulkanDeviceTable*        device_table,
                      const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
-                     const BufferInfo*                       buffer_info,
+                     const VulkanBufferInfo*                 buffer_info,
                      VkBuffer*                               new_buffer,
                      VkDeviceMemory*                         new_buffer_memory,
                      VkDeviceSize                            override_size)
@@ -251,7 +251,7 @@ VkResult CloneBuffer(VulkanObjectInfoTable&                  object_info_table,
     ci.queueFamilyIndexCount = buffer_info->queue_family_index;
     ci.pQueueFamilyIndices   = nullptr;
 
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(buffer_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(buffer_info->parent_id);
     VkDevice          device      = device_info->handle;
 
     VkResult res = device_table->CreateBuffer(device, &ci, nullptr, new_buffer);
@@ -435,8 +435,8 @@ uint32_t FindGreatestVertexIndex(const std::vector<uint8_t>& index_data,
     }
 }
 
-VkResult DumpImageToFile(const ImageInfo*                   image_info,
-                         const DeviceInfo*                  device_info,
+VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
+                         const VulkanDeviceInfo*            device_info,
                          const encode::VulkanDeviceTable*   device_table,
                          const encode::VulkanInstanceTable* instance_table,
                          VulkanObjectInfoTable&             object_info_table,
@@ -462,7 +462,7 @@ VkResult DumpImageToFile(const ImageInfo*                   image_info,
     assert(total_files == filenames.size());
     assert(scaling_supported.size() == total_files);
 
-    const PhysicalDeviceInfo* phys_dev_info = object_info_table.GetPhysicalDeviceInfo(device_info->parent_id);
+    const VulkanPhysicalDeviceInfo* phys_dev_info = object_info_table.GetVkPhysicalDeviceInfo(device_info->parent_id);
     assert(phys_dev_info);
 
     graphics::VulkanResourcesUtil resource_util(device_info->handle,
@@ -866,7 +866,7 @@ void GetFormatAspects(VkFormat format, std::vector<VkImageAspectFlagBits>& aspec
     }
 }
 
-DumpedImageFormat GetDumpedImageFormat(const DeviceInfo*                  device_info,
+DumpedImageFormat GetDumpedImageFormat(const VulkanDeviceInfo*            device_info,
                                        const encode::VulkanDeviceTable*   device_table,
                                        const encode::VulkanInstanceTable* instance_table,
                                        VulkanObjectInfoTable&             object_info_table,
@@ -876,7 +876,7 @@ DumpedImageFormat GetDumpedImageFormat(const DeviceInfo*                  device
                                        util::ScreenshotFormat             image_file_format,
                                        bool                               dump_raw)
 {
-    const PhysicalDeviceInfo* phys_dev_info = object_info_table.GetPhysicalDeviceInfo(device_info->parent_id);
+    const VulkanPhysicalDeviceInfo* phys_dev_info = object_info_table.GetVkPhysicalDeviceInfo(device_info->parent_id);
     assert(phys_dev_info);
 
     // If there's a request for images to be dumped as raw bin files

--- a/framework/decode/vulkan_replay_dump_resources_common.h
+++ b/framework/decode/vulkan_replay_dump_resources_common.h
@@ -68,7 +68,7 @@ enum DumpedImageFormat
     KFormatRaw
 };
 
-DumpedImageFormat GetDumpedImageFormat(const DeviceInfo*                  device_info,
+DumpedImageFormat GetDumpedImageFormat(const VulkanDeviceInfo*            device_info,
                                        const encode::VulkanDeviceTable*   device_table,
                                        const encode::VulkanInstanceTable* instance_table,
                                        VulkanObjectInfoTable&             object_info_table,
@@ -87,14 +87,14 @@ uint32_t GetMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_prope
 VkResult CloneImage(VulkanObjectInfoTable&                  object_info_table,
                     const encode::VulkanDeviceTable*        device_table,
                     const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
-                    const ImageInfo*                        image_info,
+                    const VulkanImageInfo*                  image_info,
                     VkImage*                                new_image,
                     VkDeviceMemory*                         new_image_memory);
 
 VkResult CloneBuffer(VulkanObjectInfoTable&                  object_info_table,
                      const encode::VulkanDeviceTable*        device_table,
                      const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
-                     const BufferInfo*                       buffer_info,
+                     const VulkanBufferInfo*                 buffer_info,
                      VkBuffer*                               new_buffer,
                      VkDeviceMemory*                         new_buffer_memory,
                      VkDeviceSize                            override_size = 0);
@@ -106,8 +106,8 @@ uint32_t FindGreatestVertexIndex(const std::vector<uint8_t>& index_data,
                                  uint32_t                    first_index,
                                  VkIndexType                 type);
 
-VkResult DumpImageToFile(const ImageInfo*                   image_info,
-                         const DeviceInfo*                  device_info,
+VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
+                         const VulkanDeviceInfo*            device_info,
                          const encode::VulkanDeviceTable*   device_table,
                          const encode::VulkanInstanceTable* instance_table,
                          VulkanObjectInfoTable&             object_info_table,

--- a/framework/decode/vulkan_replay_dump_resources_common.h
+++ b/framework/decode/vulkan_replay_dump_resources_common.h
@@ -23,7 +23,7 @@
 #ifndef GFXRECON_GENERATED_VULKAN_REPLAY_DUMP_RESOURCES_COMMON_H
 #define GFXRECON_GENERATED_VULKAN_REPLAY_DUMP_RESOURCES_COMMON_H
 
-#include "decode/vulkan_object_info_table.h"
+#include "decode/common_object_info_table.h"
 #include "vulkan/vulkan_core.h"
 #include "util/defines.h"
 #include "util/image_writer.h"
@@ -84,14 +84,14 @@ uint32_t GetMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_prope
                             uint32_t                                type_bits,
                             VkMemoryPropertyFlags                   property_flags);
 
-VkResult CloneImage(VulkanObjectInfoTable&                  object_info_table,
+VkResult CloneImage(CommonObjectInfoTable&                  object_info_table,
                     const encode::VulkanDeviceTable*        device_table,
                     const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
                     const VulkanImageInfo*                  image_info,
                     VkImage*                                new_image,
                     VkDeviceMemory*                         new_image_memory);
 
-VkResult CloneBuffer(VulkanObjectInfoTable&                  object_info_table,
+VkResult CloneBuffer(CommonObjectInfoTable&                  object_info_table,
                      const encode::VulkanDeviceTable*        device_table,
                      const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
                      const VulkanBufferInfo*                 buffer_info,
@@ -110,7 +110,7 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
                          const VulkanDeviceInfo*            device_info,
                          const encode::VulkanDeviceTable*   device_table,
                          const encode::VulkanInstanceTable* instance_table,
-                         VulkanObjectInfoTable&             object_info_table,
+                         CommonObjectInfoTable&             object_info_table,
                          const std::vector<std::string>&    filenames,
                          float                              scale,
                          std::vector<bool>&                 scaling_supported,

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -50,7 +50,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 DispatchTraceRaysDumpingContext::DispatchTraceRaysDumpingContext(const std::vector<uint64_t>&   dispatch_indices,
                                                                  const std::vector<uint64_t>&   trace_rays_indices,
-                                                                 VulkanObjectInfoTable&         object_info_table,
+                                                                 CommonObjectInfoTable&         object_info_table,
                                                                  const VulkanReplayOptions&     options,
                                                                  VulkanReplayDumpResourcesJson& dump_json,
                                                                  std::string                    capture_filename) :
@@ -1074,7 +1074,7 @@ VkResult DispatchTraceRaysDumpingContext::DumpMutableResources(uint64_t bcb_inde
             assert(mutable_resources_clones_before.images[i].image != VK_NULL_HANDLE);
 
             VulkanImageInfo modified_image_info = *mutable_resources_clones_before.images[i].original_image;
-            modified_image_info.handle    = mutable_resources_clones_before.images[i].image;
+            modified_image_info.handle          = mutable_resources_clones_before.images[i].image;
 
             const uint32_t              desc_set    = mutable_resources_clones_before.images[i].desc_set;
             const uint32_t              binding     = mutable_resources_clones_before.images[i].desc_binding;
@@ -1192,7 +1192,7 @@ VkResult DispatchTraceRaysDumpingContext::DumpMutableResources(uint64_t bcb_inde
         assert(mutable_resources_clones.images[i].image != VK_NULL_HANDLE);
 
         VulkanImageInfo modified_image_info = *mutable_resources_clones.images[i].original_image;
-        modified_image_info.handle    = mutable_resources_clones.images[i].image;
+        modified_image_info.handle          = mutable_resources_clones.images[i].image;
 
         const uint32_t              desc_set    = mutable_resources_clones.images[i].desc_set;
         const uint32_t              binding     = mutable_resources_clones.images[i].desc_binding;
@@ -1279,7 +1279,7 @@ VkResult DispatchTraceRaysDumpingContext::DumpMutableResources(uint64_t bcb_inde
         assert(mutable_resources_clones.buffers[i].original_buffer != nullptr);
         assert(mutable_resources_clones.buffers[i].buffer != VK_NULL_HANDLE);
         const VulkanBufferInfo* buffer_info = mutable_resources_clones.buffers[i].original_buffer;
-        std::vector<uint8_t> data;
+        std::vector<uint8_t>    data;
 
         VkResult res = resource_util.ReadFromBufferResource(
             mutable_resources_clones.buffers[i].buffer, buffer_info->size, 0, buffer_info->queue_family_index, data);
@@ -1777,9 +1777,9 @@ VkResult DispatchTraceRaysDumpingContext::DumpImmutableDescriptors(uint64_t qs_i
     for (const auto& buf : buffer_descriptors)
     {
         const VulkanBufferInfo* buffer_info = buf.first;
-        const VkDeviceSize offset      = buf.second.offset;
-        const VkDeviceSize range       = buf.second.range;
-        const VkDeviceSize size        = range == VK_WHOLE_SIZE ? buffer_info->size - offset : range;
+        const VkDeviceSize      offset      = buf.second.offset;
+        const VkDeviceSize      range       = buf.second.range;
+        const VkDeviceSize      size        = range == VK_WHOLE_SIZE ? buffer_info->size - offset : range;
 
         std::vector<uint8_t> data;
         VkResult             res = resource_util.ReadFromBufferResource(

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
@@ -23,9 +23,9 @@
 #ifndef GFXRECON_GENERATED_VULKAN_REPLAY_DUMP_RESOURCES_COMPUTE_RAY_TRACING_H
 #define GFXRECON_GENERATED_VULKAN_REPLAY_DUMP_RESOURCES_COMPUTE_RAY_TRACING_H
 
+#include "decode/common_object_info_table.h"
 #include "decode/vulkan_replay_dump_resources_common.h"
 #include "decode/vulkan_object_info.h"
-#include "decode/vulkan_object_info_table.h"
 #include "decode/vulkan_replay_options.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "decode/vulkan_replay_dump_resources_json.h"
@@ -48,7 +48,7 @@ class DispatchTraceRaysDumpingContext
   public:
     DispatchTraceRaysDumpingContext(const std::vector<uint64_t>&   dispatch_indices,
                                     const std::vector<uint64_t>&   trace_rays_indices,
-                                    VulkanObjectInfoTable&         object_info_table,
+                                    CommonObjectInfoTable&         object_info_table,
                                     const VulkanReplayOptions&     options,
                                     VulkanReplayDumpResourcesJson& dump_json,
                                     std::string                    capture_filename);
@@ -295,7 +295,7 @@ class DispatchTraceRaysDumpingContext
             struct DispatchIndirect
             {
                 const VulkanBufferInfo* params_buffer_info;
-                VkDeviceSize      params_buffer_offset;
+                VkDeviceSize            params_buffer_offset;
 
                 VkBuffer       new_params_buffer;
                 VkDeviceMemory new_params_memory;
@@ -354,7 +354,7 @@ class DispatchTraceRaysDumpingContext
 
         DispatchTypes type;
 
-        std::unordered_map<uint32_t, VulkanDescriptorSetInfo::DescriptorBindingsInfo> referenced_descriptors;
+        std::unordered_map<uint32_t, VulkanDescriptorSetInfo::VulkanDescriptorBindingsInfo> referenced_descriptors;
 
         MutableResourcesBackupContext mutable_resources_clones;
         MutableResourcesBackupContext mutable_resources_clones_before;
@@ -444,7 +444,7 @@ class DispatchTraceRaysDumpingContext
         TraceRaysTypes type;
 
         std::unordered_map<VkShaderStageFlagBits,
-                           std::unordered_map<uint32_t, VulkanDescriptorSetInfo::DescriptorBindingsInfo>>
+                           std::unordered_map<uint32_t, VulkanDescriptorSetInfo::VulkanDescriptorBindingsInfo>>
             referenced_descriptors;
 
         // Keep copies of all mutable resources that are changed by the dumped commands/shaders
@@ -486,7 +486,7 @@ class DispatchTraceRaysDumpingContext
     const encode::VulkanDeviceTable*        device_table;
     VkDevice                                parent_device;
     const encode::VulkanInstanceTable*      instance_table;
-    VulkanObjectInfoTable&                  object_info_table;
+    CommonObjectInfoTable&                  object_info_table;
     const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props;
     size_t                                  current_dispatch_index;
     size_t                                  current_trace_rays_index;

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -56,7 +56,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 DrawCallsDumpingContext::DrawCallsDumpingContext(const std::vector<uint64_t>&              dc_indices,
                                                  const std::vector<std::vector<uint64_t>>& rp_indices,
-                                                 VulkanObjectInfoTable&                    object_info_table,
+                                                 CommonObjectInfoTable&                    object_info_table,
                                                  const VulkanReplayOptions&                options,
                                                  VulkanReplayDumpResourcesJson&            dump_json,
                                                  std::string                               capture_filename) :
@@ -2113,9 +2113,9 @@ DrawCallsDumpingContext::DumpImmutableDescriptors(uint64_t qs_index, uint64_t bc
     for (const auto& buf : buffer_descriptors)
     {
         const VulkanBufferInfo* buffer_info = buf.first;
-        const VkDeviceSize offset      = buf.second.offset;
-        const VkDeviceSize range       = buf.second.range;
-        const VkDeviceSize size        = range == VK_WHOLE_SIZE ? buffer_info->size - offset : range;
+        const VkDeviceSize      offset      = buf.second.offset;
+        const VkDeviceSize      range       = buf.second.range;
+        const VkDeviceSize      size        = range == VK_WHOLE_SIZE ? buffer_info->size - offset : range;
 
         std::vector<uint8_t> data;
         VkResult             res = resource_util.ReadFromBufferResource(

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -93,7 +93,8 @@ void DrawCallsDumpingContext::Release()
 {
     if (original_command_buffer_info)
     {
-        const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+        const VulkanDeviceInfo* device_info =
+            object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
 
         if (device_info == nullptr)
         {
@@ -103,7 +104,8 @@ void DrawCallsDumpingContext::Release()
         VkDevice device = device_info->handle;
         assert(device_table);
 
-        const CommandPoolInfo* pool_info = object_info_table.GetCommandPoolInfo(original_command_buffer_info->pool_id);
+        const VulkanCommandPoolInfo* pool_info =
+            object_info_table.GetVkCommandPoolInfo(original_command_buffer_info->pool_id);
         assert(pool_info);
 
         if (command_buffers.size())
@@ -170,7 +172,7 @@ void DrawCallsDumpingContext::InsertNewDrawIndexedParameters(uint64_t index,
 }
 
 void DrawCallsDumpingContext::InsertNewDrawIndirectParameters(
-    uint64_t index, const BufferInfo* buffer_info, VkDeviceSize offset, uint32_t draw_count, uint32_t stride)
+    uint64_t index, const VulkanBufferInfo* buffer_info, VkDeviceSize offset, uint32_t draw_count, uint32_t stride)
 {
     auto new_entry = draw_call_params.emplace(
         std::piecewise_construct,
@@ -180,7 +182,7 @@ void DrawCallsDumpingContext::InsertNewDrawIndirectParameters(
 }
 
 void DrawCallsDumpingContext::InsertNewDrawIndexedIndirectParameters(
-    uint64_t index, const BufferInfo* buffer_info, VkDeviceSize offset, uint32_t draw_count, uint32_t stride)
+    uint64_t index, const VulkanBufferInfo* buffer_info, VkDeviceSize offset, uint32_t draw_count, uint32_t stride)
 {
     auto new_entry = draw_call_params.emplace(
         std::piecewise_construct,
@@ -189,13 +191,13 @@ void DrawCallsDumpingContext::InsertNewDrawIndexedIndirectParameters(
     assert(new_entry.second);
 }
 
-void DrawCallsDumpingContext::InsertNewIndirectCountParameters(uint64_t          index,
-                                                               const BufferInfo* buffer_info,
-                                                               VkDeviceSize      offset,
-                                                               const BufferInfo* count_buffer_info,
-                                                               VkDeviceSize      count_buffer_offset,
-                                                               uint32_t          max_draw_count,
-                                                               uint32_t          stride)
+void DrawCallsDumpingContext::InsertNewIndirectCountParameters(uint64_t                index,
+                                                               const VulkanBufferInfo* buffer_info,
+                                                               VkDeviceSize            offset,
+                                                               const VulkanBufferInfo* count_buffer_info,
+                                                               VkDeviceSize            count_buffer_offset,
+                                                               uint32_t                max_draw_count,
+                                                               uint32_t                stride)
 {
     auto new_entry = draw_call_params.emplace(std::piecewise_construct,
                                               std::forward_as_tuple(index),
@@ -209,13 +211,13 @@ void DrawCallsDumpingContext::InsertNewIndirectCountParameters(uint64_t         
     assert(new_entry.second);
 }
 
-void DrawCallsDumpingContext::InsertNewDrawIndexedIndirectCountParameters(uint64_t          index,
-                                                                          const BufferInfo* buffer_info,
-                                                                          VkDeviceSize      offset,
-                                                                          const BufferInfo* count_buffer_info,
-                                                                          VkDeviceSize      count_buffer_offset,
-                                                                          uint32_t          max_draw_count,
-                                                                          uint32_t          stride)
+void DrawCallsDumpingContext::InsertNewDrawIndexedIndirectCountParameters(uint64_t                index,
+                                                                          const VulkanBufferInfo* buffer_info,
+                                                                          VkDeviceSize            offset,
+                                                                          const VulkanBufferInfo* count_buffer_info,
+                                                                          VkDeviceSize            count_buffer_offset,
+                                                                          uint32_t                max_draw_count,
+                                                                          uint32_t                stride)
 {
     auto new_entry = draw_call_params.emplace(std::piecewise_construct,
                                               std::forward_as_tuple(index),
@@ -229,13 +231,13 @@ void DrawCallsDumpingContext::InsertNewDrawIndexedIndirectCountParameters(uint64
     assert(new_entry.second);
 }
 
-void DrawCallsDumpingContext::InsertNewDrawIndirectCountKHRParameters(uint64_t          index,
-                                                                      const BufferInfo* buffer_info,
-                                                                      VkDeviceSize      offset,
-                                                                      const BufferInfo* count_buffer_info,
-                                                                      VkDeviceSize      count_buffer_offset,
-                                                                      uint32_t          max_draw_count,
-                                                                      uint32_t          stride)
+void DrawCallsDumpingContext::InsertNewDrawIndirectCountKHRParameters(uint64_t                index,
+                                                                      const VulkanBufferInfo* buffer_info,
+                                                                      VkDeviceSize            offset,
+                                                                      const VulkanBufferInfo* count_buffer_info,
+                                                                      VkDeviceSize            count_buffer_offset,
+                                                                      uint32_t                max_draw_count,
+                                                                      uint32_t                stride)
 {
     auto new_entry = draw_call_params.emplace(std::piecewise_construct,
                                               std::forward_as_tuple(index),
@@ -249,13 +251,13 @@ void DrawCallsDumpingContext::InsertNewDrawIndirectCountKHRParameters(uint64_t  
     assert(new_entry.second);
 }
 
-void DrawCallsDumpingContext::InsertNewDrawIndexedIndirectCountKHRParameters(uint64_t          index,
-                                                                             const BufferInfo* buffer_info,
-                                                                             VkDeviceSize      offset,
-                                                                             const BufferInfo* count_buffer_info,
-                                                                             VkDeviceSize      count_buffer_offset,
-                                                                             uint32_t          max_draw_count,
-                                                                             uint32_t          stride)
+void DrawCallsDumpingContext::InsertNewDrawIndexedIndirectCountKHRParameters(uint64_t                index,
+                                                                             const VulkanBufferInfo* buffer_info,
+                                                                             VkDeviceSize            offset,
+                                                                             const VulkanBufferInfo* count_buffer_info,
+                                                                             VkDeviceSize count_buffer_offset,
+                                                                             uint32_t     max_draw_count,
+                                                                             uint32_t     stride)
 {
     auto new_entry =
         draw_call_params.emplace(std::piecewise_construct,
@@ -531,7 +533,7 @@ VkResult DrawCallsDumpingContext::CopyDrawIndirectParameters(uint64_t index)
 
 void DrawCallsDumpingContext::SnapshotBoundDescriptors(uint64_t index)
 {
-    const PipelineInfo* gr_pipeline_info = bound_pipelines[kBindPoint_graphics];
+    const VulkanPipelineInfo* gr_pipeline_info = bound_pipelines[kBindPoint_graphics];
     if (gr_pipeline_info != nullptr)
     {
         auto entry = draw_call_params.find(index);
@@ -603,7 +605,7 @@ void DrawCallsDumpingContext::CopyVertexInputStateInfo(uint64_t dc_index)
 
     DrawCallParameters& dc_params = entry->second;
 
-    const PipelineInfo* gr_pipeline_info = bound_pipelines[kBindPoint_graphics];
+    const VulkanPipelineInfo* gr_pipeline_info = bound_pipelines[kBindPoint_graphics];
     assert(gr_pipeline_info != nullptr);
 
     // Pipeline has no vertex binding and/or attribute information.
@@ -782,7 +784,8 @@ VkResult DrawCallsDumpingContext::DumpDrawCalls(
         si.signalSemaphoreCount = (cb == (n_drawcalls - 1)) ? submit_info.signalSemaphoreCount : 0;
         si.pSignalSemaphores    = (cb == (n_drawcalls - 1)) ? submit_info.pSignalSemaphores : nullptr;
 
-        const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+        const VulkanDeviceInfo* device_info =
+            object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
         assert(device_info);
 
         const VkFenceCreateInfo ci = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, 0 };
@@ -916,7 +919,7 @@ std::string DrawCallsDumpingContext::GenerateRenderTargetImageFilename(VkFormat 
     std::stringstream filename;
     filename << capture_filename << "_";
 
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
     assert(device_info);
 
     const DumpedImageFormat output_image_format = GetDumpedImageFormat(device_info,
@@ -1132,7 +1135,7 @@ void DrawCallsDumpingContext::GenerateOutputJsonDrawCallInfo(
                 continue;
             }
 
-            const ImageInfo* image_info = render_targets[rp][sp].color_att_imgs[i];
+            const VulkanImageInfo* image_info = render_targets[rp][sp].color_att_imgs[i];
             assert(image_info != nullptr);
 
             std::vector<VkImageAspectFlagBits> aspects;
@@ -1211,7 +1214,7 @@ void DrawCallsDumpingContext::GenerateOutputJsonDrawCallInfo(
     {
         auto& depth_entries = draw_call_entry["depthAttachments"];
 
-        const ImageInfo* image_info = render_targets[rp][sp].depth_att_img;
+        const VulkanImageInfo* image_info = render_targets[rp][sp].depth_att_img;
 
         std::vector<VkImageAspectFlagBits> aspects;
         GetFormatAspects(image_info->format, aspects);
@@ -1371,7 +1374,7 @@ void DrawCallsDumpingContext::GenerateOutputJsonDrawCallInfo(
                                     desc_shader_binding_json_entry["binding"]    = desc_set_binding_index;
                                     desc_shader_binding_json_entry["arrayIndex"] = img;
 
-                                    const ImageInfo* image_info = object_info_table.GetImageInfo(
+                                    const VulkanImageInfo* image_info = object_info_table.GetVkImageInfo(
                                         desc_binding.second.image_info[img].image_view_info->image_id);
                                     assert(image_info != nullptr);
 
@@ -1440,7 +1443,7 @@ void DrawCallsDumpingContext::GenerateOutputJsonDrawCallInfo(
                             {
                                 for (size_t buf = 0; buf < desc_binding.second.buffer_info.size(); ++buf)
                                 {
-                                    const BufferInfo* buf_info = desc_binding.second.buffer_info[buf].buffer_info;
+                                    const VulkanBufferInfo* buf_info = desc_binding.second.buffer_info[buf].buffer_info;
                                     if (buf_info != nullptr)
                                     {
                                         auto& desc_shader_stage_json_entry =
@@ -1548,7 +1551,7 @@ VkResult DrawCallsDumpingContext::RevertRenderTargetImageLayouts(VkQueue queue, 
             continue;
         }
 
-        ImageInfo* image_info = render_targets[rp][sp].color_att_imgs[i];
+        VulkanImageInfo* image_info = render_targets[rp][sp].color_att_imgs[i];
 
         img_barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         img_barrier.newLayout     = entry->second.color_attachment_layouts[i];
@@ -1560,7 +1563,7 @@ VkResult DrawCallsDumpingContext::RevertRenderTargetImageLayouts(VkQueue queue, 
 
     if (dump_depth && render_targets[rp][sp].depth_att_img != nullptr)
     {
-        ImageInfo* image_info = render_targets[rp][sp].depth_att_img;
+        VulkanImageInfo* image_info = render_targets[rp][sp].depth_att_img;
 
         img_barrier.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
         img_barrier.newLayout     = entry->second.depth_attachment_layout;
@@ -1602,7 +1605,8 @@ VkResult DrawCallsDumpingContext::RevertRenderTargetImageLayouts(VkQueue queue, 
         si.signalSemaphoreCount = 0;
         si.pSignalSemaphores    = nullptr;
 
-        const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+        const VulkanDeviceInfo* device_info =
+            object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
         assert(device_info);
 
         res = device_table->ResetFences(device_info->handle, 1, &aux_fence);
@@ -1648,7 +1652,7 @@ VkResult DrawCallsDumpingContext::DumpRenderTargetAttachments(
 
     assert(original_command_buffer_info);
     assert(original_command_buffer_info->parent_id != format::kNullHandleId);
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
     assert(device_info);
 
     // Dump color attachments
@@ -1660,7 +1664,7 @@ VkResult DrawCallsDumpingContext::DumpRenderTargetAttachments(
             continue;
         }
 
-        const ImageInfo* image_info = render_targets[rp][sp].color_att_imgs[i];
+        const VulkanImageInfo* image_info = render_targets[rp][sp].color_att_imgs[i];
 
         std::vector<VkImageAspectFlagBits> aspects;
         GetFormatAspects(image_info->format, aspects);
@@ -1737,7 +1741,7 @@ VkResult DrawCallsDumpingContext::DumpRenderTargetAttachments(
     // Dump depth attachment
     if (dump_depth && render_targets[rp][sp].depth_att_img != nullptr)
     {
-        const ImageInfo* image_info = render_targets[rp][sp].depth_att_img;
+        const VulkanImageInfo* image_info = render_targets[rp][sp].depth_att_img;
 
         std::vector<VkImageAspectFlagBits> aspects;
         GetFormatAspects(image_info->format, aspects);
@@ -1829,7 +1833,7 @@ std::string DrawCallsDumpingContext::GenerateImageDescriptorFilename(VkFormat   
     std::stringstream base_filename;
     base_filename << capture_filename << "_";
 
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
     assert(device_info);
 
     const DumpedImageFormat output_image_format = GetDumpedImageFormat(device_info,
@@ -1912,14 +1916,14 @@ DrawCallsDumpingContext::DumpImmutableDescriptors(uint64_t qs_index, uint64_t bc
     assert(draw_call_params.find(dc_index) != draw_call_params.end());
 
     // Create a list of all descriptors referenced by all draw calls
-    std::unordered_set<const ImageInfo*> image_descriptors;
+    std::unordered_set<const VulkanImageInfo*> image_descriptors;
 
     struct buffer_descriptor_info
     {
         VkDeviceSize offset;
         VkDeviceSize range;
     };
-    std::unordered_map<const BufferInfo*, buffer_descriptor_info> buffer_descriptors;
+    std::unordered_map<const VulkanBufferInfo*, buffer_descriptor_info> buffer_descriptors;
 
     struct inline_uniform_block_info
     {
@@ -1950,7 +1954,7 @@ DrawCallsDumpingContext::DumpImmutableDescriptors(uint64_t qs_index, uint64_t bc
                         {
                             if (desc_binding.second.image_info[img].image_view_info != nullptr)
                             {
-                                const ImageInfo* img_info = object_info_table.GetImageInfo(
+                                const VulkanImageInfo* img_info = object_info_table.GetVkImageInfo(
                                     desc_binding.second.image_info[img].image_view_info->image_id);
                                 assert(img_info);
 
@@ -1974,7 +1978,7 @@ DrawCallsDumpingContext::DumpImmutableDescriptors(uint64_t qs_index, uint64_t bc
                     {
                         for (size_t buf = 0; buf < desc_binding.second.buffer_info.size(); ++buf)
                         {
-                            const BufferInfo* buffer_info = desc_binding.second.buffer_info[buf].buffer_info;
+                            const VulkanBufferInfo* buffer_info = desc_binding.second.buffer_info[buf].buffer_info;
                             if (buffer_info != nullptr)
                             {
                                 if (render_pass_dumped_descriptors[rp].buffer_descriptors.find(buffer_info) ==
@@ -2024,7 +2028,7 @@ DrawCallsDumpingContext::DumpImmutableDescriptors(uint64_t qs_index, uint64_t bc
 
     assert(original_command_buffer_info);
     assert(original_command_buffer_info->parent_id != format::kNullHandleId);
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
     assert(device_info);
 
     for (const auto& image_info : image_descriptors)
@@ -2097,7 +2101,7 @@ DrawCallsDumpingContext::DumpImmutableDescriptors(uint64_t qs_index, uint64_t bc
         }
     }
 
-    const PhysicalDeviceInfo* phys_dev_info = object_info_table.GetPhysicalDeviceInfo(device_info->parent_id);
+    const VulkanPhysicalDeviceInfo* phys_dev_info = object_info_table.GetVkPhysicalDeviceInfo(device_info->parent_id);
     assert(phys_dev_info);
 
     graphics::VulkanResourcesUtil resource_util(device_info->handle,
@@ -2108,7 +2112,7 @@ DrawCallsDumpingContext::DumpImmutableDescriptors(uint64_t qs_index, uint64_t bc
 
     for (const auto& buf : buffer_descriptors)
     {
-        const BufferInfo*  buffer_info = buf.first;
+        const VulkanBufferInfo* buffer_info = buf.first;
         const VkDeviceSize offset      = buf.second.offset;
         const VkDeviceSize range       = buf.second.range;
         const VkDeviceSize size        = range == VK_WHOLE_SIZE ? buffer_info->size - offset : range;
@@ -2173,10 +2177,10 @@ VkResult DrawCallsDumpingContext::FetchDrawIndirectParams(uint64_t dc_index)
 {
     assert(original_command_buffer_info);
     assert(original_command_buffer_info->parent_id != format::kNullHandleId);
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
     assert(device_info);
 
-    const PhysicalDeviceInfo* phys_dev_info = object_info_table.GetPhysicalDeviceInfo(device_info->parent_id);
+    const VulkanPhysicalDeviceInfo* phys_dev_info = object_info_table.GetVkPhysicalDeviceInfo(device_info->parent_id);
     assert(phys_dev_info);
 
     graphics::VulkanResourcesUtil resource_util(device_info->handle,
@@ -2333,10 +2337,10 @@ VkResult DrawCallsDumpingContext::DumpVertexIndexBuffers(uint64_t qs_index, uint
 {
     assert(original_command_buffer_info);
     assert(original_command_buffer_info->parent_id != format::kNullHandleId);
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
     assert(device_info);
 
-    const PhysicalDeviceInfo* phys_dev_info = object_info_table.GetPhysicalDeviceInfo(device_info->parent_id);
+    const VulkanPhysicalDeviceInfo* phys_dev_info = object_info_table.GetVkPhysicalDeviceInfo(device_info->parent_id);
     assert(phys_dev_info);
 
     graphics::VulkanResourcesUtil resource_util(device_info->handle,
@@ -2680,7 +2684,7 @@ VkResult DrawCallsDumpingContext::DumpVertexIndexBuffers(uint64_t qs_index, uint
     return VK_SUCCESS;
 }
 
-VkResult DrawCallsDumpingContext::CloneCommandBuffer(CommandBufferInfo*                 orig_cmd_buf_info,
+VkResult DrawCallsDumpingContext::CloneCommandBuffer(VulkanCommandBufferInfo*           orig_cmd_buf_info,
                                                      const encode::VulkanDeviceTable*   dev_table,
                                                      const encode::VulkanInstanceTable* inst_table)
 {
@@ -2688,7 +2692,7 @@ VkResult DrawCallsDumpingContext::CloneCommandBuffer(CommandBufferInfo*         
     assert(dev_table);
     assert(inst_table);
 
-    const CommandPoolInfo* cb_pool_info = object_info_table.GetCommandPoolInfo(orig_cmd_buf_info->pool_id);
+    const VulkanCommandPoolInfo* cb_pool_info = object_info_table.GetVkCommandPoolInfo(orig_cmd_buf_info->pool_id);
 
     const VkCommandBufferAllocateInfo ai{ VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
                                           nullptr,
@@ -2696,7 +2700,7 @@ VkResult DrawCallsDumpingContext::CloneCommandBuffer(CommandBufferInfo*         
                                           VK_COMMAND_BUFFER_LEVEL_PRIMARY,
                                           1 };
 
-    const DeviceInfo* dev_info = object_info_table.GetDeviceInfo(orig_cmd_buf_info->parent_id);
+    const VulkanDeviceInfo* dev_info = object_info_table.GetVkDeviceInfo(orig_cmd_buf_info->parent_id);
 
     for (size_t i = 0; i < command_buffers.size(); ++i)
     {
@@ -2720,9 +2724,9 @@ VkResult DrawCallsDumpingContext::CloneCommandBuffer(CommandBufferInfo*         
     assert(instance_table == nullptr);
     instance_table = inst_table;
 
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
     assert(device_info->parent_id != format::kNullHandleId);
-    const PhysicalDeviceInfo* phys_dev_info = object_info_table.GetPhysicalDeviceInfo(device_info->parent_id);
+    const VulkanPhysicalDeviceInfo* phys_dev_info = object_info_table.GetVkPhysicalDeviceInfo(device_info->parent_id);
     assert(phys_dev_info);
 
     assert(phys_dev_info->replay_device_info);
@@ -2748,11 +2752,12 @@ VkResult DrawCallsDumpingContext::CloneCommandBuffer(CommandBufferInfo*         
     return VK_SUCCESS;
 }
 
-void DrawCallsDumpingContext::BindDescriptorSets(VkPipelineBindPoint                          pipeline_bind_point,
-                                                 uint32_t                                     first_set,
-                                                 const std::vector<const DescriptorSetInfo*>& descriptor_sets_infos,
-                                                 uint32_t                                     dynamicOffsetCount,
-                                                 const uint32_t*                              pDynamicOffsets)
+void DrawCallsDumpingContext::BindDescriptorSets(
+    VkPipelineBindPoint                                pipeline_bind_point,
+    uint32_t                                           first_set,
+    const std::vector<const VulkanDescriptorSetInfo*>& descriptor_sets_infos,
+    uint32_t                                           dynamicOffsetCount,
+    const uint32_t*                                    pDynamicOffsets)
 {
     if (pipeline_bind_point != VK_PIPELINE_BIND_POINT_GRAPHICS)
     {
@@ -2794,8 +2799,8 @@ void DrawCallsDumpingContext::BindDescriptorSets(VkPipelineBindPoint            
     assert((dynamic_offset_index == dynamicOffsetCount && pDynamicOffsets != nullptr) || (!dynamic_offset_index));
 }
 
-VkResult DrawCallsDumpingContext::CloneRenderPass(const RenderPassInfo*  original_render_pass,
-                                                  const FramebufferInfo* fb_info)
+VkResult DrawCallsDumpingContext::CloneRenderPass(const VulkanRenderPassInfo*  original_render_pass,
+                                                  const VulkanFramebufferInfo* fb_info)
 {
     std::vector<VkAttachmentDescription> modified_attachemnts = original_render_pass->attachment_descs;
 
@@ -2814,13 +2819,13 @@ VkResult DrawCallsDumpingContext::CloneRenderPass(const RenderPassInfo*  origina
     // Inform the original command buffer about the new image layouts
     for (const auto& att_ref : original_render_pass->subpass_refs[0].color_att_refs)
     {
-        const ImageViewInfo* att_img_view_info =
-            object_info_table.GetImageViewInfo(fb_info->attachment_image_view_ids[att_ref.attachment]);
+        const VulkanImageViewInfo* att_img_view_info =
+            object_info_table.GetVkImageViewInfo(fb_info->attachment_image_view_ids[att_ref.attachment]);
         assert(att_img_view_info != nullptr);
 
         original_command_buffer_info->image_layout_barriers[att_img_view_info->image_id] = att_ref.layout;
 
-        ImageInfo* img_info = object_info_table.GetImageInfo(att_img_view_info->image_id);
+        VulkanImageInfo* img_info = object_info_table.GetVkImageInfo(att_img_view_info->image_id);
         assert(img_info != nullptr);
         img_info->intermediate_layout = att_ref.layout;
     }
@@ -2931,7 +2936,7 @@ VkResult DrawCallsDumpingContext::CloneRenderPass(const RenderPassInfo*  origina
             }
         }
 
-        const RenderPassInfo::SubpassReferences& original_subp_ref = original_render_pass->subpass_refs[sub];
+        const VulkanRenderPassInfo::SubpassReferences& original_subp_ref = original_render_pass->subpass_refs[sub];
         auto new_subp_desc = subpass_descs.insert(subpass_descs.end(), VkSubpassDescription());
 
         new_subp_desc->flags                = original_subp_ref.flags;
@@ -2989,7 +2994,8 @@ VkResult DrawCallsDumpingContext::CloneRenderPass(const RenderPassInfo*  origina
             ci.pNext = nullptr;
         }
 
-        const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+        const VulkanDeviceInfo* device_info =
+            object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
         VkDevice          device      = device_info->handle;
 
         assert(sub < new_render_pass.size());
@@ -3004,17 +3010,17 @@ VkResult DrawCallsDumpingContext::CloneRenderPass(const RenderPassInfo*  origina
     return VK_SUCCESS;
 }
 
-VkResult DrawCallsDumpingContext::BeginRenderPass(const RenderPassInfo*  render_pass_info,
-                                                  uint32_t               clear_value_count,
-                                                  const VkClearValue*    p_clear_values,
-                                                  const FramebufferInfo* framebuffer_info,
-                                                  const VkRect2D&        render_area,
-                                                  VkSubpassContents      contents)
+VkResult DrawCallsDumpingContext::BeginRenderPass(const VulkanRenderPassInfo*  render_pass_info,
+                                                  uint32_t                     clear_value_count,
+                                                  const VkClearValue*          p_clear_values,
+                                                  const VulkanFramebufferInfo* framebuffer_info,
+                                                  const VkRect2D&              render_area,
+                                                  VkSubpassContents            contents)
 {
     assert(render_pass_info);
     assert(framebuffer_info);
 
-    std::vector<ImageInfo*> color_att_imgs;
+    std::vector<VulkanImageInfo*> color_att_imgs;
 
     current_render_pass_type = kRenderPass;
     current_subpass          = 0;
@@ -3027,26 +3033,26 @@ VkResult DrawCallsDumpingContext::BeginRenderPass(const RenderPassInfo*  render_
     {
         const uint32_t att_idx = att_ref.attachment;
 
-        const ImageViewInfo* img_view_info =
-            object_info_table.GetImageViewInfo(framebuffer_info->attachment_image_view_ids[att_idx]);
+        const VulkanImageViewInfo* img_view_info =
+            object_info_table.GetVkImageViewInfo(framebuffer_info->attachment_image_view_ids[att_idx]);
         assert(img_view_info);
 
-        ImageInfo* img_info = object_info_table.GetImageInfo(img_view_info->image_id);
+        VulkanImageInfo* img_info = object_info_table.GetVkImageInfo(img_view_info->image_id);
         assert(img_info);
 
         color_att_imgs.push_back(img_info);
     }
 
-    ImageInfo* depth_img_info;
+    VulkanImageInfo* depth_img_info;
 
     if (active_renderpass->subpass_refs[current_subpass].has_depth)
     {
         const uint32_t       depth_att_idx = active_renderpass->subpass_refs[current_subpass].depth_att_ref.attachment;
-        const ImageViewInfo* depth_img_view_info =
-            object_info_table.GetImageViewInfo(framebuffer_info->attachment_image_view_ids[depth_att_idx]);
+        const VulkanImageViewInfo* depth_img_view_info =
+            object_info_table.GetVkImageViewInfo(framebuffer_info->attachment_image_view_ids[depth_att_idx]);
         assert(depth_img_view_info);
 
-        depth_img_info = object_info_table.GetImageInfo(depth_img_view_info->image_id);
+        depth_img_info = object_info_table.GetVkImageInfo(depth_img_view_info->image_id);
         assert(depth_img_info);
     }
     else
@@ -3124,7 +3130,7 @@ void DrawCallsDumpingContext::NextSubpass(VkSubpassContents contents)
     assert(active_renderpass);
     assert(active_framebuffer);
 
-    std::vector<ImageInfo*>          color_att_imgs;
+    std::vector<VulkanImageInfo*>    color_att_imgs;
     std::vector<VkAttachmentStoreOp> color_att_storeOps;
     std::vector<VkImageLayout>       color_att_final_layouts;
 
@@ -3150,11 +3156,11 @@ void DrawCallsDumpingContext::NextSubpass(VkSubpassContents contents)
         const uint32_t att_idx = att_ref.attachment;
         assert(att_idx < active_framebuffer->attachment_image_view_ids.size());
 
-        const ImageViewInfo* img_view_info =
-            object_info_table.GetImageViewInfo(active_framebuffer->attachment_image_view_ids[att_idx]);
+        const VulkanImageViewInfo* img_view_info =
+            object_info_table.GetVkImageViewInfo(active_framebuffer->attachment_image_view_ids[att_idx]);
         assert(img_view_info);
 
-        ImageInfo* img_info = object_info_table.GetImageInfo(img_view_info->image_id);
+        VulkanImageInfo* img_info = object_info_table.GetVkImageInfo(img_view_info->image_id);
         assert(img_info);
 
         color_att_imgs.push_back(img_info);
@@ -3162,7 +3168,7 @@ void DrawCallsDumpingContext::NextSubpass(VkSubpassContents contents)
         color_att_final_layouts.push_back(active_renderpass->attachment_descs[att_idx].finalLayout);
     }
 
-    ImageInfo*          depth_img_info;
+    VulkanImageInfo*    depth_img_info;
     VkAttachmentStoreOp depth_att_storeOp;
     VkImageLayout       depth_final_layout;
 
@@ -3171,11 +3177,11 @@ void DrawCallsDumpingContext::NextSubpass(VkSubpassContents contents)
         const uint32_t depth_att_idx = active_renderpass->subpass_refs[current_subpass].depth_att_ref.attachment;
         assert(depth_att_idx < active_framebuffer->attachment_image_view_ids.size());
 
-        const ImageViewInfo* depth_img_view_info =
-            object_info_table.GetImageViewInfo(active_framebuffer->attachment_image_view_ids[depth_att_idx]);
+        const VulkanImageViewInfo* depth_img_view_info =
+            object_info_table.GetVkImageViewInfo(active_framebuffer->attachment_image_view_ids[depth_att_idx]);
         assert(depth_img_view_info);
 
-        depth_img_info = object_info_table.GetImageInfo(depth_img_view_info->image_id);
+        depth_img_info = object_info_table.GetVkImageInfo(depth_img_view_info->image_id);
         assert(depth_img_info);
         depth_att_storeOp  = active_renderpass->attachment_descs[depth_att_idx].storeOp;
         depth_final_layout = active_renderpass->attachment_descs[depth_att_idx].finalLayout;
@@ -3191,19 +3197,19 @@ void DrawCallsDumpingContext::NextSubpass(VkSubpassContents contents)
     // Inform the original command buffer about the new image layouts
     for (const auto& att_ref : active_renderpass->subpass_refs[current_subpass].color_att_refs)
     {
-        const ImageViewInfo* att_img_view_info =
-            object_info_table.GetImageViewInfo(active_framebuffer->attachment_image_view_ids[att_ref.attachment]);
+        const VulkanImageViewInfo* att_img_view_info =
+            object_info_table.GetVkImageViewInfo(active_framebuffer->attachment_image_view_ids[att_ref.attachment]);
         assert(att_img_view_info != nullptr);
 
         original_command_buffer_info->image_layout_barriers[att_img_view_info->image_id] = att_ref.layout;
 
-        ImageInfo* img_info = object_info_table.GetImageInfo(att_img_view_info->image_id);
+        VulkanImageInfo* img_info = object_info_table.GetVkImageInfo(att_img_view_info->image_id);
         assert(img_info != nullptr);
         img_info->intermediate_layout = att_ref.layout;
     }
 }
 
-void DrawCallsDumpingContext::BindPipeline(VkPipelineBindPoint pipeline_bind_point, const PipelineInfo* pipeline)
+void DrawCallsDumpingContext::BindPipeline(VkPipelineBindPoint pipeline_bind_point, const VulkanPipelineInfo* pipeline)
 {
     PipelineBindPoints bind_point = VkPipelineBindPointToPipelineBindPoint(pipeline_bind_point);
 
@@ -3254,10 +3260,10 @@ void DrawCallsDumpingContext::EndRendering()
     current_render_pass_type = kNone;
 }
 
-void DrawCallsDumpingContext::BindVertexBuffers(uint64_t                              index,
-                                                uint32_t                              firstBinding,
-                                                const std::vector<const BufferInfo*>& buffer_infos,
-                                                const VkDeviceSize*                   pOffsets)
+void DrawCallsDumpingContext::BindVertexBuffers(uint64_t                                    index,
+                                                uint32_t                                    firstBinding,
+                                                const std::vector<const VulkanBufferInfo*>& buffer_infos,
+                                                const VkDeviceSize*                         pOffsets)
 {
     if (!buffer_infos.size())
     {
@@ -3274,12 +3280,12 @@ void DrawCallsDumpingContext::BindVertexBuffers(uint64_t                        
     }
 }
 
-void DrawCallsDumpingContext::BindVertexBuffers2(uint64_t                              index,
-                                                 uint32_t                              first_binding,
-                                                 const std::vector<const BufferInfo*>& buffer_infos,
-                                                 const VkDeviceSize*                   pOffsets,
-                                                 const VkDeviceSize*                   pSizes,
-                                                 const VkDeviceSize*                   pStrides)
+void DrawCallsDumpingContext::BindVertexBuffers2(uint64_t                                    index,
+                                                 uint32_t                                    first_binding,
+                                                 const std::vector<const VulkanBufferInfo*>& buffer_infos,
+                                                 const VkDeviceSize*                         pOffsets,
+                                                 const VkDeviceSize*                         pSizes,
+                                                 const VkDeviceSize*                         pStrides)
 {
     if (!buffer_infos.size())
     {
@@ -3338,7 +3344,7 @@ void DrawCallsDumpingContext::SetVertexInput(uint32_t                           
 }
 
 void DrawCallsDumpingContext::BindIndexBuffer(
-    uint64_t index, const BufferInfo* buffer_info, VkDeviceSize offset, VkIndexType index_type, VkDeviceSize size)
+    uint64_t index, const VulkanBufferInfo* buffer_info, VkDeviceSize offset, VkIndexType index_type, VkDeviceSize size)
 {
     VkDeviceSize index_buffer_size = 0;
     if (size)
@@ -3360,9 +3366,9 @@ void DrawCallsDumpingContext::BindIndexBuffer(
     bound_index_buffer.size        = index_buffer_size;
 }
 
-void DrawCallsDumpingContext::SetRenderTargets(const std::vector<ImageInfo*>& color_att_imgs,
-                                               ImageInfo*                     depth_att_img,
-                                               bool                           new_render_pass)
+void DrawCallsDumpingContext::SetRenderTargets(const std::vector<VulkanImageInfo*>& color_att_imgs,
+                                               VulkanImageInfo*                     depth_att_img,
+                                               bool                                 new_render_pass)
 {
     if (new_render_pass)
     {
@@ -3434,7 +3440,7 @@ void DrawCallsDumpingContext::ReleaseIndirectParams()
 {
     assert(original_command_buffer_info);
     assert(original_command_buffer_info->parent_id != format::kNullHandleId);
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
 
     if (device_info == nullptr)
     {
@@ -3524,7 +3530,7 @@ void DrawCallsDumpingContext::DestroyMutableResourceBackups()
 {
     assert(original_command_buffer_info);
 
-    const DeviceInfo* device_info = object_info_table.GetDeviceInfo(original_command_buffer_info->parent_id);
+    const VulkanDeviceInfo* device_info = object_info_table.GetVkDeviceInfo(original_command_buffer_info->parent_id);
     if (device_info == nullptr)
     {
         return;
@@ -3621,11 +3627,11 @@ uint32_t DrawCallsDumpingContext::GetDrawCallActiveCommandBuffers(CommandBufferI
     return current_cb_index;
 }
 
-void DrawCallsDumpingContext::BeginRendering(const std::vector<ImageInfo*>&    color_attachments,
-                                             const std::vector<VkImageLayout>& color_attachment_layouts,
-                                             ImageInfo*                        depth_attachment,
-                                             VkImageLayout                     depth_attachment_layout,
-                                             const VkRect2D&                   render_area)
+void DrawCallsDumpingContext::BeginRendering(const std::vector<VulkanImageInfo*>& color_attachments,
+                                             const std::vector<VkImageLayout>&    color_attachment_layouts,
+                                             VulkanImageInfo*                     depth_attachment,
+                                             VkImageLayout                        depth_attachment_layout,
+                                             const VkRect2D&                      render_area)
 {
     assert(color_attachments.size() == color_attachment_layouts.size());
     assert(current_render_pass_type == kNone);

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -23,9 +23,9 @@
 #ifndef GFXRECON_GENERATED_VULKAN_REPLAY_DUMP_RESOURCES_DRAW_CALLS_H
 #define GFXRECON_GENERATED_VULKAN_REPLAY_DUMP_RESOURCES_DRAW_CALLS_H
 
+#include "decode/common_object_info_table.h"
 #include "decode/vulkan_replay_dump_resources_common.h"
 #include "decode/vulkan_object_info.h"
-#include "decode/vulkan_object_info_table.h"
 #include "decode/vulkan_replay_options.h"
 #include "decode/vulkan_replay_dump_resources_json.h"
 #include "generated/generated_vulkan_dispatch_table.h"
@@ -46,7 +46,7 @@ class DrawCallsDumpingContext
   public:
     DrawCallsDumpingContext(const std::vector<uint64_t>&              dc_indices,
                             const std::vector<std::vector<uint64_t>>& rp_indices,
-                            VulkanObjectInfoTable&                    object_info_table,
+                            CommonObjectInfoTable&                    object_info_table,
                             const VulkanReplayOptions&                options,
                             VulkanReplayDumpResourcesJson&            dump_json,
                             std::string                               capture_filename);
@@ -342,7 +342,7 @@ class DrawCallsDumpingContext
             {}
 
             const VulkanBufferInfo* buffer_info;
-            VkDeviceSize      offset;
+            VkDeviceSize            offset;
 
             // These are provided only by CmdBindVertexBuffers2
             VkDeviceSize size;
@@ -375,8 +375,8 @@ class DrawCallsDumpingContext
         {}
 
         const VulkanBufferInfo* buffer_info;
-        VkDeviceSize      offset;
-        VkIndexType       index_type;
+        VkDeviceSize            offset;
+        VkIndexType             index_type;
 
         // This is provided only by vkCmdBindIndexBuffer2KHR
         VkDeviceSize size;
@@ -507,9 +507,9 @@ class DrawCallsDumpingContext
             struct DrawIndirectParams
             {
                 const VulkanBufferInfo* params_buffer_info;
-                VkDeviceSize      params_buffer_offset;
-                uint32_t          draw_count;
-                uint32_t          stride;
+                VkDeviceSize            params_buffer_offset;
+                uint32_t                draw_count;
+                uint32_t                stride;
 
                 VkBuffer       new_params_buffer;
                 VkDeviceMemory new_params_memory;
@@ -530,11 +530,11 @@ class DrawCallsDumpingContext
             struct DrawIndirectCountParams
             {
                 const VulkanBufferInfo* params_buffer_info;
-                VkDeviceSize      params_buffer_offset;
+                VkDeviceSize            params_buffer_offset;
                 const VulkanBufferInfo* count_buffer_info;
-                VkDeviceSize      count_buffer_offset;
-                uint32_t          max_draw_count;
-                uint32_t          stride;
+                VkDeviceSize            count_buffer_offset;
+                uint32_t                max_draw_count;
+                uint32_t                stride;
 
                 VkBuffer       new_params_buffer;
                 VkDeviceMemory new_params_memory;
@@ -671,7 +671,7 @@ class DrawCallsDumpingContext
 
         // Keep copies of the descriptor bindings referenced by each draw call
         std::unordered_map<VkShaderStageFlagBits,
-                           std::unordered_map<uint32_t, VulkanDescriptorSetInfo::DescriptorBindingsInfo>>
+                           std::unordered_map<uint32_t, VulkanDescriptorSetInfo::VulkanDescriptorBindingsInfo>>
             referenced_descriptors;
     };
 
@@ -681,12 +681,12 @@ class DrawCallsDumpingContext
     struct
     {
         std::vector<const VulkanImageInfo*> original_images;
-        std::vector<VkImage>          images;
-        std::vector<VkDeviceMemory>   image_memories;
+        std::vector<VkImage>                images;
+        std::vector<VkDeviceMemory>         image_memories;
 
         std::vector<const VulkanBufferInfo*> original_buffers;
-        std::vector<VkBuffer>          buffers;
-        std::vector<VkDeviceMemory>    buffer_memories;
+        std::vector<VkBuffer>                buffers;
+        std::vector<VkDeviceMemory>          buffer_memories;
     } mutable_resource_backups;
 
     // Gather here all descriptors referenced by draw calls that have been dumped
@@ -713,7 +713,7 @@ class DrawCallsDumpingContext
 
     const encode::VulkanDeviceTable*        device_table;
     const encode::VulkanInstanceTable*      instance_table;
-    VulkanObjectInfoTable&                  object_info_table;
+    CommonObjectInfoTable&                  object_info_table;
     const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props;
     std::string                             capture_filename;
 };

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -59,61 +59,61 @@ class DrawCallsDumpingContext
 
     bool ShouldHandleRenderPass(uint64_t index) const;
 
-    void BindDescriptorSets(VkPipelineBindPoint                          pipeline_bind_point,
-                            uint32_t                                     first_set,
-                            const std::vector<const DescriptorSetInfo*>& descriptor_sets_infos,
-                            uint32_t                                     dynamicOffsetCount,
-                            const uint32_t*                              pDynamicOffsets);
+    void BindDescriptorSets(VkPipelineBindPoint                                pipeline_bind_point,
+                            uint32_t                                           first_set,
+                            const std::vector<const VulkanDescriptorSetInfo*>& descriptor_sets_infos,
+                            uint32_t                                           dynamicOffsetCount,
+                            const uint32_t*                                    pDynamicOffsets);
 
-    void BindPipeline(VkPipelineBindPoint bind_point, const PipelineInfo* pipeline);
+    void BindPipeline(VkPipelineBindPoint bind_point, const VulkanPipelineInfo* pipeline);
 
-    VkResult CloneCommandBuffer(CommandBufferInfo*                 orig_cmd_buf_info,
+    VkResult CloneCommandBuffer(VulkanCommandBufferInfo*           orig_cmd_buf_info,
                                 const encode::VulkanDeviceTable*   dev_table,
                                 const encode::VulkanInstanceTable* inst_table);
 
-    VkResult CloneRenderPass(const RenderPassInfo* original_render_pass, const FramebufferInfo* fb_info);
+    VkResult CloneRenderPass(const VulkanRenderPassInfo* original_render_pass, const VulkanFramebufferInfo* fb_info);
 
-    VkResult BeginRenderPass(const RenderPassInfo*  render_pass_info,
-                             uint32_t               clear_value_count,
-                             const VkClearValue*    p_clear_values,
-                             const FramebufferInfo* framebuffer_info,
-                             const VkRect2D&        render_area,
-                             VkSubpassContents      contents);
+    VkResult BeginRenderPass(const VulkanRenderPassInfo*  render_pass_info,
+                             uint32_t                     clear_value_count,
+                             const VkClearValue*          p_clear_values,
+                             const VulkanFramebufferInfo* framebuffer_info,
+                             const VkRect2D&              render_area,
+                             VkSubpassContents            contents);
 
     void NextSubpass(VkSubpassContents contents);
 
     void EndRenderPass();
 
-    void BeginRendering(const std::vector<ImageInfo*>&    color_attachments,
-                        const std::vector<VkImageLayout>& color_attachment_layouts,
-                        ImageInfo*                        depth_attachment,
-                        VkImageLayout                     depth_attachment_layout,
-                        const VkRect2D&                   render_area);
+    void BeginRendering(const std::vector<VulkanImageInfo*>& color_attachments,
+                        const std::vector<VkImageLayout>&    color_attachment_layouts,
+                        VulkanImageInfo*                     depth_attachment,
+                        VkImageLayout                        depth_attachment_layout,
+                        const VkRect2D&                      render_area);
 
     void EndRendering();
 
-    void BindVertexBuffers(uint64_t                              index,
-                           uint32_t                              firstBinding,
-                           const std::vector<const BufferInfo*>& buffer_infos,
-                           const VkDeviceSize*                   pOffsets);
+    void BindVertexBuffers(uint64_t                                    index,
+                           uint32_t                                    firstBinding,
+                           const std::vector<const VulkanBufferInfo*>& buffer_infos,
+                           const VkDeviceSize*                         pOffsets);
 
-    void BindVertexBuffers2(uint64_t                              index,
-                            uint32_t                              first_binding,
-                            const std::vector<const BufferInfo*>& buffer_infos,
-                            const VkDeviceSize*                   pOffsets,
-                            const VkDeviceSize*                   pSizes,
-                            const VkDeviceSize*                   pStrides);
+    void BindVertexBuffers2(uint64_t                                    index,
+                            uint32_t                                    first_binding,
+                            const std::vector<const VulkanBufferInfo*>& buffer_infos,
+                            const VkDeviceSize*                         pOffsets,
+                            const VkDeviceSize*                         pSizes,
+                            const VkDeviceSize*                         pStrides);
 
     void SetVertexInput(uint32_t                                     vertexBindingDescriptionCount,
                         const VkVertexInputBindingDescription2EXT*   pVertexBindingDescriptions,
                         uint32_t                                     vertexAttributeDescriptionCount,
                         const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions);
 
-    void BindIndexBuffer(uint64_t          index,
-                         const BufferInfo* buffer_info,
-                         VkDeviceSize      offset,
-                         VkIndexType       index_type,
-                         VkDeviceSize      size = 0);
+    void BindIndexBuffer(uint64_t                index,
+                         const VulkanBufferInfo* buffer_info,
+                         VkDeviceSize            offset,
+                         VkIndexType             index_type,
+                         VkDeviceSize            size = 0);
 
     void FinalizeCommandBuffer();
 
@@ -140,42 +140,42 @@ class DrawCallsDumpingContext
                                         uint32_t first_instance);
 
     void InsertNewDrawIndirectParameters(
-        uint64_t index, const BufferInfo* buffer_info, VkDeviceSize offset, uint32_t draw_count, uint32_t stride);
+        uint64_t index, const VulkanBufferInfo* buffer_info, VkDeviceSize offset, uint32_t draw_count, uint32_t stride);
 
     void InsertNewDrawIndexedIndirectParameters(
-        uint64_t index, const BufferInfo* buffer_info, VkDeviceSize offset, uint32_t draw_count, uint32_t stride);
+        uint64_t index, const VulkanBufferInfo* buffer_info, VkDeviceSize offset, uint32_t draw_count, uint32_t stride);
 
-    void InsertNewIndirectCountParameters(uint64_t          index,
-                                          const BufferInfo* buffer_info,
-                                          VkDeviceSize      offset,
-                                          const BufferInfo* count_buffer_info,
-                                          VkDeviceSize      count_buffer_offset,
-                                          uint32_t          max_draw_count,
-                                          uint32_t          stride);
+    void InsertNewIndirectCountParameters(uint64_t                index,
+                                          const VulkanBufferInfo* buffer_info,
+                                          VkDeviceSize            offset,
+                                          const VulkanBufferInfo* count_buffer_info,
+                                          VkDeviceSize            count_buffer_offset,
+                                          uint32_t                max_draw_count,
+                                          uint32_t                stride);
 
-    void InsertNewDrawIndexedIndirectCountParameters(uint64_t          index,
-                                                     const BufferInfo* buffer_info,
-                                                     VkDeviceSize      offset,
-                                                     const BufferInfo* count_buffer_info,
-                                                     VkDeviceSize      count_buffer_offset,
-                                                     uint32_t          max_draw_count,
-                                                     uint32_t          stride);
+    void InsertNewDrawIndexedIndirectCountParameters(uint64_t                index,
+                                                     const VulkanBufferInfo* buffer_info,
+                                                     VkDeviceSize            offset,
+                                                     const VulkanBufferInfo* count_buffer_info,
+                                                     VkDeviceSize            count_buffer_offset,
+                                                     uint32_t                max_draw_count,
+                                                     uint32_t                stride);
 
-    void InsertNewDrawIndirectCountKHRParameters(uint64_t          index,
-                                                 const BufferInfo* buffer_info,
-                                                 VkDeviceSize      offset,
-                                                 const BufferInfo* count_buffer_info,
-                                                 VkDeviceSize      count_buffer_offset,
-                                                 uint32_t          max_draw_count,
-                                                 uint32_t          stride);
+    void InsertNewDrawIndirectCountKHRParameters(uint64_t                index,
+                                                 const VulkanBufferInfo* buffer_info,
+                                                 VkDeviceSize            offset,
+                                                 const VulkanBufferInfo* count_buffer_info,
+                                                 VkDeviceSize            count_buffer_offset,
+                                                 uint32_t                max_draw_count,
+                                                 uint32_t                stride);
 
-    void InsertNewDrawIndexedIndirectCountKHRParameters(uint64_t          index,
-                                                        const BufferInfo* buffer_info,
-                                                        VkDeviceSize      offset,
-                                                        const BufferInfo* count_buffer_info,
-                                                        VkDeviceSize      count_buffer_offset,
-                                                        uint32_t          max_draw_count,
-                                                        uint32_t          stride);
+    void InsertNewDrawIndexedIndirectCountKHRParameters(uint64_t                index,
+                                                        const VulkanBufferInfo* buffer_info,
+                                                        VkDeviceSize            offset,
+                                                        const VulkanBufferInfo* count_buffer_info,
+                                                        VkDeviceSize            count_buffer_offset,
+                                                        uint32_t                max_draw_count,
+                                                        uint32_t                stride);
 
     void CopyVertexInputStateInfo(uint64_t dc_index);
 
@@ -186,7 +186,9 @@ class DrawCallsDumpingContext
     void Release();
 
   private:
-    void SetRenderTargets(const std::vector<ImageInfo*>& color_att_imgs, ImageInfo* depth_att_img, bool new_renderpass);
+    void SetRenderTargets(const std::vector<VulkanImageInfo*>& color_att_imgs,
+                          VulkanImageInfo*                     depth_att_img,
+                          bool                                 new_renderpass);
 
     void SetRenderArea(const VkRect2D& new_render_area);
 
@@ -250,14 +252,14 @@ class DrawCallsDumpingContext
 
     VkResult RevertRenderTargetImageLayouts(VkQueue queue, uint64_t dc_index);
 
-    CommandBufferInfo*                 original_command_buffer_info;
+    VulkanCommandBufferInfo*           original_command_buffer_info;
     std::vector<VkCommandBuffer>       command_buffers;
     size_t                             current_cb_index;
     std::vector<uint64_t>              dc_indices;
     std::vector<std::vector<uint64_t>> RP_indices;
-    const RenderPassInfo*              active_renderpass;
-    const FramebufferInfo*             active_framebuffer;
-    const PipelineInfo*                bound_pipelines[kBindPoint_count];
+    const VulkanRenderPassInfo*        active_renderpass;
+    const VulkanFramebufferInfo*       active_framebuffer;
+    const VulkanPipelineInfo*          bound_pipelines[kBindPoint_count];
     uint32_t                           current_renderpass;
     uint32_t                           current_subpass;
     uint32_t                           n_subpasses;
@@ -298,8 +300,8 @@ class DrawCallsDumpingContext
     {
         RenderTargets() : depth_att_img(nullptr) {}
 
-        std::vector<ImageInfo*> color_att_imgs;
-        ImageInfo*              depth_att_img;
+        std::vector<VulkanImageInfo*> color_att_imgs;
+        VulkanImageInfo*              depth_att_img;
     };
 
     // render_targets is basically a 2d array (vector of vectors). It is indexed like render_targets[rp][sp]
@@ -310,15 +312,15 @@ class DrawCallsDumpingContext
     std::vector<VkRect2D> render_area;
 
     // One entry per descriptor set
-    std::unordered_map<uint32_t, DescriptorSetInfo> bound_descriptor_sets_gr;
+    std::unordered_map<uint32_t, VulkanDescriptorSetInfo> bound_descriptor_sets_gr;
 
     struct VertexInputState
     {
         // One entry per binding
-        PipelineInfo::VertexInputBindingMap vertex_input_binding_map;
+        VulkanPipelineInfo::VertexInputBindingMap vertex_input_binding_map;
 
         // One entry per location
-        PipelineInfo::VertexInputAttributeMap vertex_input_attribute_map;
+        VulkanPipelineInfo::VertexInputAttributeMap vertex_input_attribute_map;
     };
 
     // Keep track of CmdSetVertexInputEXT
@@ -331,15 +333,15 @@ class DrawCallsDumpingContext
         {
             BufferPerBinding() : buffer_info(nullptr), offset(0), size(0), stride(0), actual_size(0) {}
 
-            BufferPerBinding(const BufferInfo* buffer_info,
-                             VkDeviceSize      offset,
-                             VkDeviceSize      size   = 0,
-                             VkDeviceSize      stride = 0) :
+            BufferPerBinding(const VulkanBufferInfo* buffer_info,
+                             VkDeviceSize            offset,
+                             VkDeviceSize            size   = 0,
+                             VkDeviceSize            stride = 0) :
                 buffer_info(buffer_info),
                 offset(offset), size(size), stride(stride), actual_size(0)
             {}
 
-            const BufferInfo* buffer_info;
+            const VulkanBufferInfo* buffer_info;
             VkDeviceSize      offset;
 
             // These are provided only by CmdBindVertexBuffers2
@@ -364,15 +366,15 @@ class DrawCallsDumpingContext
             buffer_info(nullptr), offset(0), index_type(VK_INDEX_TYPE_MAX_ENUM), size(0), actual_size(0)
         {}
 
-        BoundIndexBuffer(const BufferInfo* buffer_info,
-                         VkDeviceSize      offset,
-                         VkIndexType       index_type,
-                         VkDeviceSize      size) :
+        BoundIndexBuffer(const VulkanBufferInfo* buffer_info,
+                         VkDeviceSize            offset,
+                         VkIndexType             index_type,
+                         VkDeviceSize            size) :
             buffer_info(buffer_info),
             offset(offset), index_type(index_type), size(size), actual_size(0)
         {}
 
-        const BufferInfo* buffer_info;
+        const VulkanBufferInfo* buffer_info;
         VkDeviceSize      offset;
         VkIndexType       index_type;
 
@@ -504,7 +506,7 @@ class DrawCallsDumpingContext
 
             struct DrawIndirectParams
             {
-                const BufferInfo* params_buffer_info;
+                const VulkanBufferInfo* params_buffer_info;
                 VkDeviceSize      params_buffer_offset;
                 uint32_t          draw_count;
                 uint32_t          stride;
@@ -527,9 +529,9 @@ class DrawCallsDumpingContext
 
             struct DrawIndirectCountParams
             {
-                const BufferInfo* params_buffer_info;
+                const VulkanBufferInfo* params_buffer_info;
                 VkDeviceSize      params_buffer_offset;
-                const BufferInfo* count_buffer_info;
+                const VulkanBufferInfo* count_buffer_info;
                 VkDeviceSize      count_buffer_offset;
                 uint32_t          max_draw_count;
                 uint32_t          stride;
@@ -573,21 +575,21 @@ class DrawCallsDumpingContext
             {}
 
             // Constructor for vkCmdDrawIndirect*
-            DrawCallParamsUnion(const BufferInfo* params_buffer_info,
-                                VkDeviceSize      offset,
-                                uint32_t          draw_count,
-                                uint32_t          stride) :
+            DrawCallParamsUnion(const VulkanBufferInfo* params_buffer_info,
+                                VkDeviceSize            offset,
+                                uint32_t                draw_count,
+                                uint32_t                stride) :
                 draw_indirect{ params_buffer_info, offset, draw_count, stride, VK_NULL_HANDLE,
                                VK_NULL_HANDLE,     0,      nullptr,    nullptr }
             {}
 
             // Constructor for vkCmdDraw*IndirectCount*
-            DrawCallParamsUnion(const BufferInfo* params_buffer_info,
-                                VkDeviceSize      params_buffer_offset,
-                                const BufferInfo* count_buffer_info,
-                                VkDeviceSize      count_buffer_offset,
-                                uint32_t          max_draw_count,
-                                uint32_t          stride) :
+            DrawCallParamsUnion(const VulkanBufferInfo* params_buffer_info,
+                                VkDeviceSize            params_buffer_offset,
+                                const VulkanBufferInfo* count_buffer_info,
+                                VkDeviceSize            count_buffer_offset,
+                                uint32_t                max_draw_count,
+                                uint32_t                stride) :
                 draw_indirect_count{ params_buffer_info,
                                      params_buffer_offset,
                                      count_buffer_info,
@@ -631,11 +633,11 @@ class DrawCallsDumpingContext
         }
 
         // Constructor for vkCmdDraw*Indirect
-        DrawCallParameters(DrawCallTypes     type,
-                           const BufferInfo* params_buffer_info,
-                           VkDeviceSize      offset,
-                           uint32_t          draw_count,
-                           uint32_t          stride) :
+        DrawCallParameters(DrawCallTypes           type,
+                           const VulkanBufferInfo* params_buffer_info,
+                           VkDeviceSize            offset,
+                           uint32_t                draw_count,
+                           uint32_t                stride) :
             dc_params_union(params_buffer_info, offset, draw_count, stride),
             type(type)
         {
@@ -643,13 +645,13 @@ class DrawCallsDumpingContext
         }
 
         // Constructor for vkCmdDraw*IndirectCount*
-        DrawCallParameters(DrawCallTypes     type,
-                           const BufferInfo* buffer_info,
-                           VkDeviceSize      offset,
-                           const BufferInfo* count_buffer_info,
-                           VkDeviceSize      count_buffer_offset,
-                           uint32_t          max_draw_count,
-                           uint32_t          stride) :
+        DrawCallParameters(DrawCallTypes           type,
+                           const VulkanBufferInfo* buffer_info,
+                           VkDeviceSize            offset,
+                           const VulkanBufferInfo* count_buffer_info,
+                           VkDeviceSize            count_buffer_offset,
+                           uint32_t                max_draw_count,
+                           uint32_t                stride) :
             dc_params_union(buffer_info, offset, count_buffer_info, count_buffer_offset, max_draw_count, stride),
             type(type)
         {
@@ -669,7 +671,7 @@ class DrawCallsDumpingContext
 
         // Keep copies of the descriptor bindings referenced by each draw call
         std::unordered_map<VkShaderStageFlagBits,
-                           std::unordered_map<uint32_t, DescriptorSetInfo::DescriptorBindingsInfo>>
+                           std::unordered_map<uint32_t, VulkanDescriptorSetInfo::DescriptorBindingsInfo>>
             referenced_descriptors;
     };
 
@@ -678,11 +680,11 @@ class DrawCallsDumpingContext
 
     struct
     {
-        std::vector<const ImageInfo*> original_images;
+        std::vector<const VulkanImageInfo*> original_images;
         std::vector<VkImage>          images;
         std::vector<VkDeviceMemory>   image_memories;
 
-        std::vector<const BufferInfo*> original_buffers;
+        std::vector<const VulkanBufferInfo*> original_buffers;
         std::vector<VkBuffer>          buffers;
         std::vector<VkDeviceMemory>    buffer_memories;
     } mutable_resource_backups;
@@ -692,8 +694,8 @@ class DrawCallsDumpingContext
     // multiple times
     struct RenderPassDumpedDescriptors
     {
-        std::unordered_set<const ImageInfo*>            image_descriptors;
-        std::unordered_set<const BufferInfo*>           buffer_descriptors;
+        std::unordered_set<const VulkanImageInfo*>      image_descriptors;
+        std::unordered_set<const VulkanBufferInfo*>     buffer_descriptors;
         std::unordered_set<const std::vector<uint8_t>*> inline_uniform_blocks;
     };
 

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -195,7 +195,7 @@ void VulkanReplayDumpResourcesJson::InsertImageInfo(nlohmann::ordered_json& json
 }
 
 void VulkanReplayDumpResourcesJson::InsertBufferInfo(nlohmann::ordered_json& json_entry,
-                                                     const BufferInfo*       buffer_info,
+                                                     const VulkanBufferInfo* buffer_info,
                                                      const std::string&      filename)
 {
     assert(buffer_info != nullptr);

--- a/framework/decode/vulkan_replay_dump_resources_json.h
+++ b/framework/decode/vulkan_replay_dump_resources_json.h
@@ -71,8 +71,9 @@ class VulkanReplayDumpResourcesJson
                          uint32_t                array_layer     = 0,
                          const std::string*      filename_before = nullptr);
 
-    void
-    InsertBufferInfo(nlohmann::ordered_json& json_entry, const BufferInfo* buffer_info, const std::string& filename);
+    void InsertBufferInfo(nlohmann::ordered_json& json_entry,
+                          const VulkanBufferInfo* buffer_info,
+                          const std::string&      filename);
 
   private:
     bool InitializeFile(const std::string& filename);

--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -36,9 +36,9 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-struct DeviceMemoryInfo;
-struct BufferInfo;
-struct ImageInfo;
+struct VulkanDeviceMemoryInfo;
+struct VulkanBufferInfo;
+struct VulkanImageInfo;
 
 class VulkanResourceAllocator
 {

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -34,7 +34,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-VulkanResourceInitializer::VulkanResourceInitializer(const DeviceInfo*                       device_info,
+VulkanResourceInitializer::VulkanResourceInitializer(const VulkanDeviceInfo*                 device_info,
                                                      VkDeviceSize                            max_copy_size,
                                                      const VkPhysicalDeviceMemoryProperties& memory_properties,
                                                      bool                                    have_shader_stencil_write,

--- a/framework/decode/vulkan_resource_initializer.h
+++ b/framework/decode/vulkan_resource_initializer.h
@@ -35,12 +35,12 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-struct DeviceInfo;
+struct VulkanDeviceInfo;
 
 class VulkanResourceInitializer
 {
   public:
-    VulkanResourceInitializer(const DeviceInfo*                       device_info,
+    VulkanResourceInitializer(const VulkanDeviceInfo*                 device_info,
                               VkDeviceSize                            max_copy_size,
                               const VkPhysicalDeviceMemoryProperties& memory_properties,
                               bool                                    have_shader_stencil_write,
@@ -203,7 +203,7 @@ class VulkanResourceInitializer
     bool                                  have_shader_stencil_write_;
     VulkanResourceAllocator*              resource_allocator_;
     const encode::VulkanDeviceTable*      device_table_;
-    const DeviceInfo*                     device_info_;
+    const VulkanDeviceInfo*               device_info_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -159,10 +159,10 @@ void VulkanResourceTrackingConsumer::Process_vkCreateInstance(
 
     if ((replay_instance != nullptr) && (result == VK_SUCCESS))
     {
-        TrackedInstanceInfo instance_info;
+        TrackedVkInstanceInfo instance_info;
         instance_info.SetCaptureId(*(pInstance->GetPointer()));
         instance_info.SetHandleId(*replay_instance);
-        GetTrackedObjectInfoTable()->AddTrackedInstanceInfo(std::move(instance_info));
+        GetTrackedObjectInfoTable()->AddTrackedVkInstanceInfo(std::move(instance_info));
         AddInstanceTable(*replay_instance);
     }
 }
@@ -184,7 +184,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateDevice(
         pDevice->SetHandleLength(1);
     }
 
-    auto physical_device_info = GetTrackedObjectInfoTable()->GetTrackedPhysicalDeviceInfo(physicalDevice);
+    auto physical_device_info = GetTrackedObjectInfoTable()->GetTrackedVkPhysicalDeviceInfo(physicalDevice);
     assert(physical_device_info != nullptr);
 
     VkResult                result               = VK_ERROR_INITIALIZATION_FAILED;
@@ -202,7 +202,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateDevice(
 
         if ((replay_device != nullptr) && (result == VK_SUCCESS))
         {
-            TrackedDeviceInfo device_info;
+            TrackedVkDeviceInfo device_info;
 
             device_info.SetParentPhysicalDevice(physical_device);
 
@@ -228,7 +228,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateDevice(
 
             device_info.SetCapturePhysicalDeviceId(physical_device_info->GetCaptureId());
 
-            GetTrackedObjectInfoTable()->AddTrackedDeviceInfo(std::move(device_info));
+            GetTrackedObjectInfoTable()->AddTrackedVkDeviceInfo(std::move(device_info));
             AddDeviceTable(*replay_device, get_device_proc_addr);
         }
         else
@@ -247,7 +247,7 @@ void VulkanResourceTrackingConsumer::Process_vkEnumeratePhysicalDevices(
 {
     GFXRECON_UNREFERENCED_PARAMETER(returnValue);
 
-    auto instance_info = GetTrackedObjectInfoTable()->GetTrackedInstanceInfo(instance);
+    auto instance_info = GetTrackedObjectInfoTable()->GetTrackedVkInstanceInfo(instance);
     pPhysicalDeviceCount->AllocateOutputData(
         1, pPhysicalDeviceCount->IsNull() ? static_cast<uint32_t>(0) : (*pPhysicalDeviceCount->GetPointer()));
     if (!pPhysicalDevices->IsNull())
@@ -255,7 +255,7 @@ void VulkanResourceTrackingConsumer::Process_vkEnumeratePhysicalDevices(
         pPhysicalDevices->SetHandleLength(*pPhysicalDeviceCount->GetOutputPointer());
     }
 
-    std::vector<TrackedPhysicalDeviceInfo> handle_info(*(pPhysicalDeviceCount->GetOutputPointer()));
+    std::vector<TrackedVkPhysicalDeviceInfo> handle_info(*(pPhysicalDeviceCount->GetOutputPointer()));
 
     assert((instance_info != nullptr) && (pPhysicalDeviceCount != nullptr) &&
            (pPhysicalDeviceCount->GetPointer() != nullptr) && (pPhysicalDevices != nullptr));
@@ -288,7 +288,7 @@ void VulkanResourceTrackingConsumer::Process_vkEnumeratePhysicalDevices(
                 auto info_iterator = std::next(handle_info.begin(), i);
                 info_iterator->SetHandleId(pPhysicalDevices->GetHandlePointer()[i]);
                 info_iterator->SetCaptureId(pPhysicalDevices->GetPointer()[i]);
-                GetTrackedObjectInfoTable()->AddTrackedPhysicalDeviceInfo(std::move(*info_iterator));
+                GetTrackedObjectInfoTable()->AddTrackedVkPhysicalDeviceInfo(std::move(*info_iterator));
             }
 
             if ((playback_physical_device_length > 0) &&
@@ -298,11 +298,11 @@ void VulkanResourceTrackingConsumer::Process_vkEnumeratePhysicalDevices(
 
                 for (size_t i = playback_physical_device_length; i < capture_physical_device_length; ++i)
                 {
-                    TrackedPhysicalDeviceInfo overflow_info;
+                    TrackedVkPhysicalDeviceInfo overflow_info;
 
                     overflow_info.SetHandleId(overflow_device);
                     overflow_info.SetCaptureId(pPhysicalDevices->GetPointer()[i]);
-                    GetTrackedObjectInfoTable()->AddTrackedPhysicalDeviceInfo(std::move(overflow_info));
+                    GetTrackedObjectInfoTable()->AddTrackedVkPhysicalDeviceInfo(std::move(overflow_info));
                 }
             }
         }
@@ -330,14 +330,14 @@ void VulkanResourceTrackingConsumer::Process_vkCreateBuffer(
     auto replay_buffer      = buffer->GetHandlePointer();
     assert((buffer_create_info != nullptr) && (replay_buffer != nullptr));
 
-    auto in_device = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
+    auto in_device = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
 
     VkResult result = GetDeviceTable(in_device->GetHandleId())
                           ->CreateBuffer(in_device->GetHandleId(), buffer_create_info, nullptr, replay_buffer);
 
     if ((result == VK_SUCCESS) && (buffer_create_info != nullptr) && ((*replay_buffer) != VK_NULL_HANDLE))
     {
-        TrackedResourceInfo buffer_info;
+        TrackedVkResourceInfo buffer_info;
 
         if ((buffer_create_info->sharingMode == VK_SHARING_MODE_CONCURRENT) &&
             (buffer_create_info->queueFamilyIndexCount > 0) && (buffer_create_info->pQueueFamilyIndices != nullptr))
@@ -352,7 +352,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateBuffer(
         buffer_info.SetBufferCreateInfo(*(buffer_create_info));
         buffer_info.SetBufferReplayHandleId(*replay_buffer);
         buffer_info.SetCaptureId(*(buffer->GetPointer()));
-        GetTrackedObjectInfoTable()->AddTrackedResourceInfo(std::move(buffer_info));
+        GetTrackedObjectInfoTable()->AddTrackedVkResourceInfo(std::move(buffer_info));
     }
 }
 
@@ -373,7 +373,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateImage(
         image->SetHandleLength(1);
     }
 
-    auto in_device = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
+    auto in_device = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
 
     auto image_create_info = create_info->GetPointer();
     auto replay_image      = image->GetHandlePointer();
@@ -384,7 +384,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateImage(
 
     if ((result == VK_SUCCESS) && (image_create_info != nullptr) && ((*replay_image) != VK_NULL_HANDLE))
     {
-        TrackedResourceInfo image_info;
+        TrackedVkResourceInfo image_info;
 
         if ((image_create_info->sharingMode == VK_SHARING_MODE_CONCURRENT) &&
             (image_create_info->queueFamilyIndexCount > 0) && (image_create_info->pQueueFamilyIndices != nullptr))
@@ -401,7 +401,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateImage(
         image_info.SetCaptureId(*(image->GetPointer()));
         image_info.SetImageFlag(true);
         image_info.SetCaptureDeviceId(in_device->GetCaptureId());
-        GetTrackedObjectInfoTable()->AddTrackedResourceInfo(std::move(image_info));
+        GetTrackedObjectInfoTable()->AddTrackedVkResourceInfo(std::move(image_info));
     }
 }
 
@@ -415,8 +415,8 @@ void VulkanResourceTrackingConsumer::Process_vkAllocateMemory(
 {
     GFXRECON_UNREFERENCED_PARAMETER(returnValue);
 
-    auto                    device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
-    TrackedDeviceMemoryInfo memory_info;
+    auto                      device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
+    TrackedVkDeviceMemoryInfo memory_info;
 
     assert((allocate_info != nullptr) && (memory != nullptr));
 
@@ -448,7 +448,7 @@ void VulkanResourceTrackingConsumer::Process_vkAllocateMemory(
     }
 
     memory_info.SetCaptureId(*(memory->GetPointer()));
-    GetTrackedObjectInfoTable()->AddTrackedDeviceMemoryInfo(std::move(memory_info));
+    GetTrackedObjectInfoTable()->AddTrackedVkDeviceMemoryInfo(std::move(memory_info));
 }
 
 void VulkanResourceTrackingConsumer::Process_vkBindBufferMemory(const ApiCallInfo& call_info,
@@ -460,8 +460,8 @@ void VulkanResourceTrackingConsumer::Process_vkBindBufferMemory(const ApiCallInf
 {
     GFXRECON_UNREFERENCED_PARAMETER(returnValue);
 
-    auto buffer_info = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(buffer);
-    auto memory_info = GetTrackedObjectInfoTable()->GetTrackedDeviceMemoryInfo(memory);
+    auto buffer_info = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(buffer);
+    auto memory_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceMemoryInfo(memory);
 
     assert((buffer_info != nullptr) && (memory_info != nullptr));
 
@@ -487,8 +487,8 @@ void VulkanResourceTrackingConsumer::Process_vkBindImageMemory(const ApiCallInfo
 {
     GFXRECON_UNREFERENCED_PARAMETER(returnValue);
 
-    auto image_info  = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(image);
-    auto memory_info = GetTrackedObjectInfoTable()->GetTrackedDeviceMemoryInfo(memory);
+    auto image_info  = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(image);
+    auto memory_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceMemoryInfo(memory);
 
     assert((image_info != nullptr) && (memory_info != nullptr));
 
@@ -514,7 +514,7 @@ void VulkanResourceTrackingConsumer::Process_vkBindBufferMemory2(
 {
     GFXRECON_UNREFERENCED_PARAMETER(returnValue);
 
-    auto tracked_device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
+    auto tracked_device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
 
     assert((pBindInfos != nullptr) && (tracked_device_info != nullptr));
 
@@ -526,8 +526,8 @@ void VulkanResourceTrackingConsumer::Process_vkBindBufferMemory2(
     {
         const Decoded_VkBindBufferMemoryInfo* bind_meta_info = &replay_bind_meta_infos[i];
 
-        auto buffer_info = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(bind_meta_info->buffer);
-        auto memory_info = GetTrackedObjectInfoTable()->GetTrackedDeviceMemoryInfo(bind_meta_info->memory);
+        auto buffer_info = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(bind_meta_info->buffer);
+        auto memory_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceMemoryInfo(bind_meta_info->memory);
 
         assert((buffer_info != nullptr) && (memory_info != nullptr));
 
@@ -554,7 +554,7 @@ void VulkanResourceTrackingConsumer::Process_vkBindImageMemory2(
 {
     GFXRECON_UNREFERENCED_PARAMETER(returnValue);
 
-    auto tracked_device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
+    auto tracked_device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
 
     assert((pBindInfos != nullptr) && (tracked_device_info != nullptr));
 
@@ -566,8 +566,8 @@ void VulkanResourceTrackingConsumer::Process_vkBindImageMemory2(
     {
         const Decoded_VkBindImageMemoryInfo* bind_meta_info = &replay_bind_meta_infos[i];
 
-        auto image_info  = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(bind_meta_info->image);
-        auto memory_info = GetTrackedObjectInfoTable()->GetTrackedDeviceMemoryInfo(bind_meta_info->memory);
+        auto image_info  = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(bind_meta_info->image);
+        auto memory_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceMemoryInfo(bind_meta_info->memory);
 
         assert((image_info != nullptr) && (memory_info != nullptr));
 
@@ -596,7 +596,7 @@ void VulkanResourceTrackingConsumer::Process_vkMapMemory(const ApiCallInfo&     
 {
     GFXRECON_UNREFERENCED_PARAMETER(returnValue);
 
-    auto memory_info = GetTrackedObjectInfoTable()->GetTrackedDeviceMemoryInfo(memory);
+    auto memory_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceMemoryInfo(memory);
 
     assert((memory_info != nullptr));
 
@@ -610,8 +610,8 @@ void VulkanResourceTrackingConsumer::Process_vkGetBufferMemoryRequirements(
     format::HandleId                                    buffer,
     StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements)
 {
-    auto device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
-    auto buffer_info = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(buffer);
+    auto device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
+    auto buffer_info = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(buffer);
 
     // retrieve trace buffer memory requirements
     if (pMemoryRequirements != nullptr)
@@ -659,8 +659,8 @@ void VulkanResourceTrackingConsumer::Process_vkGetImageMemoryRequirements(
     format::HandleId                                    image,
     StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements)
 {
-    auto device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
-    auto image_info  = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(image);
+    auto device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
+    auto image_info  = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(image);
 
     // retrieve trace image memory requirements
     if (pMemoryRequirements != nullptr)
@@ -707,7 +707,7 @@ void VulkanResourceTrackingConsumer::Process_vkDestroyInstance(
     format::HandleId                                     instance,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    auto       instance_info = GetTrackedObjectInfoTable()->GetTrackedInstanceInfo(instance);
+    auto       instance_info = GetTrackedObjectInfoTable()->GetTrackedVkInstanceInfo(instance);
     VkInstance in_instance   = instance_info->GetHandleId();
 
     GetInstanceTable(in_instance)->DestroyInstance(in_instance, nullptr);
@@ -718,7 +718,7 @@ void VulkanResourceTrackingConsumer::Process_vkDestroyDevice(
     format::HandleId                                     device,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    auto     device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
+    auto     device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
     VkDevice in_device   = device_info->GetHandleId();
 
     GetDeviceTable(in_device)->DestroyDevice(in_device, nullptr);
@@ -730,8 +730,8 @@ void VulkanResourceTrackingConsumer::Process_vkDestroyBuffer(
     format::HandleId                                     buffer,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    auto     device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
-    auto     buffer_info = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(buffer);
+    auto     device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
+    auto     buffer_info = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(buffer);
     VkDevice in_device   = device_info->GetHandleId();
     VkBuffer in_buffer   = buffer_info->GetBufferReplayHandleId();
 
@@ -744,8 +744,8 @@ void VulkanResourceTrackingConsumer::Process_vkDestroyImage(
     format::HandleId                                     image,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    auto     device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
-    auto     image_info  = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(image);
+    auto     device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
+    auto     image_info  = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(image);
     VkDevice in_device   = device_info->GetHandleId();
     VkImage  in_image    = image_info->GetImageReplayHandleId();
 
@@ -757,7 +757,7 @@ void VulkanResourceTrackingConsumer::ProcessFillMemoryCommand(uint64_t       mem
                                                               uint64_t       size,
                                                               const uint8_t* data)
 {
-    auto memory_info = GetTrackedObjectInfoTable()->GetTrackedDeviceMemoryInfo(memory_id);
+    auto memory_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceMemoryInfo(memory_id);
 
     assert((memory_info != nullptr));
 
@@ -766,7 +766,7 @@ void VulkanResourceTrackingConsumer::ProcessFillMemoryCommand(uint64_t       mem
 }
 
 // Util function for sorting: compares two resources according to the trace binding offset number.
-bool CompareOffset(TrackedResourceInfo* resource1, TrackedResourceInfo* resource2)
+bool CompareOffset(TrackedVkResourceInfo* resource1, TrackedVkResourceInfo* resource2)
 {
     return (resource1->GetTraceBindOffset() < resource2->GetTraceBindOffset());
 }
@@ -774,14 +774,14 @@ bool CompareOffset(TrackedResourceInfo* resource1, TrackedResourceInfo* resource
 // Sort the bound resources in each device memory object according to their trace binding offset.
 void VulkanResourceTrackingConsumer::SortMemoriesBoundResourcesByOffset()
 {
-    auto tracked_device_memories_map = GetTrackedObjectInfoTable()->GetTrackedDeviceMemoriesInfoMap();
+    auto tracked_device_memories_map = GetTrackedObjectInfoTable()->GetTrackedVkDeviceMemoriesInfoMap();
     assert(tracked_device_memories_map != nullptr);
 
     for (auto& iterator : (*tracked_device_memories_map))
     {
-        TrackedDeviceMemoryInfo tracked_device_memory = iterator.second;
+        TrackedVkDeviceMemoryInfo tracked_device_memory = iterator.second;
 
-        std::vector<TrackedResourceInfo*>* resources = tracked_device_memory.GetBoundResourcesList();
+        std::vector<TrackedVkResourceInfo*>* resources = tracked_device_memory.GetBoundResourcesList();
 
         if (resources != nullptr)
         {
@@ -796,14 +796,14 @@ void VulkanResourceTrackingConsumer::SortMemoriesBoundResourcesByOffset()
 // Calculate the replay binding offset and memory allocation size
 void VulkanResourceTrackingConsumer::CalculateReplayBindingOffsetAndMemoryAllocationSize()
 {
-    auto tracked_device_memories_map = GetTrackedObjectInfoTable()->GetTrackedDeviceMemoriesInfoMap();
+    auto tracked_device_memories_map = GetTrackedObjectInfoTable()->GetTrackedVkDeviceMemoriesInfoMap();
     assert(tracked_device_memories_map != nullptr);
 
     for (auto& iterator : (*tracked_device_memories_map))
     {
-        TrackedDeviceMemoryInfo tracked_device_memory = iterator.second;
+        TrackedVkDeviceMemoryInfo tracked_device_memory = iterator.second;
 
-        std::vector<TrackedResourceInfo*>* resources = tracked_device_memory.GetBoundResourcesList();
+        std::vector<TrackedVkResourceInfo*>* resources = tracked_device_memory.GetBoundResourcesList();
 
         if ((*resources).empty() == false)
         {
@@ -916,8 +916,8 @@ void VulkanResourceTrackingConsumer::Process_vkGetImageSubresourceLayout(
     StructPointerDecoder<Decoded_VkImageSubresource>*  pSubresource,
     StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout)
 {
-    auto                device_info         = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
-    auto                image_info          = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(image);
+    auto                device_info         = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
+    auto                image_info          = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(image);
     VkDevice            in_device           = device_info->GetHandleId();
     VkImage             in_image            = image_info->GetImageReplayHandleId();
     auto                layout_capture_time = pLayout->GetPointer();
@@ -937,8 +937,8 @@ void VulkanResourceTrackingConsumer::Process_vkGetImageSubresourceLayout2KHR(
     StructPointerDecoder<Decoded_VkImageSubresource2KHR>*  pSubresource,
     StructPointerDecoder<Decoded_VkSubresourceLayout2KHR>* pLayout)
 {
-    auto                    device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
-    auto                    image_info  = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(image);
+    auto                    device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
+    auto                    image_info  = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(image);
     VkDevice                in_device   = device_info->GetHandleId();
     VkImage                 in_image    = image_info->GetImageReplayHandleId();
     VkSubresourceLayout2KHR subresource_layout_playback_time;
@@ -960,8 +960,8 @@ void VulkanResourceTrackingConsumer::Process_vkGetImageSubresourceLayout2EXT(
     StructPointerDecoder<Decoded_VkImageSubresource2KHR>*  pSubresource,
     StructPointerDecoder<Decoded_VkSubresourceLayout2KHR>* pLayout)
 {
-    auto                    device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
-    auto                    image_info  = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(image);
+    auto                    device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
+    auto                    image_info  = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(image);
     VkDevice                in_device   = device_info->GetHandleId();
     VkImage                 in_image    = image_info->GetImageReplayHandleId();
     VkSubresourceLayout2KHR subresource_layout_playback_time;
@@ -981,7 +981,7 @@ void VulkanResourceTrackingConsumer::Process_vkGetPhysicalDeviceProperties(
     format::HandleId                                          physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties)
 {
-    auto             physical_device_info = GetTrackedObjectInfoTable()->GetTrackedPhysicalDeviceInfo(physicalDevice);
+    auto             physical_device_info = GetTrackedObjectInfoTable()->GetTrackedVkPhysicalDeviceInfo(physicalDevice);
     VkPhysicalDevice physical_device      = physical_device_info->GetHandleId();
     VkPhysicalDeviceProperties replay_properties;
 
@@ -995,7 +995,7 @@ void VulkanResourceTrackingConsumer::Process_vkGetPhysicalDeviceProperties2(
     format::HandleId                                           physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties)
 {
-    auto             physical_device_info = GetTrackedObjectInfoTable()->GetTrackedPhysicalDeviceInfo(physicalDevice);
+    auto             physical_device_info = GetTrackedObjectInfoTable()->GetTrackedVkPhysicalDeviceInfo(physicalDevice);
     VkPhysicalDevice physical_device      = physical_device_info->GetHandleId();
     VkPhysicalDeviceProperties2 replay_properties;
 
@@ -1009,7 +1009,7 @@ void VulkanResourceTrackingConsumer::Process_vkGetPhysicalDeviceProperties2KHR(
     format::HandleId                                           physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties)
 {
-    auto             physical_device_info = GetTrackedObjectInfoTable()->GetTrackedPhysicalDeviceInfo(physicalDevice);
+    auto             physical_device_info = GetTrackedObjectInfoTable()->GetTrackedVkPhysicalDeviceInfo(physicalDevice);
     VkPhysicalDevice physical_device      = physical_device_info->GetHandleId();
     VkPhysicalDeviceProperties2 replay_properties;
 

--- a/framework/decode/vulkan_swapchain.cpp
+++ b/framework/decode/vulkan_swapchain.cpp
@@ -47,7 +47,7 @@ void VulkanSwapchain::Clean()
 }
 
 VkResult VulkanSwapchain::CreateSurface(VkResult                            original_result,
-                                        InstanceInfo*                       instance_info,
+                                        VulkanInstanceInfo*                 instance_info,
                                         const std::string&                  wsi_extension,
                                         VkFlags                             flags,
                                         HandlePointerDecoder<VkSurfaceKHR>* surface,
@@ -101,7 +101,7 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                            orig
         if ((result == VK_SUCCESS) && (replay_surface != nullptr))
         {
             auto surface_id   = surface->GetPointer();
-            auto surface_info = reinterpret_cast<SurfaceKHRInfo*>(surface->GetConsumerData(0));
+            auto surface_info = reinterpret_cast<VulkanSurfaceKHRInfo*>(surface->GetConsumerData(0));
             assert((surface_id != nullptr) && (surface_info != nullptr));
             assert(!surface_info->surface_creation_skipped);
 
@@ -117,7 +117,7 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                            orig
     {
         if (surface != nullptr)
         {
-            auto surface_info                      = reinterpret_cast<SurfaceKHRInfo*>(surface->GetConsumerData(0));
+            auto surface_info = reinterpret_cast<VulkanSurfaceKHRInfo*>(surface->GetConsumerData(0));
             surface_info->surface_creation_skipped = true;
         }
 
@@ -131,8 +131,8 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                            orig
 }
 
 void VulkanSwapchain::DestroySurface(PFN_vkDestroySurfaceKHR      func,
-                                     const InstanceInfo*          instance_info,
-                                     const SurfaceKHRInfo*        surface_info,
+                                     const VulkanInstanceInfo*    instance_info,
+                                     const VulkanSurfaceKHRInfo*  surface_info,
                                      const VkAllocationCallbacks* allocator)
 {
     assert(instance_info != nullptr);
@@ -166,11 +166,11 @@ void VulkanSwapchain::DestroySurface(PFN_vkDestroySurfaceKHR      func,
 
 VkResult VulkanSwapchain::AcquireNextImageKHR(VkResult                  original_result,
                                               PFN_vkAcquireNextImageKHR func,
-                                              const DeviceInfo*         device_info,
-                                              SwapchainKHRInfo*         swapchain_info,
+                                              const VulkanDeviceInfo*   device_info,
+                                              VulkanSwapchainKHRInfo*   swapchain_info,
                                               uint64_t                  timeout,
-                                              SemaphoreInfo*            semaphore_info,
-                                              FenceInfo*                fence_info,
+                                              VulkanSemaphoreInfo*      semaphore_info,
+                                              VulkanFenceInfo*          fence_info,
                                               uint32_t                  capture_image_index,
                                               uint32_t*                 image_index)
 {

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -63,7 +63,7 @@ class VulkanSwapchain
     void SetOptions(const VulkanSwapchainOptions& options) { swapchain_options_ = options; }
 
     virtual VkResult CreateSurface(VkResult                            original_result,
-                                   InstanceInfo*                       instance_info,
+                                   VulkanInstanceInfo*                 instance_info,
                                    const std::string&                  wsi_extension,
                                    VkFlags                             flags,
                                    HandlePointerDecoder<VkSurfaceKHR>* surface,
@@ -76,45 +76,45 @@ class VulkanSwapchain
                                    bool                                force_windowed = false);
 
     virtual void DestroySurface(PFN_vkDestroySurfaceKHR      func,
-                                const InstanceInfo*          instance_info,
-                                const SurfaceKHRInfo*        surface_info,
+                                const VulkanInstanceInfo*    instance_info,
+                                const VulkanSurfaceKHRInfo*  surface_info,
                                 const VkAllocationCallbacks* allocator);
 
     virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
                                         PFN_vkCreateSwapchainKHR              func,
-                                        const DeviceInfo*                     device_info,
+                                        const VulkanDeviceInfo*               device_info,
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
                                         const encode::VulkanDeviceTable*      device_table) = 0;
 
-    virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
-                                     const DeviceInfo*            device_info,
-                                     const SwapchainKHRInfo*      swapchain_info,
-                                     const VkAllocationCallbacks* allocator) = 0;
+    virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
+                                     const VulkanDeviceInfo*       device_info,
+                                     const VulkanSwapchainKHRInfo* swapchain_info,
+                                     const VkAllocationCallbacks*  allocator) = 0;
 
     virtual VkResult GetSwapchainImagesKHR(VkResult                    original_result,
                                            PFN_vkGetSwapchainImagesKHR func,
-                                           const DeviceInfo*           device_info,
-                                           SwapchainKHRInfo*           swapchain_info,
+                                           const VulkanDeviceInfo*     device_info,
+                                           VulkanSwapchainKHRInfo*     swapchain_info,
                                            uint32_t                    capture_image_count,
                                            uint32_t*                   image_count,
                                            VkImage*                    images) = 0;
 
     virtual VkResult AcquireNextImageKHR(VkResult                  original_result,
                                          PFN_vkAcquireNextImageKHR func,
-                                         const DeviceInfo*         device_info,
-                                         SwapchainKHRInfo*         swapchain_info,
+                                         const VulkanDeviceInfo*   device_info,
+                                         VulkanSwapchainKHRInfo*   swapchain_info,
                                          uint64_t                  timeout,
-                                         SemaphoreInfo*            semaphore_info,
-                                         FenceInfo*                fence_info,
+                                         VulkanSemaphoreInfo*      semaphore_info,
+                                         VulkanFenceInfo*          fence_info,
                                          uint32_t                  capture_image_index,
                                          uint32_t*                 image_index);
 
     virtual VkResult AcquireNextImageKHR(VkResult                  original_result,
                                          PFN_vkAcquireNextImageKHR func,
-                                         const DeviceInfo*         device_info,
-                                         SwapchainKHRInfo*         swapchain_info,
+                                         const VulkanDeviceInfo*   device_info,
+                                         VulkanSwapchainKHRInfo*   swapchain_info,
                                          uint64_t                  timeout,
                                          VkSemaphore               semaphore,
                                          VkFence                   fence,
@@ -123,52 +123,52 @@ class VulkanSwapchain
 
     virtual VkResult AcquireNextImage2KHR(VkResult                         original_result,
                                           PFN_vkAcquireNextImage2KHR       func,
-                                          const DeviceInfo*                device_info,
-                                          SwapchainKHRInfo*                swapchain_info,
+                                          const VulkanDeviceInfo*          device_info,
+                                          VulkanSwapchainKHRInfo*          swapchain_info,
                                           const VkAcquireNextImageInfoKHR* acquire_info,
                                           uint32_t                         capture_image_index,
                                           uint32_t*                        image_index) = 0;
 
-    virtual VkResult QueuePresentKHR(VkResult                              original_result,
-                                     PFN_vkQueuePresentKHR                 func,
-                                     const std::vector<uint32_t>&          capture_image_indices,
-                                     const std::vector<SwapchainKHRInfo*>& swapchain_infos,
-                                     const QueueInfo*                      queue_info,
-                                     const VkPresentInfoKHR*               present_info) = 0;
+    virtual VkResult QueuePresentKHR(VkResult                                    original_result,
+                                     PFN_vkQueuePresentKHR                       func,
+                                     const std::vector<uint32_t>&                capture_image_indices,
+                                     const std::vector<VulkanSwapchainKHRInfo*>& swapchain_infos,
+                                     const VulkanQueueInfo*                      queue_info,
+                                     const VkPresentInfoKHR*                     present_info) = 0;
 
     virtual VkResult CreateRenderPass(VkResult                      original_result,
                                       PFN_vkCreateRenderPass        func,
-                                      const DeviceInfo*             device_info,
+                                      const VulkanDeviceInfo*       device_info,
                                       const VkRenderPassCreateInfo* create_info,
                                       const VkAllocationCallbacks*  allocator,
                                       VkRenderPass*                 render_pass) = 0;
 
     virtual VkResult CreateRenderPass2(VkResult                       original_result,
                                        PFN_vkCreateRenderPass2        func,
-                                       const DeviceInfo*              device_info,
+                                       const VulkanDeviceInfo*        device_info,
                                        const VkRenderPassCreateInfo2* create_info,
                                        const VkAllocationCallbacks*   allocator,
                                        VkRenderPass*                  render_pass) = 0;
 
-    virtual void CmdPipelineBarrier(PFN_vkCmdPipelineBarrier     func,
-                                    const CommandBufferInfo*     command_buffer_info,
-                                    VkPipelineStageFlags         src_stage_mask,
-                                    VkPipelineStageFlags         dst_stage_mask,
-                                    VkDependencyFlags            dependency_flags,
-                                    uint32_t                     memory_barrier_count,
-                                    const VkMemoryBarrier*       memory_barriers,
-                                    uint32_t                     buffer_memory_barrier_count,
-                                    const VkBufferMemoryBarrier* buffer_memory_barriers,
-                                    uint32_t                     image_memory_barrier_count,
-                                    const VkImageMemoryBarrier*  image_memory_barriers) = 0;
+    virtual void CmdPipelineBarrier(PFN_vkCmdPipelineBarrier       func,
+                                    const VulkanCommandBufferInfo* command_buffer_info,
+                                    VkPipelineStageFlags           src_stage_mask,
+                                    VkPipelineStageFlags           dst_stage_mask,
+                                    VkDependencyFlags              dependency_flags,
+                                    uint32_t                       memory_barrier_count,
+                                    const VkMemoryBarrier*         memory_barriers,
+                                    uint32_t                       buffer_memory_barrier_count,
+                                    const VkBufferMemoryBarrier*   buffer_memory_barriers,
+                                    uint32_t                       image_memory_barrier_count,
+                                    const VkImageMemoryBarrier*    image_memory_barriers) = 0;
 
     virtual void CmdPipelineBarrier2(PFN_vkCmdPipelineBarrier2 func,
-                                     CommandBufferInfo*        command_buffer_info,
+                                     VulkanCommandBufferInfo*  command_buffer_info,
                                      const VkDependencyInfo*   pDependencyInfo) = 0;
 
-    virtual void ProcessSetSwapchainImageStateCommand(const DeviceInfo* device_info,
-                                                      SwapchainKHRInfo* swapchain_info,
-                                                      uint32_t          last_presented_image,
+    virtual void ProcessSetSwapchainImageStateCommand(const VulkanDeviceInfo* device_info,
+                                                      VulkanSwapchainKHRInfo* swapchain_info,
+                                                      uint32_t                last_presented_image,
                                                       const std::vector<format::SwapchainImageStateInfo>& image_info,
                                                       const VulkanObjectInfoTable& object_info_table,
                                                       SwapchainImageTracker&       swapchain_image_tracker) = 0;

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -24,7 +24,7 @@
 #define GFXRECON_DECODE_VULKAN_SWAPCHAIN_H
 
 #include "decode/vulkan_object_info.h"
-#include "decode/vulkan_object_info_table.h"
+#include "decode/common_object_info_table.h"
 #include "decode/swapchain_image_tracker.h"
 #include "decode/window.h"
 #include "util/defines.h"
@@ -170,7 +170,7 @@ class VulkanSwapchain
                                                       VulkanSwapchainKHRInfo* swapchain_info,
                                                       uint32_t                last_presented_image,
                                                       const std::vector<format::SwapchainImageStateInfo>& image_info,
-                                                      const VulkanObjectInfoTable& object_info_table,
+                                                      const CommonObjectInfoTable& object_info_table,
                                                       SwapchainImageTracker&       swapchain_image_tracker) = 0;
 
   protected:

--- a/framework/decode/vulkan_tracked_object_info.cpp
+++ b/framework/decode/vulkan_tracked_object_info.cpp
@@ -26,166 +26,166 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 // Set physical device which is the parent of this logical device
-void TrackedDeviceInfo::SetParentPhysicalDevice(VkPhysicalDevice physical_device)
+void TrackedVkDeviceInfo::SetParentPhysicalDevice(VkPhysicalDevice physical_device)
 {
     parent_ = physical_device;
 }
 
 // Get physical device which is the parent of this logical device
-VkPhysicalDevice TrackedDeviceInfo::GetParentPhysicalDevice() const
+VkPhysicalDevice TrackedVkDeviceInfo::GetParentPhysicalDevice() const
 {
     return parent_;
 }
 
 // Set capture device physical memory properties
-void TrackedDeviceInfo::SetCaptureDevicePhysicalMemoryProperties(
+void TrackedVkDeviceInfo::SetCaptureDevicePhysicalMemoryProperties(
     const VkPhysicalDeviceMemoryProperties* memory_properties)
 {
     capture_memory_properties_ = memory_properties;
 }
 
 // Get capture device physical memory properties
-const VkPhysicalDeviceMemoryProperties* TrackedDeviceInfo::GetCaptureDevicePhysicalMemoryProperties() const
+const VkPhysicalDeviceMemoryProperties* TrackedVkDeviceInfo::GetCaptureDevicePhysicalMemoryProperties() const
 {
     return capture_memory_properties_;
 }
 
 // Set replay device physical memory properties
-void TrackedDeviceInfo::SetReplayDevicePhysicalMemoryProperties(
+void TrackedVkDeviceInfo::SetReplayDevicePhysicalMemoryProperties(
     const VkPhysicalDeviceMemoryProperties* memory_properties)
 {
     replay_memory_properties_ = memory_properties;
 }
 
 // Get replay device physical memory properties
-const VkPhysicalDeviceMemoryProperties* TrackedDeviceInfo::GetReplayDevicePhysicalMemoryProperties() const
+const VkPhysicalDeviceMemoryProperties* TrackedVkDeviceInfo::GetReplayDevicePhysicalMemoryProperties() const
 {
     return replay_memory_properties_;
 }
 
 // Set trace memory allocation size
-void TrackedDeviceMemoryInfo::SetTraceMemoryAllocationSize(VkDeviceSize memory_allocation_size)
+void TrackedVkDeviceMemoryInfo::SetTraceMemoryAllocationSize(VkDeviceSize memory_allocation_size)
 {
     trace_memory_allocation_size_ = memory_allocation_size;
 }
 
 // Get trace memory allocation size
-VkDeviceSize TrackedDeviceMemoryInfo::GetTraceMemoryAllocationSize() const
+VkDeviceSize TrackedVkDeviceMemoryInfo::GetTraceMemoryAllocationSize() const
 {
     return trace_memory_allocation_size_;
 }
 
 // Insert the mapped memory size number into the mapped memories sizes list
-void TrackedDeviceMemoryInfo::InsertMappedMemorySizesList(VkDeviceSize mapped_memory_size)
+void TrackedVkDeviceMemoryInfo::InsertMappedMemorySizesList(VkDeviceSize mapped_memory_size)
 {
     mapped_memories_sizes_.push_back(mapped_memory_size);
 }
 
 // Get mapped memories sizes list
-const std::vector<VkDeviceSize>& TrackedDeviceMemoryInfo::GetMappedMemorySizesList() const
+const std::vector<VkDeviceSize>& TrackedVkDeviceMemoryInfo::GetMappedMemorySizesList() const
 {
     return mapped_memories_sizes_;
 }
 
 // Insert the mapped memory offset number into the mapped memories offsets list
-void TrackedDeviceMemoryInfo::InsertMappedMemoryOffsetsList(VkDeviceSize mapped_memory_offset)
+void TrackedVkDeviceMemoryInfo::InsertMappedMemoryOffsetsList(VkDeviceSize mapped_memory_offset)
 {
     mapped_memories_offsets_.push_back(mapped_memory_offset);
 }
 
 // Get mapped memories offsets list
-const std::vector<VkDeviceSize>& TrackedDeviceMemoryInfo::GetMappedMemoryOffsetsList() const
+const std::vector<VkDeviceSize>& TrackedVkDeviceMemoryInfo::GetMappedMemoryOffsetsList() const
 {
     return mapped_memories_offsets_;
 }
 
 // Insert the filled memory size number into the filled memories sizes list
-void TrackedDeviceMemoryInfo::InsertFilledMemorySizesList(VkDeviceSize filled_memory_size)
+void TrackedVkDeviceMemoryInfo::InsertFilledMemorySizesList(VkDeviceSize filled_memory_size)
 {
     filled_memories_sizes_.push_back(filled_memory_size);
 }
 
 // Get filled memories sizes list
-const std::vector<VkDeviceSize>& TrackedDeviceMemoryInfo::GetFilledMemorySizesList() const
+const std::vector<VkDeviceSize>& TrackedVkDeviceMemoryInfo::GetFilledMemorySizesList() const
 {
     return filled_memories_sizes_;
 }
 
 // Insert the filled memory offset number into the filled memories offsets list
-void TrackedDeviceMemoryInfo::InsertFilledMemoryOffsetsList(VkDeviceSize filled_memory_offset)
+void TrackedVkDeviceMemoryInfo::InsertFilledMemoryOffsetsList(VkDeviceSize filled_memory_offset)
 {
     filled_memories_offsets_.push_back(filled_memory_offset);
 }
 
 // Get filled memories offsets list
-const std::vector<VkDeviceSize>& TrackedDeviceMemoryInfo::GetFilledMemoryOffsetsList() const
+const std::vector<VkDeviceSize>& TrackedVkDeviceMemoryInfo::GetFilledMemoryOffsetsList() const
 {
     return filled_memories_offsets_;
 }
 
 // Insert resource into the  bound resource list
-void TrackedDeviceMemoryInfo::InsertBoundResourcesList(TrackedResourceInfo* resource)
+void TrackedVkDeviceMemoryInfo::InsertBoundResourcesList(TrackedVkResourceInfo* resource)
 {
     bound_resources_.push_back(resource);
 }
 
 // Get bound resource list
-std::vector<TrackedResourceInfo*>* TrackedDeviceMemoryInfo::GetBoundResourcesList()
+std::vector<TrackedVkResourceInfo*>* TrackedVkDeviceMemoryInfo::GetBoundResourcesList()
 {
     return &bound_resources_;
 }
 
-const std::vector<TrackedResourceInfo*>* TrackedDeviceMemoryInfo::GetBoundResourcesList() const
+const std::vector<TrackedVkResourceInfo*>* TrackedVkDeviceMemoryInfo::GetBoundResourcesList() const
 {
     return &bound_resources_;
 }
 
-void TrackedDeviceMemoryInfo::AllocateReplayMemoryAllocationSize(VkDeviceSize size)
+void TrackedVkDeviceMemoryInfo::AllocateReplayMemoryAllocationSize(VkDeviceSize size)
 {
     replay_memory_allocation_size_ = size;
 }
 
-VkDeviceSize TrackedDeviceMemoryInfo::GetReplayMemoryAllocationSize() const
+VkDeviceSize TrackedVkDeviceMemoryInfo::GetReplayMemoryAllocationSize() const
 {
     return replay_memory_allocation_size_;
 }
 
-void TrackedDeviceMemoryInfo::SetMemoryPropertyFlags(VkMemoryPropertyFlags property_flags)
+void TrackedVkDeviceMemoryInfo::SetMemoryPropertyFlags(VkMemoryPropertyFlags property_flags)
 {
     property_flags_ = property_flags;
 }
 
-VkMemoryPropertyFlags TrackedDeviceMemoryInfo::GetMemoryPropertyFlags() const
+VkMemoryPropertyFlags TrackedVkDeviceMemoryInfo::GetMemoryPropertyFlags() const
 {
     return property_flags_;
 }
 
 // Set memory ID that this resource bound to
-void TrackedResourceInfo::SetBoundMemoryId(format::HandleId memory_id)
+void TrackedVkResourceInfo::SetBoundMemoryId(format::HandleId memory_id)
 {
     memory_id_ = memory_id;
 }
 
 // Get memory ID that this resource bound to
-format::HandleId TrackedResourceInfo::GetBoundMemoryId() const
+format::HandleId TrackedVkResourceInfo::GetBoundMemoryId() const
 {
     return memory_id_;
 }
 
 // Set memory property flags that this resource bound to
-void TrackedResourceInfo::SetBoundMemoryPropertyFlags(VkMemoryPropertyFlags memory_property_flags)
+void TrackedVkResourceInfo::SetBoundMemoryPropertyFlags(VkMemoryPropertyFlags memory_property_flags)
 {
     memory_property_flags_ = memory_property_flags;
 }
 
 // Get memory property flags that this resource bound to
-VkMemoryPropertyFlags TrackedResourceInfo::GetBoundMemoryPropertyFlags() const
+VkMemoryPropertyFlags TrackedVkResourceInfo::GetBoundMemoryPropertyFlags() const
 {
     return memory_property_flags_;
 }
 
 // Set trace resource binding offset
-void TrackedResourceInfo::SetTraceBindOffset(VkDeviceSize bind_offset)
+void TrackedVkResourceInfo::SetTraceBindOffset(VkDeviceSize bind_offset)
 {
     if (bind_offset > 0)
     {
@@ -194,12 +194,12 @@ void TrackedResourceInfo::SetTraceBindOffset(VkDeviceSize bind_offset)
 }
 
 // Get trace source binding offset
-VkDeviceSize TrackedResourceInfo::GetTraceBindOffset() const
+VkDeviceSize TrackedVkResourceInfo::GetTraceBindOffset() const
 {
     return trace_bind_offset_;
 }
 
-void TrackedResourceInfo::SetReplayBindOffset(VkDeviceSize bind_offset)
+void TrackedVkResourceInfo::SetReplayBindOffset(VkDeviceSize bind_offset)
 {
     if (bind_offset > 0)
     {
@@ -207,12 +207,12 @@ void TrackedResourceInfo::SetReplayBindOffset(VkDeviceSize bind_offset)
     }
 }
 
-VkDeviceSize TrackedResourceInfo::GetReplayBindOffset() const
+VkDeviceSize TrackedVkResourceInfo::GetReplayBindOffset() const
 {
     return replay_bind_offset_;
 }
 
-void TrackedResourceInfo::SetTraceResourceSize(VkDeviceSize size)
+void TrackedVkResourceInfo::SetTraceResourceSize(VkDeviceSize size)
 {
     if (size > 0)
     {
@@ -220,12 +220,12 @@ void TrackedResourceInfo::SetTraceResourceSize(VkDeviceSize size)
     }
 }
 
-VkDeviceSize TrackedResourceInfo::GetTraceResourceSize() const
+VkDeviceSize TrackedVkResourceInfo::GetTraceResourceSize() const
 {
     return trace_size_;
 }
 
-void TrackedResourceInfo::SetTraceResourceAlignment(VkDeviceSize alignment)
+void TrackedVkResourceInfo::SetTraceResourceAlignment(VkDeviceSize alignment)
 {
     if (alignment > 0)
     {
@@ -233,22 +233,22 @@ void TrackedResourceInfo::SetTraceResourceAlignment(VkDeviceSize alignment)
     }
 }
 
-VkDeviceSize TrackedResourceInfo::GetTraceResourceAlignment() const
+VkDeviceSize TrackedVkResourceInfo::GetTraceResourceAlignment() const
 {
     return trace_alignment_;
 }
 
-void TrackedResourceInfo::SetTraceResourceMemoryTypeBits(uint32_t memory_type_bits)
+void TrackedVkResourceInfo::SetTraceResourceMemoryTypeBits(uint32_t memory_type_bits)
 {
     trace_memory_type_bits_ = memory_type_bits;
 }
 
-uint32_t TrackedResourceInfo::GetTraceResourceMemoryTypeBits() const
+uint32_t TrackedVkResourceInfo::GetTraceResourceMemoryTypeBits() const
 {
     return trace_memory_type_bits_;
 }
 
-void TrackedResourceInfo::SetReplayResourceSize(VkDeviceSize size)
+void TrackedVkResourceInfo::SetReplayResourceSize(VkDeviceSize size)
 {
     if (size > 0)
     {
@@ -256,12 +256,12 @@ void TrackedResourceInfo::SetReplayResourceSize(VkDeviceSize size)
     }
 }
 
-VkDeviceSize TrackedResourceInfo::GetReplayResourceSize() const
+VkDeviceSize TrackedVkResourceInfo::GetReplayResourceSize() const
 {
     return replay_size_;
 }
 
-void TrackedResourceInfo::SetReplayResourceAlignment(VkDeviceSize alignment)
+void TrackedVkResourceInfo::SetReplayResourceAlignment(VkDeviceSize alignment)
 {
     if (alignment > 0)
     {
@@ -269,83 +269,83 @@ void TrackedResourceInfo::SetReplayResourceAlignment(VkDeviceSize alignment)
     }
 }
 
-VkDeviceSize TrackedResourceInfo::GetReplayResourceAlignment() const
+VkDeviceSize TrackedVkResourceInfo::GetReplayResourceAlignment() const
 {
     return replay_alignment_;
 }
 
-void TrackedResourceInfo::SetReplayResourceMemoryTypeBits(uint32_t memory_type_bits)
+void TrackedVkResourceInfo::SetReplayResourceMemoryTypeBits(uint32_t memory_type_bits)
 {
     replay_memory_type_bits_ = memory_type_bits;
 }
 
-uint32_t TrackedResourceInfo::GetReplayResourceMemoryTypeBits() const
+uint32_t TrackedVkResourceInfo::GetReplayResourceMemoryTypeBits() const
 {
     return replay_memory_type_bits_;
 }
 
 // Set resource's queue family index
-void TrackedResourceInfo::SetQueueFamilyIndex(uint32_t queue_family_index)
+void TrackedVkResourceInfo::SetQueueFamilyIndex(uint32_t queue_family_index)
 {
     queue_family_index_ = queue_family_index;
 }
 
 // Get resource's queue family index
-uint32_t TrackedResourceInfo::GetQueueFamilyIndex() const
+uint32_t TrackedVkResourceInfo::GetQueueFamilyIndex() const
 {
     return queue_family_index_;
 }
 
 // Set buffer creation information
-void TrackedResourceInfo::SetBufferCreateInfo(VkBufferCreateInfo buffer_create_info)
+void TrackedVkResourceInfo::SetBufferCreateInfo(VkBufferCreateInfo buffer_create_info)
 {
     buffer_create_info_ = buffer_create_info;
 }
 
 // Get buffer binding offset
-VkBufferCreateInfo TrackedResourceInfo::GetBufferCreateInfo() const
+VkBufferCreateInfo TrackedVkResourceInfo::GetBufferCreateInfo() const
 {
     return buffer_create_info_;
 }
 
-void TrackedResourceInfo::SetImageCreateInfo(VkImageCreateInfo image_create_info)
+void TrackedVkResourceInfo::SetImageCreateInfo(VkImageCreateInfo image_create_info)
 {
     image_create_info_ = image_create_info;
 }
 
-VkImageCreateInfo TrackedResourceInfo::GetImageCreateInfo() const
+VkImageCreateInfo TrackedVkResourceInfo::GetImageCreateInfo() const
 {
     return image_create_info_;
 }
 
-void TrackedPhysicalDeviceInfo::SetCaptureDevicePhysicalMemoryProperties(
+void TrackedVkPhysicalDeviceInfo::SetCaptureDevicePhysicalMemoryProperties(
     VkPhysicalDeviceMemoryProperties memory_properties)
 {
     capture_memory_properties_ = memory_properties;
 }
 
-VkPhysicalDeviceMemoryProperties* TrackedPhysicalDeviceInfo::GetCaptureDevicePhysicalMemoryProperties()
+VkPhysicalDeviceMemoryProperties* TrackedVkPhysicalDeviceInfo::GetCaptureDevicePhysicalMemoryProperties()
 {
     return &capture_memory_properties_;
 }
 
-const VkPhysicalDeviceMemoryProperties* TrackedPhysicalDeviceInfo::GetCaptureDevicePhysicalMemoryProperties() const
+const VkPhysicalDeviceMemoryProperties* TrackedVkPhysicalDeviceInfo::GetCaptureDevicePhysicalMemoryProperties() const
 {
     return &capture_memory_properties_;
 }
 
-void TrackedPhysicalDeviceInfo::SetReplayDevicePhysicalMemoryProperties(
+void TrackedVkPhysicalDeviceInfo::SetReplayDevicePhysicalMemoryProperties(
     VkPhysicalDeviceMemoryProperties memory_properties)
 {
     replay_memory_properties_ = memory_properties;
 }
 
-VkPhysicalDeviceMemoryProperties* TrackedPhysicalDeviceInfo::GetReplayDevicePhysicalMemoryProperties()
+VkPhysicalDeviceMemoryProperties* TrackedVkPhysicalDeviceInfo::GetReplayDevicePhysicalMemoryProperties()
 {
     return &replay_memory_properties_;
 }
 
-const VkPhysicalDeviceMemoryProperties* TrackedPhysicalDeviceInfo::GetReplayDevicePhysicalMemoryProperties() const
+const VkPhysicalDeviceMemoryProperties* TrackedVkPhysicalDeviceInfo::GetReplayDevicePhysicalMemoryProperties() const
 {
     return &replay_memory_properties_;
 }

--- a/framework/decode/vulkan_tracked_object_info.h
+++ b/framework/decode/vulkan_tracked_object_info.h
@@ -35,7 +35,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 // This class stores only the instance capture Id and replay handle Id
-class TrackedInstanceInfo
+class TrackedVkInstanceInfo
 {
   public:
     // Set capture ID
@@ -59,7 +59,7 @@ class TrackedInstanceInfo
 };
 
 // This class stores only the physical device capture Id and replay handle Id
-class TrackedPhysicalDeviceInfo
+class TrackedVkPhysicalDeviceInfo
 {
   public:
     // Set capture ID
@@ -124,7 +124,7 @@ class TrackedPhysicalDeviceInfo
 // This class stores the tracked device information
 // during the first pass of the replay.
 // It is need to query the resources' memory requirement on the replay device.
-class TrackedDeviceInfo
+class TrackedVkDeviceInfo
 {
   public:
     // Set capture ID
@@ -195,7 +195,7 @@ typedef struct SubresourceLayoutInfo
 // during the first pass of the replay.
 // It is accessed by replay consumer class in second pass of
 // replay to support memory portability
-class TrackedResourceInfo
+class TrackedVkResourceInfo
 {
   public:
     // Set capture ID
@@ -526,7 +526,7 @@ class TrackedResourceInfo
 // during the first pass of the replay.
 // It is accessed by replay consumer class in second pass of
 // replay to support memory portability
-class TrackedDeviceMemoryInfo
+class TrackedVkDeviceMemoryInfo
 {
   public:
     // Set capture ID
@@ -566,11 +566,11 @@ class TrackedDeviceMemoryInfo
     const std::vector<VkDeviceSize>& GetFilledMemoryOffsetsList() const;
 
     // Insert resource into the bound resource list
-    void InsertBoundResourcesList(TrackedResourceInfo* buffer_id);
+    void InsertBoundResourcesList(TrackedVkResourceInfo* buffer_id);
 
     // Get bound resource list
-    std::vector<TrackedResourceInfo*>*       GetBoundResourcesList();
-    const std::vector<TrackedResourceInfo*>* GetBoundResourcesList() const;
+    std::vector<TrackedVkResourceInfo*>*       GetBoundResourcesList();
+    const std::vector<TrackedVkResourceInfo*>* GetBoundResourcesList() const;
 
     // Allocate replay memory allocation size by increment
     // on each resource binding call
@@ -605,7 +605,7 @@ class TrackedDeviceMemoryInfo
     std::vector<VkDeviceSize> filled_memories_offsets_;
 
     // a list of tracked resources (buffers and images) bound to this memory
-    std::vector<TrackedResourceInfo*> bound_resources_;
+    std::vector<TrackedVkResourceInfo*> bound_resources_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_tracked_object_info_table.cpp
+++ b/framework/decode/vulkan_tracked_object_info_table.cpp
@@ -26,95 +26,96 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 // Add tracked instance information into the instances table map
-void VulkanTrackedObjectInfoTable::AddTrackedInstanceInfo(TrackedInstanceInfo&& info)
+void VulkanTrackedObjectInfoTable::AddTrackedVkInstanceInfo(TrackedVkInstanceInfo&& info)
 {
-    AddTrackedObjectInfo(std::move(info), &tracked_instance_map_);
+    AddTrackedVkObjectInfo(std::move(info), &tracked_instance_map_);
 }
 
 // Add tracked physical device information into the physical devices table map
-void VulkanTrackedObjectInfoTable::AddTrackedPhysicalDeviceInfo(TrackedPhysicalDeviceInfo&& info)
+void VulkanTrackedObjectInfoTable::AddTrackedVkPhysicalDeviceInfo(TrackedVkPhysicalDeviceInfo&& info)
 {
-    AddTrackedObjectInfo(std::move(info), &tracked_physical_device_map_);
+    AddTrackedVkObjectInfo(std::move(info), &tracked_physical_device_map_);
 }
 
 // Add tracked device information into the devices table map
-void VulkanTrackedObjectInfoTable::AddTrackedDeviceInfo(TrackedDeviceInfo&& info)
+void VulkanTrackedObjectInfoTable::AddTrackedVkDeviceInfo(TrackedVkDeviceInfo&& info)
 {
-    AddTrackedObjectInfo(std::move(info), &tracked_device_map_);
+    AddTrackedVkObjectInfo(std::move(info), &tracked_device_map_);
 }
 
 // Add tracked memory information into the tracked memories information table map
-void VulkanTrackedObjectInfoTable::AddTrackedDeviceMemoryInfo(TrackedDeviceMemoryInfo&& info)
+void VulkanTrackedObjectInfoTable::AddTrackedVkDeviceMemoryInfo(TrackedVkDeviceMemoryInfo&& info)
 {
-    AddTrackedObjectInfo(std::move(info), &tracked_device_memory_map_);
+    AddTrackedVkObjectInfo(std::move(info), &tracked_device_memory_map_);
 }
 
 // Add tracked resource information into the tracked buffers information table map
-void VulkanTrackedObjectInfoTable::AddTrackedResourceInfo(TrackedResourceInfo&& info)
+void VulkanTrackedObjectInfoTable::AddTrackedVkResourceInfo(TrackedVkResourceInfo&& info)
 {
-    AddTrackedObjectInfo(std::move(info), &tracked_resource_map_);
+    AddTrackedVkObjectInfo(std::move(info), &tracked_resource_map_);
 }
 
-TrackedInstanceInfo* VulkanTrackedObjectInfoTable::GetTrackedInstanceInfo(format::HandleId id)
+TrackedVkInstanceInfo* VulkanTrackedObjectInfoTable::GetTrackedVkInstanceInfo(format::HandleId id)
 {
-    return GetTrackedObjectInfo<TrackedInstanceInfo>(id, &tracked_instance_map_);
+    return GetTrackedVkObjectInfo<TrackedVkInstanceInfo>(id, &tracked_instance_map_);
 }
 
-const TrackedInstanceInfo* VulkanTrackedObjectInfoTable::GetTrackedInstanceInfo(format::HandleId id) const
+const TrackedVkInstanceInfo* VulkanTrackedObjectInfoTable::GetTrackedVkInstanceInfo(format::HandleId id) const
 {
-    return GetTrackedObjectInfo<TrackedInstanceInfo>(id, &tracked_instance_map_);
+    return GetTrackedVkObjectInfo<TrackedVkInstanceInfo>(id, &tracked_instance_map_);
 }
 
-TrackedPhysicalDeviceInfo* VulkanTrackedObjectInfoTable::GetTrackedPhysicalDeviceInfo(format::HandleId id)
+TrackedVkPhysicalDeviceInfo* VulkanTrackedObjectInfoTable::GetTrackedVkPhysicalDeviceInfo(format::HandleId id)
 {
-    return GetTrackedObjectInfo<TrackedPhysicalDeviceInfo>(id, &tracked_physical_device_map_);
+    return GetTrackedVkObjectInfo<TrackedVkPhysicalDeviceInfo>(id, &tracked_physical_device_map_);
 }
 
-const TrackedPhysicalDeviceInfo* VulkanTrackedObjectInfoTable::GetTrackedPhysicalDeviceInfo(format::HandleId id) const
+const TrackedVkPhysicalDeviceInfo*
+VulkanTrackedObjectInfoTable::GetTrackedVkPhysicalDeviceInfo(format::HandleId id) const
 {
-    return GetTrackedObjectInfo<TrackedPhysicalDeviceInfo>(id, &tracked_physical_device_map_);
+    return GetTrackedVkObjectInfo<TrackedVkPhysicalDeviceInfo>(id, &tracked_physical_device_map_);
 }
 
-TrackedDeviceInfo* VulkanTrackedObjectInfoTable::GetTrackedDeviceInfo(format::HandleId id)
+TrackedVkDeviceInfo* VulkanTrackedObjectInfoTable::GetTrackedVkDeviceInfo(format::HandleId id)
 {
-    return GetTrackedObjectInfo<TrackedDeviceInfo>(id, &tracked_device_map_);
+    return GetTrackedVkObjectInfo<TrackedVkDeviceInfo>(id, &tracked_device_map_);
 }
 
-const TrackedDeviceInfo* VulkanTrackedObjectInfoTable::GetTrackedDeviceInfo(format::HandleId id) const
+const TrackedVkDeviceInfo* VulkanTrackedObjectInfoTable::GetTrackedVkDeviceInfo(format::HandleId id) const
 {
-    return GetTrackedObjectInfo<TrackedDeviceInfo>(id, &tracked_device_map_);
+    return GetTrackedVkObjectInfo<TrackedVkDeviceInfo>(id, &tracked_device_map_);
 }
 
 // Return specified handle ID's device memory information from the tracked memories information table map
-TrackedDeviceMemoryInfo* VulkanTrackedObjectInfoTable::GetTrackedDeviceMemoryInfo(format::HandleId id)
+TrackedVkDeviceMemoryInfo* VulkanTrackedObjectInfoTable::GetTrackedVkDeviceMemoryInfo(format::HandleId id)
 {
-    return GetTrackedObjectInfo<TrackedDeviceMemoryInfo>(id, &tracked_device_memory_map_);
+    return GetTrackedVkObjectInfo<TrackedVkDeviceMemoryInfo>(id, &tracked_device_memory_map_);
 }
 
-const TrackedDeviceMemoryInfo* VulkanTrackedObjectInfoTable::GetTrackedDeviceMemoryInfo(format::HandleId id) const
+const TrackedVkDeviceMemoryInfo* VulkanTrackedObjectInfoTable::GetTrackedVkDeviceMemoryInfo(format::HandleId id) const
 {
-    return GetTrackedObjectInfo<TrackedDeviceMemoryInfo>(id, &tracked_device_memory_map_);
+    return GetTrackedVkObjectInfo<TrackedVkDeviceMemoryInfo>(id, &tracked_device_memory_map_);
 }
 
 // Return specified handle ID's buffer information from the tracked buffers information table map
-TrackedResourceInfo* VulkanTrackedObjectInfoTable::GetTrackedResourceInfo(format::HandleId id)
+TrackedVkResourceInfo* VulkanTrackedObjectInfoTable::GetTrackedVkResourceInfo(format::HandleId id)
 {
-    return GetTrackedObjectInfo<TrackedResourceInfo>(id, &tracked_resource_map_);
+    return GetTrackedVkObjectInfo<TrackedVkResourceInfo>(id, &tracked_resource_map_);
 }
 
-const TrackedResourceInfo* VulkanTrackedObjectInfoTable::GetTrackedResourceInfo(format::HandleId id) const
+const TrackedVkResourceInfo* VulkanTrackedObjectInfoTable::GetTrackedVkResourceInfo(format::HandleId id) const
 {
-    return GetTrackedObjectInfo<TrackedResourceInfo>(id, &tracked_resource_map_);
+    return GetTrackedVkObjectInfo<TrackedVkResourceInfo>(id, &tracked_resource_map_);
 }
 
-std::unordered_map<format::HandleId, TrackedDeviceMemoryInfo>*
-VulkanTrackedObjectInfoTable::GetTrackedDeviceMemoriesInfoMap()
+std::unordered_map<format::HandleId, TrackedVkDeviceMemoryInfo>*
+VulkanTrackedObjectInfoTable::GetTrackedVkDeviceMemoriesInfoMap()
 {
     return &tracked_device_memory_map_;
 }
 
-const std::unordered_map<format::HandleId, TrackedDeviceMemoryInfo>*
-VulkanTrackedObjectInfoTable::GetTrackedDeviceMemoriesInfoMap() const
+const std::unordered_map<format::HandleId, TrackedVkDeviceMemoryInfo>*
+VulkanTrackedObjectInfoTable::GetTrackedVkDeviceMemoriesInfoMap() const
 {
     return &tracked_device_memory_map_;
 }

--- a/framework/decode/vulkan_tracked_object_info_table.h
+++ b/framework/decode/vulkan_tracked_object_info_table.h
@@ -45,49 +45,49 @@ class VulkanTrackedObjectInfoTable
 {
   public:
     // Add tracked instance information into the table map
-    void AddTrackedInstanceInfo(TrackedInstanceInfo&& info);
+    void AddTrackedVkInstanceInfo(TrackedVkInstanceInfo&& info);
 
     // Add tracked physical device information into the table map
-    void AddTrackedPhysicalDeviceInfo(TrackedPhysicalDeviceInfo&& info);
+    void AddTrackedVkPhysicalDeviceInfo(TrackedVkPhysicalDeviceInfo&& info);
 
     // Add tracked device information into the table map
-    void AddTrackedDeviceInfo(TrackedDeviceInfo&& info);
+    void AddTrackedVkDeviceInfo(TrackedVkDeviceInfo&& info);
 
     // Add tracked memory information into the tracked memories information table map
-    void AddTrackedDeviceMemoryInfo(TrackedDeviceMemoryInfo&& info);
+    void AddTrackedVkDeviceMemoryInfo(TrackedVkDeviceMemoryInfo&& info);
 
     // Add tracked resource information into the tracked resource (buffers and images) information table map
-    void AddTrackedResourceInfo(TrackedResourceInfo&& info);
+    void AddTrackedVkResourceInfo(TrackedVkResourceInfo&& info);
 
     // Return specified handle ID's instance information from the tracked instances information table map
-    TrackedInstanceInfo*       GetTrackedInstanceInfo(format::HandleId id);
-    const TrackedInstanceInfo* GetTrackedInstanceInfo(format::HandleId id) const;
+    TrackedVkInstanceInfo*       GetTrackedVkInstanceInfo(format::HandleId id);
+    const TrackedVkInstanceInfo* GetTrackedVkInstanceInfo(format::HandleId id) const;
 
     // Return specified handle ID's physical device information from the tracked physical device information table map
-    TrackedPhysicalDeviceInfo*       GetTrackedPhysicalDeviceInfo(format::HandleId id);
-    const TrackedPhysicalDeviceInfo* GetTrackedPhysicalDeviceInfo(format::HandleId id) const;
+    TrackedVkPhysicalDeviceInfo*       GetTrackedVkPhysicalDeviceInfo(format::HandleId id);
+    const TrackedVkPhysicalDeviceInfo* GetTrackedVkPhysicalDeviceInfo(format::HandleId id) const;
 
     // Return specified handle ID's device information from the tracked device information table map
-    TrackedDeviceInfo*       GetTrackedDeviceInfo(format::HandleId id);
-    const TrackedDeviceInfo* GetTrackedDeviceInfo(format::HandleId id) const;
+    TrackedVkDeviceInfo*       GetTrackedVkDeviceInfo(format::HandleId id);
+    const TrackedVkDeviceInfo* GetTrackedVkDeviceInfo(format::HandleId id) const;
 
     // Return specified handle ID's device memory information from the tracked memories information table map
-    TrackedDeviceMemoryInfo*       GetTrackedDeviceMemoryInfo(format::HandleId id);
-    const TrackedDeviceMemoryInfo* GetTrackedDeviceMemoryInfo(format::HandleId id) const;
+    TrackedVkDeviceMemoryInfo*       GetTrackedVkDeviceMemoryInfo(format::HandleId id);
+    const TrackedVkDeviceMemoryInfo* GetTrackedVkDeviceMemoryInfo(format::HandleId id) const;
 
     // Return specified handle ID's resource information from the tracked resources information table map
-    TrackedResourceInfo*       GetTrackedResourceInfo(format::HandleId id);
-    const TrackedResourceInfo* GetTrackedResourceInfo(format::HandleId id) const;
+    TrackedVkResourceInfo*       GetTrackedVkResourceInfo(format::HandleId id);
+    const TrackedVkResourceInfo* GetTrackedVkResourceInfo(format::HandleId id) const;
 
     // Return tracked device memories information table map
-    std::unordered_map<format::HandleId, TrackedDeviceMemoryInfo>*       GetTrackedDeviceMemoriesInfoMap();
-    const std::unordered_map<format::HandleId, TrackedDeviceMemoryInfo>* GetTrackedDeviceMemoriesInfoMap() const;
+    std::unordered_map<format::HandleId, TrackedVkDeviceMemoryInfo>*       GetTrackedVkDeviceMemoriesInfoMap();
+    const std::unordered_map<format::HandleId, TrackedVkDeviceMemoryInfo>* GetTrackedVkDeviceMemoriesInfoMap() const;
 
   private:
     // Helper template function for updating tracked objects ID with the information
     // into the objects' table map
     template <typename T>
-    void AddTrackedObjectInfo(T&& info, std::unordered_map<format::HandleId, T>* map)
+    void AddTrackedVkObjectInfo(T&& info, std::unordered_map<format::HandleId, T>* map)
     {
         assert(map != nullptr);
 
@@ -106,7 +106,7 @@ class VulkanTrackedObjectInfoTable
     // Helper template function for retrieving tracked objects information
     // with the specified ID from the objects' table map
     template <typename T>
-    T* GetTrackedObjectInfo(format::HandleId id, std::unordered_map<format::HandleId, T>* map)
+    T* GetTrackedVkObjectInfo(format::HandleId id, std::unordered_map<format::HandleId, T>* map)
     {
         assert(map != nullptr);
 
@@ -132,7 +132,7 @@ class VulkanTrackedObjectInfoTable
     // Helper template function for retrieving tracked objects information
     // with the specified ID from the objects' table map
     template <typename T>
-    const T* GetTrackedObjectInfo(format::HandleId id, const std::unordered_map<format::HandleId, T>* map) const
+    const T* GetTrackedVkObjectInfo(format::HandleId id, const std::unordered_map<format::HandleId, T>* map) const
     {
         assert(map != nullptr);
 
@@ -156,11 +156,11 @@ class VulkanTrackedObjectInfoTable
     }
 
   private:
-    std::unordered_map<format::HandleId, TrackedInstanceInfo>       tracked_instance_map_;
-    std::unordered_map<format::HandleId, TrackedPhysicalDeviceInfo> tracked_physical_device_map_;
-    std::unordered_map<format::HandleId, TrackedDeviceInfo>         tracked_device_map_;
-    std::unordered_map<format::HandleId, TrackedDeviceMemoryInfo>   tracked_device_memory_map_;
-    std::unordered_map<format::HandleId, TrackedResourceInfo>       tracked_resource_map_;
+    std::unordered_map<format::HandleId, TrackedVkInstanceInfo>       tracked_instance_map_;
+    std::unordered_map<format::HandleId, TrackedVkPhysicalDeviceInfo> tracked_physical_device_map_;
+    std::unordered_map<format::HandleId, TrackedVkDeviceInfo>         tracked_device_map_;
+    std::unordered_map<format::HandleId, TrackedVkDeviceMemoryInfo>   tracked_device_memory_map_;
+    std::unordered_map<format::HandleId, TrackedVkResourceInfo>       tracked_resource_map_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -44,7 +44,7 @@ bool VulkanVirtualSwapchain::AddSwapchainResourceData(VkSwapchainKHR swapchain)
 
 VkResult VulkanVirtualSwapchain::CreateSwapchainKHR(VkResult                              original_result,
                                                     PFN_vkCreateSwapchainKHR              func,
-                                                    const DeviceInfo*                     device_info,
+                                                    const VulkanDeviceInfo*               device_info,
                                                     const VkSwapchainCreateInfoKHR*       create_info,
                                                     const VkAllocationCallbacks*          allocator,
                                                     HandlePointerDecoder<VkSwapchainKHR>* swapchain,
@@ -89,8 +89,8 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainKHR(VkResult                    
     return result;
 }
 
-void VulkanVirtualSwapchain::CleanSwapchainResourceData(const DeviceInfo*       device_info,
-                                                        const SwapchainKHRInfo* swapchain_info)
+void VulkanVirtualSwapchain::CleanSwapchainResourceData(const VulkanDeviceInfo*       device_info,
+                                                        const VulkanSwapchainKHRInfo* swapchain_info)
 {
     VkDevice       device    = VK_NULL_HANDLE;
     VkSwapchainKHR swapchain = VK_NULL_HANDLE;
@@ -103,7 +103,7 @@ void VulkanVirtualSwapchain::CleanSwapchainResourceData(const DeviceInfo*       
         auto allocator = device_info->allocator.get();
         assert(allocator != nullptr);
 
-        for (const ImageInfo& image_info : swapchain_info->image_infos)
+        for (const VulkanImageInfo& image_info : swapchain_info->image_infos)
         {
             allocator->DestroyImageDirect(image_info.handle, nullptr, image_info.allocator_data);
             allocator->FreeMemoryDirect(image_info.memory, nullptr, image_info.memory_allocator_data);
@@ -145,10 +145,10 @@ void VulkanVirtualSwapchain::CleanSwapchainResourceData(const DeviceInfo*       
     }
 }
 
-void VulkanVirtualSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
-                                                 const DeviceInfo*            device_info,
-                                                 const SwapchainKHRInfo*      swapchain_info,
-                                                 const VkAllocationCallbacks* allocator)
+void VulkanVirtualSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
+                                                 const VulkanDeviceInfo*       device_info,
+                                                 const VulkanSwapchainKHRInfo* swapchain_info,
+                                                 const VkAllocationCallbacks*  allocator)
 {
     if ((device_info != nullptr) && (swapchain_info != nullptr))
     {
@@ -161,12 +161,12 @@ void VulkanVirtualSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    fu
 }
 
 // Offscreen only need virtual_swapchain_images. Skip ther other tasks for offscreen.
-VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const DeviceInfo*       device_info,
-                                                             const SwapchainKHRInfo* swapchain_info,
-                                                             uint32_t                capture_image_count,
-                                                             uint32_t*               replay_image_count,
-                                                             VkImage*                images,
-                                                             bool                    offscreen)
+VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceInfo*       device_info,
+                                                             const VulkanSwapchainKHRInfo* swapchain_info,
+                                                             uint32_t                      capture_image_count,
+                                                             uint32_t*                     replay_image_count,
+                                                             VkImage*                      images,
+                                                             bool                          offscreen)
 {
     VkDevice       device    = VK_NULL_HANDLE;
     VkSwapchainKHR swapchain = VK_NULL_HANDLE;
@@ -570,8 +570,8 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const DeviceInfo*  
 
 VkResult VulkanVirtualSwapchain::GetSwapchainImagesKHR(VkResult                    original_result,
                                                        PFN_vkGetSwapchainImagesKHR func,
-                                                       const DeviceInfo*           device_info,
-                                                       SwapchainKHRInfo*           swapchain_info,
+                                                       const VulkanDeviceInfo*     device_info,
+                                                       VulkanSwapchainKHRInfo*     swapchain_info,
                                                        uint32_t                    capture_image_count,
                                                        uint32_t*                   image_count,
                                                        VkImage*                    images)
@@ -634,8 +634,8 @@ VkResult VulkanVirtualSwapchain::GetSwapchainImagesKHR(VkResult                 
 
 VkResult VulkanVirtualSwapchain::AcquireNextImageKHR(VkResult                  original_result,
                                                      PFN_vkAcquireNextImageKHR func,
-                                                     const DeviceInfo*         device_info,
-                                                     SwapchainKHRInfo*         swapchain_info,
+                                                     const VulkanDeviceInfo*   device_info,
+                                                     VulkanSwapchainKHRInfo*   swapchain_info,
                                                      uint64_t                  timeout,
                                                      VkSemaphore               semaphore,
                                                      VkFence                   fence,
@@ -669,8 +669,8 @@ VkResult VulkanVirtualSwapchain::AcquireNextImageKHR(VkResult                  o
 
 VkResult VulkanVirtualSwapchain::AcquireNextImage2KHR(VkResult                         original_result,
                                                       PFN_vkAcquireNextImage2KHR       func,
-                                                      const DeviceInfo*                device_info,
-                                                      SwapchainKHRInfo*                swapchain_info,
+                                                      const VulkanDeviceInfo*          device_info,
+                                                      VulkanSwapchainKHRInfo*          swapchain_info,
                                                       const VkAcquireNextImageInfoKHR* acquire_info,
                                                       uint32_t                         capture_image_index,
                                                       uint32_t*                        image_index)
@@ -693,12 +693,12 @@ VkResult VulkanVirtualSwapchain::AcquireNextImage2KHR(VkResult                  
     return result;
 }
 
-VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                              original_result,
-                                                 PFN_vkQueuePresentKHR                 func,
-                                                 const std::vector<uint32_t>&          capture_image_indices,
-                                                 const std::vector<SwapchainKHRInfo*>& swapchain_infos,
-                                                 const QueueInfo*                      queue_info,
-                                                 const VkPresentInfoKHR*               present_info)
+VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                                    original_result,
+                                                 PFN_vkQueuePresentKHR                       func,
+                                                 const std::vector<uint32_t>&                capture_image_indices,
+                                                 const std::vector<VulkanSwapchainKHRInfo*>& swapchain_infos,
+                                                 const VulkanQueueInfo*                      queue_info,
+                                                 const VkPresentInfoKHR*                     present_info)
 {
     VkResult result = VK_ERROR_UNKNOWN;
     if (queue_info == nullptr)
@@ -960,7 +960,7 @@ VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                       
 
 VkResult VulkanVirtualSwapchain::CreateRenderPass(VkResult                      original_result,
                                                   PFN_vkCreateRenderPass        func,
-                                                  const DeviceInfo*             device_info,
+                                                  const VulkanDeviceInfo*       device_info,
                                                   const VkRenderPassCreateInfo* create_info,
                                                   const VkAllocationCallbacks*  allocator,
                                                   VkRenderPass*                 render_pass)
@@ -977,7 +977,7 @@ VkResult VulkanVirtualSwapchain::CreateRenderPass(VkResult                      
 
 VkResult VulkanVirtualSwapchain::CreateRenderPass2(VkResult                       original_result,
                                                    PFN_vkCreateRenderPass2        func,
-                                                   const DeviceInfo*              device_info,
+                                                   const VulkanDeviceInfo*        device_info,
                                                    const VkRenderPassCreateInfo2* create_info,
                                                    const VkAllocationCallbacks*   allocator,
                                                    VkRenderPass*                  render_pass)
@@ -992,17 +992,17 @@ VkResult VulkanVirtualSwapchain::CreateRenderPass2(VkResult                     
     return func(device, create_info, allocator, render_pass);
 }
 
-void VulkanVirtualSwapchain::CmdPipelineBarrier(PFN_vkCmdPipelineBarrier     func,
-                                                const CommandBufferInfo*     command_buffer_info,
-                                                VkPipelineStageFlags         src_stage_mask,
-                                                VkPipelineStageFlags         dst_stage_mask,
-                                                VkDependencyFlags            dependency_flags,
-                                                uint32_t                     memory_barrier_count,
-                                                const VkMemoryBarrier*       memory_barriers,
-                                                uint32_t                     buffer_memory_barrier_count,
-                                                const VkBufferMemoryBarrier* buffer_memory_barriers,
-                                                uint32_t                     image_memory_barrier_count,
-                                                const VkImageMemoryBarrier*  image_memory_barriers)
+void VulkanVirtualSwapchain::CmdPipelineBarrier(PFN_vkCmdPipelineBarrier       func,
+                                                const VulkanCommandBufferInfo* command_buffer_info,
+                                                VkPipelineStageFlags           src_stage_mask,
+                                                VkPipelineStageFlags           dst_stage_mask,
+                                                VkDependencyFlags              dependency_flags,
+                                                uint32_t                       memory_barrier_count,
+                                                const VkMemoryBarrier*         memory_barriers,
+                                                uint32_t                       buffer_memory_barrier_count,
+                                                const VkBufferMemoryBarrier*   buffer_memory_barriers,
+                                                uint32_t                       image_memory_barrier_count,
+                                                const VkImageMemoryBarrier*    image_memory_barriers)
 {
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
 
@@ -1024,7 +1024,7 @@ void VulkanVirtualSwapchain::CmdPipelineBarrier(PFN_vkCmdPipelineBarrier     fun
 }
 
 void VulkanVirtualSwapchain::CmdPipelineBarrier2(PFN_vkCmdPipelineBarrier2 func,
-                                                 CommandBufferInfo*        command_buffer_info,
+                                                 VulkanCommandBufferInfo*  command_buffer_info,
                                                  const VkDependencyInfo*   pDependencyInfo)
 {
 
@@ -1038,7 +1038,7 @@ void VulkanVirtualSwapchain::CmdPipelineBarrier2(PFN_vkCmdPipelineBarrier2 func,
     func(command_buffer, pDependencyInfo);
 }
 
-VkResult VulkanVirtualSwapchain::CreateVirtualSwapchainImage(const DeviceInfo*        device_info,
+VkResult VulkanVirtualSwapchain::CreateVirtualSwapchainImage(const VulkanDeviceInfo*  device_info,
                                                              const VkImageCreateInfo& image_create_info,
                                                              VirtualImage&            image)
 {

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -35,29 +35,29 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
 
     virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
                                         PFN_vkCreateSwapchainKHR              func,
-                                        const DeviceInfo*                     device_info,
+                                        const VulkanDeviceInfo*               device_info,
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
                                         const encode::VulkanDeviceTable*      device_table) override;
 
-    virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
-                                     const DeviceInfo*            device_info,
-                                     const SwapchainKHRInfo*      swapchain_info,
-                                     const VkAllocationCallbacks* allocator) override;
+    virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
+                                     const VulkanDeviceInfo*       device_info,
+                                     const VulkanSwapchainKHRInfo* swapchain_info,
+                                     const VkAllocationCallbacks*  allocator) override;
 
     virtual VkResult GetSwapchainImagesKHR(VkResult                    original_result,
                                            PFN_vkGetSwapchainImagesKHR func,
-                                           const DeviceInfo*           device_info,
-                                           SwapchainKHRInfo*           swapchain_info,
+                                           const VulkanDeviceInfo*     device_info,
+                                           VulkanSwapchainKHRInfo*     swapchain_info,
                                            uint32_t                    capture_image_count,
                                            uint32_t*                   image_count,
                                            VkImage*                    images) override;
 
     virtual VkResult AcquireNextImageKHR(VkResult                  original_result,
                                          PFN_vkAcquireNextImageKHR func,
-                                         const DeviceInfo*         device_info,
-                                         SwapchainKHRInfo*         swapchain_info,
+                                         const VulkanDeviceInfo*   device_info,
+                                         VulkanSwapchainKHRInfo*   swapchain_info,
                                          uint64_t                  timeout,
                                          VkSemaphore               semaphore,
                                          VkFence                   fence,
@@ -66,52 +66,52 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
 
     virtual VkResult AcquireNextImage2KHR(VkResult                         original_result,
                                           PFN_vkAcquireNextImage2KHR       func,
-                                          const DeviceInfo*                device_info,
-                                          SwapchainKHRInfo*                swapchain_info,
+                                          const VulkanDeviceInfo*          device_info,
+                                          VulkanSwapchainKHRInfo*          swapchain_info,
                                           const VkAcquireNextImageInfoKHR* acquire_info,
                                           uint32_t                         capture_image_index,
                                           uint32_t*                        image_index) override;
 
-    virtual VkResult QueuePresentKHR(VkResult                              original_result,
-                                     PFN_vkQueuePresentKHR                 func,
-                                     const std::vector<uint32_t>&          capture_image_indices,
-                                     const std::vector<SwapchainKHRInfo*>& swapchain_infos,
-                                     const QueueInfo*                      queue_info,
-                                     const VkPresentInfoKHR*               present_info) override;
+    virtual VkResult QueuePresentKHR(VkResult                                    original_result,
+                                     PFN_vkQueuePresentKHR                       func,
+                                     const std::vector<uint32_t>&                capture_image_indices,
+                                     const std::vector<VulkanSwapchainKHRInfo*>& swapchain_infos,
+                                     const VulkanQueueInfo*                      queue_info,
+                                     const VkPresentInfoKHR*                     present_info) override;
 
     virtual VkResult CreateRenderPass(VkResult                      original_result,
                                       PFN_vkCreateRenderPass        func,
-                                      const DeviceInfo*             device_info,
+                                      const VulkanDeviceInfo*       device_info,
                                       const VkRenderPassCreateInfo* create_info,
                                       const VkAllocationCallbacks*  allocator,
                                       VkRenderPass*                 render_pass) override;
 
     virtual VkResult CreateRenderPass2(VkResult                       original_result,
                                        PFN_vkCreateRenderPass2        func,
-                                       const DeviceInfo*              device_info,
+                                       const VulkanDeviceInfo*        device_info,
                                        const VkRenderPassCreateInfo2* create_info,
                                        const VkAllocationCallbacks*   allocator,
                                        VkRenderPass*                  render_pass) override;
 
-    virtual void CmdPipelineBarrier(PFN_vkCmdPipelineBarrier     func,
-                                    const CommandBufferInfo*     command_buffer_info,
-                                    VkPipelineStageFlags         src_stage_mask,
-                                    VkPipelineStageFlags         dst_stage_mask,
-                                    VkDependencyFlags            dependency_flags,
-                                    uint32_t                     memory_barrier_count,
-                                    const VkMemoryBarrier*       memory_barriers,
-                                    uint32_t                     buffer_memory_barrier_count,
-                                    const VkBufferMemoryBarrier* buffer_memory_barriers,
-                                    uint32_t                     image_memory_barrier_count,
-                                    const VkImageMemoryBarrier*  image_memory_barriers) override;
+    virtual void CmdPipelineBarrier(PFN_vkCmdPipelineBarrier       func,
+                                    const VulkanCommandBufferInfo* command_buffer_info,
+                                    VkPipelineStageFlags           src_stage_mask,
+                                    VkPipelineStageFlags           dst_stage_mask,
+                                    VkDependencyFlags              dependency_flags,
+                                    uint32_t                       memory_barrier_count,
+                                    const VkMemoryBarrier*         memory_barriers,
+                                    uint32_t                       buffer_memory_barrier_count,
+                                    const VkBufferMemoryBarrier*   buffer_memory_barriers,
+                                    uint32_t                       image_memory_barrier_count,
+                                    const VkImageMemoryBarrier*    image_memory_barriers) override;
 
     virtual void CmdPipelineBarrier2(PFN_vkCmdPipelineBarrier2 func,
-                                     CommandBufferInfo*        command_buffer_info,
+                                     VulkanCommandBufferInfo*  command_buffer_info,
                                      const VkDependencyInfo*   pDependencyInfo) override;
 
-    virtual void ProcessSetSwapchainImageStateCommand(const DeviceInfo* device_info,
-                                                      SwapchainKHRInfo* swapchain_info,
-                                                      uint32_t          last_presented_image,
+    virtual void ProcessSetSwapchainImageStateCommand(const VulkanDeviceInfo* device_info,
+                                                      VulkanSwapchainKHRInfo* swapchain_info,
+                                                      uint32_t                last_presented_image,
                                                       const std::vector<format::SwapchainImageStateInfo>& image_info,
                                                       const VulkanObjectInfoTable& object_info_table,
                                                       SwapchainImageTracker&       swapchain_image_tracker) override
@@ -153,16 +153,16 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
 
     bool AddSwapchainResourceData(VkSwapchainKHR swapchain);
 
-    VkResult CreateSwapchainResourceData(const DeviceInfo*       device_info,
-                                         const SwapchainKHRInfo* swapchain_info,
-                                         uint32_t                capture_image_count,
-                                         uint32_t*               replay_image_count,
-                                         VkImage*                images,
-                                         bool                    offscreen);
+    VkResult CreateSwapchainResourceData(const VulkanDeviceInfo*       device_info,
+                                         const VulkanSwapchainKHRInfo* swapchain_info,
+                                         uint32_t                      capture_image_count,
+                                         uint32_t*                     replay_image_count,
+                                         VkImage*                      images,
+                                         bool                          offscreen);
 
-    void CleanSwapchainResourceData(const DeviceInfo* device_info, const SwapchainKHRInfo* swapchain_info);
+    void CleanSwapchainResourceData(const VulkanDeviceInfo* device_info, const VulkanSwapchainKHRInfo* swapchain_info);
 
-    VkResult CreateVirtualSwapchainImage(const DeviceInfo*        device_info,
+    VkResult CreateVirtualSwapchainImage(const VulkanDeviceInfo*  device_info,
                                          const VkImageCreateInfo& image_create_info,
                                          VirtualImage&            image);
 

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -113,7 +113,7 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
                                                       VulkanSwapchainKHRInfo* swapchain_info,
                                                       uint32_t                last_presented_image,
                                                       const std::vector<format::SwapchainImageStateInfo>& image_info,
-                                                      const VulkanObjectInfoTable& object_info_table,
+                                                      const CommonObjectInfoTable& object_info_table,
                                                       SwapchainImageTracker&       swapchain_image_tracker) override
     {}
 

--- a/framework/generated/base_generators/base_struct_decoders_body_generator.py
+++ b/framework/generated/base_generators/base_struct_decoders_body_generator.py
@@ -21,7 +21,10 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+import re
+import sys
 from base_generator import write
+from copy import deepcopy
 
 
 class BaseStructDecodersBodyGenerator():
@@ -53,27 +56,35 @@ class BaseStructDecodersBodyGenerator():
 
     def make_decode_struct_body(self, name, values):
         """Generate C++ code for the decoder method body."""
-        body = ''
+        preamble = ''
+        main_body = ''
+        epilogue = ''
 
         for value in values:
             # pNext fields require special treatment and are not processed by type name
             if 'pNext' in value.name and value.base_type == 'void':
-                body += '    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->{}));\n'.format(
+                main_body += '    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->{}));\n'.format(
                     value.name
                 )
-                body += '    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;\n'
+                main_body += '    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;\n'
+            elif 'next' == value.name and value.base_type == 'void':
+                main_body += '    bytes_read += DecodeNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->{}));\n'.format(
+                    value.name
+                )
+                main_body += '    value->next = wrapper->next ? wrapper->next->GetPointer() : nullptr;\n'
             else:
-                body += BaseStructDecodersBodyGenerator.make_decode_invocation(
-                    self, name, value
+                preamble, main_body, epilogue = BaseStructDecodersBodyGenerator.make_decode_invocation(
+                    self, name, value, preamble, main_body, epilogue
                 )
 
+        if len(preamble) > 0:
+            preamble += '\n'
+        body = preamble + main_body + epilogue
         return body
 
-    def make_decode_invocation(self, name, value):
+    def make_decode_invocation(self, name, value, preamble, main_body, epilogue):
         """Generate the struct member decoder function call invocation."""
         buffer_args = '(buffer + bytes_read), (buffer_size - bytes_read)'
-
-        body = ''
 
         is_struct = False
         is_class = False
@@ -81,6 +92,7 @@ class BaseStructDecodersBodyGenerator():
         is_funcp = False
         is_handle = False
         is_enum = False
+        is_atom = False
 
         type_name = self.make_invocation_type_name(value.base_type)
 
@@ -94,6 +106,8 @@ class BaseStructDecodersBodyGenerator():
             is_funcp = True
         elif self.is_handle(value.base_type):
             is_handle = True
+        elif self.is_atom(value.base_type):
+            is_atom = True
         elif type_name == 'Enum':
             is_enum = True
 
@@ -101,136 +115,232 @@ class BaseStructDecodersBodyGenerator():
         if value.is_pointer or value.is_array:
             if type_name in self.EXTERNAL_OBJECT_TYPES and not value.is_array:
                 # Pointer to an unknown object type, encoded as a 64-bit integer ID.
-                body += '    bytes_read += ValueDecoder::DecodeAddress({}, &(wrapper->{}));\n'.format(
+                main_body += '    bytes_read += ValueDecoder::DecodeAddress({}, &(wrapper->{}));\n'.format(
                     buffer_args, value.name
                 )
-                body += '    value->{} = nullptr;\n'.format(value.name)
+                main_body += '    value->{} = nullptr;\n'.format(value.name)
             else:
                 is_static_array = True if (
                     value.is_array and not value.is_dynamic
                 ) else False
                 access_op = '.'
 
-                if is_struct:
-                    body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(
-                        value.name, self.make_decoded_param_type(value)
-                    )
-                    access_op = '->'
-
-                if is_static_array:
-                    array_dimension = ''
-                    # dx12 treats 2d array as 1d array. EX: [8][2] -> [16], so dx12's 2d array needs *. 
-                    # But vk keeps 2d array.
-                    if self.is_dx12_class() and value.array_dimension and value.array_dimension > 0:
-                        array_dimension = '*'
-                    # The pointer decoder will write directly to the struct member's memory.
-                    body += '    wrapper->{name}{}SetExternalMemory({}value->{name}, {arraylen});\n'.format(
-                        access_op,
-                        array_dimension,
-                        name=value.name,
-                        arraylen=value.array_capacity
-                    )
-
-                if is_struct or is_string or is_handle or (
-                    is_class and value.pointer_count > 1
-                ):
-                    body += '    bytes_read += wrapper->{}{}Decode({});\n'.format(
-                        value.name, access_op, buffer_args
-                    )
-                elif is_class and value.pointer_count == 1:
-                    body += '    bytes_read += ValueDecoder::DecodeHandleIdValue({}, &(wrapper->{}));\n'.format(
-                        buffer_args, value.name
-                    )
-                elif self.has_basetype(value.base_type):
-                    base_type = self.get_basetype(value.base_type)
-                    body += '    bytes_read += wrapper->{}.Decode{}({});\n'.format(
-                        value.name, self.encode_types[base_type], buffer_args
-                    )
-                else:
-                    body += '    bytes_read += wrapper->{}.Decode{}({});\n'.format(
-                        value.name, type_name, buffer_args
-                    )
-
-                if not is_static_array:
-                    if is_handle or is_class:
-                        # Point the real struct's member pointer to the handle pointer decoder's handle memory.
-                        body += '    value->{} = nullptr;\n'.format(value.name)
-                    else:
-                        # Point the real struct's member pointer to the pointer decoder's memory.
-                        convert_const_cast_begin = ''
-                        convert_const_cast_end = ''
-
-                        if value.full_type.find('LPCWSTR *') != -1:
-                            convert_const_cast_end = ')'
-                            convert_const_cast_begin = 'const_cast<LPCWSTR*>('
-
-                        elif value.full_type.find('LPCSTR *') != -1:
-                            convert_const_cast_end = ')'
-                            convert_const_cast_begin = 'const_cast<LPCSTR*>('
-
-                        body += '    value->{name} = {}wrapper->{name}{}GetPointer(){};\n'.format(
-                            convert_const_cast_begin,
-                            access_op,
-                            convert_const_cast_end,
-                            name=value.name
+                if value.base_type in self.base_header_structs.keys():
+                    if value.pointer_count == 1:
+                        main_body += f'    switch (wrapper->{value.name}->GetPointer()->type)\n'
+                        main_body += '    {\n'
+                        main_body += '        default:\n'
+                        main_body += '            wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(
+                            value.name, self.make_decoded_param_type(value)
                         )
+
+                        if is_static_array:
+                            array_dimension = ''
+                            # The pointer decoder will write directly to the struct member's memory.
+                            main_body += '            wrapper->{name}->SetExternalMemory({}value->{name}, {arraylen});\n'.format(
+                                array_dimension,
+                                name=value.name,
+                                arraylen=value.array_capacity
+                            )
+                        main_body += '            bytes_read += wrapper->{}->Decode({});\n'.format(
+                            value.name, buffer_args
+                        )
+                        main_body += '            break;\n'
+                        for child in self.base_header_structs[value.base_type]:
+                            type = re.sub('([a-z0-9])([A-Z])', r'\1_\2', child)
+                            type = type.upper()
+                            switch_type = re.sub('XR_', 'XR_TYPE_', type)
+                            if 'OPEN_GLESFB' in switch_type:
+                                type = switch_type
+                                switch_type = re.sub('OPEN_GLESFB', 'OPENGL_ES_FB', type)
+
+                            new_value = deepcopy(value)
+                            new_value.base_type = child
+                            decode_type = self.make_decoded_param_type(new_value)
+                            var_name = value.name + '_' + child.lower()
+                            preamble += f'    {decode_type}* {var_name};\n'
+
+                            main_body += f'        case {switch_type}:\n'
+                            main_body += '            {} = DecodeAllocator::Allocate<{}>();\n'.format(
+                                var_name, decode_type
+                            )
+                            main_body += '            bytes_read += {}->Decode({});\n'.format(
+                                var_name, buffer_args
+                            )
+                            main_body += '            wrapper->{} = std::move(reinterpret_cast<StructPointerDecoder<Decoded_{}>*>({}));\n'.format(
+                                value.name, value.base_type, var_name
+                            )
+                            main_body += '            break;\n'
+                        main_body += '    }\n'
+                    else:
+                        # TODO: Doesn't currently support arrays of pointers
+                        main_body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(
+                            value.name, self.make_decoded_param_type(value)
+                        )
+                else:
+                    if is_struct:
+                        main_body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(
+                            value.name, self.make_decoded_param_type(value)
+                        )
+                        access_op = '->'
+
+                    if is_static_array:
+                        array_dimension = ''
+                        # dx12 treats 2d array as 1d array. EX: [8][2] -> [16], so dx12's 2d array needs *.
+                        # But vk keeps 2d array.
+                        if self.is_dx12_class() and value.array_dimension and value.array_dimension > 0:
+                            array_dimension = '*'
+                        # The pointer decoder will write directly to the struct member's memory.
+                        main_body += '    wrapper->{name}{}SetExternalMemory({}value->{name}, {arraylen});\n'.format(
+                            access_op,
+                            array_dimension,
+                            name=value.name,
+                            arraylen=value.array_capacity
+                        )
+
+                    if is_struct or is_string or is_handle or is_atom or (
+                        is_class and value.pointer_count > 1
+                    ):
+                        main_body += '    bytes_read += wrapper->{}{}Decode({});\n'.format(
+                            value.name, access_op, buffer_args
+                        )
+                    elif is_class and value.pointer_count == 1:
+                        main_body += '    bytes_read += ValueDecoder::DecodeHandleIdValue({}, &(wrapper->{}));\n'.format(
+                            buffer_args, value.name
+                        )
+                    elif self.has_basetype(value.base_type):
+                        base_type = self.get_basetype(value.base_type)
+                        main_body += '    bytes_read += wrapper->{}.Decode{}({});\n'.format(
+                            value.name, self.encode_types[base_type], buffer_args
+                        )
+                    else:
+                        main_body += '    bytes_read += wrapper->{}.Decode{}({});\n'.format(
+                            value.name, type_name, buffer_args
+                        )
+
+                    if not is_static_array:
+                        if is_handle or is_atom or is_class:
+                            # Point the real struct's member pointer to the handle pointer decoder's handle memory.
+                            main_body += '    value->{} = nullptr;\n'.format(value.name)
+                        else:
+                            # Point the real struct's member pointer to the pointer decoder's memory.
+                            convert_const_cast_begin = ''
+                            convert_const_cast_end = ''
+
+                            if value.full_type.find('LPCWSTR *') != -1:
+                                convert_const_cast_end = ')'
+                                convert_const_cast_begin = 'const_cast<LPCWSTR*>('
+
+                            elif value.full_type.find('LPCSTR *') != -1:
+                                convert_const_cast_end = ')'
+                                convert_const_cast_begin = 'const_cast<LPCSTR*>('
+
+                            main_body += '    value->{name} = {}wrapper->{name}{}GetPointer(){};\n'.format(
+                                convert_const_cast_begin,
+                                access_op,
+                                convert_const_cast_end,
+                                name=value.name
+                            )
         else:
             if is_struct:
-                body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(
-                    value.name, self.make_decoded_param_type(value)
-                )
-                body += '    wrapper->{name}->decoded_value = &(value->{name});\n'.format(
-                    name=value.name
-                )
-                body += '    bytes_read += DecodeStruct({}, wrapper->{});\n'.format(
-                    buffer_args, value.name
-                )
+                if value.base_type in self.base_header_structs.keys():
+                    main_body += f'        switch ({value.name}->GetPointer()->type)\n'
+                    main_body += '        {\n'
+                    main_body += '            default:\n'
+                    main_body += '                wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(
+                        value.name, self.make_decoded_param_type(value)
+                    )
+                    main_body += '                wrapper->{name}->decoded_value = &(value->{name});\n'.format(
+                        name=value.name
+                    )
+                    main_body += '                bytes_read += DecodeStruct({}, wrapper->{});\n'.format(
+                        buffer_args, value.name
+                    )
+                    main_body += '                break;\n'
+                    for child in self.base_header_structs[value.base_type]:
+                        type = re.sub('([a-z0-9])([A-Z])', r'\1_\2', child)
+                        type = type.upper()
+                        switch_type = re.sub('XR_', 'XR_TYPE_', type)
+                        if 'OPEN_GLESFB' in switch_type:
+                            type = switch_type
+                            switch_type = re.sub('OPEN_GLESFB', 'OPENGL_ES_FB', type)
+
+                        new_value = deepcopy(value)
+                        new_value.base_type = child
+                        decode_type = self.make_decoded_param_type(new_value)
+                        var_name = value.name + '_' + child.lower()
+                        preamble += f'    {decode_type}* {var_name};\n'
+
+                        main_body += f'            case {switch_type}:\n'
+
+                        main_body += '            {} = DecodeAllocator::Allocate<{}>();\n'.format(
+                            var_name, decode_type
+                        )
+                        main_body += '            bytes_read += {}->Decode({});\n'.format(
+                            var_name, buffer_args
+                        )
+                        main_body += '            wrapper->{} = std::move(reinterpret_cast<StructPointerDecoder<Decoded_{}>*>({}));\n'.format(
+                            value.name, value.base_type, var_name
+                        )
+                        main_body += '            break;\n'
+                    main_body += '        }\n'
+                else:
+                    main_body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(
+                        value.name, self.make_decoded_param_type(value)
+                    )
+                    main_body += '    wrapper->{name}->decoded_value = &(value->{name});\n'.format(
+                        name=value.name
+                    )
+                    main_body += '    bytes_read += DecodeStruct({}, wrapper->{});\n'.format(
+                        buffer_args, value.name
+                    )
             elif is_funcp:
-                body += '    bytes_read += ValueDecoder::DecodeAddress({}, &(wrapper->{}));\n'.format(
+                main_body += '    bytes_read += ValueDecoder::DecodeAddress({}, &(wrapper->{}));\n'.format(
                     buffer_args, value.name
                 )
-                body += '    value->{} = nullptr;\n'.format(value.name)
-            elif is_handle:
-                body += '    bytes_read += ValueDecoder::DecodeHandleIdValue({}, &(wrapper->{}));\n'.format(
+                main_body += '    value->{} = nullptr;\n'.format(value.name)
+            elif is_handle or is_atom:
+                main_body += '    bytes_read += ValueDecoder::DecodeHandleIdValue({}, &(wrapper->{}));\n'.format(
                     buffer_args, value.name
                 )
-                body += '    value->{} = VK_NULL_HANDLE;\n'.format(value.name)
+                default_type = self.get_default_handle_atom_value(value.base_type)
+                main_body += '    value->{} = {};\n'.format(value.name, default_type)
             elif self.is_generic_struct_handle_value(name, value.name):
-                body += '    bytes_read += ValueDecoder::DecodeUInt64Value({}, &(wrapper->{}));\n'.format(
+                main_body += '    bytes_read += ValueDecoder::DecodeUInt64Value({}, &(wrapper->{}));\n'.format(
                     buffer_args, value.name
                 )
-                body += '    value->{} = 0;\n'.format(value.name)
+                main_body += '    value->{} = 0;\n'.format(value.name)
             elif value.bitfield_width:
                 # Bit fields need to be read into a tempoaray and then assigned to the struct member.
                 temp_param_name = 'temp_{}'.format(value.name)
-                body += '    {} {};\n'.format(value.base_type, temp_param_name)
-                body += '    bytes_read += ValueDecoder::Decode{}Value({}, &{});\n'.format(
+                main_body += '    {} {};\n'.format(value.base_type, temp_param_name)
+                main_body += '    bytes_read += ValueDecoder::Decode{}Value({}, &{});\n'.format(
                     type_name, buffer_args, temp_param_name
                 )
-                body += '    value->{} = {};\n'.format(
+                main_body += '    value->{} = {};\n'.format(
                     value.name, temp_param_name
                 )
             elif is_enum:
-                body += '    bytes_read += ValueDecoder::DecodeEnumValue({}, &(value->{}));\n'.format(
+                main_body += '    bytes_read += ValueDecoder::DecodeEnumValue({}, &(value->{}));\n'.format(
                     buffer_args, value.name
                 )
             elif self.has_basetype(type_name):
                 base_type = self.get_basetype(type_name)
-                body += '    bytes_read += ValueDecoder::Decode{}Value({}, &(value->{}));\n'.format(
+                main_body += '    bytes_read += ValueDecoder::Decode{}Value({}, &(value->{}));\n'.format(
                     self.encode_types[base_type], buffer_args, value.name
                 )
             elif 'Flags' in type_name:
                 if 'Flags64' in type_name:
-                    body += '    bytes_read += ValueDecoder::DecodeFlags64Value({}, &(value->{}));\n'.format(
+                    main_body += '    bytes_read += ValueDecoder::DecodeFlags64Value({}, &(value->{}));\n'.format(
                         buffer_args, value.name
                     )
                 else:
-                    body += '    bytes_read += ValueDecoder::DecodeFlagsValue({}, &(value->{}));\n'.format(
+                    main_body += '    bytes_read += ValueDecoder::DecodeFlagsValue({}, &(value->{}));\n'.format(
                         buffer_args, value.name
                     )
             else:
-                body += '    bytes_read += ValueDecoder::Decode{}Value({}, &(value->{}));\n'.format(
+                main_body += '    bytes_read += ValueDecoder::Decode{}Value({}, &(value->{}));\n'.format(
                     type_name, buffer_args, value.name
                 )
 
-        return body
+        return preamble, main_body, epilogue

--- a/framework/generated/base_generators/base_struct_handle_mappers_body_generator.py
+++ b/framework/generated/base_generators/base_struct_handle_mappers_body_generator.py
@@ -233,9 +233,10 @@ class BaseStructHandleMappersBodyGenerator():
             else:
                 type = member.base_type
                 if not is_dx12_class:
-                    type = member.base_type[2:] + 'Info'
+                    type = 'Vulkan' + member.base_type[2:] + 'Info'
+                    func_id = member.base_type + 'Info'
                     object_info_table_get = ', &VulkanObjectInfoTable::Get{}'.format(
-                        type
+                        func_id
                     )
 
                 # If it is an array or pointer, map with the utility function.
@@ -331,9 +332,10 @@ class BaseStructHandleMappersBodyGenerator():
             else:
                 type = member.base_type
                 if not is_dx12_class:
-                    type = member.base_type[2:] + 'Info'
+                    type = 'Vulkan' + member.base_type[2:] + 'Info'
+                    func_id = member.base_type + 'Info'
                     object_info_table_add = ', &VulkanObjectInfoTable::Add{}'.format(
-                        type
+                        func_id
                     )
 
                 # If it is an array or pointer, add with the utility function.

--- a/framework/generated/base_generators/base_struct_handle_mappers_header_generator.py
+++ b/framework/generated/base_generators/base_struct_handle_mappers_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2019-2020 Valve Corporation
-# Copyright (c) 2019-2020 LunarG, Inc.
+# Copyright (c) 2019-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -29,7 +29,8 @@ class BaseStructHandleMappersHeaderGenerator():
     """Base class for generating struct handle mappers header code."""
 
     def endFile(self):
-        platform_type = 'Vulkan'
+        platform_type = self.get_api_prefix()
+        object_type = 'Common'
         map_types = 'Handles'
         map_type = 'Handle'
         map_table = ''
@@ -37,7 +38,7 @@ class BaseStructHandleMappersHeaderGenerator():
 
         is_dx12_class = self.is_dx12_class()
         if is_dx12_class:
-            platform_type = 'Dx12'
+            object_type = platform_type
             map_types = 'Objects'
             map_type = 'Object'
             map_table = ', const graphics::Dx12GpuVaMap& gpu_va_map'
@@ -45,72 +46,81 @@ class BaseStructHandleMappersHeaderGenerator():
 
         if not is_dx12_class:
             self.newline()
-            write(
-                'void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectInfoTable& object_info_table);',
-                file=self.outFile
-            )
+            if platform_type == 'Vulkan':
+                write(
+                    f'void MapPNextStructHandles(const void* value, void* wrapper, const CommonObjectInfoTable& object_info_table);',
+                    file=self.outFile
+                )
+            else:
+                write(
+                    f'void MapNextStructHandles(const void* value, void* wrapper, const CommonObjectInfoTable& object_info_table);',
+                    file=self.outFile
+                )
 
         self.newline()
-        write('template <typename T>', file=self.outFile)
-        write(
-            'void MapStructArray{}(T* structs, size_t len, const {}ObjectInfoTable& object_info_table{})'
-            .format(map_types, platform_type, map_table),
-            file=self.outFile
-        )
-        write('{', file=self.outFile)
-        write('    if (structs != nullptr)', file=self.outFile)
-        write('    {', file=self.outFile)
-        write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
-        write('        {', file=self.outFile)
-        write(
-            '            MapStruct{}(&structs[i], object_info_table{});'.
-            format(map_types, map_object),
-            file=self.outFile
-        )
-        write('        }', file=self.outFile)
-        write('    }', file=self.outFile)
-        write('}', file=self.outFile)
-        self.newline()
+
+        if is_dx12_class:
+            write('template <typename T>', file=self.outFile)
+            write(
+                'void MapStructArray{}(T* structs, size_t len, const {}ObjectInfoTable& object_info_table{})'
+                .format(map_types, object_type, map_table),
+                file=self.outFile
+            )
+            write('{', file=self.outFile)
+            write('    if (structs != nullptr)', file=self.outFile)
+            write('    {', file=self.outFile)
+            write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
+            write('        {', file=self.outFile)
+            write(
+                '            MapStruct{}(&structs[i], object_info_table{});'.
+                format(map_types, map_object),
+                file=self.outFile
+            )
+            write('        }', file=self.outFile)
+            write('    }', file=self.outFile)
+            write('}', file=self.outFile)
+            self.newline()
 
         for struct in self.output_structs_with_handles:
             write(
                 'void AddStruct{}(format::HandleId parent_id, const Decoded_{type}* id_wrapper, const {type}* handle_struct, {}ObjectInfoTable* object_info_table{});'
-                .format(map_types, platform_type, map_table, type=struct),
+                .format(map_types, object_type, map_table, type=struct),
                 file=self.outFile
             )
             self.newline()
 
-        write('template <typename T>', file=self.outFile)
-        write(
-            'void AddStructArray{}(format::HandleId parent_id, const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, {}ObjectInfoTable* object_info_table{})'
-            .format(map_types, platform_type, map_table),
-            file=self.outFile
-        )
-        write('{', file=self.outFile)
-        write(
-            '    if (id_wrappers != nullptr && handle_structs != nullptr)',
-            file=self.outFile
-        )
-        write('    {', file=self.outFile)
-        write(
-            '        // TODO: Improved handling of array size mismatch.',
-            file=self.outFile
-        )
-        write(
-            '        size_t len = std::min(id_len, handle_len);',
-            file=self.outFile
-        )
-        write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
-        write('        {', file=self.outFile)
-        write(
-            '            AddStruct{}(parent_id, &id_wrappers[i], &handle_structs[i], object_info_table);'
-            .format(map_types),
-            file=self.outFile
-        )
-        write('        }', file=self.outFile)
-        write('    }', file=self.outFile)
-        write('}', file=self.outFile)
-        self.newline()
+        if is_dx12_class:
+            write('template <typename T>', file=self.outFile)
+            write(
+                'void AddStructArray{}(format::HandleId parent_id, const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, {}ObjectInfoTable* object_info_table{})'
+                .format(map_types, object_type, map_table),
+                file=self.outFile
+            )
+            write('{', file=self.outFile)
+            write(
+                '    if (id_wrappers != nullptr && handle_structs != nullptr)',
+                file=self.outFile
+            )
+            write('    {', file=self.outFile)
+            write(
+                '        // TODO: Improved handling of array size mismatch.',
+                file=self.outFile
+            )
+            write(
+                '        size_t len = std::min(id_len, handle_len);',
+                file=self.outFile
+            )
+            write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
+            write('        {', file=self.outFile)
+            write(
+                '            AddStruct{}(parent_id, &id_wrappers[i], &handle_structs[i], object_info_table);'
+                .format(map_types),
+                file=self.outFile
+            )
+            write('        }', file=self.outFile)
+            write('    }', file=self.outFile)
+            write('}', file=self.outFile)
+            self.newline()
 
         for struct in self.output_structs_with_handles:
             if struct in self.structs_with_handle_ptrs:
@@ -121,36 +131,39 @@ class BaseStructHandleMappersHeaderGenerator():
                 )
                 self.newline()
 
-        write('template <typename T>', file=self.outFile)
-        write(
-            'void SetStructArray{}Lengths(T* wrappers, size_t len)'.
-            format(map_type),
-            file=self.outFile
-        )
-        write('{', file=self.outFile)
-        write('    if (wrappers != nullptr)', file=self.outFile)
-        write('    {', file=self.outFile)
-        write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
-        write('        {', file=self.outFile)
-        write(
-            '            SetStruct{}Lengths(&wrappers[i]);'.format(map_type),
-            file=self.outFile
-        )
-        write('        }', file=self.outFile)
-        write('    }', file=self.outFile)
-        write('}', file=self.outFile)
-        self.newline()
+        if is_dx12_class:
+            write('template <typename T>', file=self.outFile)
+            write(
+                'void SetStructArray{}Lengths(T* wrappers, size_t len)'.
+                format(map_type),
+                file=self.outFile
+            )
+            write('{', file=self.outFile)
+            write('    if (wrappers != nullptr)', file=self.outFile)
+            write('    {', file=self.outFile)
+            write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
+            write('        {', file=self.outFile)
+            write(
+                '            SetStruct{}Lengths(&wrappers[i]);'.format(map_type),
+                file=self.outFile
+            )
+            write('        }', file=self.outFile)
+            write('    }', file=self.outFile)
+            write('}', file=self.outFile)
+            self.newline()
+        else:
+            write('#include "decode/common_struct_handle_mappers.h"', file=self.outFile)
 
         write('GFXRECON_END_NAMESPACE(decode)', file=self.outFile)
         write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)
 
     def generate_feature(self):
         """Performs C++ code generation for the feature."""
-        platform_type = 'Vulkan'
+        object_table = 'Common'
         map_type = 'Handles'
         map_table = ''
         if self.is_dx12_class():
-            platform_type = 'Dx12'
+            object_table = 'Dx12'
             map_type = 'Objects'
             map_table = ', const graphics::Dx12GpuVaMap& gpu_va_map'
 
@@ -162,6 +175,6 @@ class BaseStructHandleMappersHeaderGenerator():
             ) and (struct not in self.STRUCT_MAPPERS_BLACKLIST):
                 body = '\n'
                 body += 'void MapStruct{}(Decoded_{}* wrapper, const {}ObjectInfoTable& object_info_table{});'.format(
-                    map_type, struct, platform_type, map_table
+                    map_type, struct, object_table, map_table
                 )
                 write(body, file=self.outFile)

--- a/framework/generated/dx12_generators/dx12_base_generator.py
+++ b/framework/generated/dx12_generators/dx12_base_generator.py
@@ -166,13 +166,14 @@ class Dx12BaseGenerator(BaseGenerator):
         dx12_prefix_strings,
         err_file=sys.stderr,
         warn_file=sys.stderr,
-        diag_file=sys.stdout
+        diag_file=sys.stdout,
+        feature_break=True
     ):
         BaseGenerator.__init__(
             self,
             process_cmds=True,
             process_structs=True,
-            feature_break=True,
+            feature_break=feature_break,
             err_file=err_file,
             warn_file=warn_file,
             diag_file=diag_file
@@ -375,7 +376,7 @@ class Dx12BaseGenerator(BaseGenerator):
     def get_api_prefix(self):
         return 'Dx12'
 
-    def get_prefix_from_type(self):
+    def get_prefix_from_type(self, type):
         return 'Dx12'
 
     def get_wrapper_prefix_from_type(self):

--- a/framework/generated/dx12_generators/dx12_decoder_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_decoder_body_generator.py
@@ -20,6 +20,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+import sys
 from base_generator import write
 from dx12_base_generator import Dx12BaseGenerator
 from dx12_decoder_header_generator import Dx12DecoderHeaderGenerator
@@ -32,6 +33,17 @@ class Dx12DecoderBodyGenerator(
     BaseDecoderBodyGenerator
 ):
     """Generates C++ functions responsible for decoding Dx12 API calls."""
+    def __init__(self, source_dict, dx12_prefix_strings, diag_file):
+        Dx12DecoderHeaderGenerator.__init__(self, source_dict, dx12_prefix_strings,
+            err_file=sys.stderr,
+            warn_file=sys.stderr,
+            diag_file=sys.stdout,
+            feature_break=False
+            )
+        
+        BaseStructDecodersBodyGenerator.__init__(self)
+        BaseDecoderBodyGenerator.__init__(self)
+
 
     def write_include(self):
         """Method override."""
@@ -46,11 +58,11 @@ class Dx12DecoderBodyGenerator(
 
     def generate_feature(self):
         """Method override."""
-        self.cmd_names = []
         self.method_names = []
         Dx12BaseGenerator.generate_feature(self)
         self.write_function_call()
         BaseDecoderBodyGenerator.generate_feature(self)
+        BaseDecoderBodyGenerator.generate_commands(self) # Dx12 only has one "feature", so no need to push this to endFile
         self.newline()
         self.generate_dx12_method_feature()
 

--- a/framework/generated/dx12_generators/dx12_decoder_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_decoder_header_generator.py
@@ -37,11 +37,12 @@ class Dx12DecoderHeaderGenerator(
         dx12_prefix_strings,
         err_file=sys.stderr,
         warn_file=sys.stderr,
-        diag_file=sys.stdout
+        diag_file=sys.stdout,
+        feature_break=True
     ):
         Dx12BaseGenerator.__init__(
             self, source_dict, dx12_prefix_strings, err_file, warn_file,
-            diag_file
+            diag_file, feature_break=feature_break
         )
 
     def beginFile(self, gen_opts):

--- a/framework/generated/generated_vulkan_object_info_table_base2.h
+++ b/framework/generated/generated_vulkan_object_info_table_base2.h
@@ -42,300 +42,300 @@ class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase
     VulkanObjectInfoTableBase2() {}
     ~VulkanObjectInfoTableBase2() {}
 
-    void AddAccelerationStructureKHRInfo(AccelerationStructureKHRInfo&& info) { AddObjectInfo(std::move(info), &accelerationStructureKHR_map_); }
-    void AddAccelerationStructureNVInfo(AccelerationStructureNVInfo&& info) { AddObjectInfo(std::move(info), &accelerationStructureNV_map_); }
-    void AddBufferInfo(BufferInfo&& info) { AddObjectInfo(std::move(info), &buffer_map_); }
-    void AddBufferViewInfo(BufferViewInfo&& info) { AddObjectInfo(std::move(info), &bufferView_map_); }
-    void AddCommandBufferInfo(CommandBufferInfo&& info) { AddObjectInfo(std::move(info), &commandBuffer_map_); }
-    void AddCommandPoolInfo(CommandPoolInfo&& info) { AddObjectInfo(std::move(info), &commandPool_map_); }
-    void AddDebugReportCallbackEXTInfo(DebugReportCallbackEXTInfo&& info) { AddObjectInfo(std::move(info), &debugReportCallbackEXT_map_); }
-    void AddDebugUtilsMessengerEXTInfo(DebugUtilsMessengerEXTInfo&& info) { AddObjectInfo(std::move(info), &debugUtilsMessengerEXT_map_); }
-    void AddDeferredOperationKHRInfo(DeferredOperationKHRInfo&& info) { AddObjectInfo(std::move(info), &deferredOperationKHR_map_); }
-    void AddDescriptorPoolInfo(DescriptorPoolInfo&& info) { AddObjectInfo(std::move(info), &descriptorPool_map_); }
-    void AddDescriptorSetInfo(DescriptorSetInfo&& info) { AddObjectInfo(std::move(info), &descriptorSet_map_); }
-    void AddDescriptorSetLayoutInfo(DescriptorSetLayoutInfo&& info) { AddObjectInfo(std::move(info), &descriptorSetLayout_map_); }
-    void AddDescriptorUpdateTemplateInfo(DescriptorUpdateTemplateInfo&& info) { AddObjectInfo(std::move(info), &descriptorUpdateTemplate_map_); }
-    void AddDeviceInfo(DeviceInfo&& info) { AddObjectInfo(std::move(info), &device_map_); }
-    void AddDeviceMemoryInfo(DeviceMemoryInfo&& info) { AddObjectInfo(std::move(info), &deviceMemory_map_); }
-    void AddDisplayKHRInfo(DisplayKHRInfo&& info) { AddObjectInfo(std::move(info), &displayKHR_map_); }
-    void AddDisplayModeKHRInfo(DisplayModeKHRInfo&& info) { AddObjectInfo(std::move(info), &displayModeKHR_map_); }
-    void AddEventInfo(EventInfo&& info) { AddObjectInfo(std::move(info), &event_map_); }
-    void AddFenceInfo(FenceInfo&& info) { AddObjectInfo(std::move(info), &fence_map_); }
-    void AddFramebufferInfo(FramebufferInfo&& info) { AddObjectInfo(std::move(info), &framebuffer_map_); }
-    void AddImageInfo(ImageInfo&& info) { AddObjectInfo(std::move(info), &image_map_); }
-    void AddImageViewInfo(ImageViewInfo&& info) { AddObjectInfo(std::move(info), &imageView_map_); }
-    void AddIndirectCommandsLayoutEXTInfo(IndirectCommandsLayoutEXTInfo&& info) { AddObjectInfo(std::move(info), &indirectCommandsLayoutEXT_map_); }
-    void AddIndirectCommandsLayoutNVInfo(IndirectCommandsLayoutNVInfo&& info) { AddObjectInfo(std::move(info), &indirectCommandsLayoutNV_map_); }
-    void AddIndirectExecutionSetEXTInfo(IndirectExecutionSetEXTInfo&& info) { AddObjectInfo(std::move(info), &indirectExecutionSetEXT_map_); }
-    void AddInstanceInfo(InstanceInfo&& info) { AddObjectInfo(std::move(info), &instance_map_); }
-    void AddMicromapEXTInfo(MicromapEXTInfo&& info) { AddObjectInfo(std::move(info), &micromapEXT_map_); }
-    void AddOpticalFlowSessionNVInfo(OpticalFlowSessionNVInfo&& info) { AddObjectInfo(std::move(info), &opticalFlowSessionNV_map_); }
-    void AddPerformanceConfigurationINTELInfo(PerformanceConfigurationINTELInfo&& info) { AddObjectInfo(std::move(info), &performanceConfigurationINTEL_map_); }
-    void AddPhysicalDeviceInfo(PhysicalDeviceInfo&& info) { AddObjectInfo(std::move(info), &physicalDevice_map_); }
-    void AddPipelineInfo(PipelineInfo&& info) { AddObjectInfo(std::move(info), &pipeline_map_); }
-    void AddPipelineBinaryKHRInfo(PipelineBinaryKHRInfo&& info) { AddObjectInfo(std::move(info), &pipelineBinaryKHR_map_); }
-    void AddPipelineCacheInfo(PipelineCacheInfo&& info) { AddObjectInfo(std::move(info), &pipelineCache_map_); }
-    void AddPipelineLayoutInfo(PipelineLayoutInfo&& info) { AddObjectInfo(std::move(info), &pipelineLayout_map_); }
-    void AddPrivateDataSlotInfo(PrivateDataSlotInfo&& info) { AddObjectInfo(std::move(info), &privateDataSlot_map_); }
-    void AddQueryPoolInfo(QueryPoolInfo&& info) { AddObjectInfo(std::move(info), &queryPool_map_); }
-    void AddQueueInfo(QueueInfo&& info) { AddObjectInfo(std::move(info), &queue_map_); }
-    void AddRenderPassInfo(RenderPassInfo&& info) { AddObjectInfo(std::move(info), &renderPass_map_); }
-    void AddSamplerInfo(SamplerInfo&& info) { AddObjectInfo(std::move(info), &sampler_map_); }
-    void AddSamplerYcbcrConversionInfo(SamplerYcbcrConversionInfo&& info) { AddObjectInfo(std::move(info), &samplerYcbcrConversion_map_); }
-    void AddSemaphoreInfo(SemaphoreInfo&& info) { AddObjectInfo(std::move(info), &semaphore_map_); }
-    void AddShaderEXTInfo(ShaderEXTInfo&& info) { AddObjectInfo(std::move(info), &shaderEXT_map_); }
-    void AddShaderModuleInfo(ShaderModuleInfo&& info) { AddObjectInfo(std::move(info), &shaderModule_map_); }
-    void AddSurfaceKHRInfo(SurfaceKHRInfo&& info) { AddObjectInfo(std::move(info), &surfaceKHR_map_); }
-    void AddSwapchainKHRInfo(SwapchainKHRInfo&& info) { AddObjectInfo(std::move(info), &swapchainKHR_map_); }
-    void AddValidationCacheEXTInfo(ValidationCacheEXTInfo&& info) { AddObjectInfo(std::move(info), &validationCacheEXT_map_); }
-    void AddVideoSessionKHRInfo(VideoSessionKHRInfo&& info) { AddObjectInfo(std::move(info), &videoSessionKHR_map_); }
-    void AddVideoSessionParametersKHRInfo(VideoSessionParametersKHRInfo&& info) { AddObjectInfo(std::move(info), &videoSessionParametersKHR_map_); }
+    void AddVkAccelerationStructureKHRInfo(VulkanAccelerationStructureKHRInfo&& info) { AddObjectInfo(std::move(info), &accelerationStructureKHR_map_); }
+    void AddVkAccelerationStructureNVInfo(VulkanAccelerationStructureNVInfo&& info) { AddObjectInfo(std::move(info), &accelerationStructureNV_map_); }
+    void AddVkBufferInfo(VulkanBufferInfo&& info) { AddObjectInfo(std::move(info), &buffer_map_); }
+    void AddVkBufferViewInfo(VulkanBufferViewInfo&& info) { AddObjectInfo(std::move(info), &bufferView_map_); }
+    void AddVkCommandBufferInfo(VulkanCommandBufferInfo&& info) { AddObjectInfo(std::move(info), &commandBuffer_map_); }
+    void AddVkCommandPoolInfo(VulkanCommandPoolInfo&& info) { AddObjectInfo(std::move(info), &commandPool_map_); }
+    void AddVkDebugReportCallbackEXTInfo(VulkanDebugReportCallbackEXTInfo&& info) { AddObjectInfo(std::move(info), &debugReportCallbackEXT_map_); }
+    void AddVkDebugUtilsMessengerEXTInfo(VulkanDebugUtilsMessengerEXTInfo&& info) { AddObjectInfo(std::move(info), &debugUtilsMessengerEXT_map_); }
+    void AddVkDeferredOperationKHRInfo(VulkanDeferredOperationKHRInfo&& info) { AddObjectInfo(std::move(info), &deferredOperationKHR_map_); }
+    void AddVkDescriptorPoolInfo(VulkanDescriptorPoolInfo&& info) { AddObjectInfo(std::move(info), &descriptorPool_map_); }
+    void AddVkDescriptorSetInfo(VulkanDescriptorSetInfo&& info) { AddObjectInfo(std::move(info), &descriptorSet_map_); }
+    void AddVkDescriptorSetLayoutInfo(VulkanDescriptorSetLayoutInfo&& info) { AddObjectInfo(std::move(info), &descriptorSetLayout_map_); }
+    void AddVkDescriptorUpdateTemplateInfo(VulkanDescriptorUpdateTemplateInfo&& info) { AddObjectInfo(std::move(info), &descriptorUpdateTemplate_map_); }
+    void AddVkDeviceInfo(VulkanDeviceInfo&& info) { AddObjectInfo(std::move(info), &device_map_); }
+    void AddVkDeviceMemoryInfo(VulkanDeviceMemoryInfo&& info) { AddObjectInfo(std::move(info), &deviceMemory_map_); }
+    void AddVkDisplayKHRInfo(VulkanDisplayKHRInfo&& info) { AddObjectInfo(std::move(info), &displayKHR_map_); }
+    void AddVkDisplayModeKHRInfo(VulkanDisplayModeKHRInfo&& info) { AddObjectInfo(std::move(info), &displayModeKHR_map_); }
+    void AddVkEventInfo(VulkanEventInfo&& info) { AddObjectInfo(std::move(info), &event_map_); }
+    void AddVkFenceInfo(VulkanFenceInfo&& info) { AddObjectInfo(std::move(info), &fence_map_); }
+    void AddVkFramebufferInfo(VulkanFramebufferInfo&& info) { AddObjectInfo(std::move(info), &framebuffer_map_); }
+    void AddVkImageInfo(VulkanImageInfo&& info) { AddObjectInfo(std::move(info), &image_map_); }
+    void AddVkImageViewInfo(VulkanImageViewInfo&& info) { AddObjectInfo(std::move(info), &imageView_map_); }
+    void AddVkIndirectCommandsLayoutEXTInfo(VulkanIndirectCommandsLayoutEXTInfo&& info) { AddObjectInfo(std::move(info), &indirectCommandsLayoutEXT_map_); }
+    void AddVkIndirectCommandsLayoutNVInfo(VulkanIndirectCommandsLayoutNVInfo&& info) { AddObjectInfo(std::move(info), &indirectCommandsLayoutNV_map_); }
+    void AddVkIndirectExecutionSetEXTInfo(VulkanIndirectExecutionSetEXTInfo&& info) { AddObjectInfo(std::move(info), &indirectExecutionSetEXT_map_); }
+    void AddVkInstanceInfo(VulkanInstanceInfo&& info) { AddObjectInfo(std::move(info), &instance_map_); }
+    void AddVkMicromapEXTInfo(VulkanMicromapEXTInfo&& info) { AddObjectInfo(std::move(info), &micromapEXT_map_); }
+    void AddVkOpticalFlowSessionNVInfo(VulkanOpticalFlowSessionNVInfo&& info) { AddObjectInfo(std::move(info), &opticalFlowSessionNV_map_); }
+    void AddVkPerformanceConfigurationINTELInfo(VulkanPerformanceConfigurationINTELInfo&& info) { AddObjectInfo(std::move(info), &performanceConfigurationINTEL_map_); }
+    void AddVkPhysicalDeviceInfo(VulkanPhysicalDeviceInfo&& info) { AddObjectInfo(std::move(info), &physicalDevice_map_); }
+    void AddVkPipelineInfo(VulkanPipelineInfo&& info) { AddObjectInfo(std::move(info), &pipeline_map_); }
+    void AddVkPipelineBinaryKHRInfo(VulkanPipelineBinaryKHRInfo&& info) { AddObjectInfo(std::move(info), &pipelineBinaryKHR_map_); }
+    void AddVkPipelineCacheInfo(VulkanPipelineCacheInfo&& info) { AddObjectInfo(std::move(info), &pipelineCache_map_); }
+    void AddVkPipelineLayoutInfo(VulkanPipelineLayoutInfo&& info) { AddObjectInfo(std::move(info), &pipelineLayout_map_); }
+    void AddVkPrivateDataSlotInfo(VulkanPrivateDataSlotInfo&& info) { AddObjectInfo(std::move(info), &privateDataSlot_map_); }
+    void AddVkQueryPoolInfo(VulkanQueryPoolInfo&& info) { AddObjectInfo(std::move(info), &queryPool_map_); }
+    void AddVkQueueInfo(VulkanQueueInfo&& info) { AddObjectInfo(std::move(info), &queue_map_); }
+    void AddVkRenderPassInfo(VulkanRenderPassInfo&& info) { AddObjectInfo(std::move(info), &renderPass_map_); }
+    void AddVkSamplerInfo(VulkanSamplerInfo&& info) { AddObjectInfo(std::move(info), &sampler_map_); }
+    void AddVkSamplerYcbcrConversionInfo(VulkanSamplerYcbcrConversionInfo&& info) { AddObjectInfo(std::move(info), &samplerYcbcrConversion_map_); }
+    void AddVkSemaphoreInfo(VulkanSemaphoreInfo&& info) { AddObjectInfo(std::move(info), &semaphore_map_); }
+    void AddVkShaderEXTInfo(VulkanShaderEXTInfo&& info) { AddObjectInfo(std::move(info), &shaderEXT_map_); }
+    void AddVkShaderModuleInfo(VulkanShaderModuleInfo&& info) { AddObjectInfo(std::move(info), &shaderModule_map_); }
+    void AddVkSurfaceKHRInfo(VulkanSurfaceKHRInfo&& info) { AddObjectInfo(std::move(info), &surfaceKHR_map_); }
+    void AddVkSwapchainKHRInfo(VulkanSwapchainKHRInfo&& info) { AddObjectInfo(std::move(info), &swapchainKHR_map_); }
+    void AddVkValidationCacheEXTInfo(VulkanValidationCacheEXTInfo&& info) { AddObjectInfo(std::move(info), &validationCacheEXT_map_); }
+    void AddVkVideoSessionKHRInfo(VulkanVideoSessionKHRInfo&& info) { AddObjectInfo(std::move(info), &videoSessionKHR_map_); }
+    void AddVkVideoSessionParametersKHRInfo(VulkanVideoSessionParametersKHRInfo&& info) { AddObjectInfo(std::move(info), &videoSessionParametersKHR_map_); }
 
-    void RemoveAccelerationStructureKHRInfo(format::HandleId id) { accelerationStructureKHR_map_.erase(id); }
-    void RemoveAccelerationStructureNVInfo(format::HandleId id) { accelerationStructureNV_map_.erase(id); }
-    void RemoveBufferInfo(format::HandleId id) { buffer_map_.erase(id); }
-    void RemoveBufferViewInfo(format::HandleId id) { bufferView_map_.erase(id); }
-    void RemoveCommandBufferInfo(format::HandleId id) { commandBuffer_map_.erase(id); }
-    void RemoveCommandPoolInfo(format::HandleId id) { commandPool_map_.erase(id); }
-    void RemoveDebugReportCallbackEXTInfo(format::HandleId id) { debugReportCallbackEXT_map_.erase(id); }
-    void RemoveDebugUtilsMessengerEXTInfo(format::HandleId id) { debugUtilsMessengerEXT_map_.erase(id); }
-    void RemoveDeferredOperationKHRInfo(format::HandleId id) { deferredOperationKHR_map_.erase(id); }
-    void RemoveDescriptorPoolInfo(format::HandleId id) { descriptorPool_map_.erase(id); }
-    void RemoveDescriptorSetInfo(format::HandleId id) { descriptorSet_map_.erase(id); }
-    void RemoveDescriptorSetLayoutInfo(format::HandleId id) { descriptorSetLayout_map_.erase(id); }
-    void RemoveDescriptorUpdateTemplateInfo(format::HandleId id) { descriptorUpdateTemplate_map_.erase(id); }
-    void RemoveDeviceInfo(format::HandleId id) { device_map_.erase(id); }
-    void RemoveDeviceMemoryInfo(format::HandleId id) { deviceMemory_map_.erase(id); }
-    void RemoveDisplayKHRInfo(format::HandleId id) { displayKHR_map_.erase(id); }
-    void RemoveDisplayModeKHRInfo(format::HandleId id) { displayModeKHR_map_.erase(id); }
-    void RemoveEventInfo(format::HandleId id) { event_map_.erase(id); }
-    void RemoveFenceInfo(format::HandleId id) { fence_map_.erase(id); }
-    void RemoveFramebufferInfo(format::HandleId id) { framebuffer_map_.erase(id); }
-    void RemoveImageInfo(format::HandleId id) { image_map_.erase(id); }
-    void RemoveImageViewInfo(format::HandleId id) { imageView_map_.erase(id); }
-    void RemoveIndirectCommandsLayoutEXTInfo(format::HandleId id) { indirectCommandsLayoutEXT_map_.erase(id); }
-    void RemoveIndirectCommandsLayoutNVInfo(format::HandleId id) { indirectCommandsLayoutNV_map_.erase(id); }
-    void RemoveIndirectExecutionSetEXTInfo(format::HandleId id) { indirectExecutionSetEXT_map_.erase(id); }
-    void RemoveInstanceInfo(format::HandleId id) { instance_map_.erase(id); }
-    void RemoveMicromapEXTInfo(format::HandleId id) { micromapEXT_map_.erase(id); }
-    void RemoveOpticalFlowSessionNVInfo(format::HandleId id) { opticalFlowSessionNV_map_.erase(id); }
-    void RemovePerformanceConfigurationINTELInfo(format::HandleId id) { performanceConfigurationINTEL_map_.erase(id); }
-    void RemovePhysicalDeviceInfo(format::HandleId id) { physicalDevice_map_.erase(id); }
-    void RemovePipelineInfo(format::HandleId id) { pipeline_map_.erase(id); }
-    void RemovePipelineBinaryKHRInfo(format::HandleId id) { pipelineBinaryKHR_map_.erase(id); }
-    void RemovePipelineCacheInfo(format::HandleId id) { pipelineCache_map_.erase(id); }
-    void RemovePipelineLayoutInfo(format::HandleId id) { pipelineLayout_map_.erase(id); }
-    void RemovePrivateDataSlotInfo(format::HandleId id) { privateDataSlot_map_.erase(id); }
-    void RemoveQueryPoolInfo(format::HandleId id) { queryPool_map_.erase(id); }
-    void RemoveQueueInfo(format::HandleId id) { queue_map_.erase(id); }
-    void RemoveRenderPassInfo(format::HandleId id) { renderPass_map_.erase(id); }
-    void RemoveSamplerInfo(format::HandleId id) { sampler_map_.erase(id); }
-    void RemoveSamplerYcbcrConversionInfo(format::HandleId id) { samplerYcbcrConversion_map_.erase(id); }
-    void RemoveSemaphoreInfo(format::HandleId id) { semaphore_map_.erase(id); }
-    void RemoveShaderEXTInfo(format::HandleId id) { shaderEXT_map_.erase(id); }
-    void RemoveShaderModuleInfo(format::HandleId id) { shaderModule_map_.erase(id); }
-    void RemoveSurfaceKHRInfo(format::HandleId id) { surfaceKHR_map_.erase(id); }
-    void RemoveSwapchainKHRInfo(format::HandleId id) { swapchainKHR_map_.erase(id); }
-    void RemoveValidationCacheEXTInfo(format::HandleId id) { validationCacheEXT_map_.erase(id); }
-    void RemoveVideoSessionKHRInfo(format::HandleId id) { videoSessionKHR_map_.erase(id); }
-    void RemoveVideoSessionParametersKHRInfo(format::HandleId id) { videoSessionParametersKHR_map_.erase(id); }
+    void RemoveVkAccelerationStructureKHRInfo(format::HandleId id) { accelerationStructureKHR_map_.erase(id); }
+    void RemoveVkAccelerationStructureNVInfo(format::HandleId id) { accelerationStructureNV_map_.erase(id); }
+    void RemoveVkBufferInfo(format::HandleId id) { buffer_map_.erase(id); }
+    void RemoveVkBufferViewInfo(format::HandleId id) { bufferView_map_.erase(id); }
+    void RemoveVkCommandBufferInfo(format::HandleId id) { commandBuffer_map_.erase(id); }
+    void RemoveVkCommandPoolInfo(format::HandleId id) { commandPool_map_.erase(id); }
+    void RemoveVkDebugReportCallbackEXTInfo(format::HandleId id) { debugReportCallbackEXT_map_.erase(id); }
+    void RemoveVkDebugUtilsMessengerEXTInfo(format::HandleId id) { debugUtilsMessengerEXT_map_.erase(id); }
+    void RemoveVkDeferredOperationKHRInfo(format::HandleId id) { deferredOperationKHR_map_.erase(id); }
+    void RemoveVkDescriptorPoolInfo(format::HandleId id) { descriptorPool_map_.erase(id); }
+    void RemoveVkDescriptorSetInfo(format::HandleId id) { descriptorSet_map_.erase(id); }
+    void RemoveVkDescriptorSetLayoutInfo(format::HandleId id) { descriptorSetLayout_map_.erase(id); }
+    void RemoveVkDescriptorUpdateTemplateInfo(format::HandleId id) { descriptorUpdateTemplate_map_.erase(id); }
+    void RemoveVkDeviceInfo(format::HandleId id) { device_map_.erase(id); }
+    void RemoveVkDeviceMemoryInfo(format::HandleId id) { deviceMemory_map_.erase(id); }
+    void RemoveVkDisplayKHRInfo(format::HandleId id) { displayKHR_map_.erase(id); }
+    void RemoveVkDisplayModeKHRInfo(format::HandleId id) { displayModeKHR_map_.erase(id); }
+    void RemoveVkEventInfo(format::HandleId id) { event_map_.erase(id); }
+    void RemoveVkFenceInfo(format::HandleId id) { fence_map_.erase(id); }
+    void RemoveVkFramebufferInfo(format::HandleId id) { framebuffer_map_.erase(id); }
+    void RemoveVkImageInfo(format::HandleId id) { image_map_.erase(id); }
+    void RemoveVkImageViewInfo(format::HandleId id) { imageView_map_.erase(id); }
+    void RemoveVkIndirectCommandsLayoutEXTInfo(format::HandleId id) { indirectCommandsLayoutEXT_map_.erase(id); }
+    void RemoveVkIndirectCommandsLayoutNVInfo(format::HandleId id) { indirectCommandsLayoutNV_map_.erase(id); }
+    void RemoveVkIndirectExecutionSetEXTInfo(format::HandleId id) { indirectExecutionSetEXT_map_.erase(id); }
+    void RemoveVkInstanceInfo(format::HandleId id) { instance_map_.erase(id); }
+    void RemoveVkMicromapEXTInfo(format::HandleId id) { micromapEXT_map_.erase(id); }
+    void RemoveVkOpticalFlowSessionNVInfo(format::HandleId id) { opticalFlowSessionNV_map_.erase(id); }
+    void RemoveVkPerformanceConfigurationINTELInfo(format::HandleId id) { performanceConfigurationINTEL_map_.erase(id); }
+    void RemoveVkPhysicalDeviceInfo(format::HandleId id) { physicalDevice_map_.erase(id); }
+    void RemoveVkPipelineInfo(format::HandleId id) { pipeline_map_.erase(id); }
+    void RemoveVkPipelineBinaryKHRInfo(format::HandleId id) { pipelineBinaryKHR_map_.erase(id); }
+    void RemoveVkPipelineCacheInfo(format::HandleId id) { pipelineCache_map_.erase(id); }
+    void RemoveVkPipelineLayoutInfo(format::HandleId id) { pipelineLayout_map_.erase(id); }
+    void RemoveVkPrivateDataSlotInfo(format::HandleId id) { privateDataSlot_map_.erase(id); }
+    void RemoveVkQueryPoolInfo(format::HandleId id) { queryPool_map_.erase(id); }
+    void RemoveVkQueueInfo(format::HandleId id) { queue_map_.erase(id); }
+    void RemoveVkRenderPassInfo(format::HandleId id) { renderPass_map_.erase(id); }
+    void RemoveVkSamplerInfo(format::HandleId id) { sampler_map_.erase(id); }
+    void RemoveVkSamplerYcbcrConversionInfo(format::HandleId id) { samplerYcbcrConversion_map_.erase(id); }
+    void RemoveVkSemaphoreInfo(format::HandleId id) { semaphore_map_.erase(id); }
+    void RemoveVkShaderEXTInfo(format::HandleId id) { shaderEXT_map_.erase(id); }
+    void RemoveVkShaderModuleInfo(format::HandleId id) { shaderModule_map_.erase(id); }
+    void RemoveVkSurfaceKHRInfo(format::HandleId id) { surfaceKHR_map_.erase(id); }
+    void RemoveVkSwapchainKHRInfo(format::HandleId id) { swapchainKHR_map_.erase(id); }
+    void RemoveVkValidationCacheEXTInfo(format::HandleId id) { validationCacheEXT_map_.erase(id); }
+    void RemoveVkVideoSessionKHRInfo(format::HandleId id) { videoSessionKHR_map_.erase(id); }
+    void RemoveVkVideoSessionParametersKHRInfo(format::HandleId id) { videoSessionParametersKHR_map_.erase(id); }
 
-    const AccelerationStructureKHRInfo* GetAccelerationStructureKHRInfo(format::HandleId id) const { return GetObjectInfo<AccelerationStructureKHRInfo>(id, &accelerationStructureKHR_map_); }
-    const AccelerationStructureNVInfo* GetAccelerationStructureNVInfo(format::HandleId id) const { return GetObjectInfo<AccelerationStructureNVInfo>(id, &accelerationStructureNV_map_); }
-    const BufferInfo* GetBufferInfo(format::HandleId id) const { return GetObjectInfo<BufferInfo>(id, &buffer_map_); }
-    const BufferViewInfo* GetBufferViewInfo(format::HandleId id) const { return GetObjectInfo<BufferViewInfo>(id, &bufferView_map_); }
-    const CommandBufferInfo* GetCommandBufferInfo(format::HandleId id) const { return GetObjectInfo<CommandBufferInfo>(id, &commandBuffer_map_); }
-    const CommandPoolInfo* GetCommandPoolInfo(format::HandleId id) const { return GetObjectInfo<CommandPoolInfo>(id, &commandPool_map_); }
-    const DebugReportCallbackEXTInfo* GetDebugReportCallbackEXTInfo(format::HandleId id) const { return GetObjectInfo<DebugReportCallbackEXTInfo>(id, &debugReportCallbackEXT_map_); }
-    const DebugUtilsMessengerEXTInfo* GetDebugUtilsMessengerEXTInfo(format::HandleId id) const { return GetObjectInfo<DebugUtilsMessengerEXTInfo>(id, &debugUtilsMessengerEXT_map_); }
-    const DeferredOperationKHRInfo* GetDeferredOperationKHRInfo(format::HandleId id) const { return GetObjectInfo<DeferredOperationKHRInfo>(id, &deferredOperationKHR_map_); }
-    const DescriptorPoolInfo* GetDescriptorPoolInfo(format::HandleId id) const { return GetObjectInfo<DescriptorPoolInfo>(id, &descriptorPool_map_); }
-    const DescriptorSetInfo* GetDescriptorSetInfo(format::HandleId id) const { return GetObjectInfo<DescriptorSetInfo>(id, &descriptorSet_map_); }
-    const DescriptorSetLayoutInfo* GetDescriptorSetLayoutInfo(format::HandleId id) const { return GetObjectInfo<DescriptorSetLayoutInfo>(id, &descriptorSetLayout_map_); }
-    const DescriptorUpdateTemplateInfo* GetDescriptorUpdateTemplateInfo(format::HandleId id) const { return GetObjectInfo<DescriptorUpdateTemplateInfo>(id, &descriptorUpdateTemplate_map_); }
-    const DeviceInfo* GetDeviceInfo(format::HandleId id) const { return GetObjectInfo<DeviceInfo>(id, &device_map_); }
-    const DeviceMemoryInfo* GetDeviceMemoryInfo(format::HandleId id) const { return GetObjectInfo<DeviceMemoryInfo>(id, &deviceMemory_map_); }
-    const DisplayKHRInfo* GetDisplayKHRInfo(format::HandleId id) const { return GetObjectInfo<DisplayKHRInfo>(id, &displayKHR_map_); }
-    const DisplayModeKHRInfo* GetDisplayModeKHRInfo(format::HandleId id) const { return GetObjectInfo<DisplayModeKHRInfo>(id, &displayModeKHR_map_); }
-    const EventInfo* GetEventInfo(format::HandleId id) const { return GetObjectInfo<EventInfo>(id, &event_map_); }
-    const FenceInfo* GetFenceInfo(format::HandleId id) const { return GetObjectInfo<FenceInfo>(id, &fence_map_); }
-    const FramebufferInfo* GetFramebufferInfo(format::HandleId id) const { return GetObjectInfo<FramebufferInfo>(id, &framebuffer_map_); }
-    const ImageInfo* GetImageInfo(format::HandleId id) const { return GetObjectInfo<ImageInfo>(id, &image_map_); }
-    const ImageViewInfo* GetImageViewInfo(format::HandleId id) const { return GetObjectInfo<ImageViewInfo>(id, &imageView_map_); }
-    const IndirectCommandsLayoutEXTInfo* GetIndirectCommandsLayoutEXTInfo(format::HandleId id) const { return GetObjectInfo<IndirectCommandsLayoutEXTInfo>(id, &indirectCommandsLayoutEXT_map_); }
-    const IndirectCommandsLayoutNVInfo* GetIndirectCommandsLayoutNVInfo(format::HandleId id) const { return GetObjectInfo<IndirectCommandsLayoutNVInfo>(id, &indirectCommandsLayoutNV_map_); }
-    const IndirectExecutionSetEXTInfo* GetIndirectExecutionSetEXTInfo(format::HandleId id) const { return GetObjectInfo<IndirectExecutionSetEXTInfo>(id, &indirectExecutionSetEXT_map_); }
-    const InstanceInfo* GetInstanceInfo(format::HandleId id) const { return GetObjectInfo<InstanceInfo>(id, &instance_map_); }
-    const MicromapEXTInfo* GetMicromapEXTInfo(format::HandleId id) const { return GetObjectInfo<MicromapEXTInfo>(id, &micromapEXT_map_); }
-    const OpticalFlowSessionNVInfo* GetOpticalFlowSessionNVInfo(format::HandleId id) const { return GetObjectInfo<OpticalFlowSessionNVInfo>(id, &opticalFlowSessionNV_map_); }
-    const PerformanceConfigurationINTELInfo* GetPerformanceConfigurationINTELInfo(format::HandleId id) const { return GetObjectInfo<PerformanceConfigurationINTELInfo>(id, &performanceConfigurationINTEL_map_); }
-    const PhysicalDeviceInfo* GetPhysicalDeviceInfo(format::HandleId id) const { return GetObjectInfo<PhysicalDeviceInfo>(id, &physicalDevice_map_); }
-    const PipelineInfo* GetPipelineInfo(format::HandleId id) const { return GetObjectInfo<PipelineInfo>(id, &pipeline_map_); }
-    const PipelineBinaryKHRInfo* GetPipelineBinaryKHRInfo(format::HandleId id) const { return GetObjectInfo<PipelineBinaryKHRInfo>(id, &pipelineBinaryKHR_map_); }
-    const PipelineCacheInfo* GetPipelineCacheInfo(format::HandleId id) const { return GetObjectInfo<PipelineCacheInfo>(id, &pipelineCache_map_); }
-    const PipelineLayoutInfo* GetPipelineLayoutInfo(format::HandleId id) const { return GetObjectInfo<PipelineLayoutInfo>(id, &pipelineLayout_map_); }
-    const PrivateDataSlotInfo* GetPrivateDataSlotInfo(format::HandleId id) const { return GetObjectInfo<PrivateDataSlotInfo>(id, &privateDataSlot_map_); }
-    const QueryPoolInfo* GetQueryPoolInfo(format::HandleId id) const { return GetObjectInfo<QueryPoolInfo>(id, &queryPool_map_); }
-    const QueueInfo* GetQueueInfo(format::HandleId id) const { return GetObjectInfo<QueueInfo>(id, &queue_map_); }
-    const RenderPassInfo* GetRenderPassInfo(format::HandleId id) const { return GetObjectInfo<RenderPassInfo>(id, &renderPass_map_); }
-    const SamplerInfo* GetSamplerInfo(format::HandleId id) const { return GetObjectInfo<SamplerInfo>(id, &sampler_map_); }
-    const SamplerYcbcrConversionInfo* GetSamplerYcbcrConversionInfo(format::HandleId id) const { return GetObjectInfo<SamplerYcbcrConversionInfo>(id, &samplerYcbcrConversion_map_); }
-    const SemaphoreInfo* GetSemaphoreInfo(format::HandleId id) const { return GetObjectInfo<SemaphoreInfo>(id, &semaphore_map_); }
-    const ShaderEXTInfo* GetShaderEXTInfo(format::HandleId id) const { return GetObjectInfo<ShaderEXTInfo>(id, &shaderEXT_map_); }
-    const ShaderModuleInfo* GetShaderModuleInfo(format::HandleId id) const { return GetObjectInfo<ShaderModuleInfo>(id, &shaderModule_map_); }
-    const SurfaceKHRInfo* GetSurfaceKHRInfo(format::HandleId id) const { return GetObjectInfo<SurfaceKHRInfo>(id, &surfaceKHR_map_); }
-    const SwapchainKHRInfo* GetSwapchainKHRInfo(format::HandleId id) const { return GetObjectInfo<SwapchainKHRInfo>(id, &swapchainKHR_map_); }
-    const ValidationCacheEXTInfo* GetValidationCacheEXTInfo(format::HandleId id) const { return GetObjectInfo<ValidationCacheEXTInfo>(id, &validationCacheEXT_map_); }
-    const VideoSessionKHRInfo* GetVideoSessionKHRInfo(format::HandleId id) const { return GetObjectInfo<VideoSessionKHRInfo>(id, &videoSessionKHR_map_); }
-    const VideoSessionParametersKHRInfo* GetVideoSessionParametersKHRInfo(format::HandleId id) const { return GetObjectInfo<VideoSessionParametersKHRInfo>(id, &videoSessionParametersKHR_map_); }
+    const VulkanAccelerationStructureKHRInfo* GetVkAccelerationStructureKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanAccelerationStructureKHRInfo>(id, &accelerationStructureKHR_map_); }
+    const VulkanAccelerationStructureNVInfo* GetVkAccelerationStructureNVInfo(format::HandleId id) const { return GetObjectInfo<VulkanAccelerationStructureNVInfo>(id, &accelerationStructureNV_map_); }
+    const VulkanBufferInfo* GetVkBufferInfo(format::HandleId id) const { return GetObjectInfo<VulkanBufferInfo>(id, &buffer_map_); }
+    const VulkanBufferViewInfo* GetVkBufferViewInfo(format::HandleId id) const { return GetObjectInfo<VulkanBufferViewInfo>(id, &bufferView_map_); }
+    const VulkanCommandBufferInfo* GetVkCommandBufferInfo(format::HandleId id) const { return GetObjectInfo<VulkanCommandBufferInfo>(id, &commandBuffer_map_); }
+    const VulkanCommandPoolInfo* GetVkCommandPoolInfo(format::HandleId id) const { return GetObjectInfo<VulkanCommandPoolInfo>(id, &commandPool_map_); }
+    const VulkanDebugReportCallbackEXTInfo* GetVkDebugReportCallbackEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanDebugReportCallbackEXTInfo>(id, &debugReportCallbackEXT_map_); }
+    const VulkanDebugUtilsMessengerEXTInfo* GetVkDebugUtilsMessengerEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanDebugUtilsMessengerEXTInfo>(id, &debugUtilsMessengerEXT_map_); }
+    const VulkanDeferredOperationKHRInfo* GetVkDeferredOperationKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanDeferredOperationKHRInfo>(id, &deferredOperationKHR_map_); }
+    const VulkanDescriptorPoolInfo* GetVkDescriptorPoolInfo(format::HandleId id) const { return GetObjectInfo<VulkanDescriptorPoolInfo>(id, &descriptorPool_map_); }
+    const VulkanDescriptorSetInfo* GetVkDescriptorSetInfo(format::HandleId id) const { return GetObjectInfo<VulkanDescriptorSetInfo>(id, &descriptorSet_map_); }
+    const VulkanDescriptorSetLayoutInfo* GetVkDescriptorSetLayoutInfo(format::HandleId id) const { return GetObjectInfo<VulkanDescriptorSetLayoutInfo>(id, &descriptorSetLayout_map_); }
+    const VulkanDescriptorUpdateTemplateInfo* GetVkDescriptorUpdateTemplateInfo(format::HandleId id) const { return GetObjectInfo<VulkanDescriptorUpdateTemplateInfo>(id, &descriptorUpdateTemplate_map_); }
+    const VulkanDeviceInfo* GetVkDeviceInfo(format::HandleId id) const { return GetObjectInfo<VulkanDeviceInfo>(id, &device_map_); }
+    const VulkanDeviceMemoryInfo* GetVkDeviceMemoryInfo(format::HandleId id) const { return GetObjectInfo<VulkanDeviceMemoryInfo>(id, &deviceMemory_map_); }
+    const VulkanDisplayKHRInfo* GetVkDisplayKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanDisplayKHRInfo>(id, &displayKHR_map_); }
+    const VulkanDisplayModeKHRInfo* GetVkDisplayModeKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanDisplayModeKHRInfo>(id, &displayModeKHR_map_); }
+    const VulkanEventInfo* GetVkEventInfo(format::HandleId id) const { return GetObjectInfo<VulkanEventInfo>(id, &event_map_); }
+    const VulkanFenceInfo* GetVkFenceInfo(format::HandleId id) const { return GetObjectInfo<VulkanFenceInfo>(id, &fence_map_); }
+    const VulkanFramebufferInfo* GetVkFramebufferInfo(format::HandleId id) const { return GetObjectInfo<VulkanFramebufferInfo>(id, &framebuffer_map_); }
+    const VulkanImageInfo* GetVkImageInfo(format::HandleId id) const { return GetObjectInfo<VulkanImageInfo>(id, &image_map_); }
+    const VulkanImageViewInfo* GetVkImageViewInfo(format::HandleId id) const { return GetObjectInfo<VulkanImageViewInfo>(id, &imageView_map_); }
+    const VulkanIndirectCommandsLayoutEXTInfo* GetVkIndirectCommandsLayoutEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanIndirectCommandsLayoutEXTInfo>(id, &indirectCommandsLayoutEXT_map_); }
+    const VulkanIndirectCommandsLayoutNVInfo* GetVkIndirectCommandsLayoutNVInfo(format::HandleId id) const { return GetObjectInfo<VulkanIndirectCommandsLayoutNVInfo>(id, &indirectCommandsLayoutNV_map_); }
+    const VulkanIndirectExecutionSetEXTInfo* GetVkIndirectExecutionSetEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanIndirectExecutionSetEXTInfo>(id, &indirectExecutionSetEXT_map_); }
+    const VulkanInstanceInfo* GetVkInstanceInfo(format::HandleId id) const { return GetObjectInfo<VulkanInstanceInfo>(id, &instance_map_); }
+    const VulkanMicromapEXTInfo* GetVkMicromapEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanMicromapEXTInfo>(id, &micromapEXT_map_); }
+    const VulkanOpticalFlowSessionNVInfo* GetVkOpticalFlowSessionNVInfo(format::HandleId id) const { return GetObjectInfo<VulkanOpticalFlowSessionNVInfo>(id, &opticalFlowSessionNV_map_); }
+    const VulkanPerformanceConfigurationINTELInfo* GetVkPerformanceConfigurationINTELInfo(format::HandleId id) const { return GetObjectInfo<VulkanPerformanceConfigurationINTELInfo>(id, &performanceConfigurationINTEL_map_); }
+    const VulkanPhysicalDeviceInfo* GetVkPhysicalDeviceInfo(format::HandleId id) const { return GetObjectInfo<VulkanPhysicalDeviceInfo>(id, &physicalDevice_map_); }
+    const VulkanPipelineInfo* GetVkPipelineInfo(format::HandleId id) const { return GetObjectInfo<VulkanPipelineInfo>(id, &pipeline_map_); }
+    const VulkanPipelineBinaryKHRInfo* GetVkPipelineBinaryKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanPipelineBinaryKHRInfo>(id, &pipelineBinaryKHR_map_); }
+    const VulkanPipelineCacheInfo* GetVkPipelineCacheInfo(format::HandleId id) const { return GetObjectInfo<VulkanPipelineCacheInfo>(id, &pipelineCache_map_); }
+    const VulkanPipelineLayoutInfo* GetVkPipelineLayoutInfo(format::HandleId id) const { return GetObjectInfo<VulkanPipelineLayoutInfo>(id, &pipelineLayout_map_); }
+    const VulkanPrivateDataSlotInfo* GetVkPrivateDataSlotInfo(format::HandleId id) const { return GetObjectInfo<VulkanPrivateDataSlotInfo>(id, &privateDataSlot_map_); }
+    const VulkanQueryPoolInfo* GetVkQueryPoolInfo(format::HandleId id) const { return GetObjectInfo<VulkanQueryPoolInfo>(id, &queryPool_map_); }
+    const VulkanQueueInfo* GetVkQueueInfo(format::HandleId id) const { return GetObjectInfo<VulkanQueueInfo>(id, &queue_map_); }
+    const VulkanRenderPassInfo* GetVkRenderPassInfo(format::HandleId id) const { return GetObjectInfo<VulkanRenderPassInfo>(id, &renderPass_map_); }
+    const VulkanSamplerInfo* GetVkSamplerInfo(format::HandleId id) const { return GetObjectInfo<VulkanSamplerInfo>(id, &sampler_map_); }
+    const VulkanSamplerYcbcrConversionInfo* GetVkSamplerYcbcrConversionInfo(format::HandleId id) const { return GetObjectInfo<VulkanSamplerYcbcrConversionInfo>(id, &samplerYcbcrConversion_map_); }
+    const VulkanSemaphoreInfo* GetVkSemaphoreInfo(format::HandleId id) const { return GetObjectInfo<VulkanSemaphoreInfo>(id, &semaphore_map_); }
+    const VulkanShaderEXTInfo* GetVkShaderEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanShaderEXTInfo>(id, &shaderEXT_map_); }
+    const VulkanShaderModuleInfo* GetVkShaderModuleInfo(format::HandleId id) const { return GetObjectInfo<VulkanShaderModuleInfo>(id, &shaderModule_map_); }
+    const VulkanSurfaceKHRInfo* GetVkSurfaceKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanSurfaceKHRInfo>(id, &surfaceKHR_map_); }
+    const VulkanSwapchainKHRInfo* GetVkSwapchainKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanSwapchainKHRInfo>(id, &swapchainKHR_map_); }
+    const VulkanValidationCacheEXTInfo* GetVkValidationCacheEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanValidationCacheEXTInfo>(id, &validationCacheEXT_map_); }
+    const VulkanVideoSessionKHRInfo* GetVkVideoSessionKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanVideoSessionKHRInfo>(id, &videoSessionKHR_map_); }
+    const VulkanVideoSessionParametersKHRInfo* GetVkVideoSessionParametersKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanVideoSessionParametersKHRInfo>(id, &videoSessionParametersKHR_map_); }
 
-    AccelerationStructureKHRInfo* GetAccelerationStructureKHRInfo(format::HandleId id) { return GetObjectInfo<AccelerationStructureKHRInfo>(id, &accelerationStructureKHR_map_); }
-    AccelerationStructureNVInfo* GetAccelerationStructureNVInfo(format::HandleId id) { return GetObjectInfo<AccelerationStructureNVInfo>(id, &accelerationStructureNV_map_); }
-    BufferInfo* GetBufferInfo(format::HandleId id) { return GetObjectInfo<BufferInfo>(id, &buffer_map_); }
-    BufferViewInfo* GetBufferViewInfo(format::HandleId id) { return GetObjectInfo<BufferViewInfo>(id, &bufferView_map_); }
-    CommandBufferInfo* GetCommandBufferInfo(format::HandleId id) { return GetObjectInfo<CommandBufferInfo>(id, &commandBuffer_map_); }
-    CommandPoolInfo* GetCommandPoolInfo(format::HandleId id) { return GetObjectInfo<CommandPoolInfo>(id, &commandPool_map_); }
-    DebugReportCallbackEXTInfo* GetDebugReportCallbackEXTInfo(format::HandleId id) { return GetObjectInfo<DebugReportCallbackEXTInfo>(id, &debugReportCallbackEXT_map_); }
-    DebugUtilsMessengerEXTInfo* GetDebugUtilsMessengerEXTInfo(format::HandleId id) { return GetObjectInfo<DebugUtilsMessengerEXTInfo>(id, &debugUtilsMessengerEXT_map_); }
-    DeferredOperationKHRInfo* GetDeferredOperationKHRInfo(format::HandleId id) { return GetObjectInfo<DeferredOperationKHRInfo>(id, &deferredOperationKHR_map_); }
-    DescriptorPoolInfo* GetDescriptorPoolInfo(format::HandleId id) { return GetObjectInfo<DescriptorPoolInfo>(id, &descriptorPool_map_); }
-    DescriptorSetInfo* GetDescriptorSetInfo(format::HandleId id) { return GetObjectInfo<DescriptorSetInfo>(id, &descriptorSet_map_); }
-    DescriptorSetLayoutInfo* GetDescriptorSetLayoutInfo(format::HandleId id) { return GetObjectInfo<DescriptorSetLayoutInfo>(id, &descriptorSetLayout_map_); }
-    DescriptorUpdateTemplateInfo* GetDescriptorUpdateTemplateInfo(format::HandleId id) { return GetObjectInfo<DescriptorUpdateTemplateInfo>(id, &descriptorUpdateTemplate_map_); }
-    DeviceInfo* GetDeviceInfo(format::HandleId id) { return GetObjectInfo<DeviceInfo>(id, &device_map_); }
-    DeviceMemoryInfo* GetDeviceMemoryInfo(format::HandleId id) { return GetObjectInfo<DeviceMemoryInfo>(id, &deviceMemory_map_); }
-    DisplayKHRInfo* GetDisplayKHRInfo(format::HandleId id) { return GetObjectInfo<DisplayKHRInfo>(id, &displayKHR_map_); }
-    DisplayModeKHRInfo* GetDisplayModeKHRInfo(format::HandleId id) { return GetObjectInfo<DisplayModeKHRInfo>(id, &displayModeKHR_map_); }
-    EventInfo* GetEventInfo(format::HandleId id) { return GetObjectInfo<EventInfo>(id, &event_map_); }
-    FenceInfo* GetFenceInfo(format::HandleId id) { return GetObjectInfo<FenceInfo>(id, &fence_map_); }
-    FramebufferInfo* GetFramebufferInfo(format::HandleId id) { return GetObjectInfo<FramebufferInfo>(id, &framebuffer_map_); }
-    ImageInfo* GetImageInfo(format::HandleId id) { return GetObjectInfo<ImageInfo>(id, &image_map_); }
-    ImageViewInfo* GetImageViewInfo(format::HandleId id) { return GetObjectInfo<ImageViewInfo>(id, &imageView_map_); }
-    IndirectCommandsLayoutEXTInfo* GetIndirectCommandsLayoutEXTInfo(format::HandleId id) { return GetObjectInfo<IndirectCommandsLayoutEXTInfo>(id, &indirectCommandsLayoutEXT_map_); }
-    IndirectCommandsLayoutNVInfo* GetIndirectCommandsLayoutNVInfo(format::HandleId id) { return GetObjectInfo<IndirectCommandsLayoutNVInfo>(id, &indirectCommandsLayoutNV_map_); }
-    IndirectExecutionSetEXTInfo* GetIndirectExecutionSetEXTInfo(format::HandleId id) { return GetObjectInfo<IndirectExecutionSetEXTInfo>(id, &indirectExecutionSetEXT_map_); }
-    InstanceInfo* GetInstanceInfo(format::HandleId id) { return GetObjectInfo<InstanceInfo>(id, &instance_map_); }
-    MicromapEXTInfo* GetMicromapEXTInfo(format::HandleId id) { return GetObjectInfo<MicromapEXTInfo>(id, &micromapEXT_map_); }
-    OpticalFlowSessionNVInfo* GetOpticalFlowSessionNVInfo(format::HandleId id) { return GetObjectInfo<OpticalFlowSessionNVInfo>(id, &opticalFlowSessionNV_map_); }
-    PerformanceConfigurationINTELInfo* GetPerformanceConfigurationINTELInfo(format::HandleId id) { return GetObjectInfo<PerformanceConfigurationINTELInfo>(id, &performanceConfigurationINTEL_map_); }
-    PhysicalDeviceInfo* GetPhysicalDeviceInfo(format::HandleId id) { return GetObjectInfo<PhysicalDeviceInfo>(id, &physicalDevice_map_); }
-    PipelineInfo* GetPipelineInfo(format::HandleId id) { return GetObjectInfo<PipelineInfo>(id, &pipeline_map_); }
-    PipelineBinaryKHRInfo* GetPipelineBinaryKHRInfo(format::HandleId id) { return GetObjectInfo<PipelineBinaryKHRInfo>(id, &pipelineBinaryKHR_map_); }
-    PipelineCacheInfo* GetPipelineCacheInfo(format::HandleId id) { return GetObjectInfo<PipelineCacheInfo>(id, &pipelineCache_map_); }
-    PipelineLayoutInfo* GetPipelineLayoutInfo(format::HandleId id) { return GetObjectInfo<PipelineLayoutInfo>(id, &pipelineLayout_map_); }
-    PrivateDataSlotInfo* GetPrivateDataSlotInfo(format::HandleId id) { return GetObjectInfo<PrivateDataSlotInfo>(id, &privateDataSlot_map_); }
-    QueryPoolInfo* GetQueryPoolInfo(format::HandleId id) { return GetObjectInfo<QueryPoolInfo>(id, &queryPool_map_); }
-    QueueInfo* GetQueueInfo(format::HandleId id) { return GetObjectInfo<QueueInfo>(id, &queue_map_); }
-    RenderPassInfo* GetRenderPassInfo(format::HandleId id) { return GetObjectInfo<RenderPassInfo>(id, &renderPass_map_); }
-    SamplerInfo* GetSamplerInfo(format::HandleId id) { return GetObjectInfo<SamplerInfo>(id, &sampler_map_); }
-    SamplerYcbcrConversionInfo* GetSamplerYcbcrConversionInfo(format::HandleId id) { return GetObjectInfo<SamplerYcbcrConversionInfo>(id, &samplerYcbcrConversion_map_); }
-    SemaphoreInfo* GetSemaphoreInfo(format::HandleId id) { return GetObjectInfo<SemaphoreInfo>(id, &semaphore_map_); }
-    ShaderEXTInfo* GetShaderEXTInfo(format::HandleId id) { return GetObjectInfo<ShaderEXTInfo>(id, &shaderEXT_map_); }
-    ShaderModuleInfo* GetShaderModuleInfo(format::HandleId id) { return GetObjectInfo<ShaderModuleInfo>(id, &shaderModule_map_); }
-    SurfaceKHRInfo* GetSurfaceKHRInfo(format::HandleId id) { return GetObjectInfo<SurfaceKHRInfo>(id, &surfaceKHR_map_); }
-    SwapchainKHRInfo* GetSwapchainKHRInfo(format::HandleId id) { return GetObjectInfo<SwapchainKHRInfo>(id, &swapchainKHR_map_); }
-    ValidationCacheEXTInfo* GetValidationCacheEXTInfo(format::HandleId id) { return GetObjectInfo<ValidationCacheEXTInfo>(id, &validationCacheEXT_map_); }
-    VideoSessionKHRInfo* GetVideoSessionKHRInfo(format::HandleId id) { return GetObjectInfo<VideoSessionKHRInfo>(id, &videoSessionKHR_map_); }
-    VideoSessionParametersKHRInfo* GetVideoSessionParametersKHRInfo(format::HandleId id) { return GetObjectInfo<VideoSessionParametersKHRInfo>(id, &videoSessionParametersKHR_map_); }
+    VulkanAccelerationStructureKHRInfo* GetVkAccelerationStructureKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanAccelerationStructureKHRInfo>(id, &accelerationStructureKHR_map_); }
+    VulkanAccelerationStructureNVInfo* GetVkAccelerationStructureNVInfo(format::HandleId id) { return GetObjectInfo<VulkanAccelerationStructureNVInfo>(id, &accelerationStructureNV_map_); }
+    VulkanBufferInfo* GetVkBufferInfo(format::HandleId id) { return GetObjectInfo<VulkanBufferInfo>(id, &buffer_map_); }
+    VulkanBufferViewInfo* GetVkBufferViewInfo(format::HandleId id) { return GetObjectInfo<VulkanBufferViewInfo>(id, &bufferView_map_); }
+    VulkanCommandBufferInfo* GetVkCommandBufferInfo(format::HandleId id) { return GetObjectInfo<VulkanCommandBufferInfo>(id, &commandBuffer_map_); }
+    VulkanCommandPoolInfo* GetVkCommandPoolInfo(format::HandleId id) { return GetObjectInfo<VulkanCommandPoolInfo>(id, &commandPool_map_); }
+    VulkanDebugReportCallbackEXTInfo* GetVkDebugReportCallbackEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanDebugReportCallbackEXTInfo>(id, &debugReportCallbackEXT_map_); }
+    VulkanDebugUtilsMessengerEXTInfo* GetVkDebugUtilsMessengerEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanDebugUtilsMessengerEXTInfo>(id, &debugUtilsMessengerEXT_map_); }
+    VulkanDeferredOperationKHRInfo* GetVkDeferredOperationKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanDeferredOperationKHRInfo>(id, &deferredOperationKHR_map_); }
+    VulkanDescriptorPoolInfo* GetVkDescriptorPoolInfo(format::HandleId id) { return GetObjectInfo<VulkanDescriptorPoolInfo>(id, &descriptorPool_map_); }
+    VulkanDescriptorSetInfo* GetVkDescriptorSetInfo(format::HandleId id) { return GetObjectInfo<VulkanDescriptorSetInfo>(id, &descriptorSet_map_); }
+    VulkanDescriptorSetLayoutInfo* GetVkDescriptorSetLayoutInfo(format::HandleId id) { return GetObjectInfo<VulkanDescriptorSetLayoutInfo>(id, &descriptorSetLayout_map_); }
+    VulkanDescriptorUpdateTemplateInfo* GetVkDescriptorUpdateTemplateInfo(format::HandleId id) { return GetObjectInfo<VulkanDescriptorUpdateTemplateInfo>(id, &descriptorUpdateTemplate_map_); }
+    VulkanDeviceInfo* GetVkDeviceInfo(format::HandleId id) { return GetObjectInfo<VulkanDeviceInfo>(id, &device_map_); }
+    VulkanDeviceMemoryInfo* GetVkDeviceMemoryInfo(format::HandleId id) { return GetObjectInfo<VulkanDeviceMemoryInfo>(id, &deviceMemory_map_); }
+    VulkanDisplayKHRInfo* GetVkDisplayKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanDisplayKHRInfo>(id, &displayKHR_map_); }
+    VulkanDisplayModeKHRInfo* GetVkDisplayModeKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanDisplayModeKHRInfo>(id, &displayModeKHR_map_); }
+    VulkanEventInfo* GetVkEventInfo(format::HandleId id) { return GetObjectInfo<VulkanEventInfo>(id, &event_map_); }
+    VulkanFenceInfo* GetVkFenceInfo(format::HandleId id) { return GetObjectInfo<VulkanFenceInfo>(id, &fence_map_); }
+    VulkanFramebufferInfo* GetVkFramebufferInfo(format::HandleId id) { return GetObjectInfo<VulkanFramebufferInfo>(id, &framebuffer_map_); }
+    VulkanImageInfo* GetVkImageInfo(format::HandleId id) { return GetObjectInfo<VulkanImageInfo>(id, &image_map_); }
+    VulkanImageViewInfo* GetVkImageViewInfo(format::HandleId id) { return GetObjectInfo<VulkanImageViewInfo>(id, &imageView_map_); }
+    VulkanIndirectCommandsLayoutEXTInfo* GetVkIndirectCommandsLayoutEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanIndirectCommandsLayoutEXTInfo>(id, &indirectCommandsLayoutEXT_map_); }
+    VulkanIndirectCommandsLayoutNVInfo* GetVkIndirectCommandsLayoutNVInfo(format::HandleId id) { return GetObjectInfo<VulkanIndirectCommandsLayoutNVInfo>(id, &indirectCommandsLayoutNV_map_); }
+    VulkanIndirectExecutionSetEXTInfo* GetVkIndirectExecutionSetEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanIndirectExecutionSetEXTInfo>(id, &indirectExecutionSetEXT_map_); }
+    VulkanInstanceInfo* GetVkInstanceInfo(format::HandleId id) { return GetObjectInfo<VulkanInstanceInfo>(id, &instance_map_); }
+    VulkanMicromapEXTInfo* GetVkMicromapEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanMicromapEXTInfo>(id, &micromapEXT_map_); }
+    VulkanOpticalFlowSessionNVInfo* GetVkOpticalFlowSessionNVInfo(format::HandleId id) { return GetObjectInfo<VulkanOpticalFlowSessionNVInfo>(id, &opticalFlowSessionNV_map_); }
+    VulkanPerformanceConfigurationINTELInfo* GetVkPerformanceConfigurationINTELInfo(format::HandleId id) { return GetObjectInfo<VulkanPerformanceConfigurationINTELInfo>(id, &performanceConfigurationINTEL_map_); }
+    VulkanPhysicalDeviceInfo* GetVkPhysicalDeviceInfo(format::HandleId id) { return GetObjectInfo<VulkanPhysicalDeviceInfo>(id, &physicalDevice_map_); }
+    VulkanPipelineInfo* GetVkPipelineInfo(format::HandleId id) { return GetObjectInfo<VulkanPipelineInfo>(id, &pipeline_map_); }
+    VulkanPipelineBinaryKHRInfo* GetVkPipelineBinaryKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanPipelineBinaryKHRInfo>(id, &pipelineBinaryKHR_map_); }
+    VulkanPipelineCacheInfo* GetVkPipelineCacheInfo(format::HandleId id) { return GetObjectInfo<VulkanPipelineCacheInfo>(id, &pipelineCache_map_); }
+    VulkanPipelineLayoutInfo* GetVkPipelineLayoutInfo(format::HandleId id) { return GetObjectInfo<VulkanPipelineLayoutInfo>(id, &pipelineLayout_map_); }
+    VulkanPrivateDataSlotInfo* GetVkPrivateDataSlotInfo(format::HandleId id) { return GetObjectInfo<VulkanPrivateDataSlotInfo>(id, &privateDataSlot_map_); }
+    VulkanQueryPoolInfo* GetVkQueryPoolInfo(format::HandleId id) { return GetObjectInfo<VulkanQueryPoolInfo>(id, &queryPool_map_); }
+    VulkanQueueInfo* GetVkQueueInfo(format::HandleId id) { return GetObjectInfo<VulkanQueueInfo>(id, &queue_map_); }
+    VulkanRenderPassInfo* GetVkRenderPassInfo(format::HandleId id) { return GetObjectInfo<VulkanRenderPassInfo>(id, &renderPass_map_); }
+    VulkanSamplerInfo* GetVkSamplerInfo(format::HandleId id) { return GetObjectInfo<VulkanSamplerInfo>(id, &sampler_map_); }
+    VulkanSamplerYcbcrConversionInfo* GetVkSamplerYcbcrConversionInfo(format::HandleId id) { return GetObjectInfo<VulkanSamplerYcbcrConversionInfo>(id, &samplerYcbcrConversion_map_); }
+    VulkanSemaphoreInfo* GetVkSemaphoreInfo(format::HandleId id) { return GetObjectInfo<VulkanSemaphoreInfo>(id, &semaphore_map_); }
+    VulkanShaderEXTInfo* GetVkShaderEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanShaderEXTInfo>(id, &shaderEXT_map_); }
+    VulkanShaderModuleInfo* GetVkShaderModuleInfo(format::HandleId id) { return GetObjectInfo<VulkanShaderModuleInfo>(id, &shaderModule_map_); }
+    VulkanSurfaceKHRInfo* GetVkSurfaceKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanSurfaceKHRInfo>(id, &surfaceKHR_map_); }
+    VulkanSwapchainKHRInfo* GetVkSwapchainKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanSwapchainKHRInfo>(id, &swapchainKHR_map_); }
+    VulkanValidationCacheEXTInfo* GetVkValidationCacheEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanValidationCacheEXTInfo>(id, &validationCacheEXT_map_); }
+    VulkanVideoSessionKHRInfo* GetVkVideoSessionKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanVideoSessionKHRInfo>(id, &videoSessionKHR_map_); }
+    VulkanVideoSessionParametersKHRInfo* GetVkVideoSessionParametersKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanVideoSessionParametersKHRInfo>(id, &videoSessionParametersKHR_map_); }
 
-    void VisitAccelerationStructureKHRInfo(std::function<void(const AccelerationStructureKHRInfo*)> visitor) const {  for (const auto& entry : accelerationStructureKHR_map_) { visitor(&entry.second); }  }
-    void VisitAccelerationStructureNVInfo(std::function<void(const AccelerationStructureNVInfo*)> visitor) const {  for (const auto& entry : accelerationStructureNV_map_) { visitor(&entry.second); }  }
-    void VisitBufferInfo(std::function<void(const BufferInfo*)> visitor) const {  for (const auto& entry : buffer_map_) { visitor(&entry.second); }  }
-    void VisitBufferViewInfo(std::function<void(const BufferViewInfo*)> visitor) const {  for (const auto& entry : bufferView_map_) { visitor(&entry.second); }  }
-    void VisitCommandBufferInfo(std::function<void(const CommandBufferInfo*)> visitor) const {  for (const auto& entry : commandBuffer_map_) { visitor(&entry.second); }  }
-    void VisitCommandPoolInfo(std::function<void(const CommandPoolInfo*)> visitor) const {  for (const auto& entry : commandPool_map_) { visitor(&entry.second); }  }
-    void VisitDebugReportCallbackEXTInfo(std::function<void(const DebugReportCallbackEXTInfo*)> visitor) const {  for (const auto& entry : debugReportCallbackEXT_map_) { visitor(&entry.second); }  }
-    void VisitDebugUtilsMessengerEXTInfo(std::function<void(const DebugUtilsMessengerEXTInfo*)> visitor) const {  for (const auto& entry : debugUtilsMessengerEXT_map_) { visitor(&entry.second); }  }
-    void VisitDeferredOperationKHRInfo(std::function<void(const DeferredOperationKHRInfo*)> visitor) const {  for (const auto& entry : deferredOperationKHR_map_) { visitor(&entry.second); }  }
-    void VisitDescriptorPoolInfo(std::function<void(const DescriptorPoolInfo*)> visitor) const {  for (const auto& entry : descriptorPool_map_) { visitor(&entry.second); }  }
-    void VisitDescriptorSetInfo(std::function<void(const DescriptorSetInfo*)> visitor) const {  for (const auto& entry : descriptorSet_map_) { visitor(&entry.second); }  }
-    void VisitDescriptorSetLayoutInfo(std::function<void(const DescriptorSetLayoutInfo*)> visitor) const {  for (const auto& entry : descriptorSetLayout_map_) { visitor(&entry.second); }  }
-    void VisitDescriptorUpdateTemplateInfo(std::function<void(const DescriptorUpdateTemplateInfo*)> visitor) const {  for (const auto& entry : descriptorUpdateTemplate_map_) { visitor(&entry.second); }  }
-    void VisitDeviceInfo(std::function<void(const DeviceInfo*)> visitor) const {  for (const auto& entry : device_map_) { visitor(&entry.second); }  }
-    void VisitDeviceMemoryInfo(std::function<void(const DeviceMemoryInfo*)> visitor) const {  for (const auto& entry : deviceMemory_map_) { visitor(&entry.second); }  }
-    void VisitDisplayKHRInfo(std::function<void(const DisplayKHRInfo*)> visitor) const {  for (const auto& entry : displayKHR_map_) { visitor(&entry.second); }  }
-    void VisitDisplayModeKHRInfo(std::function<void(const DisplayModeKHRInfo*)> visitor) const {  for (const auto& entry : displayModeKHR_map_) { visitor(&entry.second); }  }
-    void VisitEventInfo(std::function<void(const EventInfo*)> visitor) const {  for (const auto& entry : event_map_) { visitor(&entry.second); }  }
-    void VisitFenceInfo(std::function<void(const FenceInfo*)> visitor) const {  for (const auto& entry : fence_map_) { visitor(&entry.second); }  }
-    void VisitFramebufferInfo(std::function<void(const FramebufferInfo*)> visitor) const {  for (const auto& entry : framebuffer_map_) { visitor(&entry.second); }  }
-    void VisitImageInfo(std::function<void(const ImageInfo*)> visitor) const {  for (const auto& entry : image_map_) { visitor(&entry.second); }  }
-    void VisitImageViewInfo(std::function<void(const ImageViewInfo*)> visitor) const {  for (const auto& entry : imageView_map_) { visitor(&entry.second); }  }
-    void VisitIndirectCommandsLayoutEXTInfo(std::function<void(const IndirectCommandsLayoutEXTInfo*)> visitor) const {  for (const auto& entry : indirectCommandsLayoutEXT_map_) { visitor(&entry.second); }  }
-    void VisitIndirectCommandsLayoutNVInfo(std::function<void(const IndirectCommandsLayoutNVInfo*)> visitor) const {  for (const auto& entry : indirectCommandsLayoutNV_map_) { visitor(&entry.second); }  }
-    void VisitIndirectExecutionSetEXTInfo(std::function<void(const IndirectExecutionSetEXTInfo*)> visitor) const {  for (const auto& entry : indirectExecutionSetEXT_map_) { visitor(&entry.second); }  }
-    void VisitInstanceInfo(std::function<void(const InstanceInfo*)> visitor) const {  for (const auto& entry : instance_map_) { visitor(&entry.second); }  }
-    void VisitMicromapEXTInfo(std::function<void(const MicromapEXTInfo*)> visitor) const {  for (const auto& entry : micromapEXT_map_) { visitor(&entry.second); }  }
-    void VisitOpticalFlowSessionNVInfo(std::function<void(const OpticalFlowSessionNVInfo*)> visitor) const {  for (const auto& entry : opticalFlowSessionNV_map_) { visitor(&entry.second); }  }
-    void VisitPerformanceConfigurationINTELInfo(std::function<void(const PerformanceConfigurationINTELInfo*)> visitor) const {  for (const auto& entry : performanceConfigurationINTEL_map_) { visitor(&entry.second); }  }
-    void VisitPhysicalDeviceInfo(std::function<void(const PhysicalDeviceInfo*)> visitor) const {  for (const auto& entry : physicalDevice_map_) { visitor(&entry.second); }  }
-    void VisitPipelineInfo(std::function<void(const PipelineInfo*)> visitor) const {  for (const auto& entry : pipeline_map_) { visitor(&entry.second); }  }
-    void VisitPipelineBinaryKHRInfo(std::function<void(const PipelineBinaryKHRInfo*)> visitor) const {  for (const auto& entry : pipelineBinaryKHR_map_) { visitor(&entry.second); }  }
-    void VisitPipelineCacheInfo(std::function<void(const PipelineCacheInfo*)> visitor) const {  for (const auto& entry : pipelineCache_map_) { visitor(&entry.second); }  }
-    void VisitPipelineLayoutInfo(std::function<void(const PipelineLayoutInfo*)> visitor) const {  for (const auto& entry : pipelineLayout_map_) { visitor(&entry.second); }  }
-    void VisitPrivateDataSlotInfo(std::function<void(const PrivateDataSlotInfo*)> visitor) const {  for (const auto& entry : privateDataSlot_map_) { visitor(&entry.second); }  }
-    void VisitQueryPoolInfo(std::function<void(const QueryPoolInfo*)> visitor) const {  for (const auto& entry : queryPool_map_) { visitor(&entry.second); }  }
-    void VisitQueueInfo(std::function<void(const QueueInfo*)> visitor) const {  for (const auto& entry : queue_map_) { visitor(&entry.second); }  }
-    void VisitRenderPassInfo(std::function<void(const RenderPassInfo*)> visitor) const {  for (const auto& entry : renderPass_map_) { visitor(&entry.second); }  }
-    void VisitSamplerInfo(std::function<void(const SamplerInfo*)> visitor) const {  for (const auto& entry : sampler_map_) { visitor(&entry.second); }  }
-    void VisitSamplerYcbcrConversionInfo(std::function<void(const SamplerYcbcrConversionInfo*)> visitor) const {  for (const auto& entry : samplerYcbcrConversion_map_) { visitor(&entry.second); }  }
-    void VisitSemaphoreInfo(std::function<void(const SemaphoreInfo*)> visitor) const {  for (const auto& entry : semaphore_map_) { visitor(&entry.second); }  }
-    void VisitShaderEXTInfo(std::function<void(const ShaderEXTInfo*)> visitor) const {  for (const auto& entry : shaderEXT_map_) { visitor(&entry.second); }  }
-    void VisitShaderModuleInfo(std::function<void(const ShaderModuleInfo*)> visitor) const {  for (const auto& entry : shaderModule_map_) { visitor(&entry.second); }  }
-    void VisitSurfaceKHRInfo(std::function<void(const SurfaceKHRInfo*)> visitor) const {  for (const auto& entry : surfaceKHR_map_) { visitor(&entry.second); }  }
-    void VisitSwapchainKHRInfo(std::function<void(const SwapchainKHRInfo*)> visitor) const {  for (const auto& entry : swapchainKHR_map_) { visitor(&entry.second); }  }
-    void VisitValidationCacheEXTInfo(std::function<void(const ValidationCacheEXTInfo*)> visitor) const {  for (const auto& entry : validationCacheEXT_map_) { visitor(&entry.second); }  }
-    void VisitVideoSessionKHRInfo(std::function<void(const VideoSessionKHRInfo*)> visitor) const {  for (const auto& entry : videoSessionKHR_map_) { visitor(&entry.second); }  }
-    void VisitVideoSessionParametersKHRInfo(std::function<void(const VideoSessionParametersKHRInfo*)> visitor) const {  for (const auto& entry : videoSessionParametersKHR_map_) { visitor(&entry.second); }  }
+    void VisitVkAccelerationStructureKHRInfo(std::function<void(const VulkanAccelerationStructureKHRInfo*)> visitor) const {  for (const auto& entry : accelerationStructureKHR_map_) { visitor(&entry.second); }  }
+    void VisitVkAccelerationStructureNVInfo(std::function<void(const VulkanAccelerationStructureNVInfo*)> visitor) const {  for (const auto& entry : accelerationStructureNV_map_) { visitor(&entry.second); }  }
+    void VisitVkBufferInfo(std::function<void(const VulkanBufferInfo*)> visitor) const {  for (const auto& entry : buffer_map_) { visitor(&entry.second); }  }
+    void VisitVkBufferViewInfo(std::function<void(const VulkanBufferViewInfo*)> visitor) const {  for (const auto& entry : bufferView_map_) { visitor(&entry.second); }  }
+    void VisitVkCommandBufferInfo(std::function<void(const VulkanCommandBufferInfo*)> visitor) const {  for (const auto& entry : commandBuffer_map_) { visitor(&entry.second); }  }
+    void VisitVkCommandPoolInfo(std::function<void(const VulkanCommandPoolInfo*)> visitor) const {  for (const auto& entry : commandPool_map_) { visitor(&entry.second); }  }
+    void VisitVkDebugReportCallbackEXTInfo(std::function<void(const VulkanDebugReportCallbackEXTInfo*)> visitor) const {  for (const auto& entry : debugReportCallbackEXT_map_) { visitor(&entry.second); }  }
+    void VisitVkDebugUtilsMessengerEXTInfo(std::function<void(const VulkanDebugUtilsMessengerEXTInfo*)> visitor) const {  for (const auto& entry : debugUtilsMessengerEXT_map_) { visitor(&entry.second); }  }
+    void VisitVkDeferredOperationKHRInfo(std::function<void(const VulkanDeferredOperationKHRInfo*)> visitor) const {  for (const auto& entry : deferredOperationKHR_map_) { visitor(&entry.second); }  }
+    void VisitVkDescriptorPoolInfo(std::function<void(const VulkanDescriptorPoolInfo*)> visitor) const {  for (const auto& entry : descriptorPool_map_) { visitor(&entry.second); }  }
+    void VisitVkDescriptorSetInfo(std::function<void(const VulkanDescriptorSetInfo*)> visitor) const {  for (const auto& entry : descriptorSet_map_) { visitor(&entry.second); }  }
+    void VisitVkDescriptorSetLayoutInfo(std::function<void(const VulkanDescriptorSetLayoutInfo*)> visitor) const {  for (const auto& entry : descriptorSetLayout_map_) { visitor(&entry.second); }  }
+    void VisitVkDescriptorUpdateTemplateInfo(std::function<void(const VulkanDescriptorUpdateTemplateInfo*)> visitor) const {  for (const auto& entry : descriptorUpdateTemplate_map_) { visitor(&entry.second); }  }
+    void VisitVkDeviceInfo(std::function<void(const VulkanDeviceInfo*)> visitor) const {  for (const auto& entry : device_map_) { visitor(&entry.second); }  }
+    void VisitVkDeviceMemoryInfo(std::function<void(const VulkanDeviceMemoryInfo*)> visitor) const {  for (const auto& entry : deviceMemory_map_) { visitor(&entry.second); }  }
+    void VisitVkDisplayKHRInfo(std::function<void(const VulkanDisplayKHRInfo*)> visitor) const {  for (const auto& entry : displayKHR_map_) { visitor(&entry.second); }  }
+    void VisitVkDisplayModeKHRInfo(std::function<void(const VulkanDisplayModeKHRInfo*)> visitor) const {  for (const auto& entry : displayModeKHR_map_) { visitor(&entry.second); }  }
+    void VisitVkEventInfo(std::function<void(const VulkanEventInfo*)> visitor) const {  for (const auto& entry : event_map_) { visitor(&entry.second); }  }
+    void VisitVkFenceInfo(std::function<void(const VulkanFenceInfo*)> visitor) const {  for (const auto& entry : fence_map_) { visitor(&entry.second); }  }
+    void VisitVkFramebufferInfo(std::function<void(const VulkanFramebufferInfo*)> visitor) const {  for (const auto& entry : framebuffer_map_) { visitor(&entry.second); }  }
+    void VisitVkImageInfo(std::function<void(const VulkanImageInfo*)> visitor) const {  for (const auto& entry : image_map_) { visitor(&entry.second); }  }
+    void VisitVkImageViewInfo(std::function<void(const VulkanImageViewInfo*)> visitor) const {  for (const auto& entry : imageView_map_) { visitor(&entry.second); }  }
+    void VisitVkIndirectCommandsLayoutEXTInfo(std::function<void(const VulkanIndirectCommandsLayoutEXTInfo*)> visitor) const {  for (const auto& entry : indirectCommandsLayoutEXT_map_) { visitor(&entry.second); }  }
+    void VisitVkIndirectCommandsLayoutNVInfo(std::function<void(const VulkanIndirectCommandsLayoutNVInfo*)> visitor) const {  for (const auto& entry : indirectCommandsLayoutNV_map_) { visitor(&entry.second); }  }
+    void VisitVkIndirectExecutionSetEXTInfo(std::function<void(const VulkanIndirectExecutionSetEXTInfo*)> visitor) const {  for (const auto& entry : indirectExecutionSetEXT_map_) { visitor(&entry.second); }  }
+    void VisitVkInstanceInfo(std::function<void(const VulkanInstanceInfo*)> visitor) const {  for (const auto& entry : instance_map_) { visitor(&entry.second); }  }
+    void VisitVkMicromapEXTInfo(std::function<void(const VulkanMicromapEXTInfo*)> visitor) const {  for (const auto& entry : micromapEXT_map_) { visitor(&entry.second); }  }
+    void VisitVkOpticalFlowSessionNVInfo(std::function<void(const VulkanOpticalFlowSessionNVInfo*)> visitor) const {  for (const auto& entry : opticalFlowSessionNV_map_) { visitor(&entry.second); }  }
+    void VisitVkPerformanceConfigurationINTELInfo(std::function<void(const VulkanPerformanceConfigurationINTELInfo*)> visitor) const {  for (const auto& entry : performanceConfigurationINTEL_map_) { visitor(&entry.second); }  }
+    void VisitVkPhysicalDeviceInfo(std::function<void(const VulkanPhysicalDeviceInfo*)> visitor) const {  for (const auto& entry : physicalDevice_map_) { visitor(&entry.second); }  }
+    void VisitVkPipelineInfo(std::function<void(const VulkanPipelineInfo*)> visitor) const {  for (const auto& entry : pipeline_map_) { visitor(&entry.second); }  }
+    void VisitVkPipelineBinaryKHRInfo(std::function<void(const VulkanPipelineBinaryKHRInfo*)> visitor) const {  for (const auto& entry : pipelineBinaryKHR_map_) { visitor(&entry.second); }  }
+    void VisitVkPipelineCacheInfo(std::function<void(const VulkanPipelineCacheInfo*)> visitor) const {  for (const auto& entry : pipelineCache_map_) { visitor(&entry.second); }  }
+    void VisitVkPipelineLayoutInfo(std::function<void(const VulkanPipelineLayoutInfo*)> visitor) const {  for (const auto& entry : pipelineLayout_map_) { visitor(&entry.second); }  }
+    void VisitVkPrivateDataSlotInfo(std::function<void(const VulkanPrivateDataSlotInfo*)> visitor) const {  for (const auto& entry : privateDataSlot_map_) { visitor(&entry.second); }  }
+    void VisitVkQueryPoolInfo(std::function<void(const VulkanQueryPoolInfo*)> visitor) const {  for (const auto& entry : queryPool_map_) { visitor(&entry.second); }  }
+    void VisitVkQueueInfo(std::function<void(const VulkanQueueInfo*)> visitor) const {  for (const auto& entry : queue_map_) { visitor(&entry.second); }  }
+    void VisitVkRenderPassInfo(std::function<void(const VulkanRenderPassInfo*)> visitor) const {  for (const auto& entry : renderPass_map_) { visitor(&entry.second); }  }
+    void VisitVkSamplerInfo(std::function<void(const VulkanSamplerInfo*)> visitor) const {  for (const auto& entry : sampler_map_) { visitor(&entry.second); }  }
+    void VisitVkSamplerYcbcrConversionInfo(std::function<void(const VulkanSamplerYcbcrConversionInfo*)> visitor) const {  for (const auto& entry : samplerYcbcrConversion_map_) { visitor(&entry.second); }  }
+    void VisitVkSemaphoreInfo(std::function<void(const VulkanSemaphoreInfo*)> visitor) const {  for (const auto& entry : semaphore_map_) { visitor(&entry.second); }  }
+    void VisitVkShaderEXTInfo(std::function<void(const VulkanShaderEXTInfo*)> visitor) const {  for (const auto& entry : shaderEXT_map_) { visitor(&entry.second); }  }
+    void VisitVkShaderModuleInfo(std::function<void(const VulkanShaderModuleInfo*)> visitor) const {  for (const auto& entry : shaderModule_map_) { visitor(&entry.second); }  }
+    void VisitVkSurfaceKHRInfo(std::function<void(const VulkanSurfaceKHRInfo*)> visitor) const {  for (const auto& entry : surfaceKHR_map_) { visitor(&entry.second); }  }
+    void VisitVkSwapchainKHRInfo(std::function<void(const VulkanSwapchainKHRInfo*)> visitor) const {  for (const auto& entry : swapchainKHR_map_) { visitor(&entry.second); }  }
+    void VisitVkValidationCacheEXTInfo(std::function<void(const VulkanValidationCacheEXTInfo*)> visitor) const {  for (const auto& entry : validationCacheEXT_map_) { visitor(&entry.second); }  }
+    void VisitVkVideoSessionKHRInfo(std::function<void(const VulkanVideoSessionKHRInfo*)> visitor) const {  for (const auto& entry : videoSessionKHR_map_) { visitor(&entry.second); }  }
+    void VisitVkVideoSessionParametersKHRInfo(std::function<void(const VulkanVideoSessionParametersKHRInfo*)> visitor) const {  for (const auto& entry : videoSessionParametersKHR_map_) { visitor(&entry.second); }  }
 
   protected:
-     std::unordered_map<format::HandleId, AccelerationStructureKHRInfo> accelerationStructureKHR_map_;
-     std::unordered_map<format::HandleId, AccelerationStructureNVInfo> accelerationStructureNV_map_;
-     std::unordered_map<format::HandleId, BufferInfo> buffer_map_;
-     std::unordered_map<format::HandleId, BufferViewInfo> bufferView_map_;
-     std::unordered_map<format::HandleId, CommandBufferInfo> commandBuffer_map_;
-     std::unordered_map<format::HandleId, CommandPoolInfo> commandPool_map_;
-     std::unordered_map<format::HandleId, DebugReportCallbackEXTInfo> debugReportCallbackEXT_map_;
-     std::unordered_map<format::HandleId, DebugUtilsMessengerEXTInfo> debugUtilsMessengerEXT_map_;
-     std::unordered_map<format::HandleId, DeferredOperationKHRInfo> deferredOperationKHR_map_;
-     std::unordered_map<format::HandleId, DescriptorPoolInfo> descriptorPool_map_;
-     std::unordered_map<format::HandleId, DescriptorSetInfo> descriptorSet_map_;
-     std::unordered_map<format::HandleId, DescriptorSetLayoutInfo> descriptorSetLayout_map_;
-     std::unordered_map<format::HandleId, DescriptorUpdateTemplateInfo> descriptorUpdateTemplate_map_;
-     std::unordered_map<format::HandleId, DeviceInfo> device_map_;
-     std::unordered_map<format::HandleId, DeviceMemoryInfo> deviceMemory_map_;
-     std::unordered_map<format::HandleId, DisplayKHRInfo> displayKHR_map_;
-     std::unordered_map<format::HandleId, DisplayModeKHRInfo> displayModeKHR_map_;
-     std::unordered_map<format::HandleId, EventInfo> event_map_;
-     std::unordered_map<format::HandleId, FenceInfo> fence_map_;
-     std::unordered_map<format::HandleId, FramebufferInfo> framebuffer_map_;
-     std::unordered_map<format::HandleId, ImageInfo> image_map_;
-     std::unordered_map<format::HandleId, ImageViewInfo> imageView_map_;
-     std::unordered_map<format::HandleId, IndirectCommandsLayoutEXTInfo> indirectCommandsLayoutEXT_map_;
-     std::unordered_map<format::HandleId, IndirectCommandsLayoutNVInfo> indirectCommandsLayoutNV_map_;
-     std::unordered_map<format::HandleId, IndirectExecutionSetEXTInfo> indirectExecutionSetEXT_map_;
-     std::unordered_map<format::HandleId, InstanceInfo> instance_map_;
-     std::unordered_map<format::HandleId, MicromapEXTInfo> micromapEXT_map_;
-     std::unordered_map<format::HandleId, OpticalFlowSessionNVInfo> opticalFlowSessionNV_map_;
-     std::unordered_map<format::HandleId, PerformanceConfigurationINTELInfo> performanceConfigurationINTEL_map_;
-     std::unordered_map<format::HandleId, PhysicalDeviceInfo> physicalDevice_map_;
-     std::unordered_map<format::HandleId, PipelineInfo> pipeline_map_;
-     std::unordered_map<format::HandleId, PipelineBinaryKHRInfo> pipelineBinaryKHR_map_;
-     std::unordered_map<format::HandleId, PipelineCacheInfo> pipelineCache_map_;
-     std::unordered_map<format::HandleId, PipelineLayoutInfo> pipelineLayout_map_;
-     std::unordered_map<format::HandleId, PrivateDataSlotInfo> privateDataSlot_map_;
-     std::unordered_map<format::HandleId, QueryPoolInfo> queryPool_map_;
-     std::unordered_map<format::HandleId, QueueInfo> queue_map_;
-     std::unordered_map<format::HandleId, RenderPassInfo> renderPass_map_;
-     std::unordered_map<format::HandleId, SamplerInfo> sampler_map_;
-     std::unordered_map<format::HandleId, SamplerYcbcrConversionInfo> samplerYcbcrConversion_map_;
-     std::unordered_map<format::HandleId, SemaphoreInfo> semaphore_map_;
-     std::unordered_map<format::HandleId, ShaderEXTInfo> shaderEXT_map_;
-     std::unordered_map<format::HandleId, ShaderModuleInfo> shaderModule_map_;
-     std::unordered_map<format::HandleId, SurfaceKHRInfo> surfaceKHR_map_;
-     std::unordered_map<format::HandleId, SwapchainKHRInfo> swapchainKHR_map_;
-     std::unordered_map<format::HandleId, ValidationCacheEXTInfo> validationCacheEXT_map_;
-     std::unordered_map<format::HandleId, VideoSessionKHRInfo> videoSessionKHR_map_;
-     std::unordered_map<format::HandleId, VideoSessionParametersKHRInfo> videoSessionParametersKHR_map_;
+     std::unordered_map<format::HandleId, VulkanAccelerationStructureKHRInfo> accelerationStructureKHR_map_;
+     std::unordered_map<format::HandleId, VulkanAccelerationStructureNVInfo> accelerationStructureNV_map_;
+     std::unordered_map<format::HandleId, VulkanBufferInfo> buffer_map_;
+     std::unordered_map<format::HandleId, VulkanBufferViewInfo> bufferView_map_;
+     std::unordered_map<format::HandleId, VulkanCommandBufferInfo> commandBuffer_map_;
+     std::unordered_map<format::HandleId, VulkanCommandPoolInfo> commandPool_map_;
+     std::unordered_map<format::HandleId, VulkanDebugReportCallbackEXTInfo> debugReportCallbackEXT_map_;
+     std::unordered_map<format::HandleId, VulkanDebugUtilsMessengerEXTInfo> debugUtilsMessengerEXT_map_;
+     std::unordered_map<format::HandleId, VulkanDeferredOperationKHRInfo> deferredOperationKHR_map_;
+     std::unordered_map<format::HandleId, VulkanDescriptorPoolInfo> descriptorPool_map_;
+     std::unordered_map<format::HandleId, VulkanDescriptorSetInfo> descriptorSet_map_;
+     std::unordered_map<format::HandleId, VulkanDescriptorSetLayoutInfo> descriptorSetLayout_map_;
+     std::unordered_map<format::HandleId, VulkanDescriptorUpdateTemplateInfo> descriptorUpdateTemplate_map_;
+     std::unordered_map<format::HandleId, VulkanDeviceInfo> device_map_;
+     std::unordered_map<format::HandleId, VulkanDeviceMemoryInfo> deviceMemory_map_;
+     std::unordered_map<format::HandleId, VulkanDisplayKHRInfo> displayKHR_map_;
+     std::unordered_map<format::HandleId, VulkanDisplayModeKHRInfo> displayModeKHR_map_;
+     std::unordered_map<format::HandleId, VulkanEventInfo> event_map_;
+     std::unordered_map<format::HandleId, VulkanFenceInfo> fence_map_;
+     std::unordered_map<format::HandleId, VulkanFramebufferInfo> framebuffer_map_;
+     std::unordered_map<format::HandleId, VulkanImageInfo> image_map_;
+     std::unordered_map<format::HandleId, VulkanImageViewInfo> imageView_map_;
+     std::unordered_map<format::HandleId, VulkanIndirectCommandsLayoutEXTInfo> indirectCommandsLayoutEXT_map_;
+     std::unordered_map<format::HandleId, VulkanIndirectCommandsLayoutNVInfo> indirectCommandsLayoutNV_map_;
+     std::unordered_map<format::HandleId, VulkanIndirectExecutionSetEXTInfo> indirectExecutionSetEXT_map_;
+     std::unordered_map<format::HandleId, VulkanInstanceInfo> instance_map_;
+     std::unordered_map<format::HandleId, VulkanMicromapEXTInfo> micromapEXT_map_;
+     std::unordered_map<format::HandleId, VulkanOpticalFlowSessionNVInfo> opticalFlowSessionNV_map_;
+     std::unordered_map<format::HandleId, VulkanPerformanceConfigurationINTELInfo> performanceConfigurationINTEL_map_;
+     std::unordered_map<format::HandleId, VulkanPhysicalDeviceInfo> physicalDevice_map_;
+     std::unordered_map<format::HandleId, VulkanPipelineInfo> pipeline_map_;
+     std::unordered_map<format::HandleId, VulkanPipelineBinaryKHRInfo> pipelineBinaryKHR_map_;
+     std::unordered_map<format::HandleId, VulkanPipelineCacheInfo> pipelineCache_map_;
+     std::unordered_map<format::HandleId, VulkanPipelineLayoutInfo> pipelineLayout_map_;
+     std::unordered_map<format::HandleId, VulkanPrivateDataSlotInfo> privateDataSlot_map_;
+     std::unordered_map<format::HandleId, VulkanQueryPoolInfo> queryPool_map_;
+     std::unordered_map<format::HandleId, VulkanQueueInfo> queue_map_;
+     std::unordered_map<format::HandleId, VulkanRenderPassInfo> renderPass_map_;
+     std::unordered_map<format::HandleId, VulkanSamplerInfo> sampler_map_;
+     std::unordered_map<format::HandleId, VulkanSamplerYcbcrConversionInfo> samplerYcbcrConversion_map_;
+     std::unordered_map<format::HandleId, VulkanSemaphoreInfo> semaphore_map_;
+     std::unordered_map<format::HandleId, VulkanShaderEXTInfo> shaderEXT_map_;
+     std::unordered_map<format::HandleId, VulkanShaderModuleInfo> shaderModule_map_;
+     std::unordered_map<format::HandleId, VulkanSurfaceKHRInfo> surfaceKHR_map_;
+     std::unordered_map<format::HandleId, VulkanSwapchainKHRInfo> swapchainKHR_map_;
+     std::unordered_map<format::HandleId, VulkanValidationCacheEXTInfo> validationCacheEXT_map_;
+     std::unordered_map<format::HandleId, VulkanVideoSessionKHRInfo> videoSessionKHR_map_;
+     std::unordered_map<format::HandleId, VulkanVideoSessionParametersKHRInfo> videoSessionParametersKHR_map_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_object_info_table_base2.h
+++ b/framework/generated/generated_vulkan_object_info_table_base2.h
@@ -42,54 +42,54 @@ class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase
     VulkanObjectInfoTableBase2() {}
     ~VulkanObjectInfoTableBase2() {}
 
-    void AddVkAccelerationStructureKHRInfo(VulkanAccelerationStructureKHRInfo&& info) { AddObjectInfo(std::move(info), &accelerationStructureKHR_map_); }
-    void AddVkAccelerationStructureNVInfo(VulkanAccelerationStructureNVInfo&& info) { AddObjectInfo(std::move(info), &accelerationStructureNV_map_); }
-    void AddVkBufferInfo(VulkanBufferInfo&& info) { AddObjectInfo(std::move(info), &buffer_map_); }
-    void AddVkBufferViewInfo(VulkanBufferViewInfo&& info) { AddObjectInfo(std::move(info), &bufferView_map_); }
-    void AddVkCommandBufferInfo(VulkanCommandBufferInfo&& info) { AddObjectInfo(std::move(info), &commandBuffer_map_); }
-    void AddVkCommandPoolInfo(VulkanCommandPoolInfo&& info) { AddObjectInfo(std::move(info), &commandPool_map_); }
-    void AddVkDebugReportCallbackEXTInfo(VulkanDebugReportCallbackEXTInfo&& info) { AddObjectInfo(std::move(info), &debugReportCallbackEXT_map_); }
-    void AddVkDebugUtilsMessengerEXTInfo(VulkanDebugUtilsMessengerEXTInfo&& info) { AddObjectInfo(std::move(info), &debugUtilsMessengerEXT_map_); }
-    void AddVkDeferredOperationKHRInfo(VulkanDeferredOperationKHRInfo&& info) { AddObjectInfo(std::move(info), &deferredOperationKHR_map_); }
-    void AddVkDescriptorPoolInfo(VulkanDescriptorPoolInfo&& info) { AddObjectInfo(std::move(info), &descriptorPool_map_); }
-    void AddVkDescriptorSetInfo(VulkanDescriptorSetInfo&& info) { AddObjectInfo(std::move(info), &descriptorSet_map_); }
-    void AddVkDescriptorSetLayoutInfo(VulkanDescriptorSetLayoutInfo&& info) { AddObjectInfo(std::move(info), &descriptorSetLayout_map_); }
-    void AddVkDescriptorUpdateTemplateInfo(VulkanDescriptorUpdateTemplateInfo&& info) { AddObjectInfo(std::move(info), &descriptorUpdateTemplate_map_); }
-    void AddVkDeviceInfo(VulkanDeviceInfo&& info) { AddObjectInfo(std::move(info), &device_map_); }
-    void AddVkDeviceMemoryInfo(VulkanDeviceMemoryInfo&& info) { AddObjectInfo(std::move(info), &deviceMemory_map_); }
-    void AddVkDisplayKHRInfo(VulkanDisplayKHRInfo&& info) { AddObjectInfo(std::move(info), &displayKHR_map_); }
-    void AddVkDisplayModeKHRInfo(VulkanDisplayModeKHRInfo&& info) { AddObjectInfo(std::move(info), &displayModeKHR_map_); }
-    void AddVkEventInfo(VulkanEventInfo&& info) { AddObjectInfo(std::move(info), &event_map_); }
-    void AddVkFenceInfo(VulkanFenceInfo&& info) { AddObjectInfo(std::move(info), &fence_map_); }
-    void AddVkFramebufferInfo(VulkanFramebufferInfo&& info) { AddObjectInfo(std::move(info), &framebuffer_map_); }
-    void AddVkImageInfo(VulkanImageInfo&& info) { AddObjectInfo(std::move(info), &image_map_); }
-    void AddVkImageViewInfo(VulkanImageViewInfo&& info) { AddObjectInfo(std::move(info), &imageView_map_); }
-    void AddVkIndirectCommandsLayoutEXTInfo(VulkanIndirectCommandsLayoutEXTInfo&& info) { AddObjectInfo(std::move(info), &indirectCommandsLayoutEXT_map_); }
-    void AddVkIndirectCommandsLayoutNVInfo(VulkanIndirectCommandsLayoutNVInfo&& info) { AddObjectInfo(std::move(info), &indirectCommandsLayoutNV_map_); }
-    void AddVkIndirectExecutionSetEXTInfo(VulkanIndirectExecutionSetEXTInfo&& info) { AddObjectInfo(std::move(info), &indirectExecutionSetEXT_map_); }
-    void AddVkInstanceInfo(VulkanInstanceInfo&& info) { AddObjectInfo(std::move(info), &instance_map_); }
-    void AddVkMicromapEXTInfo(VulkanMicromapEXTInfo&& info) { AddObjectInfo(std::move(info), &micromapEXT_map_); }
-    void AddVkOpticalFlowSessionNVInfo(VulkanOpticalFlowSessionNVInfo&& info) { AddObjectInfo(std::move(info), &opticalFlowSessionNV_map_); }
-    void AddVkPerformanceConfigurationINTELInfo(VulkanPerformanceConfigurationINTELInfo&& info) { AddObjectInfo(std::move(info), &performanceConfigurationINTEL_map_); }
-    void AddVkPhysicalDeviceInfo(VulkanPhysicalDeviceInfo&& info) { AddObjectInfo(std::move(info), &physicalDevice_map_); }
-    void AddVkPipelineInfo(VulkanPipelineInfo&& info) { AddObjectInfo(std::move(info), &pipeline_map_); }
-    void AddVkPipelineBinaryKHRInfo(VulkanPipelineBinaryKHRInfo&& info) { AddObjectInfo(std::move(info), &pipelineBinaryKHR_map_); }
-    void AddVkPipelineCacheInfo(VulkanPipelineCacheInfo&& info) { AddObjectInfo(std::move(info), &pipelineCache_map_); }
-    void AddVkPipelineLayoutInfo(VulkanPipelineLayoutInfo&& info) { AddObjectInfo(std::move(info), &pipelineLayout_map_); }
-    void AddVkPrivateDataSlotInfo(VulkanPrivateDataSlotInfo&& info) { AddObjectInfo(std::move(info), &privateDataSlot_map_); }
-    void AddVkQueryPoolInfo(VulkanQueryPoolInfo&& info) { AddObjectInfo(std::move(info), &queryPool_map_); }
-    void AddVkQueueInfo(VulkanQueueInfo&& info) { AddObjectInfo(std::move(info), &queue_map_); }
-    void AddVkRenderPassInfo(VulkanRenderPassInfo&& info) { AddObjectInfo(std::move(info), &renderPass_map_); }
-    void AddVkSamplerInfo(VulkanSamplerInfo&& info) { AddObjectInfo(std::move(info), &sampler_map_); }
-    void AddVkSamplerYcbcrConversionInfo(VulkanSamplerYcbcrConversionInfo&& info) { AddObjectInfo(std::move(info), &samplerYcbcrConversion_map_); }
-    void AddVkSemaphoreInfo(VulkanSemaphoreInfo&& info) { AddObjectInfo(std::move(info), &semaphore_map_); }
-    void AddVkShaderEXTInfo(VulkanShaderEXTInfo&& info) { AddObjectInfo(std::move(info), &shaderEXT_map_); }
-    void AddVkShaderModuleInfo(VulkanShaderModuleInfo&& info) { AddObjectInfo(std::move(info), &shaderModule_map_); }
-    void AddVkSurfaceKHRInfo(VulkanSurfaceKHRInfo&& info) { AddObjectInfo(std::move(info), &surfaceKHR_map_); }
-    void AddVkSwapchainKHRInfo(VulkanSwapchainKHRInfo&& info) { AddObjectInfo(std::move(info), &swapchainKHR_map_); }
-    void AddVkValidationCacheEXTInfo(VulkanValidationCacheEXTInfo&& info) { AddObjectInfo(std::move(info), &validationCacheEXT_map_); }
-    void AddVkVideoSessionKHRInfo(VulkanVideoSessionKHRInfo&& info) { AddObjectInfo(std::move(info), &videoSessionKHR_map_); }
-    void AddVkVideoSessionParametersKHRInfo(VulkanVideoSessionParametersKHRInfo&& info) { AddObjectInfo(std::move(info), &videoSessionParametersKHR_map_); }
+    void AddVkAccelerationStructureKHRInfo(VulkanAccelerationStructureKHRInfo&& info) { AddVkObjectInfo(std::move(info), &accelerationStructureKHR_map_); }
+    void AddVkAccelerationStructureNVInfo(VulkanAccelerationStructureNVInfo&& info) { AddVkObjectInfo(std::move(info), &accelerationStructureNV_map_); }
+    void AddVkBufferInfo(VulkanBufferInfo&& info) { AddVkObjectInfo(std::move(info), &buffer_map_); }
+    void AddVkBufferViewInfo(VulkanBufferViewInfo&& info) { AddVkObjectInfo(std::move(info), &bufferView_map_); }
+    void AddVkCommandBufferInfo(VulkanCommandBufferInfo&& info) { AddVkObjectInfo(std::move(info), &commandBuffer_map_); }
+    void AddVkCommandPoolInfo(VulkanCommandPoolInfo&& info) { AddVkObjectInfo(std::move(info), &commandPool_map_); }
+    void AddVkDebugReportCallbackEXTInfo(VulkanDebugReportCallbackEXTInfo&& info) { AddVkObjectInfo(std::move(info), &debugReportCallbackEXT_map_); }
+    void AddVkDebugUtilsMessengerEXTInfo(VulkanDebugUtilsMessengerEXTInfo&& info) { AddVkObjectInfo(std::move(info), &debugUtilsMessengerEXT_map_); }
+    void AddVkDeferredOperationKHRInfo(VulkanDeferredOperationKHRInfo&& info) { AddVkObjectInfo(std::move(info), &deferredOperationKHR_map_); }
+    void AddVkDescriptorPoolInfo(VulkanDescriptorPoolInfo&& info) { AddVkObjectInfo(std::move(info), &descriptorPool_map_); }
+    void AddVkDescriptorSetInfo(VulkanDescriptorSetInfo&& info) { AddVkObjectInfo(std::move(info), &descriptorSet_map_); }
+    void AddVkDescriptorSetLayoutInfo(VulkanDescriptorSetLayoutInfo&& info) { AddVkObjectInfo(std::move(info), &descriptorSetLayout_map_); }
+    void AddVkDescriptorUpdateTemplateInfo(VulkanDescriptorUpdateTemplateInfo&& info) { AddVkObjectInfo(std::move(info), &descriptorUpdateTemplate_map_); }
+    void AddVkDeviceInfo(VulkanDeviceInfo&& info) { AddVkObjectInfo(std::move(info), &device_map_); }
+    void AddVkDeviceMemoryInfo(VulkanDeviceMemoryInfo&& info) { AddVkObjectInfo(std::move(info), &deviceMemory_map_); }
+    void AddVkDisplayKHRInfo(VulkanDisplayKHRInfo&& info) { AddVkObjectInfo(std::move(info), &displayKHR_map_); }
+    void AddVkDisplayModeKHRInfo(VulkanDisplayModeKHRInfo&& info) { AddVkObjectInfo(std::move(info), &displayModeKHR_map_); }
+    void AddVkEventInfo(VulkanEventInfo&& info) { AddVkObjectInfo(std::move(info), &event_map_); }
+    void AddVkFenceInfo(VulkanFenceInfo&& info) { AddVkObjectInfo(std::move(info), &fence_map_); }
+    void AddVkFramebufferInfo(VulkanFramebufferInfo&& info) { AddVkObjectInfo(std::move(info), &framebuffer_map_); }
+    void AddVkImageInfo(VulkanImageInfo&& info) { AddVkObjectInfo(std::move(info), &image_map_); }
+    void AddVkImageViewInfo(VulkanImageViewInfo&& info) { AddVkObjectInfo(std::move(info), &imageView_map_); }
+    void AddVkIndirectCommandsLayoutEXTInfo(VulkanIndirectCommandsLayoutEXTInfo&& info) { AddVkObjectInfo(std::move(info), &indirectCommandsLayoutEXT_map_); }
+    void AddVkIndirectCommandsLayoutNVInfo(VulkanIndirectCommandsLayoutNVInfo&& info) { AddVkObjectInfo(std::move(info), &indirectCommandsLayoutNV_map_); }
+    void AddVkIndirectExecutionSetEXTInfo(VulkanIndirectExecutionSetEXTInfo&& info) { AddVkObjectInfo(std::move(info), &indirectExecutionSetEXT_map_); }
+    void AddVkInstanceInfo(VulkanInstanceInfo&& info) { AddVkObjectInfo(std::move(info), &instance_map_); }
+    void AddVkMicromapEXTInfo(VulkanMicromapEXTInfo&& info) { AddVkObjectInfo(std::move(info), &micromapEXT_map_); }
+    void AddVkOpticalFlowSessionNVInfo(VulkanOpticalFlowSessionNVInfo&& info) { AddVkObjectInfo(std::move(info), &opticalFlowSessionNV_map_); }
+    void AddVkPerformanceConfigurationINTELInfo(VulkanPerformanceConfigurationINTELInfo&& info) { AddVkObjectInfo(std::move(info), &performanceConfigurationINTEL_map_); }
+    void AddVkPhysicalDeviceInfo(VulkanPhysicalDeviceInfo&& info) { AddVkObjectInfo(std::move(info), &physicalDevice_map_); }
+    void AddVkPipelineInfo(VulkanPipelineInfo&& info) { AddVkObjectInfo(std::move(info), &pipeline_map_); }
+    void AddVkPipelineBinaryKHRInfo(VulkanPipelineBinaryKHRInfo&& info) { AddVkObjectInfo(std::move(info), &pipelineBinaryKHR_map_); }
+    void AddVkPipelineCacheInfo(VulkanPipelineCacheInfo&& info) { AddVkObjectInfo(std::move(info), &pipelineCache_map_); }
+    void AddVkPipelineLayoutInfo(VulkanPipelineLayoutInfo&& info) { AddVkObjectInfo(std::move(info), &pipelineLayout_map_); }
+    void AddVkPrivateDataSlotInfo(VulkanPrivateDataSlotInfo&& info) { AddVkObjectInfo(std::move(info), &privateDataSlot_map_); }
+    void AddVkQueryPoolInfo(VulkanQueryPoolInfo&& info) { AddVkObjectInfo(std::move(info), &queryPool_map_); }
+    void AddVkQueueInfo(VulkanQueueInfo&& info) { AddVkObjectInfo(std::move(info), &queue_map_); }
+    void AddVkRenderPassInfo(VulkanRenderPassInfo&& info) { AddVkObjectInfo(std::move(info), &renderPass_map_); }
+    void AddVkSamplerInfo(VulkanSamplerInfo&& info) { AddVkObjectInfo(std::move(info), &sampler_map_); }
+    void AddVkSamplerYcbcrConversionInfo(VulkanSamplerYcbcrConversionInfo&& info) { AddVkObjectInfo(std::move(info), &samplerYcbcrConversion_map_); }
+    void AddVkSemaphoreInfo(VulkanSemaphoreInfo&& info) { AddVkObjectInfo(std::move(info), &semaphore_map_); }
+    void AddVkShaderEXTInfo(VulkanShaderEXTInfo&& info) { AddVkObjectInfo(std::move(info), &shaderEXT_map_); }
+    void AddVkShaderModuleInfo(VulkanShaderModuleInfo&& info) { AddVkObjectInfo(std::move(info), &shaderModule_map_); }
+    void AddVkSurfaceKHRInfo(VulkanSurfaceKHRInfo&& info) { AddVkObjectInfo(std::move(info), &surfaceKHR_map_); }
+    void AddVkSwapchainKHRInfo(VulkanSwapchainKHRInfo&& info) { AddVkObjectInfo(std::move(info), &swapchainKHR_map_); }
+    void AddVkValidationCacheEXTInfo(VulkanValidationCacheEXTInfo&& info) { AddVkObjectInfo(std::move(info), &validationCacheEXT_map_); }
+    void AddVkVideoSessionKHRInfo(VulkanVideoSessionKHRInfo&& info) { AddVkObjectInfo(std::move(info), &videoSessionKHR_map_); }
+    void AddVkVideoSessionParametersKHRInfo(VulkanVideoSessionParametersKHRInfo&& info) { AddVkObjectInfo(std::move(info), &videoSessionParametersKHR_map_); }
 
     void RemoveVkAccelerationStructureKHRInfo(format::HandleId id) { accelerationStructureKHR_map_.erase(id); }
     void RemoveVkAccelerationStructureNVInfo(format::HandleId id) { accelerationStructureNV_map_.erase(id); }
@@ -140,103 +140,103 @@ class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase
     void RemoveVkVideoSessionKHRInfo(format::HandleId id) { videoSessionKHR_map_.erase(id); }
     void RemoveVkVideoSessionParametersKHRInfo(format::HandleId id) { videoSessionParametersKHR_map_.erase(id); }
 
-    const VulkanAccelerationStructureKHRInfo* GetVkAccelerationStructureKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanAccelerationStructureKHRInfo>(id, &accelerationStructureKHR_map_); }
-    const VulkanAccelerationStructureNVInfo* GetVkAccelerationStructureNVInfo(format::HandleId id) const { return GetObjectInfo<VulkanAccelerationStructureNVInfo>(id, &accelerationStructureNV_map_); }
-    const VulkanBufferInfo* GetVkBufferInfo(format::HandleId id) const { return GetObjectInfo<VulkanBufferInfo>(id, &buffer_map_); }
-    const VulkanBufferViewInfo* GetVkBufferViewInfo(format::HandleId id) const { return GetObjectInfo<VulkanBufferViewInfo>(id, &bufferView_map_); }
-    const VulkanCommandBufferInfo* GetVkCommandBufferInfo(format::HandleId id) const { return GetObjectInfo<VulkanCommandBufferInfo>(id, &commandBuffer_map_); }
-    const VulkanCommandPoolInfo* GetVkCommandPoolInfo(format::HandleId id) const { return GetObjectInfo<VulkanCommandPoolInfo>(id, &commandPool_map_); }
-    const VulkanDebugReportCallbackEXTInfo* GetVkDebugReportCallbackEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanDebugReportCallbackEXTInfo>(id, &debugReportCallbackEXT_map_); }
-    const VulkanDebugUtilsMessengerEXTInfo* GetVkDebugUtilsMessengerEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanDebugUtilsMessengerEXTInfo>(id, &debugUtilsMessengerEXT_map_); }
-    const VulkanDeferredOperationKHRInfo* GetVkDeferredOperationKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanDeferredOperationKHRInfo>(id, &deferredOperationKHR_map_); }
-    const VulkanDescriptorPoolInfo* GetVkDescriptorPoolInfo(format::HandleId id) const { return GetObjectInfo<VulkanDescriptorPoolInfo>(id, &descriptorPool_map_); }
-    const VulkanDescriptorSetInfo* GetVkDescriptorSetInfo(format::HandleId id) const { return GetObjectInfo<VulkanDescriptorSetInfo>(id, &descriptorSet_map_); }
-    const VulkanDescriptorSetLayoutInfo* GetVkDescriptorSetLayoutInfo(format::HandleId id) const { return GetObjectInfo<VulkanDescriptorSetLayoutInfo>(id, &descriptorSetLayout_map_); }
-    const VulkanDescriptorUpdateTemplateInfo* GetVkDescriptorUpdateTemplateInfo(format::HandleId id) const { return GetObjectInfo<VulkanDescriptorUpdateTemplateInfo>(id, &descriptorUpdateTemplate_map_); }
-    const VulkanDeviceInfo* GetVkDeviceInfo(format::HandleId id) const { return GetObjectInfo<VulkanDeviceInfo>(id, &device_map_); }
-    const VulkanDeviceMemoryInfo* GetVkDeviceMemoryInfo(format::HandleId id) const { return GetObjectInfo<VulkanDeviceMemoryInfo>(id, &deviceMemory_map_); }
-    const VulkanDisplayKHRInfo* GetVkDisplayKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanDisplayKHRInfo>(id, &displayKHR_map_); }
-    const VulkanDisplayModeKHRInfo* GetVkDisplayModeKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanDisplayModeKHRInfo>(id, &displayModeKHR_map_); }
-    const VulkanEventInfo* GetVkEventInfo(format::HandleId id) const { return GetObjectInfo<VulkanEventInfo>(id, &event_map_); }
-    const VulkanFenceInfo* GetVkFenceInfo(format::HandleId id) const { return GetObjectInfo<VulkanFenceInfo>(id, &fence_map_); }
-    const VulkanFramebufferInfo* GetVkFramebufferInfo(format::HandleId id) const { return GetObjectInfo<VulkanFramebufferInfo>(id, &framebuffer_map_); }
-    const VulkanImageInfo* GetVkImageInfo(format::HandleId id) const { return GetObjectInfo<VulkanImageInfo>(id, &image_map_); }
-    const VulkanImageViewInfo* GetVkImageViewInfo(format::HandleId id) const { return GetObjectInfo<VulkanImageViewInfo>(id, &imageView_map_); }
-    const VulkanIndirectCommandsLayoutEXTInfo* GetVkIndirectCommandsLayoutEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanIndirectCommandsLayoutEXTInfo>(id, &indirectCommandsLayoutEXT_map_); }
-    const VulkanIndirectCommandsLayoutNVInfo* GetVkIndirectCommandsLayoutNVInfo(format::HandleId id) const { return GetObjectInfo<VulkanIndirectCommandsLayoutNVInfo>(id, &indirectCommandsLayoutNV_map_); }
-    const VulkanIndirectExecutionSetEXTInfo* GetVkIndirectExecutionSetEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanIndirectExecutionSetEXTInfo>(id, &indirectExecutionSetEXT_map_); }
-    const VulkanInstanceInfo* GetVkInstanceInfo(format::HandleId id) const { return GetObjectInfo<VulkanInstanceInfo>(id, &instance_map_); }
-    const VulkanMicromapEXTInfo* GetVkMicromapEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanMicromapEXTInfo>(id, &micromapEXT_map_); }
-    const VulkanOpticalFlowSessionNVInfo* GetVkOpticalFlowSessionNVInfo(format::HandleId id) const { return GetObjectInfo<VulkanOpticalFlowSessionNVInfo>(id, &opticalFlowSessionNV_map_); }
-    const VulkanPerformanceConfigurationINTELInfo* GetVkPerformanceConfigurationINTELInfo(format::HandleId id) const { return GetObjectInfo<VulkanPerformanceConfigurationINTELInfo>(id, &performanceConfigurationINTEL_map_); }
-    const VulkanPhysicalDeviceInfo* GetVkPhysicalDeviceInfo(format::HandleId id) const { return GetObjectInfo<VulkanPhysicalDeviceInfo>(id, &physicalDevice_map_); }
-    const VulkanPipelineInfo* GetVkPipelineInfo(format::HandleId id) const { return GetObjectInfo<VulkanPipelineInfo>(id, &pipeline_map_); }
-    const VulkanPipelineBinaryKHRInfo* GetVkPipelineBinaryKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanPipelineBinaryKHRInfo>(id, &pipelineBinaryKHR_map_); }
-    const VulkanPipelineCacheInfo* GetVkPipelineCacheInfo(format::HandleId id) const { return GetObjectInfo<VulkanPipelineCacheInfo>(id, &pipelineCache_map_); }
-    const VulkanPipelineLayoutInfo* GetVkPipelineLayoutInfo(format::HandleId id) const { return GetObjectInfo<VulkanPipelineLayoutInfo>(id, &pipelineLayout_map_); }
-    const VulkanPrivateDataSlotInfo* GetVkPrivateDataSlotInfo(format::HandleId id) const { return GetObjectInfo<VulkanPrivateDataSlotInfo>(id, &privateDataSlot_map_); }
-    const VulkanQueryPoolInfo* GetVkQueryPoolInfo(format::HandleId id) const { return GetObjectInfo<VulkanQueryPoolInfo>(id, &queryPool_map_); }
-    const VulkanQueueInfo* GetVkQueueInfo(format::HandleId id) const { return GetObjectInfo<VulkanQueueInfo>(id, &queue_map_); }
-    const VulkanRenderPassInfo* GetVkRenderPassInfo(format::HandleId id) const { return GetObjectInfo<VulkanRenderPassInfo>(id, &renderPass_map_); }
-    const VulkanSamplerInfo* GetVkSamplerInfo(format::HandleId id) const { return GetObjectInfo<VulkanSamplerInfo>(id, &sampler_map_); }
-    const VulkanSamplerYcbcrConversionInfo* GetVkSamplerYcbcrConversionInfo(format::HandleId id) const { return GetObjectInfo<VulkanSamplerYcbcrConversionInfo>(id, &samplerYcbcrConversion_map_); }
-    const VulkanSemaphoreInfo* GetVkSemaphoreInfo(format::HandleId id) const { return GetObjectInfo<VulkanSemaphoreInfo>(id, &semaphore_map_); }
-    const VulkanShaderEXTInfo* GetVkShaderEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanShaderEXTInfo>(id, &shaderEXT_map_); }
-    const VulkanShaderModuleInfo* GetVkShaderModuleInfo(format::HandleId id) const { return GetObjectInfo<VulkanShaderModuleInfo>(id, &shaderModule_map_); }
-    const VulkanSurfaceKHRInfo* GetVkSurfaceKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanSurfaceKHRInfo>(id, &surfaceKHR_map_); }
-    const VulkanSwapchainKHRInfo* GetVkSwapchainKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanSwapchainKHRInfo>(id, &swapchainKHR_map_); }
-    const VulkanValidationCacheEXTInfo* GetVkValidationCacheEXTInfo(format::HandleId id) const { return GetObjectInfo<VulkanValidationCacheEXTInfo>(id, &validationCacheEXT_map_); }
-    const VulkanVideoSessionKHRInfo* GetVkVideoSessionKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanVideoSessionKHRInfo>(id, &videoSessionKHR_map_); }
-    const VulkanVideoSessionParametersKHRInfo* GetVkVideoSessionParametersKHRInfo(format::HandleId id) const { return GetObjectInfo<VulkanVideoSessionParametersKHRInfo>(id, &videoSessionParametersKHR_map_); }
+    const VulkanAccelerationStructureKHRInfo* GetVkAccelerationStructureKHRInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanAccelerationStructureKHRInfo>(id, &accelerationStructureKHR_map_); }
+    const VulkanAccelerationStructureNVInfo* GetVkAccelerationStructureNVInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanAccelerationStructureNVInfo>(id, &accelerationStructureNV_map_); }
+    const VulkanBufferInfo* GetVkBufferInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanBufferInfo>(id, &buffer_map_); }
+    const VulkanBufferViewInfo* GetVkBufferViewInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanBufferViewInfo>(id, &bufferView_map_); }
+    const VulkanCommandBufferInfo* GetVkCommandBufferInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanCommandBufferInfo>(id, &commandBuffer_map_); }
+    const VulkanCommandPoolInfo* GetVkCommandPoolInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanCommandPoolInfo>(id, &commandPool_map_); }
+    const VulkanDebugReportCallbackEXTInfo* GetVkDebugReportCallbackEXTInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDebugReportCallbackEXTInfo>(id, &debugReportCallbackEXT_map_); }
+    const VulkanDebugUtilsMessengerEXTInfo* GetVkDebugUtilsMessengerEXTInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDebugUtilsMessengerEXTInfo>(id, &debugUtilsMessengerEXT_map_); }
+    const VulkanDeferredOperationKHRInfo* GetVkDeferredOperationKHRInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDeferredOperationKHRInfo>(id, &deferredOperationKHR_map_); }
+    const VulkanDescriptorPoolInfo* GetVkDescriptorPoolInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDescriptorPoolInfo>(id, &descriptorPool_map_); }
+    const VulkanDescriptorSetInfo* GetVkDescriptorSetInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDescriptorSetInfo>(id, &descriptorSet_map_); }
+    const VulkanDescriptorSetLayoutInfo* GetVkDescriptorSetLayoutInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDescriptorSetLayoutInfo>(id, &descriptorSetLayout_map_); }
+    const VulkanDescriptorUpdateTemplateInfo* GetVkDescriptorUpdateTemplateInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDescriptorUpdateTemplateInfo>(id, &descriptorUpdateTemplate_map_); }
+    const VulkanDeviceInfo* GetVkDeviceInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDeviceInfo>(id, &device_map_); }
+    const VulkanDeviceMemoryInfo* GetVkDeviceMemoryInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDeviceMemoryInfo>(id, &deviceMemory_map_); }
+    const VulkanDisplayKHRInfo* GetVkDisplayKHRInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDisplayKHRInfo>(id, &displayKHR_map_); }
+    const VulkanDisplayModeKHRInfo* GetVkDisplayModeKHRInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanDisplayModeKHRInfo>(id, &displayModeKHR_map_); }
+    const VulkanEventInfo* GetVkEventInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanEventInfo>(id, &event_map_); }
+    const VulkanFenceInfo* GetVkFenceInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanFenceInfo>(id, &fence_map_); }
+    const VulkanFramebufferInfo* GetVkFramebufferInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanFramebufferInfo>(id, &framebuffer_map_); }
+    const VulkanImageInfo* GetVkImageInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanImageInfo>(id, &image_map_); }
+    const VulkanImageViewInfo* GetVkImageViewInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanImageViewInfo>(id, &imageView_map_); }
+    const VulkanIndirectCommandsLayoutEXTInfo* GetVkIndirectCommandsLayoutEXTInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanIndirectCommandsLayoutEXTInfo>(id, &indirectCommandsLayoutEXT_map_); }
+    const VulkanIndirectCommandsLayoutNVInfo* GetVkIndirectCommandsLayoutNVInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanIndirectCommandsLayoutNVInfo>(id, &indirectCommandsLayoutNV_map_); }
+    const VulkanIndirectExecutionSetEXTInfo* GetVkIndirectExecutionSetEXTInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanIndirectExecutionSetEXTInfo>(id, &indirectExecutionSetEXT_map_); }
+    const VulkanInstanceInfo* GetVkInstanceInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanInstanceInfo>(id, &instance_map_); }
+    const VulkanMicromapEXTInfo* GetVkMicromapEXTInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanMicromapEXTInfo>(id, &micromapEXT_map_); }
+    const VulkanOpticalFlowSessionNVInfo* GetVkOpticalFlowSessionNVInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanOpticalFlowSessionNVInfo>(id, &opticalFlowSessionNV_map_); }
+    const VulkanPerformanceConfigurationINTELInfo* GetVkPerformanceConfigurationINTELInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanPerformanceConfigurationINTELInfo>(id, &performanceConfigurationINTEL_map_); }
+    const VulkanPhysicalDeviceInfo* GetVkPhysicalDeviceInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanPhysicalDeviceInfo>(id, &physicalDevice_map_); }
+    const VulkanPipelineInfo* GetVkPipelineInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanPipelineInfo>(id, &pipeline_map_); }
+    const VulkanPipelineBinaryKHRInfo* GetVkPipelineBinaryKHRInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanPipelineBinaryKHRInfo>(id, &pipelineBinaryKHR_map_); }
+    const VulkanPipelineCacheInfo* GetVkPipelineCacheInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanPipelineCacheInfo>(id, &pipelineCache_map_); }
+    const VulkanPipelineLayoutInfo* GetVkPipelineLayoutInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanPipelineLayoutInfo>(id, &pipelineLayout_map_); }
+    const VulkanPrivateDataSlotInfo* GetVkPrivateDataSlotInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanPrivateDataSlotInfo>(id, &privateDataSlot_map_); }
+    const VulkanQueryPoolInfo* GetVkQueryPoolInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanQueryPoolInfo>(id, &queryPool_map_); }
+    const VulkanQueueInfo* GetVkQueueInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanQueueInfo>(id, &queue_map_); }
+    const VulkanRenderPassInfo* GetVkRenderPassInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanRenderPassInfo>(id, &renderPass_map_); }
+    const VulkanSamplerInfo* GetVkSamplerInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanSamplerInfo>(id, &sampler_map_); }
+    const VulkanSamplerYcbcrConversionInfo* GetVkSamplerYcbcrConversionInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanSamplerYcbcrConversionInfo>(id, &samplerYcbcrConversion_map_); }
+    const VulkanSemaphoreInfo* GetVkSemaphoreInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanSemaphoreInfo>(id, &semaphore_map_); }
+    const VulkanShaderEXTInfo* GetVkShaderEXTInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanShaderEXTInfo>(id, &shaderEXT_map_); }
+    const VulkanShaderModuleInfo* GetVkShaderModuleInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanShaderModuleInfo>(id, &shaderModule_map_); }
+    const VulkanSurfaceKHRInfo* GetVkSurfaceKHRInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanSurfaceKHRInfo>(id, &surfaceKHR_map_); }
+    const VulkanSwapchainKHRInfo* GetVkSwapchainKHRInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanSwapchainKHRInfo>(id, &swapchainKHR_map_); }
+    const VulkanValidationCacheEXTInfo* GetVkValidationCacheEXTInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanValidationCacheEXTInfo>(id, &validationCacheEXT_map_); }
+    const VulkanVideoSessionKHRInfo* GetVkVideoSessionKHRInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanVideoSessionKHRInfo>(id, &videoSessionKHR_map_); }
+    const VulkanVideoSessionParametersKHRInfo* GetVkVideoSessionParametersKHRInfo(format::HandleId id) const { return GetVkObjectInfo<VulkanVideoSessionParametersKHRInfo>(id, &videoSessionParametersKHR_map_); }
 
-    VulkanAccelerationStructureKHRInfo* GetVkAccelerationStructureKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanAccelerationStructureKHRInfo>(id, &accelerationStructureKHR_map_); }
-    VulkanAccelerationStructureNVInfo* GetVkAccelerationStructureNVInfo(format::HandleId id) { return GetObjectInfo<VulkanAccelerationStructureNVInfo>(id, &accelerationStructureNV_map_); }
-    VulkanBufferInfo* GetVkBufferInfo(format::HandleId id) { return GetObjectInfo<VulkanBufferInfo>(id, &buffer_map_); }
-    VulkanBufferViewInfo* GetVkBufferViewInfo(format::HandleId id) { return GetObjectInfo<VulkanBufferViewInfo>(id, &bufferView_map_); }
-    VulkanCommandBufferInfo* GetVkCommandBufferInfo(format::HandleId id) { return GetObjectInfo<VulkanCommandBufferInfo>(id, &commandBuffer_map_); }
-    VulkanCommandPoolInfo* GetVkCommandPoolInfo(format::HandleId id) { return GetObjectInfo<VulkanCommandPoolInfo>(id, &commandPool_map_); }
-    VulkanDebugReportCallbackEXTInfo* GetVkDebugReportCallbackEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanDebugReportCallbackEXTInfo>(id, &debugReportCallbackEXT_map_); }
-    VulkanDebugUtilsMessengerEXTInfo* GetVkDebugUtilsMessengerEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanDebugUtilsMessengerEXTInfo>(id, &debugUtilsMessengerEXT_map_); }
-    VulkanDeferredOperationKHRInfo* GetVkDeferredOperationKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanDeferredOperationKHRInfo>(id, &deferredOperationKHR_map_); }
-    VulkanDescriptorPoolInfo* GetVkDescriptorPoolInfo(format::HandleId id) { return GetObjectInfo<VulkanDescriptorPoolInfo>(id, &descriptorPool_map_); }
-    VulkanDescriptorSetInfo* GetVkDescriptorSetInfo(format::HandleId id) { return GetObjectInfo<VulkanDescriptorSetInfo>(id, &descriptorSet_map_); }
-    VulkanDescriptorSetLayoutInfo* GetVkDescriptorSetLayoutInfo(format::HandleId id) { return GetObjectInfo<VulkanDescriptorSetLayoutInfo>(id, &descriptorSetLayout_map_); }
-    VulkanDescriptorUpdateTemplateInfo* GetVkDescriptorUpdateTemplateInfo(format::HandleId id) { return GetObjectInfo<VulkanDescriptorUpdateTemplateInfo>(id, &descriptorUpdateTemplate_map_); }
-    VulkanDeviceInfo* GetVkDeviceInfo(format::HandleId id) { return GetObjectInfo<VulkanDeviceInfo>(id, &device_map_); }
-    VulkanDeviceMemoryInfo* GetVkDeviceMemoryInfo(format::HandleId id) { return GetObjectInfo<VulkanDeviceMemoryInfo>(id, &deviceMemory_map_); }
-    VulkanDisplayKHRInfo* GetVkDisplayKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanDisplayKHRInfo>(id, &displayKHR_map_); }
-    VulkanDisplayModeKHRInfo* GetVkDisplayModeKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanDisplayModeKHRInfo>(id, &displayModeKHR_map_); }
-    VulkanEventInfo* GetVkEventInfo(format::HandleId id) { return GetObjectInfo<VulkanEventInfo>(id, &event_map_); }
-    VulkanFenceInfo* GetVkFenceInfo(format::HandleId id) { return GetObjectInfo<VulkanFenceInfo>(id, &fence_map_); }
-    VulkanFramebufferInfo* GetVkFramebufferInfo(format::HandleId id) { return GetObjectInfo<VulkanFramebufferInfo>(id, &framebuffer_map_); }
-    VulkanImageInfo* GetVkImageInfo(format::HandleId id) { return GetObjectInfo<VulkanImageInfo>(id, &image_map_); }
-    VulkanImageViewInfo* GetVkImageViewInfo(format::HandleId id) { return GetObjectInfo<VulkanImageViewInfo>(id, &imageView_map_); }
-    VulkanIndirectCommandsLayoutEXTInfo* GetVkIndirectCommandsLayoutEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanIndirectCommandsLayoutEXTInfo>(id, &indirectCommandsLayoutEXT_map_); }
-    VulkanIndirectCommandsLayoutNVInfo* GetVkIndirectCommandsLayoutNVInfo(format::HandleId id) { return GetObjectInfo<VulkanIndirectCommandsLayoutNVInfo>(id, &indirectCommandsLayoutNV_map_); }
-    VulkanIndirectExecutionSetEXTInfo* GetVkIndirectExecutionSetEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanIndirectExecutionSetEXTInfo>(id, &indirectExecutionSetEXT_map_); }
-    VulkanInstanceInfo* GetVkInstanceInfo(format::HandleId id) { return GetObjectInfo<VulkanInstanceInfo>(id, &instance_map_); }
-    VulkanMicromapEXTInfo* GetVkMicromapEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanMicromapEXTInfo>(id, &micromapEXT_map_); }
-    VulkanOpticalFlowSessionNVInfo* GetVkOpticalFlowSessionNVInfo(format::HandleId id) { return GetObjectInfo<VulkanOpticalFlowSessionNVInfo>(id, &opticalFlowSessionNV_map_); }
-    VulkanPerformanceConfigurationINTELInfo* GetVkPerformanceConfigurationINTELInfo(format::HandleId id) { return GetObjectInfo<VulkanPerformanceConfigurationINTELInfo>(id, &performanceConfigurationINTEL_map_); }
-    VulkanPhysicalDeviceInfo* GetVkPhysicalDeviceInfo(format::HandleId id) { return GetObjectInfo<VulkanPhysicalDeviceInfo>(id, &physicalDevice_map_); }
-    VulkanPipelineInfo* GetVkPipelineInfo(format::HandleId id) { return GetObjectInfo<VulkanPipelineInfo>(id, &pipeline_map_); }
-    VulkanPipelineBinaryKHRInfo* GetVkPipelineBinaryKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanPipelineBinaryKHRInfo>(id, &pipelineBinaryKHR_map_); }
-    VulkanPipelineCacheInfo* GetVkPipelineCacheInfo(format::HandleId id) { return GetObjectInfo<VulkanPipelineCacheInfo>(id, &pipelineCache_map_); }
-    VulkanPipelineLayoutInfo* GetVkPipelineLayoutInfo(format::HandleId id) { return GetObjectInfo<VulkanPipelineLayoutInfo>(id, &pipelineLayout_map_); }
-    VulkanPrivateDataSlotInfo* GetVkPrivateDataSlotInfo(format::HandleId id) { return GetObjectInfo<VulkanPrivateDataSlotInfo>(id, &privateDataSlot_map_); }
-    VulkanQueryPoolInfo* GetVkQueryPoolInfo(format::HandleId id) { return GetObjectInfo<VulkanQueryPoolInfo>(id, &queryPool_map_); }
-    VulkanQueueInfo* GetVkQueueInfo(format::HandleId id) { return GetObjectInfo<VulkanQueueInfo>(id, &queue_map_); }
-    VulkanRenderPassInfo* GetVkRenderPassInfo(format::HandleId id) { return GetObjectInfo<VulkanRenderPassInfo>(id, &renderPass_map_); }
-    VulkanSamplerInfo* GetVkSamplerInfo(format::HandleId id) { return GetObjectInfo<VulkanSamplerInfo>(id, &sampler_map_); }
-    VulkanSamplerYcbcrConversionInfo* GetVkSamplerYcbcrConversionInfo(format::HandleId id) { return GetObjectInfo<VulkanSamplerYcbcrConversionInfo>(id, &samplerYcbcrConversion_map_); }
-    VulkanSemaphoreInfo* GetVkSemaphoreInfo(format::HandleId id) { return GetObjectInfo<VulkanSemaphoreInfo>(id, &semaphore_map_); }
-    VulkanShaderEXTInfo* GetVkShaderEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanShaderEXTInfo>(id, &shaderEXT_map_); }
-    VulkanShaderModuleInfo* GetVkShaderModuleInfo(format::HandleId id) { return GetObjectInfo<VulkanShaderModuleInfo>(id, &shaderModule_map_); }
-    VulkanSurfaceKHRInfo* GetVkSurfaceKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanSurfaceKHRInfo>(id, &surfaceKHR_map_); }
-    VulkanSwapchainKHRInfo* GetVkSwapchainKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanSwapchainKHRInfo>(id, &swapchainKHR_map_); }
-    VulkanValidationCacheEXTInfo* GetVkValidationCacheEXTInfo(format::HandleId id) { return GetObjectInfo<VulkanValidationCacheEXTInfo>(id, &validationCacheEXT_map_); }
-    VulkanVideoSessionKHRInfo* GetVkVideoSessionKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanVideoSessionKHRInfo>(id, &videoSessionKHR_map_); }
-    VulkanVideoSessionParametersKHRInfo* GetVkVideoSessionParametersKHRInfo(format::HandleId id) { return GetObjectInfo<VulkanVideoSessionParametersKHRInfo>(id, &videoSessionParametersKHR_map_); }
+    VulkanAccelerationStructureKHRInfo* GetVkAccelerationStructureKHRInfo(format::HandleId id) { return GetVkObjectInfo<VulkanAccelerationStructureKHRInfo>(id, &accelerationStructureKHR_map_); }
+    VulkanAccelerationStructureNVInfo* GetVkAccelerationStructureNVInfo(format::HandleId id) { return GetVkObjectInfo<VulkanAccelerationStructureNVInfo>(id, &accelerationStructureNV_map_); }
+    VulkanBufferInfo* GetVkBufferInfo(format::HandleId id) { return GetVkObjectInfo<VulkanBufferInfo>(id, &buffer_map_); }
+    VulkanBufferViewInfo* GetVkBufferViewInfo(format::HandleId id) { return GetVkObjectInfo<VulkanBufferViewInfo>(id, &bufferView_map_); }
+    VulkanCommandBufferInfo* GetVkCommandBufferInfo(format::HandleId id) { return GetVkObjectInfo<VulkanCommandBufferInfo>(id, &commandBuffer_map_); }
+    VulkanCommandPoolInfo* GetVkCommandPoolInfo(format::HandleId id) { return GetVkObjectInfo<VulkanCommandPoolInfo>(id, &commandPool_map_); }
+    VulkanDebugReportCallbackEXTInfo* GetVkDebugReportCallbackEXTInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDebugReportCallbackEXTInfo>(id, &debugReportCallbackEXT_map_); }
+    VulkanDebugUtilsMessengerEXTInfo* GetVkDebugUtilsMessengerEXTInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDebugUtilsMessengerEXTInfo>(id, &debugUtilsMessengerEXT_map_); }
+    VulkanDeferredOperationKHRInfo* GetVkDeferredOperationKHRInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDeferredOperationKHRInfo>(id, &deferredOperationKHR_map_); }
+    VulkanDescriptorPoolInfo* GetVkDescriptorPoolInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDescriptorPoolInfo>(id, &descriptorPool_map_); }
+    VulkanDescriptorSetInfo* GetVkDescriptorSetInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDescriptorSetInfo>(id, &descriptorSet_map_); }
+    VulkanDescriptorSetLayoutInfo* GetVkDescriptorSetLayoutInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDescriptorSetLayoutInfo>(id, &descriptorSetLayout_map_); }
+    VulkanDescriptorUpdateTemplateInfo* GetVkDescriptorUpdateTemplateInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDescriptorUpdateTemplateInfo>(id, &descriptorUpdateTemplate_map_); }
+    VulkanDeviceInfo* GetVkDeviceInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDeviceInfo>(id, &device_map_); }
+    VulkanDeviceMemoryInfo* GetVkDeviceMemoryInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDeviceMemoryInfo>(id, &deviceMemory_map_); }
+    VulkanDisplayKHRInfo* GetVkDisplayKHRInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDisplayKHRInfo>(id, &displayKHR_map_); }
+    VulkanDisplayModeKHRInfo* GetVkDisplayModeKHRInfo(format::HandleId id) { return GetVkObjectInfo<VulkanDisplayModeKHRInfo>(id, &displayModeKHR_map_); }
+    VulkanEventInfo* GetVkEventInfo(format::HandleId id) { return GetVkObjectInfo<VulkanEventInfo>(id, &event_map_); }
+    VulkanFenceInfo* GetVkFenceInfo(format::HandleId id) { return GetVkObjectInfo<VulkanFenceInfo>(id, &fence_map_); }
+    VulkanFramebufferInfo* GetVkFramebufferInfo(format::HandleId id) { return GetVkObjectInfo<VulkanFramebufferInfo>(id, &framebuffer_map_); }
+    VulkanImageInfo* GetVkImageInfo(format::HandleId id) { return GetVkObjectInfo<VulkanImageInfo>(id, &image_map_); }
+    VulkanImageViewInfo* GetVkImageViewInfo(format::HandleId id) { return GetVkObjectInfo<VulkanImageViewInfo>(id, &imageView_map_); }
+    VulkanIndirectCommandsLayoutEXTInfo* GetVkIndirectCommandsLayoutEXTInfo(format::HandleId id) { return GetVkObjectInfo<VulkanIndirectCommandsLayoutEXTInfo>(id, &indirectCommandsLayoutEXT_map_); }
+    VulkanIndirectCommandsLayoutNVInfo* GetVkIndirectCommandsLayoutNVInfo(format::HandleId id) { return GetVkObjectInfo<VulkanIndirectCommandsLayoutNVInfo>(id, &indirectCommandsLayoutNV_map_); }
+    VulkanIndirectExecutionSetEXTInfo* GetVkIndirectExecutionSetEXTInfo(format::HandleId id) { return GetVkObjectInfo<VulkanIndirectExecutionSetEXTInfo>(id, &indirectExecutionSetEXT_map_); }
+    VulkanInstanceInfo* GetVkInstanceInfo(format::HandleId id) { return GetVkObjectInfo<VulkanInstanceInfo>(id, &instance_map_); }
+    VulkanMicromapEXTInfo* GetVkMicromapEXTInfo(format::HandleId id) { return GetVkObjectInfo<VulkanMicromapEXTInfo>(id, &micromapEXT_map_); }
+    VulkanOpticalFlowSessionNVInfo* GetVkOpticalFlowSessionNVInfo(format::HandleId id) { return GetVkObjectInfo<VulkanOpticalFlowSessionNVInfo>(id, &opticalFlowSessionNV_map_); }
+    VulkanPerformanceConfigurationINTELInfo* GetVkPerformanceConfigurationINTELInfo(format::HandleId id) { return GetVkObjectInfo<VulkanPerformanceConfigurationINTELInfo>(id, &performanceConfigurationINTEL_map_); }
+    VulkanPhysicalDeviceInfo* GetVkPhysicalDeviceInfo(format::HandleId id) { return GetVkObjectInfo<VulkanPhysicalDeviceInfo>(id, &physicalDevice_map_); }
+    VulkanPipelineInfo* GetVkPipelineInfo(format::HandleId id) { return GetVkObjectInfo<VulkanPipelineInfo>(id, &pipeline_map_); }
+    VulkanPipelineBinaryKHRInfo* GetVkPipelineBinaryKHRInfo(format::HandleId id) { return GetVkObjectInfo<VulkanPipelineBinaryKHRInfo>(id, &pipelineBinaryKHR_map_); }
+    VulkanPipelineCacheInfo* GetVkPipelineCacheInfo(format::HandleId id) { return GetVkObjectInfo<VulkanPipelineCacheInfo>(id, &pipelineCache_map_); }
+    VulkanPipelineLayoutInfo* GetVkPipelineLayoutInfo(format::HandleId id) { return GetVkObjectInfo<VulkanPipelineLayoutInfo>(id, &pipelineLayout_map_); }
+    VulkanPrivateDataSlotInfo* GetVkPrivateDataSlotInfo(format::HandleId id) { return GetVkObjectInfo<VulkanPrivateDataSlotInfo>(id, &privateDataSlot_map_); }
+    VulkanQueryPoolInfo* GetVkQueryPoolInfo(format::HandleId id) { return GetVkObjectInfo<VulkanQueryPoolInfo>(id, &queryPool_map_); }
+    VulkanQueueInfo* GetVkQueueInfo(format::HandleId id) { return GetVkObjectInfo<VulkanQueueInfo>(id, &queue_map_); }
+    VulkanRenderPassInfo* GetVkRenderPassInfo(format::HandleId id) { return GetVkObjectInfo<VulkanRenderPassInfo>(id, &renderPass_map_); }
+    VulkanSamplerInfo* GetVkSamplerInfo(format::HandleId id) { return GetVkObjectInfo<VulkanSamplerInfo>(id, &sampler_map_); }
+    VulkanSamplerYcbcrConversionInfo* GetVkSamplerYcbcrConversionInfo(format::HandleId id) { return GetVkObjectInfo<VulkanSamplerYcbcrConversionInfo>(id, &samplerYcbcrConversion_map_); }
+    VulkanSemaphoreInfo* GetVkSemaphoreInfo(format::HandleId id) { return GetVkObjectInfo<VulkanSemaphoreInfo>(id, &semaphore_map_); }
+    VulkanShaderEXTInfo* GetVkShaderEXTInfo(format::HandleId id) { return GetVkObjectInfo<VulkanShaderEXTInfo>(id, &shaderEXT_map_); }
+    VulkanShaderModuleInfo* GetVkShaderModuleInfo(format::HandleId id) { return GetVkObjectInfo<VulkanShaderModuleInfo>(id, &shaderModule_map_); }
+    VulkanSurfaceKHRInfo* GetVkSurfaceKHRInfo(format::HandleId id) { return GetVkObjectInfo<VulkanSurfaceKHRInfo>(id, &surfaceKHR_map_); }
+    VulkanSwapchainKHRInfo* GetVkSwapchainKHRInfo(format::HandleId id) { return GetVkObjectInfo<VulkanSwapchainKHRInfo>(id, &swapchainKHR_map_); }
+    VulkanValidationCacheEXTInfo* GetVkValidationCacheEXTInfo(format::HandleId id) { return GetVkObjectInfo<VulkanValidationCacheEXTInfo>(id, &validationCacheEXT_map_); }
+    VulkanVideoSessionKHRInfo* GetVkVideoSessionKHRInfo(format::HandleId id) { return GetVkObjectInfo<VulkanVideoSessionKHRInfo>(id, &videoSessionKHR_map_); }
+    VulkanVideoSessionParametersKHRInfo* GetVkVideoSessionParametersKHRInfo(format::HandleId id) { return GetVkObjectInfo<VulkanVideoSessionParametersKHRInfo>(id, &videoSessionParametersKHR_map_); }
 
     void VisitVkAccelerationStructureKHRInfo(std::function<void(const VulkanAccelerationStructureKHRInfo*)> visitor) const {  for (const auto& entry : accelerationStructureKHR_map_) { visitor(&entry.second); }  }
     void VisitVkAccelerationStructureNVInfo(std::function<void(const VulkanAccelerationStructureNVInfo*)> visitor) const {  for (const auto& entry : accelerationStructureNV_map_) { visitor(&entry.second); }  }

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -55,7 +55,7 @@ void VulkanReplayConsumer::Process_vkCreateInstance(
     VkResult replay_result = OverrideCreateInstance(returnValue, pCreateInfo, pAllocator, pInstance);
     CheckResult("vkCreateInstance", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanInstanceInfo>(format::kNullHandleId, pInstance->GetPointer(), pInstance->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkInstanceInfo);
+    AddHandle<VulkanInstanceInfo>(format::kNullHandleId, pInstance->GetPointer(), pInstance->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkInstanceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyInstance(
@@ -63,11 +63,11 @@ void VulkanReplayConsumer::Process_vkDestroyInstance(
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetInstanceTable(in_instance)->DestroyInstance(in_instance, in_pAllocator);
-    RemoveHandle(instance, &VulkanObjectInfoTable::RemoveVkInstanceInfo);
+    RemoveHandle(instance, &CommonObjectInfoTable::RemoveVkInstanceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
@@ -78,7 +78,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
     HandlePointerDecoder<VkPhysicalDevice>*     pPhysicalDevices)
 {
     auto in_instance = GetObjectInfoTable().GetVkInstanceInfo(instance);
-    pPhysicalDeviceCount->IsNull() ? nullptr : pPhysicalDeviceCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanInstanceInfo>("vkEnumeratePhysicalDevices", returnValue, instance, kInstanceArrayEnumeratePhysicalDevices, pPhysicalDeviceCount, pPhysicalDevices, &VulkanObjectInfoTable::GetVkInstanceInfo));
+    pPhysicalDeviceCount->IsNull() ? nullptr : pPhysicalDeviceCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanInstanceInfo>("vkEnumeratePhysicalDevices", returnValue, instance, kInstanceArrayEnumeratePhysicalDevices, pPhysicalDeviceCount, pPhysicalDevices, &CommonObjectInfoTable::GetVkInstanceInfo));
     if (!pPhysicalDevices->IsNull()) { pPhysicalDevices->SetHandleLength(*pPhysicalDeviceCount->GetOutputPointer()); }
     std::vector<VulkanPhysicalDeviceInfo> handle_info(*pPhysicalDeviceCount->GetOutputPointer());
     for (size_t i = 0; i < *pPhysicalDeviceCount->GetOutputPointer(); ++i) { pPhysicalDevices->SetConsumerData(i, &handle_info[i]); }
@@ -86,8 +86,8 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
     VkResult replay_result = OverrideEnumeratePhysicalDevices(GetInstanceTable(in_instance->handle)->EnumeratePhysicalDevices, returnValue, in_instance, pPhysicalDeviceCount, pPhysicalDevices);
     CheckResult("vkEnumeratePhysicalDevices", returnValue, replay_result, call_info);
 
-    if (pPhysicalDevices->IsNull()) { SetOutputArrayCount<VulkanInstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDevices, *pPhysicalDeviceCount->GetOutputPointer(), &VulkanObjectInfoTable::GetVkInstanceInfo); }
-    AddHandles<VulkanPhysicalDeviceInfo>(instance, pPhysicalDevices->GetPointer(), pPhysicalDevices->GetLength(), pPhysicalDevices->GetHandlePointer(), *pPhysicalDeviceCount->GetOutputPointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkPhysicalDeviceInfo);
+    if (pPhysicalDevices->IsNull()) { SetOutputArrayCount<VulkanInstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDevices, *pPhysicalDeviceCount->GetOutputPointer(), &CommonObjectInfoTable::GetVkInstanceInfo); }
+    AddHandles<VulkanPhysicalDeviceInfo>(instance, pPhysicalDevices->GetPointer(), pPhysicalDevices->GetLength(), pPhysicalDevices->GetHandlePointer(), *pPhysicalDeviceCount->GetOutputPointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkPhysicalDeviceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures(
@@ -95,7 +95,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures(
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>* pFeatures)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     VkPhysicalDeviceFeatures* out_pFeatures = pFeatures->IsNull() ? nullptr : pFeatures->AllocateOutputData(1);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceFeatures(in_physicalDevice, out_pFeatures);
@@ -107,7 +107,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties(
     VkFormat                                    format,
     StructPointerDecoder<Decoded_VkFormatProperties>* pFormatProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     VkFormatProperties* out_pFormatProperties = pFormatProperties->IsNull() ? nullptr : pFormatProperties->AllocateOutputData(1);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceFormatProperties(in_physicalDevice, format, out_pFormatProperties);
@@ -124,7 +124,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
     VkImageCreateFlags                          flags,
     StructPointerDecoder<Decoded_VkImageFormatProperties>* pImageFormatProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     VkImageFormatProperties* out_pImageFormatProperties = pImageFormatProperties->IsNull() ? nullptr : pImageFormatProperties->AllocateOutputData(1);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceImageFormatProperties(in_physicalDevice, format, type, tiling, usage, flags, out_pImageFormatProperties);
@@ -148,13 +148,13 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
     PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
     StructPointerDecoder<Decoded_VkQueueFamilyProperties>* pQueueFamilyProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->IsNull() ? nullptr : pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->IsNull() ? nullptr : pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties, pQueueFamilyPropertyCount, pQueueFamilyProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkQueueFamilyProperties* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
 
-    if (pQueueFamilyProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties, *out_pQueueFamilyPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pQueueFamilyProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties, *out_pQueueFamilyPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
@@ -186,7 +186,7 @@ void VulkanReplayConsumer::Process_vkCreateDevice(
     VkResult replay_result = OverrideCreateDevice(returnValue, in_physicalDevice, pCreateInfo, pAllocator, pDevice);
     CheckResult("vkCreateDevice", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDeviceInfo>(physicalDevice, pDevice->GetPointer(), pDevice->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkDeviceInfo);
+    AddHandle<VulkanDeviceInfo>(physicalDevice, pDevice->GetPointer(), pDevice->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkDeviceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDevice(
@@ -197,7 +197,7 @@ void VulkanReplayConsumer::Process_vkDestroyDevice(
     auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
 
     OverrideDestroyDevice(GetDeviceTable(in_device->handle)->DestroyDevice, in_device, pAllocator);
-    RemoveHandle(device, &VulkanObjectInfoTable::RemoveVkDeviceInfo);
+    RemoveHandle(device, &CommonObjectInfoTable::RemoveVkDeviceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceQueue(
@@ -214,7 +214,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceQueue(
 
     OverrideGetDeviceQueue(GetDeviceTable(in_device->handle)->GetDeviceQueue, in_device, queueFamilyIndex, queueIndex, pQueue);
 
-    AddHandle<VulkanQueueInfo>(device, pQueue->GetPointer(), pQueue->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkQueueInfo);
+    AddHandle<VulkanQueueInfo>(device, pQueue->GetPointer(), pQueue->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkQueueInfo);
 }
 
 void VulkanReplayConsumer::Process_vkQueueSubmit(
@@ -239,7 +239,7 @@ void VulkanReplayConsumer::Process_vkQueueWaitIdle(
     VkResult                                    returnValue,
     format::HandleId                            queue)
 {
-    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &VulkanObjectInfoTable::GetVkQueueInfo);
+    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &CommonObjectInfoTable::GetVkQueueInfo);
 
     VkResult replay_result = GetDeviceTable(in_queue)->QueueWaitIdle(in_queue);
     CheckResult("vkQueueWaitIdle", returnValue, replay_result, call_info);
@@ -250,7 +250,7 @@ void VulkanReplayConsumer::Process_vkDeviceWaitIdle(
     VkResult                                    returnValue,
     format::HandleId                            device)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->DeviceWaitIdle(in_device);
     CheckResult("vkDeviceWaitIdle", returnValue, replay_result, call_info);
@@ -274,7 +274,7 @@ void VulkanReplayConsumer::Process_vkAllocateMemory(
     VkResult replay_result = OverrideAllocateMemory(GetDeviceTable(in_device->handle)->AllocateMemory, returnValue, in_device, pAllocateInfo, pAllocator, pMemory);
     CheckResult("vkAllocateMemory", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDeviceMemoryInfo>(device, pMemory->GetPointer(), pMemory->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkDeviceMemoryInfo);
+    AddHandle<VulkanDeviceMemoryInfo>(device, pMemory->GetPointer(), pMemory->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkDeviceMemoryInfo);
 }
 
 void VulkanReplayConsumer::Process_vkFreeMemory(
@@ -287,7 +287,7 @@ void VulkanReplayConsumer::Process_vkFreeMemory(
     auto in_memory = GetObjectInfoTable().GetVkDeviceMemoryInfo(memory);
 
     OverrideFreeMemory(GetDeviceTable(in_device->handle)->FreeMemory, in_device, in_memory, pAllocator);
-    RemoveHandle(memory, &VulkanObjectInfoTable::RemoveVkDeviceMemoryInfo);
+    RemoveHandle(memory, &CommonObjectInfoTable::RemoveVkDeviceMemoryInfo);
 }
 
 void VulkanReplayConsumer::Process_vkMapMemory(
@@ -357,8 +357,8 @@ void VulkanReplayConsumer::Process_vkGetDeviceMemoryCommitment(
     format::HandleId                            memory,
     PointerDecoder<VkDeviceSize>*               pCommittedMemoryInBytes)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeviceMemory in_memory = MapHandle<VulkanDeviceMemoryInfo>(memory, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeviceMemory in_memory = MapHandle<VulkanDeviceMemoryInfo>(memory, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     VkDeviceSize* out_pCommittedMemoryInBytes = pCommittedMemoryInBytes->IsNull() ? nullptr : pCommittedMemoryInBytes->AllocateOutputData(1, static_cast<VkDeviceSize>(0));
 
     GetDeviceTable(in_device)->GetDeviceMemoryCommitment(in_device, in_memory, out_pCommittedMemoryInBytes);
@@ -402,8 +402,8 @@ void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements(
     format::HandleId                            buffer,
     StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
     VkMemoryRequirements* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1);
 
     GetDeviceTable(in_device)->GetBufferMemoryRequirements(in_device, in_buffer, out_pMemoryRequirements);
@@ -415,8 +415,8 @@ void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements(
     format::HandleId                            image,
     StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkImage in_image = MapHandle<VulkanImageInfo>(image, &VulkanObjectInfoTable::GetVkImageInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkImage in_image = MapHandle<VulkanImageInfo>(image, &CommonObjectInfoTable::GetVkImageInfo);
     VkMemoryRequirements* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1);
 
     GetDeviceTable(in_device)->GetImageMemoryRequirements(in_device, in_image, out_pMemoryRequirements);
@@ -429,14 +429,14 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements(
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
     StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements>* pSparseMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkImage in_image = MapHandle<VulkanImageInfo>(image, &VulkanObjectInfoTable::GetVkImageInfo);
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanImageInfo>("vkGetImageSparseMemoryRequirements", VK_SUCCESS, image, kImageArrayGetImageSparseMemoryRequirements, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetVkImageInfo));
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkImage in_image = MapHandle<VulkanImageInfo>(image, &CommonObjectInfoTable::GetVkImageInfo);
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanImageInfo>("vkGetImageSparseMemoryRequirements", VK_SUCCESS, image, kImageArrayGetImageSparseMemoryRequirements, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &CommonObjectInfoTable::GetVkImageInfo));
     VkSparseImageMemoryRequirements* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount);
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements(in_device, in_image, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
 
-    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanImageInfo>(image, kImageArrayGetImageSparseMemoryRequirements, *out_pSparseMemoryRequirementCount, &VulkanObjectInfoTable::GetVkImageInfo); }
+    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanImageInfo>(image, kImageArrayGetImageSparseMemoryRequirements, *out_pSparseMemoryRequirementCount, &CommonObjectInfoTable::GetVkImageInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties(
@@ -450,13 +450,13 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkSparseImageFormatProperties>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkSparseImageFormatProperties* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties(in_physicalDevice, format, type, samples, usage, tiling, out_pPropertyCount, out_pProperties);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkQueueBindSparse(
@@ -484,7 +484,7 @@ void VulkanReplayConsumer::Process_vkCreateFence(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkFence>*              pFence)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkFenceCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pFence->IsNull()) { pFence->SetHandleLength(1); }
@@ -493,7 +493,7 @@ void VulkanReplayConsumer::Process_vkCreateFence(
     VkResult replay_result = GetDeviceTable(in_device)->CreateFence(in_device, in_pCreateInfo, in_pAllocator, out_pFence);
     CheckResult("vkCreateFence", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanFenceInfo>(device, pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddVkFenceInfo);
+    AddHandle<VulkanFenceInfo>(device, pFence->GetPointer(), out_pFence, &CommonObjectInfoTable::AddVkFenceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyFence(
@@ -502,12 +502,12 @@ void VulkanReplayConsumer::Process_vkDestroyFence(
     format::HandleId                            fence,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkFence in_fence = MapHandle<VulkanFenceInfo>(fence, &VulkanObjectInfoTable::GetVkFenceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkFence in_fence = MapHandle<VulkanFenceInfo>(fence, &CommonObjectInfoTable::GetVkFenceInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyFence(in_device, in_fence, in_pAllocator);
-    RemoveHandle(fence, &VulkanObjectInfoTable::RemoveVkFenceInfo);
+    RemoveHandle(fence, &CommonObjectInfoTable::RemoveVkFenceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkResetFences(
@@ -517,8 +517,8 @@ void VulkanReplayConsumer::Process_vkResetFences(
     uint32_t                                    fenceCount,
     HandlePointerDecoder<VkFence>*              pFences)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    const VkFence* in_pFences = MapHandles<VulkanFenceInfo>(pFences, fenceCount, &VulkanObjectInfoTable::GetVkFenceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    const VkFence* in_pFences = MapHandles<VulkanFenceInfo>(pFences, fenceCount, &CommonObjectInfoTable::GetVkFenceInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->ResetFences(in_device, fenceCount, in_pFences);
     CheckResult("vkResetFences", returnValue, replay_result, call_info);
@@ -547,7 +547,7 @@ void VulkanReplayConsumer::Process_vkWaitForFences(
     uint64_t                                    timeout)
 {
     auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
-    MapHandles<VulkanFenceInfo>(pFences, fenceCount, &VulkanObjectInfoTable::GetVkFenceInfo);
+    MapHandles<VulkanFenceInfo>(pFences, fenceCount, &CommonObjectInfoTable::GetVkFenceInfo);
 
     VkResult replay_result = OverrideWaitForFences(GetDeviceTable(in_device->handle)->WaitForFences, returnValue, in_device, fenceCount, pFences, waitAll, timeout);
     CheckResult("vkWaitForFences", returnValue, replay_result, call_info);
@@ -561,7 +561,7 @@ void VulkanReplayConsumer::Process_vkCreateSemaphore(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSemaphore>*          pSemaphore)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkSemaphoreCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pSemaphore->IsNull()) { pSemaphore->SetHandleLength(1); }
@@ -570,7 +570,7 @@ void VulkanReplayConsumer::Process_vkCreateSemaphore(
     VkResult replay_result = GetDeviceTable(in_device)->CreateSemaphore(in_device, in_pCreateInfo, in_pAllocator, out_pSemaphore);
     CheckResult("vkCreateSemaphore", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSemaphoreInfo>(device, pSemaphore->GetPointer(), out_pSemaphore, &VulkanObjectInfoTable::AddVkSemaphoreInfo);
+    AddHandle<VulkanSemaphoreInfo>(device, pSemaphore->GetPointer(), out_pSemaphore, &CommonObjectInfoTable::AddVkSemaphoreInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySemaphore(
@@ -579,12 +579,12 @@ void VulkanReplayConsumer::Process_vkDestroySemaphore(
     format::HandleId                            semaphore,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSemaphore in_semaphore = MapHandle<VulkanSemaphoreInfo>(semaphore, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSemaphore in_semaphore = MapHandle<VulkanSemaphoreInfo>(semaphore, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroySemaphore(in_device, in_semaphore, in_pAllocator);
-    RemoveHandle(semaphore, &VulkanObjectInfoTable::RemoveVkSemaphoreInfo);
+    RemoveHandle(semaphore, &CommonObjectInfoTable::RemoveVkSemaphoreInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateEvent(
@@ -595,7 +595,7 @@ void VulkanReplayConsumer::Process_vkCreateEvent(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkEvent>*              pEvent)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkEventCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pEvent->IsNull()) { pEvent->SetHandleLength(1); }
@@ -604,7 +604,7 @@ void VulkanReplayConsumer::Process_vkCreateEvent(
     VkResult replay_result = GetDeviceTable(in_device)->CreateEvent(in_device, in_pCreateInfo, in_pAllocator, out_pEvent);
     CheckResult("vkCreateEvent", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanEventInfo>(device, pEvent->GetPointer(), out_pEvent, &VulkanObjectInfoTable::AddVkEventInfo);
+    AddHandle<VulkanEventInfo>(device, pEvent->GetPointer(), out_pEvent, &CommonObjectInfoTable::AddVkEventInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyEvent(
@@ -613,12 +613,12 @@ void VulkanReplayConsumer::Process_vkDestroyEvent(
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &CommonObjectInfoTable::GetVkEventInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyEvent(in_device, in_event, in_pAllocator);
-    RemoveHandle(event, &VulkanObjectInfoTable::RemoveVkEventInfo);
+    RemoveHandle(event, &CommonObjectInfoTable::RemoveVkEventInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetEventStatus(
@@ -640,8 +640,8 @@ void VulkanReplayConsumer::Process_vkSetEvent(
     format::HandleId                            device,
     format::HandleId                            event)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &CommonObjectInfoTable::GetVkEventInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->SetEvent(in_device, in_event);
     CheckResult("vkSetEvent", returnValue, replay_result, call_info);
@@ -653,8 +653,8 @@ void VulkanReplayConsumer::Process_vkResetEvent(
     format::HandleId                            device,
     format::HandleId                            event)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &CommonObjectInfoTable::GetVkEventInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->ResetEvent(in_device, in_event);
     CheckResult("vkResetEvent", returnValue, replay_result, call_info);
@@ -668,7 +668,7 @@ void VulkanReplayConsumer::Process_vkCreateQueryPool(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkQueryPool>*          pQueryPool)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkQueryPoolCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pQueryPool->IsNull()) { pQueryPool->SetHandleLength(1); }
@@ -677,7 +677,7 @@ void VulkanReplayConsumer::Process_vkCreateQueryPool(
     VkResult replay_result = GetDeviceTable(in_device)->CreateQueryPool(in_device, in_pCreateInfo, in_pAllocator, out_pQueryPool);
     CheckResult("vkCreateQueryPool", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanQueryPoolInfo>(device, pQueryPool->GetPointer(), out_pQueryPool, &VulkanObjectInfoTable::AddVkQueryPoolInfo);
+    AddHandle<VulkanQueryPoolInfo>(device, pQueryPool->GetPointer(), out_pQueryPool, &CommonObjectInfoTable::AddVkQueryPoolInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyQueryPool(
@@ -686,12 +686,12 @@ void VulkanReplayConsumer::Process_vkDestroyQueryPool(
     format::HandleId                            queryPool,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyQueryPool(in_device, in_queryPool, in_pAllocator);
-    RemoveHandle(queryPool, &VulkanObjectInfoTable::RemoveVkQueryPoolInfo);
+    RemoveHandle(queryPool, &CommonObjectInfoTable::RemoveVkQueryPoolInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetQueryPoolResults(
@@ -730,7 +730,7 @@ void VulkanReplayConsumer::Process_vkCreateBuffer(
     VkResult replay_result = OverrideCreateBuffer(GetDeviceTable(in_device->handle)->CreateBuffer, returnValue, in_device, pCreateInfo, pAllocator, pBuffer);
     CheckResult("vkCreateBuffer", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanBufferInfo>(device, pBuffer->GetPointer(), pBuffer->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkBufferInfo);
+    AddHandle<VulkanBufferInfo>(device, pBuffer->GetPointer(), pBuffer->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyBuffer(
@@ -743,7 +743,7 @@ void VulkanReplayConsumer::Process_vkDestroyBuffer(
     auto in_buffer = GetObjectInfoTable().GetVkBufferInfo(buffer);
 
     OverrideDestroyBuffer(GetDeviceTable(in_device->handle)->DestroyBuffer, in_device, in_buffer, pAllocator);
-    RemoveHandle(buffer, &VulkanObjectInfoTable::RemoveVkBufferInfo);
+    RemoveHandle(buffer, &CommonObjectInfoTable::RemoveVkBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateBufferView(
@@ -754,7 +754,7 @@ void VulkanReplayConsumer::Process_vkCreateBufferView(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkBufferView>*         pView)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkBufferViewCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -764,7 +764,7 @@ void VulkanReplayConsumer::Process_vkCreateBufferView(
     VkResult replay_result = GetDeviceTable(in_device)->CreateBufferView(in_device, in_pCreateInfo, in_pAllocator, out_pView);
     CheckResult("vkCreateBufferView", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanBufferViewInfo>(device, pView->GetPointer(), out_pView, &VulkanObjectInfoTable::AddVkBufferViewInfo);
+    AddHandle<VulkanBufferViewInfo>(device, pView->GetPointer(), out_pView, &CommonObjectInfoTable::AddVkBufferViewInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyBufferView(
@@ -773,12 +773,12 @@ void VulkanReplayConsumer::Process_vkDestroyBufferView(
     format::HandleId                            bufferView,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkBufferView in_bufferView = MapHandle<VulkanBufferViewInfo>(bufferView, &VulkanObjectInfoTable::GetVkBufferViewInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkBufferView in_bufferView = MapHandle<VulkanBufferViewInfo>(bufferView, &CommonObjectInfoTable::GetVkBufferViewInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyBufferView(in_device, in_bufferView, in_pAllocator);
-    RemoveHandle(bufferView, &VulkanObjectInfoTable::RemoveVkBufferViewInfo);
+    RemoveHandle(bufferView, &CommonObjectInfoTable::RemoveVkBufferViewInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateImage(
@@ -799,7 +799,7 @@ void VulkanReplayConsumer::Process_vkCreateImage(
     VkResult replay_result = OverrideCreateImage(GetDeviceTable(in_device->handle)->CreateImage, returnValue, in_device, pCreateInfo, pAllocator, pImage);
     CheckResult("vkCreateImage", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanImageInfo>(device, pImage->GetPointer(), pImage->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkImageInfo);
+    AddHandle<VulkanImageInfo>(device, pImage->GetPointer(), pImage->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkImageInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyImage(
@@ -812,7 +812,7 @@ void VulkanReplayConsumer::Process_vkDestroyImage(
     auto in_image = GetObjectInfoTable().GetVkImageInfo(image);
 
     OverrideDestroyImage(GetDeviceTable(in_device->handle)->DestroyImage, in_device, in_image, pAllocator);
-    RemoveHandle(image, &VulkanObjectInfoTable::RemoveVkImageInfo);
+    RemoveHandle(image, &CommonObjectInfoTable::RemoveVkImageInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetImageSubresourceLayout(
@@ -847,7 +847,7 @@ void VulkanReplayConsumer::Process_vkCreateImageView(
     VkResult replay_result = OverrideCreateImageView(GetDeviceTable(in_device->handle)->CreateImageView, returnValue, in_device, pCreateInfo, pAllocator, pView);
     CheckResult("vkCreateImageView", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanImageViewInfo>(device, pView->GetPointer(), pView->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkImageViewInfo);
+    AddHandle<VulkanImageViewInfo>(device, pView->GetPointer(), pView->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkImageViewInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyImageView(
@@ -856,12 +856,12 @@ void VulkanReplayConsumer::Process_vkDestroyImageView(
     format::HandleId                            imageView,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkImageView in_imageView = MapHandle<VulkanImageViewInfo>(imageView, &VulkanObjectInfoTable::GetVkImageViewInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkImageView in_imageView = MapHandle<VulkanImageViewInfo>(imageView, &CommonObjectInfoTable::GetVkImageViewInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyImageView(in_device, in_imageView, in_pAllocator);
-    RemoveHandle(imageView, &VulkanObjectInfoTable::RemoveVkImageViewInfo);
+    RemoveHandle(imageView, &CommonObjectInfoTable::RemoveVkImageViewInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateShaderModule(
@@ -882,7 +882,7 @@ void VulkanReplayConsumer::Process_vkCreateShaderModule(
     VkResult replay_result = OverrideCreateShaderModule(GetDeviceTable(in_device->handle)->CreateShaderModule, returnValue, in_device, pCreateInfo, pAllocator, pShaderModule);
     CheckResult("vkCreateShaderModule", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanShaderModuleInfo>(device, pShaderModule->GetPointer(), pShaderModule->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkShaderModuleInfo);
+    AddHandle<VulkanShaderModuleInfo>(device, pShaderModule->GetPointer(), pShaderModule->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkShaderModuleInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyShaderModule(
@@ -895,7 +895,7 @@ void VulkanReplayConsumer::Process_vkDestroyShaderModule(
     auto in_shaderModule = GetObjectInfoTable().GetVkShaderModuleInfo(shaderModule);
 
     OverrideDestroyShaderModule(GetDeviceTable(in_device->handle)->DestroyShaderModule, in_device, in_shaderModule, pAllocator);
-    RemoveHandle(shaderModule, &VulkanObjectInfoTable::RemoveVkShaderModuleInfo);
+    RemoveHandle(shaderModule, &CommonObjectInfoTable::RemoveVkShaderModuleInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreatePipelineCache(
@@ -914,7 +914,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineCache(
     VkResult replay_result = OverrideCreatePipelineCache(GetDeviceTable(in_device->handle)->CreatePipelineCache, returnValue, in_device, pCreateInfo, pAllocator, pPipelineCache);
     CheckResult("vkCreatePipelineCache", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanPipelineCacheInfo>(device, pPipelineCache->GetPointer(), pPipelineCache->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkPipelineCacheInfo);
+    AddHandle<VulkanPipelineCacheInfo>(device, pPipelineCache->GetPointer(), pPipelineCache->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkPipelineCacheInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPipelineCache(
@@ -923,12 +923,12 @@ void VulkanReplayConsumer::Process_vkDestroyPipelineCache(
     format::HandleId                            pipelineCache,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPipelineCache in_pipelineCache = MapHandle<VulkanPipelineCacheInfo>(pipelineCache, &VulkanObjectInfoTable::GetVkPipelineCacheInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPipelineCache in_pipelineCache = MapHandle<VulkanPipelineCacheInfo>(pipelineCache, &CommonObjectInfoTable::GetVkPipelineCacheInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyPipelineCache(in_device, in_pipelineCache, in_pAllocator);
-    RemoveHandle(pipelineCache, &VulkanObjectInfoTable::RemoveVkPipelineCacheInfo);
+    RemoveHandle(pipelineCache, &CommonObjectInfoTable::RemoveVkPipelineCacheInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineCacheData(
@@ -941,13 +941,13 @@ void VulkanReplayConsumer::Process_vkGetPipelineCacheData(
 {
     auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
     auto in_pipelineCache = GetObjectInfoTable().GetVkPipelineCacheInfo(pipelineCache);
-    pDataSize->IsNull() ? nullptr : pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanPipelineCacheInfo>("vkGetPipelineCacheData", returnValue, pipelineCache, kPipelineCacheArrayGetPipelineCacheData, pDataSize, pData, &VulkanObjectInfoTable::GetVkPipelineCacheInfo));
+    pDataSize->IsNull() ? nullptr : pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanPipelineCacheInfo>("vkGetPipelineCacheData", returnValue, pipelineCache, kPipelineCacheArrayGetPipelineCacheData, pDataSize, pData, &CommonObjectInfoTable::GetVkPipelineCacheInfo));
     if (!pData->IsNull()) { pData->AllocateOutputData(*pDataSize->GetOutputPointer()); }
 
     VkResult replay_result = OverrideGetPipelineCacheData(GetDeviceTable(in_device->handle)->GetPipelineCacheData, returnValue, in_device, in_pipelineCache, pDataSize, pData);
     CheckResult("vkGetPipelineCacheData", returnValue, replay_result, call_info);
 
-    if (pData->IsNull()) { SetOutputArrayCount<VulkanPipelineCacheInfo>(pipelineCache, kPipelineCacheArrayGetPipelineCacheData, *pDataSize->GetOutputPointer(), &VulkanObjectInfoTable::GetVkPipelineCacheInfo); }
+    if (pData->IsNull()) { SetOutputArrayCount<VulkanPipelineCacheInfo>(pipelineCache, kPipelineCacheArrayGetPipelineCacheData, *pDataSize->GetOutputPointer(), &CommonObjectInfoTable::GetVkPipelineCacheInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkMergePipelineCaches(
@@ -958,9 +958,9 @@ void VulkanReplayConsumer::Process_vkMergePipelineCaches(
     uint32_t                                    srcCacheCount,
     HandlePointerDecoder<VkPipelineCache>*      pSrcCaches)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPipelineCache in_dstCache = MapHandle<VulkanPipelineCacheInfo>(dstCache, &VulkanObjectInfoTable::GetVkPipelineCacheInfo);
-    const VkPipelineCache* in_pSrcCaches = MapHandles<VulkanPipelineCacheInfo>(pSrcCaches, srcCacheCount, &VulkanObjectInfoTable::GetVkPipelineCacheInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPipelineCache in_dstCache = MapHandle<VulkanPipelineCacheInfo>(dstCache, &CommonObjectInfoTable::GetVkPipelineCacheInfo);
+    const VkPipelineCache* in_pSrcCaches = MapHandles<VulkanPipelineCacheInfo>(pSrcCaches, srcCacheCount, &CommonObjectInfoTable::GetVkPipelineCacheInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->MergePipelineCaches(in_device, in_dstCache, srcCacheCount, in_pSrcCaches);
     CheckResult("vkMergePipelineCaches", returnValue, replay_result, call_info);
@@ -997,7 +997,7 @@ void VulkanReplayConsumer::Process_vkCreateGraphicsPipelines(
     VkResult replay_result = OverrideCreateGraphicsPipelines(GetDeviceTable(in_device->handle)->CreateGraphicsPipelines, returnValue, in_device, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
     CheckResult("vkCreateGraphicsPipelines", returnValue, replay_result, call_info);
 
-    AddHandles<VulkanPipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), pPipelines->GetHandlePointer(), createInfoCount, std::move(handle_info), &VulkanObjectInfoTable::AddVkPipelineInfo);
+    AddHandles<VulkanPipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), pPipelines->GetHandlePointer(), createInfoCount, std::move(handle_info), &CommonObjectInfoTable::AddVkPipelineInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateComputePipelines(
@@ -1031,7 +1031,7 @@ void VulkanReplayConsumer::Process_vkCreateComputePipelines(
     VkResult replay_result = OverrideCreateComputePipelines(GetDeviceTable(in_device->handle)->CreateComputePipelines, returnValue, in_device, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
     CheckResult("vkCreateComputePipelines", returnValue, replay_result, call_info);
 
-    AddHandles<VulkanPipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), pPipelines->GetHandlePointer(), createInfoCount, std::move(handle_info), &VulkanObjectInfoTable::AddVkPipelineInfo);
+    AddHandles<VulkanPipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), pPipelines->GetHandlePointer(), createInfoCount, std::move(handle_info), &CommonObjectInfoTable::AddVkPipelineInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPipeline(
@@ -1044,7 +1044,7 @@ void VulkanReplayConsumer::Process_vkDestroyPipeline(
     auto in_pipeline = GetObjectInfoTable().GetVkPipelineInfo(pipeline);
 
     OverrideDestroyPipeline(GetDeviceTable(in_device->handle)->DestroyPipeline, in_device, in_pipeline, pAllocator);
-    RemoveHandle(pipeline, &VulkanObjectInfoTable::RemoveVkPipelineInfo);
+    RemoveHandle(pipeline, &CommonObjectInfoTable::RemoveVkPipelineInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreatePipelineLayout(
@@ -1055,7 +1055,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineLayout(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkPipelineLayout>*     pPipelineLayout)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPipelineLayoutCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -1065,7 +1065,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineLayout(
     VkResult replay_result = GetDeviceTable(in_device)->CreatePipelineLayout(in_device, in_pCreateInfo, in_pAllocator, out_pPipelineLayout);
     CheckResult("vkCreatePipelineLayout", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanPipelineLayoutInfo>(device, pPipelineLayout->GetPointer(), out_pPipelineLayout, &VulkanObjectInfoTable::AddVkPipelineLayoutInfo);
+    AddHandle<VulkanPipelineLayoutInfo>(device, pPipelineLayout->GetPointer(), out_pPipelineLayout, &CommonObjectInfoTable::AddVkPipelineLayoutInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPipelineLayout(
@@ -1074,12 +1074,12 @@ void VulkanReplayConsumer::Process_vkDestroyPipelineLayout(
     format::HandleId                            pipelineLayout,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPipelineLayout in_pipelineLayout = MapHandle<VulkanPipelineLayoutInfo>(pipelineLayout, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPipelineLayout in_pipelineLayout = MapHandle<VulkanPipelineLayoutInfo>(pipelineLayout, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyPipelineLayout(in_device, in_pipelineLayout, in_pAllocator);
-    RemoveHandle(pipelineLayout, &VulkanObjectInfoTable::RemoveVkPipelineLayoutInfo);
+    RemoveHandle(pipelineLayout, &CommonObjectInfoTable::RemoveVkPipelineLayoutInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateSampler(
@@ -1090,7 +1090,7 @@ void VulkanReplayConsumer::Process_vkCreateSampler(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSampler>*            pSampler)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkSamplerCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -1100,7 +1100,7 @@ void VulkanReplayConsumer::Process_vkCreateSampler(
     VkResult replay_result = GetDeviceTable(in_device)->CreateSampler(in_device, in_pCreateInfo, in_pAllocator, out_pSampler);
     CheckResult("vkCreateSampler", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSamplerInfo>(device, pSampler->GetPointer(), out_pSampler, &VulkanObjectInfoTable::AddVkSamplerInfo);
+    AddHandle<VulkanSamplerInfo>(device, pSampler->GetPointer(), out_pSampler, &CommonObjectInfoTable::AddVkSamplerInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySampler(
@@ -1109,12 +1109,12 @@ void VulkanReplayConsumer::Process_vkDestroySampler(
     format::HandleId                            sampler,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSampler in_sampler = MapHandle<VulkanSamplerInfo>(sampler, &VulkanObjectInfoTable::GetVkSamplerInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSampler in_sampler = MapHandle<VulkanSamplerInfo>(sampler, &CommonObjectInfoTable::GetVkSamplerInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroySampler(in_device, in_sampler, in_pAllocator);
-    RemoveHandle(sampler, &VulkanObjectInfoTable::RemoveVkSamplerInfo);
+    RemoveHandle(sampler, &CommonObjectInfoTable::RemoveVkSamplerInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDescriptorSetLayout(
@@ -1135,7 +1135,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorSetLayout(
     VkResult replay_result = OverrideCreateDescriptorSetLayout(GetDeviceTable(in_device->handle)->CreateDescriptorSetLayout, returnValue, in_device, pCreateInfo, pAllocator, pSetLayout);
     CheckResult("vkCreateDescriptorSetLayout", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDescriptorSetLayoutInfo>(device, pSetLayout->GetPointer(), pSetLayout->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkDescriptorSetLayoutInfo);
+    AddHandle<VulkanDescriptorSetLayoutInfo>(device, pSetLayout->GetPointer(), pSetLayout->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkDescriptorSetLayoutInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorSetLayout(
@@ -1144,12 +1144,12 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorSetLayout(
     format::HandleId                            descriptorSetLayout,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDescriptorSetLayout in_descriptorSetLayout = MapHandle<VulkanDescriptorSetLayoutInfo>(descriptorSetLayout, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDescriptorSetLayout in_descriptorSetLayout = MapHandle<VulkanDescriptorSetLayoutInfo>(descriptorSetLayout, &CommonObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyDescriptorSetLayout(in_device, in_descriptorSetLayout, in_pAllocator);
-    RemoveHandle(descriptorSetLayout, &VulkanObjectInfoTable::RemoveVkDescriptorSetLayoutInfo);
+    RemoveHandle(descriptorSetLayout, &CommonObjectInfoTable::RemoveVkDescriptorSetLayoutInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDescriptorPool(
@@ -1168,7 +1168,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorPool(
     VkResult replay_result = OverrideCreateDescriptorPool(GetDeviceTable(in_device->handle)->CreateDescriptorPool, returnValue, in_device, pCreateInfo, pAllocator, pDescriptorPool);
     CheckResult("vkCreateDescriptorPool", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDescriptorPoolInfo>(device, pDescriptorPool->GetPointer(), pDescriptorPool->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkDescriptorPoolInfo);
+    AddHandle<VulkanDescriptorPoolInfo>(device, pDescriptorPool->GetPointer(), pDescriptorPool->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkDescriptorPoolInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorPool(
@@ -1181,7 +1181,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorPool(
     auto in_descriptorPool = GetObjectInfoTable().GetVkDescriptorPoolInfo(descriptorPool);
 
     OverrideDestroyDescriptorPool(GetDeviceTable(in_device->handle)->DestroyDescriptorPool, in_device, in_descriptorPool, pAllocator);
-    RemovePoolHandle<VulkanDescriptorPoolInfo>(descriptorPool, &VulkanObjectInfoTable::GetVkDescriptorPoolInfo, &VulkanObjectInfoTable::RemoveVkDescriptorPoolInfo, &VulkanObjectInfoTable::RemoveVkDescriptorSetInfo);
+    RemovePoolHandle<VulkanDescriptorPoolInfo>(descriptorPool, &CommonObjectInfoTable::GetVkDescriptorPoolInfo, &CommonObjectInfoTable::RemoveVkDescriptorPoolInfo, &CommonObjectInfoTable::RemoveVkDescriptorSetInfo);
 }
 
 void VulkanReplayConsumer::Process_vkResetDescriptorPool(
@@ -1215,7 +1215,7 @@ void VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
     VkResult replay_result = OverrideAllocateDescriptorSets(GetDeviceTable(in_device->handle)->AllocateDescriptorSets, returnValue, in_device, pAllocateInfo, pDescriptorSets);
     CheckResult("vkAllocateDescriptorSets", returnValue, replay_result, call_info);
 
-    AddPoolHandles<VulkanDescriptorPoolInfo, VulkanDescriptorSetInfo>(device, handle_mapping::GetPoolId(pAllocateInfo->GetMetaStructPointer()), pDescriptorSets->GetPointer(), pDescriptorSets->GetLength(), pDescriptorSets->GetHandlePointer(), pAllocateInfo->GetPointer()->descriptorSetCount, std::move(handle_info), &VulkanObjectInfoTable::GetVkDescriptorPoolInfo, &VulkanObjectInfoTable::AddVkDescriptorSetInfo);
+    AddPoolHandles<VulkanDescriptorPoolInfo, VulkanDescriptorSetInfo>(device, handle_mapping::GetPoolId(pAllocateInfo->GetMetaStructPointer()), pDescriptorSets->GetPointer(), pDescriptorSets->GetLength(), pDescriptorSets->GetHandlePointer(), pAllocateInfo->GetPointer()->descriptorSetCount, std::move(handle_info), &CommonObjectInfoTable::GetVkDescriptorPoolInfo, &CommonObjectInfoTable::AddVkDescriptorSetInfo);
 }
 
 void VulkanReplayConsumer::Process_vkFreeDescriptorSets(
@@ -1226,13 +1226,13 @@ void VulkanReplayConsumer::Process_vkFreeDescriptorSets(
     uint32_t                                    descriptorSetCount,
     HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDescriptorPool in_descriptorPool = MapHandle<VulkanDescriptorPoolInfo>(descriptorPool, &VulkanObjectInfoTable::GetVkDescriptorPoolInfo);
-    const VkDescriptorSet* in_pDescriptorSets = MapHandles<VulkanDescriptorSetInfo>(pDescriptorSets, descriptorSetCount, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDescriptorPool in_descriptorPool = MapHandle<VulkanDescriptorPoolInfo>(descriptorPool, &CommonObjectInfoTable::GetVkDescriptorPoolInfo);
+    const VkDescriptorSet* in_pDescriptorSets = MapHandles<VulkanDescriptorSetInfo>(pDescriptorSets, descriptorSetCount, &CommonObjectInfoTable::GetVkDescriptorSetInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->FreeDescriptorSets(in_device, in_descriptorPool, descriptorSetCount, in_pDescriptorSets);
     CheckResult("vkFreeDescriptorSets", returnValue, replay_result, call_info);
-    RemovePoolHandles<VulkanDescriptorPoolInfo, VulkanDescriptorSetInfo>(descriptorPool, pDescriptorSets, descriptorSetCount, &VulkanObjectInfoTable::GetVkDescriptorPoolInfo, &VulkanObjectInfoTable::RemoveVkDescriptorSetInfo);
+    RemovePoolHandles<VulkanDescriptorPoolInfo, VulkanDescriptorSetInfo>(descriptorPool, pDescriptorSets, descriptorSetCount, &CommonObjectInfoTable::GetVkDescriptorPoolInfo, &CommonObjectInfoTable::RemoveVkDescriptorSetInfo);
 }
 
 void VulkanReplayConsumer::Process_vkUpdateDescriptorSets(
@@ -1270,7 +1270,7 @@ void VulkanReplayConsumer::Process_vkCreateFramebuffer(
     VkResult replay_result = OverrideCreateFramebuffer(GetDeviceTable(in_device->handle)->CreateFramebuffer, returnValue, in_device, pCreateInfo, pAllocator, pFramebuffer);
     CheckResult("vkCreateFramebuffer", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanFramebufferInfo>(device, pFramebuffer->GetPointer(), pFramebuffer->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkFramebufferInfo);
+    AddHandle<VulkanFramebufferInfo>(device, pFramebuffer->GetPointer(), pFramebuffer->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkFramebufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyFramebuffer(
@@ -1279,12 +1279,12 @@ void VulkanReplayConsumer::Process_vkDestroyFramebuffer(
     format::HandleId                            framebuffer,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkFramebuffer in_framebuffer = MapHandle<VulkanFramebufferInfo>(framebuffer, &VulkanObjectInfoTable::GetVkFramebufferInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkFramebuffer in_framebuffer = MapHandle<VulkanFramebufferInfo>(framebuffer, &CommonObjectInfoTable::GetVkFramebufferInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyFramebuffer(in_device, in_framebuffer, in_pAllocator);
-    RemoveHandle(framebuffer, &VulkanObjectInfoTable::RemoveVkFramebufferInfo);
+    RemoveHandle(framebuffer, &CommonObjectInfoTable::RemoveVkFramebufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateRenderPass(
@@ -1303,7 +1303,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass(
     VkResult replay_result = OverrideCreateRenderPass(GetDeviceTable(in_device->handle)->CreateRenderPass, returnValue, in_device, pCreateInfo, pAllocator, pRenderPass);
     CheckResult("vkCreateRenderPass", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanRenderPassInfo>(device, pRenderPass->GetPointer(), pRenderPass->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkRenderPassInfo);
+    AddHandle<VulkanRenderPassInfo>(device, pRenderPass->GetPointer(), pRenderPass->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkRenderPassInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyRenderPass(
@@ -1316,7 +1316,7 @@ void VulkanReplayConsumer::Process_vkDestroyRenderPass(
     auto in_renderPass = GetObjectInfoTable().GetVkRenderPassInfo(renderPass);
 
     OverrideDestroyRenderPass(GetDeviceTable(in_device->handle)->DestroyRenderPass, in_device, in_renderPass, pAllocator);
-    RemoveHandle(renderPass, &VulkanObjectInfoTable::RemoveVkRenderPassInfo);
+    RemoveHandle(renderPass, &CommonObjectInfoTable::RemoveVkRenderPassInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetRenderAreaGranularity(
@@ -1325,8 +1325,8 @@ void VulkanReplayConsumer::Process_vkGetRenderAreaGranularity(
     format::HandleId                            renderPass,
     StructPointerDecoder<Decoded_VkExtent2D>*   pGranularity)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkRenderPass in_renderPass = MapHandle<VulkanRenderPassInfo>(renderPass, &VulkanObjectInfoTable::GetVkRenderPassInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkRenderPass in_renderPass = MapHandle<VulkanRenderPassInfo>(renderPass, &CommonObjectInfoTable::GetVkRenderPassInfo);
     VkExtent2D* out_pGranularity = pGranularity->IsNull() ? nullptr : pGranularity->AllocateOutputData(1);
 
     GetDeviceTable(in_device)->GetRenderAreaGranularity(in_device, in_renderPass, out_pGranularity);
@@ -1340,7 +1340,7 @@ void VulkanReplayConsumer::Process_vkCreateCommandPool(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkCommandPool>*        pCommandPool)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkCommandPoolCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pCommandPool->IsNull()) { pCommandPool->SetHandleLength(1); }
@@ -1349,7 +1349,7 @@ void VulkanReplayConsumer::Process_vkCreateCommandPool(
     VkResult replay_result = GetDeviceTable(in_device)->CreateCommandPool(in_device, in_pCreateInfo, in_pAllocator, out_pCommandPool);
     CheckResult("vkCreateCommandPool", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanCommandPoolInfo>(device, pCommandPool->GetPointer(), out_pCommandPool, &VulkanObjectInfoTable::AddVkCommandPoolInfo);
+    AddHandle<VulkanCommandPoolInfo>(device, pCommandPool->GetPointer(), out_pCommandPool, &CommonObjectInfoTable::AddVkCommandPoolInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyCommandPool(
@@ -1362,7 +1362,7 @@ void VulkanReplayConsumer::Process_vkDestroyCommandPool(
     auto in_commandPool = GetObjectInfoTable().GetVkCommandPoolInfo(commandPool);
 
     OverrideDestroyCommandPool(GetDeviceTable(in_device->handle)->DestroyCommandPool, in_device, in_commandPool, pAllocator);
-    RemovePoolHandle<VulkanCommandPoolInfo>(commandPool, &VulkanObjectInfoTable::GetVkCommandPoolInfo, &VulkanObjectInfoTable::RemoveVkCommandPoolInfo, &VulkanObjectInfoTable::RemoveVkCommandBufferInfo);
+    RemovePoolHandle<VulkanCommandPoolInfo>(commandPool, &CommonObjectInfoTable::GetVkCommandPoolInfo, &CommonObjectInfoTable::RemoveVkCommandPoolInfo, &CommonObjectInfoTable::RemoveVkCommandBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkResetCommandPool(
@@ -1396,7 +1396,7 @@ void VulkanReplayConsumer::Process_vkAllocateCommandBuffers(
     VkResult replay_result = OverrideAllocateCommandBuffers(GetDeviceTable(in_device->handle)->AllocateCommandBuffers, returnValue, in_device, pAllocateInfo, pCommandBuffers);
     CheckResult("vkAllocateCommandBuffers", returnValue, replay_result, call_info);
 
-    AddPoolHandles<VulkanCommandPoolInfo, VulkanCommandBufferInfo>(device, handle_mapping::GetPoolId(pAllocateInfo->GetMetaStructPointer()), pCommandBuffers->GetPointer(), pCommandBuffers->GetLength(), pCommandBuffers->GetHandlePointer(), pAllocateInfo->GetPointer()->commandBufferCount, std::move(handle_info), &VulkanObjectInfoTable::GetVkCommandPoolInfo, &VulkanObjectInfoTable::AddVkCommandBufferInfo);
+    AddPoolHandles<VulkanCommandPoolInfo, VulkanCommandBufferInfo>(device, handle_mapping::GetPoolId(pAllocateInfo->GetMetaStructPointer()), pCommandBuffers->GetPointer(), pCommandBuffers->GetLength(), pCommandBuffers->GetHandlePointer(), pAllocateInfo->GetPointer()->commandBufferCount, std::move(handle_info), &CommonObjectInfoTable::GetVkCommandPoolInfo, &CommonObjectInfoTable::AddVkCommandBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkFreeCommandBuffers(
@@ -1408,10 +1408,10 @@ void VulkanReplayConsumer::Process_vkFreeCommandBuffers(
 {
     auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
     auto in_commandPool = GetObjectInfoTable().GetVkCommandPoolInfo(commandPool);
-    MapHandles<VulkanCommandBufferInfo>(pCommandBuffers, commandBufferCount, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    MapHandles<VulkanCommandBufferInfo>(pCommandBuffers, commandBufferCount, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     OverrideFreeCommandBuffers(GetDeviceTable(in_device->handle)->FreeCommandBuffers, in_device, in_commandPool, commandBufferCount, pCommandBuffers);
-    RemovePoolHandles<VulkanCommandPoolInfo, VulkanCommandBufferInfo>(commandPool, pCommandBuffers, commandBufferCount, &VulkanObjectInfoTable::GetVkCommandPoolInfo, &VulkanObjectInfoTable::RemoveVkCommandBufferInfo);
+    RemovePoolHandles<VulkanCommandPoolInfo, VulkanCommandBufferInfo>(commandPool, pCommandBuffers, commandBufferCount, &CommonObjectInfoTable::GetVkCommandPoolInfo, &CommonObjectInfoTable::RemoveVkCommandBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkBeginCommandBuffer(
@@ -1433,14 +1433,14 @@ void VulkanReplayConsumer::Process_vkEndCommandBuffer(
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     VkResult replay_result = GetDeviceTable(in_commandBuffer)->EndCommandBuffer(in_commandBuffer);
     CheckResult("vkEndCommandBuffer", returnValue, replay_result, call_info);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkEndCommandBuffer(call_info, GetDeviceTable(in_commandBuffer)->EndCommandBuffer, returnValue, in_commandBuffer);
+        resource_dumper_.Process_vkEndCommandBuffer(call_info, GetDeviceTable(in_commandBuffer)->EndCommandBuffer, returnValue, in_commandBuffer);
     }
 }
 
@@ -1462,14 +1462,14 @@ void VulkanReplayConsumer::Process_vkCmdBindPipeline(
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            pipeline)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &VulkanObjectInfoTable::GetVkPipelineInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &CommonObjectInfoTable::GetVkPipelineInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdBindPipeline(in_commandBuffer, pipelineBindPoint, in_pipeline);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindPipeline(call_info, GetDeviceTable(in_commandBuffer)->CmdBindPipeline, in_commandBuffer, pipelineBindPoint, GetObjectInfoTable().GetVkPipelineInfo(pipeline));
+        resource_dumper_.Process_vkCmdBindPipeline(call_info, GetDeviceTable(in_commandBuffer)->CmdBindPipeline, in_commandBuffer, pipelineBindPoint, GetObjectInfoTable().GetVkPipelineInfo(pipeline));
     }
 }
 
@@ -1480,14 +1480,14 @@ void VulkanReplayConsumer::Process_vkCmdSetViewport(
     uint32_t                                    viewportCount,
     StructPointerDecoder<Decoded_VkViewport>*   pViewports)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkViewport* in_pViewports = pViewports->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetViewport(in_commandBuffer, firstViewport, viewportCount, in_pViewports);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetViewport(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewport, in_commandBuffer, firstViewport, viewportCount, in_pViewports);
+        resource_dumper_.Process_vkCmdSetViewport(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewport, in_commandBuffer, firstViewport, viewportCount, in_pViewports);
     }
 }
 
@@ -1498,14 +1498,14 @@ void VulkanReplayConsumer::Process_vkCmdSetScissor(
     uint32_t                                    scissorCount,
     StructPointerDecoder<Decoded_VkRect2D>*     pScissors)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkRect2D* in_pScissors = pScissors->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetScissor(in_commandBuffer, firstScissor, scissorCount, in_pScissors);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetScissor(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissor, in_commandBuffer, firstScissor, scissorCount, in_pScissors);
+        resource_dumper_.Process_vkCmdSetScissor(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissor, in_commandBuffer, firstScissor, scissorCount, in_pScissors);
     }
 }
 
@@ -1514,13 +1514,13 @@ void VulkanReplayConsumer::Process_vkCmdSetLineWidth(
     format::HandleId                            commandBuffer,
     float                                       lineWidth)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetLineWidth(in_commandBuffer, lineWidth);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetLineWidth(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineWidth, in_commandBuffer, lineWidth);
+        resource_dumper_.Process_vkCmdSetLineWidth(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineWidth, in_commandBuffer, lineWidth);
     }
 }
 
@@ -1531,13 +1531,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBias(
     float                                       depthBiasClamp,
     float                                       depthBiasSlopeFactor)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthBias(in_commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthBias(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBias, in_commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
+        resource_dumper_.Process_vkCmdSetDepthBias(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBias, in_commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
     }
 }
 
@@ -1546,14 +1546,14 @@ void VulkanReplayConsumer::Process_vkCmdSetBlendConstants(
     format::HandleId                            commandBuffer,
     PointerDecoder<float>*                      blendConstants)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const float* in_blendConstants = blendConstants->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetBlendConstants(in_commandBuffer, in_blendConstants);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetBlendConstants(call_info, GetDeviceTable(in_commandBuffer)->CmdSetBlendConstants, in_commandBuffer, in_blendConstants);
+        resource_dumper_.Process_vkCmdSetBlendConstants(call_info, GetDeviceTable(in_commandBuffer)->CmdSetBlendConstants, in_commandBuffer, in_blendConstants);
     }
 }
 
@@ -1563,13 +1563,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBounds(
     float                                       minDepthBounds,
     float                                       maxDepthBounds)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthBounds(in_commandBuffer, minDepthBounds, maxDepthBounds);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthBounds(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBounds, in_commandBuffer, minDepthBounds, maxDepthBounds);
+        resource_dumper_.Process_vkCmdSetDepthBounds(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBounds, in_commandBuffer, minDepthBounds, maxDepthBounds);
     }
 }
 
@@ -1579,13 +1579,13 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilCompareMask(
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    compareMask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetStencilCompareMask(in_commandBuffer, faceMask, compareMask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetStencilCompareMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilCompareMask, in_commandBuffer, faceMask, compareMask);
+        resource_dumper_.Process_vkCmdSetStencilCompareMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilCompareMask, in_commandBuffer, faceMask, compareMask);
     }
 }
 
@@ -1595,13 +1595,13 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilWriteMask(
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    writeMask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetStencilWriteMask(in_commandBuffer, faceMask, writeMask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetStencilWriteMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilWriteMask, in_commandBuffer, faceMask, writeMask);
+        resource_dumper_.Process_vkCmdSetStencilWriteMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilWriteMask, in_commandBuffer, faceMask, writeMask);
     }
 }
 
@@ -1611,13 +1611,13 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilReference(
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    reference)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetStencilReference(in_commandBuffer, faceMask, reference);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetStencilReference(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilReference, in_commandBuffer, faceMask, reference);
+        resource_dumper_.Process_vkCmdSetStencilReference(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilReference, in_commandBuffer, faceMask, reference);
     }
 }
 
@@ -1632,16 +1632,16 @@ void VulkanReplayConsumer::Process_vkCmdBindDescriptorSets(
     uint32_t                                    dynamicOffsetCount,
     PointerDecoder<uint32_t>*                   pDynamicOffsets)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkPipelineLayout in_layout = MapHandle<VulkanPipelineLayoutInfo>(layout, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
-    const VkDescriptorSet* in_pDescriptorSets = MapHandles<VulkanDescriptorSetInfo>(pDescriptorSets, descriptorSetCount, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkPipelineLayout in_layout = MapHandle<VulkanPipelineLayoutInfo>(layout, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
+    const VkDescriptorSet* in_pDescriptorSets = MapHandles<VulkanDescriptorSetInfo>(pDescriptorSets, descriptorSetCount, &CommonObjectInfoTable::GetVkDescriptorSetInfo);
     const uint32_t* in_pDynamicOffsets = pDynamicOffsets->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdBindDescriptorSets(in_commandBuffer, pipelineBindPoint, in_layout, firstSet, descriptorSetCount, in_pDescriptorSets, dynamicOffsetCount, in_pDynamicOffsets);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindDescriptorSets(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorSets, in_commandBuffer, pipelineBindPoint, GetObjectInfoTable().GetVkPipelineLayoutInfo(layout), firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, in_pDynamicOffsets);
+        resource_dumper_.Process_vkCmdBindDescriptorSets(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorSets, in_commandBuffer, pipelineBindPoint, GetObjectInfoTable().GetVkPipelineLayoutInfo(layout), firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, in_pDynamicOffsets);
     }
 }
 
@@ -1652,14 +1652,14 @@ void VulkanReplayConsumer::Process_vkCmdBindIndexBuffer(
     VkDeviceSize                                offset,
     VkIndexType                                 indexType)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdBindIndexBuffer(in_commandBuffer, in_buffer, offset, indexType);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindIndexBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdBindIndexBuffer, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, indexType);
+        resource_dumper_.Process_vkCmdBindIndexBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdBindIndexBuffer, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, indexType);
     }
 }
 
@@ -1671,15 +1671,15 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers(
     HandlePointerDecoder<VkBuffer>*             pBuffers,
     PointerDecoder<VkDeviceSize>*               pOffsets)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkBuffer* in_pBuffers = MapHandles<VulkanBufferInfo>(pBuffers, bindingCount, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkBuffer* in_pBuffers = MapHandles<VulkanBufferInfo>(pBuffers, bindingCount, &CommonObjectInfoTable::GetVkBufferInfo);
     const VkDeviceSize* in_pOffsets = pOffsets->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers(in_commandBuffer, firstBinding, bindingCount, in_pBuffers, in_pOffsets);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindVertexBuffers(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers, in_commandBuffer, firstBinding, bindingCount, pBuffers, in_pOffsets);
+        resource_dumper_.Process_vkCmdBindVertexBuffers(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers, in_commandBuffer, firstBinding, bindingCount, pBuffers, in_pOffsets);
     }
 }
 
@@ -1691,13 +1691,13 @@ void VulkanReplayConsumer::Process_vkCmdDraw(
     uint32_t                                    firstVertex,
     uint32_t                                    firstInstance)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDraw(in_commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDraw(call_info, GetDeviceTable(in_commandBuffer)->CmdDraw, in_commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
+        resource_dumper_.Process_vkCmdDraw(call_info, GetDeviceTable(in_commandBuffer)->CmdDraw, in_commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
     }
 }
 
@@ -1710,13 +1710,13 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexed(
     int32_t                                     vertexOffset,
     uint32_t                                    firstInstance)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawIndexed(in_commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawIndexed(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexed, in_commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
+        resource_dumper_.Process_vkCmdDrawIndexed(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexed, in_commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
     }
 }
 
@@ -1728,14 +1728,14 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirect(
     uint32_t                                    drawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawIndirect(in_commandBuffer, in_buffer, offset, drawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, drawCount, stride);
+        resource_dumper_.Process_vkCmdDrawIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, drawCount, stride);
     }
 }
 
@@ -1747,14 +1747,14 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirect(
     uint32_t                                    drawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirect(in_commandBuffer, in_buffer, offset, drawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawIndexedIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, drawCount, stride);
+        resource_dumper_.Process_vkCmdDrawIndexedIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, drawCount, stride);
     }
 }
 
@@ -1765,13 +1765,13 @@ void VulkanReplayConsumer::Process_vkCmdDispatch(
     uint32_t                                    groupCountY,
     uint32_t                                    groupCountZ)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDispatch(in_commandBuffer, groupCountX, groupCountY, groupCountZ);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDispatch(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatch, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
+        resource_dumper_.Process_vkCmdDispatch(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatch, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
     }
 }
 
@@ -1781,14 +1781,14 @@ void VulkanReplayConsumer::Process_vkCmdDispatchIndirect(
     format::HandleId                            buffer,
     VkDeviceSize                                offset)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDispatchIndirect(in_commandBuffer, in_buffer, offset);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDispatchIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset);
+        resource_dumper_.Process_vkCmdDispatchIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset);
     }
 }
 
@@ -1800,16 +1800,16 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer(
     uint32_t                                    regionCount,
     StructPointerDecoder<Decoded_VkBufferCopy>* pRegions)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_srcBuffer = MapHandle<VulkanBufferInfo>(srcBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_srcBuffer = MapHandle<VulkanBufferInfo>(srcBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
     const VkBufferCopy* in_pRegions = pRegions->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdCopyBuffer(in_commandBuffer, in_srcBuffer, in_dstBuffer, regionCount, in_pRegions);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer, in_commandBuffer, in_srcBuffer, in_dstBuffer, regionCount, in_pRegions);
+        resource_dumper_.Process_vkCmdCopyBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer, in_commandBuffer, in_srcBuffer, in_dstBuffer, regionCount, in_pRegions);
     }
 }
 
@@ -1823,16 +1823,16 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage(
     uint32_t                                    regionCount,
     StructPointerDecoder<Decoded_VkImageCopy>*  pRegions)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkImage in_srcImage = MapHandle<VulkanImageInfo>(srcImage, &VulkanObjectInfoTable::GetVkImageInfo);
-    VkImage in_dstImage = MapHandle<VulkanImageInfo>(dstImage, &VulkanObjectInfoTable::GetVkImageInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkImage in_srcImage = MapHandle<VulkanImageInfo>(srcImage, &CommonObjectInfoTable::GetVkImageInfo);
+    VkImage in_dstImage = MapHandle<VulkanImageInfo>(dstImage, &CommonObjectInfoTable::GetVkImageInfo);
     const VkImageCopy* in_pRegions = pRegions->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdCopyImage(in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyImage(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions);
+        resource_dumper_.Process_vkCmdCopyImage(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions);
     }
 }
 
@@ -1847,16 +1847,16 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage(
     StructPointerDecoder<Decoded_VkImageBlit>*  pRegions,
     VkFilter                                    filter)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkImage in_srcImage = MapHandle<VulkanImageInfo>(srcImage, &VulkanObjectInfoTable::GetVkImageInfo);
-    VkImage in_dstImage = MapHandle<VulkanImageInfo>(dstImage, &VulkanObjectInfoTable::GetVkImageInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkImage in_srcImage = MapHandle<VulkanImageInfo>(srcImage, &CommonObjectInfoTable::GetVkImageInfo);
+    VkImage in_dstImage = MapHandle<VulkanImageInfo>(dstImage, &CommonObjectInfoTable::GetVkImageInfo);
     const VkImageBlit* in_pRegions = pRegions->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdBlitImage(in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions, filter);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBlitImage(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions, filter);
+        resource_dumper_.Process_vkCmdBlitImage(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions, filter);
     }
 }
 
@@ -1869,16 +1869,16 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage(
     uint32_t                                    regionCount,
     StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_srcBuffer = MapHandle<VulkanBufferInfo>(srcBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkImage in_dstImage = MapHandle<VulkanImageInfo>(dstImage, &VulkanObjectInfoTable::GetVkImageInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_srcBuffer = MapHandle<VulkanBufferInfo>(srcBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkImage in_dstImage = MapHandle<VulkanImageInfo>(dstImage, &CommonObjectInfoTable::GetVkImageInfo);
     const VkBufferImageCopy* in_pRegions = pRegions->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage(in_commandBuffer, in_srcBuffer, in_dstImage, dstImageLayout, regionCount, in_pRegions);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyBufferToImage(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage, in_commandBuffer, in_srcBuffer, in_dstImage, dstImageLayout, regionCount, in_pRegions);
+        resource_dumper_.Process_vkCmdCopyBufferToImage(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage, in_commandBuffer, in_srcBuffer, in_dstImage, dstImageLayout, regionCount, in_pRegions);
     }
 }
 
@@ -1891,16 +1891,16 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer(
     uint32_t                                    regionCount,
     StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkImage in_srcImage = MapHandle<VulkanImageInfo>(srcImage, &VulkanObjectInfoTable::GetVkImageInfo);
-    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkImage in_srcImage = MapHandle<VulkanImageInfo>(srcImage, &CommonObjectInfoTable::GetVkImageInfo);
+    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
     const VkBufferImageCopy* in_pRegions = pRegions->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer(in_commandBuffer, in_srcImage, srcImageLayout, in_dstBuffer, regionCount, in_pRegions);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyImageToBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer, in_commandBuffer, in_srcImage, srcImageLayout, in_dstBuffer, regionCount, in_pRegions);
+        resource_dumper_.Process_vkCmdCopyImageToBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer, in_commandBuffer, in_srcImage, srcImageLayout, in_dstBuffer, regionCount, in_pRegions);
     }
 }
 
@@ -1912,15 +1912,15 @@ void VulkanReplayConsumer::Process_vkCmdUpdateBuffer(
     VkDeviceSize                                dataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
     const void* in_pData = pData->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdUpdateBuffer(in_commandBuffer, in_dstBuffer, dstOffset, dataSize, in_pData);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdUpdateBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdUpdateBuffer, in_commandBuffer, in_dstBuffer, dstOffset, dataSize, in_pData);
+        resource_dumper_.Process_vkCmdUpdateBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdUpdateBuffer, in_commandBuffer, in_dstBuffer, dstOffset, dataSize, in_pData);
     }
 }
 
@@ -1932,14 +1932,14 @@ void VulkanReplayConsumer::Process_vkCmdFillBuffer(
     VkDeviceSize                                size,
     uint32_t                                    data)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdFillBuffer(in_commandBuffer, in_dstBuffer, dstOffset, size, data);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdFillBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdFillBuffer, in_commandBuffer, in_dstBuffer, dstOffset, size, data);
+        resource_dumper_.Process_vkCmdFillBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdFillBuffer, in_commandBuffer, in_dstBuffer, dstOffset, size, data);
     }
 }
 
@@ -1952,8 +1952,8 @@ void VulkanReplayConsumer::Process_vkCmdClearColorImage(
     uint32_t                                    rangeCount,
     StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkImage in_image = MapHandle<VulkanImageInfo>(image, &VulkanObjectInfoTable::GetVkImageInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkImage in_image = MapHandle<VulkanImageInfo>(image, &CommonObjectInfoTable::GetVkImageInfo);
     const VkClearColorValue* in_pColor = pColor->GetPointer();
     const VkImageSubresourceRange* in_pRanges = pRanges->GetPointer();
 
@@ -1961,7 +1961,7 @@ void VulkanReplayConsumer::Process_vkCmdClearColorImage(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdClearColorImage(call_info, GetDeviceTable(in_commandBuffer)->CmdClearColorImage, in_commandBuffer, in_image, imageLayout, in_pColor, rangeCount, in_pRanges);
+        resource_dumper_.Process_vkCmdClearColorImage(call_info, GetDeviceTable(in_commandBuffer)->CmdClearColorImage, in_commandBuffer, in_image, imageLayout, in_pColor, rangeCount, in_pRanges);
     }
 }
 
@@ -1974,8 +1974,8 @@ void VulkanReplayConsumer::Process_vkCmdClearDepthStencilImage(
     uint32_t                                    rangeCount,
     StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkImage in_image = MapHandle<VulkanImageInfo>(image, &VulkanObjectInfoTable::GetVkImageInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkImage in_image = MapHandle<VulkanImageInfo>(image, &CommonObjectInfoTable::GetVkImageInfo);
     const VkClearDepthStencilValue* in_pDepthStencil = pDepthStencil->GetPointer();
     const VkImageSubresourceRange* in_pRanges = pRanges->GetPointer();
 
@@ -1983,7 +1983,7 @@ void VulkanReplayConsumer::Process_vkCmdClearDepthStencilImage(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdClearDepthStencilImage(call_info, GetDeviceTable(in_commandBuffer)->CmdClearDepthStencilImage, in_commandBuffer, in_image, imageLayout, in_pDepthStencil, rangeCount, in_pRanges);
+        resource_dumper_.Process_vkCmdClearDepthStencilImage(call_info, GetDeviceTable(in_commandBuffer)->CmdClearDepthStencilImage, in_commandBuffer, in_image, imageLayout, in_pDepthStencil, rangeCount, in_pRanges);
     }
 }
 
@@ -1995,7 +1995,7 @@ void VulkanReplayConsumer::Process_vkCmdClearAttachments(
     uint32_t                                    rectCount,
     StructPointerDecoder<Decoded_VkClearRect>*  pRects)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkClearAttachment* in_pAttachments = pAttachments->GetPointer();
     const VkClearRect* in_pRects = pRects->GetPointer();
 
@@ -2003,7 +2003,7 @@ void VulkanReplayConsumer::Process_vkCmdClearAttachments(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdClearAttachments(call_info, GetDeviceTable(in_commandBuffer)->CmdClearAttachments, in_commandBuffer, attachmentCount, in_pAttachments, rectCount, in_pRects);
+        resource_dumper_.Process_vkCmdClearAttachments(call_info, GetDeviceTable(in_commandBuffer)->CmdClearAttachments, in_commandBuffer, attachmentCount, in_pAttachments, rectCount, in_pRects);
     }
 }
 
@@ -2017,16 +2017,16 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage(
     uint32_t                                    regionCount,
     StructPointerDecoder<Decoded_VkImageResolve>* pRegions)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkImage in_srcImage = MapHandle<VulkanImageInfo>(srcImage, &VulkanObjectInfoTable::GetVkImageInfo);
-    VkImage in_dstImage = MapHandle<VulkanImageInfo>(dstImage, &VulkanObjectInfoTable::GetVkImageInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkImage in_srcImage = MapHandle<VulkanImageInfo>(srcImage, &CommonObjectInfoTable::GetVkImageInfo);
+    VkImage in_dstImage = MapHandle<VulkanImageInfo>(dstImage, &CommonObjectInfoTable::GetVkImageInfo);
     const VkImageResolve* in_pRegions = pRegions->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdResolveImage(in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdResolveImage(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions);
+        resource_dumper_.Process_vkCmdResolveImage(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions);
     }
 }
 
@@ -2036,14 +2036,14 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent(
     format::HandleId                            event,
     VkPipelineStageFlags                        stageMask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &CommonObjectInfoTable::GetVkEventInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetEvent(in_commandBuffer, in_event, stageMask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetEvent(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent, in_commandBuffer, in_event, stageMask);
+        resource_dumper_.Process_vkCmdSetEvent(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent, in_commandBuffer, in_event, stageMask);
     }
 }
 
@@ -2053,14 +2053,14 @@ void VulkanReplayConsumer::Process_vkCmdResetEvent(
     format::HandleId                            event,
     VkPipelineStageFlags                        stageMask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &CommonObjectInfoTable::GetVkEventInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdResetEvent(in_commandBuffer, in_event, stageMask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdResetEvent(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent, in_commandBuffer, in_event, stageMask);
+        resource_dumper_.Process_vkCmdResetEvent(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent, in_commandBuffer, in_event, stageMask);
     }
 }
 
@@ -2078,8 +2078,8 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents(
     uint32_t                                    imageMemoryBarrierCount,
     StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkEvent* in_pEvents = MapHandles<VulkanEventInfo>(pEvents, eventCount, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkEvent* in_pEvents = MapHandles<VulkanEventInfo>(pEvents, eventCount, &CommonObjectInfoTable::GetVkEventInfo);
     const VkMemoryBarrier* in_pMemoryBarriers = pMemoryBarriers->GetPointer();
     const VkBufferMemoryBarrier* in_pBufferMemoryBarriers = pBufferMemoryBarriers->GetPointer();
     MapStructArrayHandles(pBufferMemoryBarriers->GetMetaStructPointer(), pBufferMemoryBarriers->GetLength(), GetObjectInfoTable());
@@ -2090,7 +2090,7 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWaitEvents(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents, in_commandBuffer, eventCount, in_pEvents, srcStageMask, dstStageMask, memoryBarrierCount, in_pMemoryBarriers, bufferMemoryBarrierCount, in_pBufferMemoryBarriers, imageMemoryBarrierCount, in_pImageMemoryBarriers);
+        resource_dumper_.Process_vkCmdWaitEvents(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents, in_commandBuffer, eventCount, in_pEvents, srcStageMask, dstStageMask, memoryBarrierCount, in_pMemoryBarriers, bufferMemoryBarrierCount, in_pBufferMemoryBarriers, imageMemoryBarrierCount, in_pImageMemoryBarriers);
     }
 }
 
@@ -2117,7 +2117,7 @@ void VulkanReplayConsumer::Process_vkCmdPipelineBarrier(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdPipelineBarrier(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier, in_commandBuffer->handle, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers->GetPointer(), bufferMemoryBarrierCount, pBufferMemoryBarriers->GetPointer(), imageMemoryBarrierCount, pImageMemoryBarriers->GetPointer());
+        resource_dumper_.Process_vkCmdPipelineBarrier(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier, in_commandBuffer->handle, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers->GetPointer(), bufferMemoryBarrierCount, pBufferMemoryBarriers->GetPointer(), imageMemoryBarrierCount, pImageMemoryBarriers->GetPointer());
     }
 }
 
@@ -2128,14 +2128,14 @@ void VulkanReplayConsumer::Process_vkCmdBeginQuery(
     uint32_t                                    query,
     VkQueryControlFlags                         flags)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdBeginQuery(in_commandBuffer, in_queryPool, query, flags);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginQuery(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginQuery, in_commandBuffer, in_queryPool, query, flags);
+        resource_dumper_.Process_vkCmdBeginQuery(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginQuery, in_commandBuffer, in_queryPool, query, flags);
     }
 }
 
@@ -2145,14 +2145,14 @@ void VulkanReplayConsumer::Process_vkCmdEndQuery(
     format::HandleId                            queryPool,
     uint32_t                                    query)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdEndQuery(in_commandBuffer, in_queryPool, query);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndQuery(call_info, GetDeviceTable(in_commandBuffer)->CmdEndQuery, in_commandBuffer, in_queryPool, query);
+        resource_dumper_.Process_vkCmdEndQuery(call_info, GetDeviceTable(in_commandBuffer)->CmdEndQuery, in_commandBuffer, in_queryPool, query);
     }
 }
 
@@ -2163,14 +2163,14 @@ void VulkanReplayConsumer::Process_vkCmdResetQueryPool(
     uint32_t                                    firstQuery,
     uint32_t                                    queryCount)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdResetQueryPool(in_commandBuffer, in_queryPool, firstQuery, queryCount);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdResetQueryPool(call_info, GetDeviceTable(in_commandBuffer)->CmdResetQueryPool, in_commandBuffer, in_queryPool, firstQuery, queryCount);
+        resource_dumper_.Process_vkCmdResetQueryPool(call_info, GetDeviceTable(in_commandBuffer)->CmdResetQueryPool, in_commandBuffer, in_queryPool, firstQuery, queryCount);
     }
 }
 
@@ -2181,14 +2181,14 @@ void VulkanReplayConsumer::Process_vkCmdWriteTimestamp(
     format::HandleId                            queryPool,
     uint32_t                                    query)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp(in_commandBuffer, pipelineStage, in_queryPool, query);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWriteTimestamp(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp, in_commandBuffer, pipelineStage, in_queryPool, query);
+        resource_dumper_.Process_vkCmdWriteTimestamp(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp, in_commandBuffer, pipelineStage, in_queryPool, query);
     }
 }
 
@@ -2203,15 +2203,15 @@ void VulkanReplayConsumer::Process_vkCmdCopyQueryPoolResults(
     VkDeviceSize                                stride,
     VkQueryResultFlags                          flags)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
-    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
+    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdCopyQueryPoolResults(in_commandBuffer, in_queryPool, firstQuery, queryCount, in_dstBuffer, dstOffset, stride, flags);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyQueryPoolResults(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyQueryPoolResults, in_commandBuffer, in_queryPool, firstQuery, queryCount, in_dstBuffer, dstOffset, stride, flags);
+        resource_dumper_.Process_vkCmdCopyQueryPoolResults(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyQueryPoolResults, in_commandBuffer, in_queryPool, firstQuery, queryCount, in_dstBuffer, dstOffset, stride, flags);
     }
 }
 
@@ -2224,15 +2224,15 @@ void VulkanReplayConsumer::Process_vkCmdPushConstants(
     uint32_t                                    size,
     PointerDecoder<uint8_t>*                    pValues)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkPipelineLayout in_layout = MapHandle<VulkanPipelineLayoutInfo>(layout, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkPipelineLayout in_layout = MapHandle<VulkanPipelineLayoutInfo>(layout, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
     const void* in_pValues = pValues->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdPushConstants(in_commandBuffer, in_layout, stageFlags, offset, size, in_pValues);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdPushConstants(call_info, GetDeviceTable(in_commandBuffer)->CmdPushConstants, in_commandBuffer, in_layout, stageFlags, offset, size, in_pValues);
+        resource_dumper_.Process_vkCmdPushConstants(call_info, GetDeviceTable(in_commandBuffer)->CmdPushConstants, in_commandBuffer, in_layout, stageFlags, offset, size, in_pValues);
     }
 }
 
@@ -2250,7 +2250,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginRenderPass(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass, in_commandBuffer->handle, pRenderPassBegin, contents);
+        resource_dumper_.Process_vkCmdBeginRenderPass(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass, in_commandBuffer->handle, pRenderPassBegin, contents);
     }
 }
 
@@ -2259,13 +2259,13 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass(
     format::HandleId                            commandBuffer,
     VkSubpassContents                           contents)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdNextSubpass(in_commandBuffer, contents);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdNextSubpass(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass, in_commandBuffer, contents);
+        resource_dumper_.Process_vkCmdNextSubpass(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass, in_commandBuffer, contents);
     }
 }
 
@@ -2273,13 +2273,13 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderPass(
     const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdEndRenderPass(in_commandBuffer);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndRenderPass(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass, in_commandBuffer);
+        resource_dumper_.Process_vkCmdEndRenderPass(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass, in_commandBuffer);
     }
 }
 
@@ -2289,14 +2289,14 @@ void VulkanReplayConsumer::Process_vkCmdExecuteCommands(
     uint32_t                                    commandBufferCount,
     HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkCommandBuffer* in_pCommandBuffers = MapHandles<VulkanCommandBufferInfo>(pCommandBuffers, commandBufferCount, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkCommandBuffer* in_pCommandBuffers = MapHandles<VulkanCommandBufferInfo>(pCommandBuffers, commandBufferCount, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdExecuteCommands(in_commandBuffer, commandBufferCount, in_pCommandBuffers);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdExecuteCommands(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteCommands, in_commandBuffer, commandBufferCount, in_pCommandBuffers);
+        resource_dumper_.Process_vkCmdExecuteCommands(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteCommands, in_commandBuffer, commandBufferCount, in_pCommandBuffers);
     }
 }
 
@@ -2338,7 +2338,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeatures(
     uint32_t                                    remoteDeviceIndex,
     PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     VkPeerMemoryFeatureFlags* out_pPeerMemoryFeatures = pPeerMemoryFeatures->IsNull() ? nullptr : pPeerMemoryFeatures->AllocateOutputData(1, static_cast<VkPeerMemoryFeatureFlags>(0));
 
     GetDeviceTable(in_device)->GetDeviceGroupPeerMemoryFeatures(in_device, heapIndex, localDeviceIndex, remoteDeviceIndex, out_pPeerMemoryFeatures);
@@ -2349,13 +2349,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDeviceMask(
     format::HandleId                            commandBuffer,
     uint32_t                                    deviceMask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDeviceMask(in_commandBuffer, deviceMask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDeviceMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDeviceMask, in_commandBuffer, deviceMask);
+        resource_dumper_.Process_vkCmdSetDeviceMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDeviceMask, in_commandBuffer, deviceMask);
     }
 }
 
@@ -2369,13 +2369,13 @@ void VulkanReplayConsumer::Process_vkCmdDispatchBase(
     uint32_t                                    groupCountY,
     uint32_t                                    groupCountZ)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDispatchBase(in_commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDispatchBase(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchBase, in_commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+        resource_dumper_.Process_vkCmdDispatchBase(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchBase, in_commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
     }
 }
 
@@ -2387,14 +2387,14 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties)
 {
     auto in_instance = GetObjectInfoTable().GetVkInstanceInfo(instance);
-    pPhysicalDeviceGroupCount->IsNull() ? nullptr : pPhysicalDeviceGroupCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanInstanceInfo>("vkEnumeratePhysicalDeviceGroups", returnValue, instance, kInstanceArrayEnumeratePhysicalDeviceGroups, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, &VulkanObjectInfoTable::GetVkInstanceInfo));
+    pPhysicalDeviceGroupCount->IsNull() ? nullptr : pPhysicalDeviceGroupCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanInstanceInfo>("vkEnumeratePhysicalDeviceGroups", returnValue, instance, kInstanceArrayEnumeratePhysicalDeviceGroups, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, &CommonObjectInfoTable::GetVkInstanceInfo));
     SetStructArrayHandleLengths<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength());
     if (!pPhysicalDeviceGroupProperties->IsNull()) { pPhysicalDeviceGroupProperties->AllocateOutputData(*pPhysicalDeviceGroupCount->GetOutputPointer(), VkPhysicalDeviceGroupProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, nullptr }); }
 
     VkResult replay_result = OverrideEnumeratePhysicalDeviceGroups(GetInstanceTable(in_instance->handle)->EnumeratePhysicalDeviceGroups, returnValue, in_instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
     CheckResult("vkEnumeratePhysicalDeviceGroups", returnValue, replay_result, call_info);
 
-    if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<VulkanInstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroups, *pPhysicalDeviceGroupCount->GetOutputPointer(), &VulkanObjectInfoTable::GetVkInstanceInfo); }
+    if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<VulkanInstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroups, *pPhysicalDeviceGroupCount->GetOutputPointer(), &CommonObjectInfoTable::GetVkInstanceInfo); }
     AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(instance, pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), pPhysicalDeviceGroupProperties->GetOutputPointer(), *pPhysicalDeviceGroupCount->GetOutputPointer(), &GetObjectInfoTable());
 }
 
@@ -2404,7 +2404,7 @@ void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2(
     StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkImageMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
@@ -2419,7 +2419,7 @@ void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements2(
     StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkBufferMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
@@ -2435,15 +2435,15 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2(
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
     StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkImageSparseMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetImageSparseMemoryRequirements2", VK_SUCCESS, device, kDeviceArrayGetImageSparseMemoryRequirements2, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetVkDeviceInfo));
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetImageSparseMemoryRequirements2", VK_SUCCESS, device, kDeviceArrayGetImageSparseMemoryRequirements2, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &CommonObjectInfoTable::GetVkDeviceInfo));
     VkSparseImageMemoryRequirements2* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements2(in_device, in_pInfo, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
 
-    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetImageSparseMemoryRequirements2, *out_pSparseMemoryRequirementCount, &VulkanObjectInfoTable::GetVkDeviceInfo); }
+    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetImageSparseMemoryRequirements2, *out_pSparseMemoryRequirementCount, &CommonObjectInfoTable::GetVkDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures2(
@@ -2451,7 +2451,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures2(
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     VkPhysicalDeviceFeatures2* out_pFeatures = pFeatures->IsNull() ? nullptr : pFeatures->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, nullptr });
     InitializeOutputStructPNext(pFeatures);
 
@@ -2476,7 +2476,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
     VkFormat                                    format,
     StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     VkFormatProperties2* out_pFormatProperties = pFormatProperties->IsNull() ? nullptr : pFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, nullptr });
     InitializeOutputStructPNext(pFormatProperties);
 
@@ -2490,7 +2490,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
     StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
     StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceImageFormatInfo2* in_pImageFormatInfo = pImageFormatInfo->GetPointer();
     VkImageFormatProperties2* out_pImageFormatProperties = pImageFormatProperties->IsNull() ? nullptr : pImageFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
     InitializeOutputStructPNext(pImageFormatProperties);
@@ -2505,13 +2505,13 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
     PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
     StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->IsNull() ? nullptr : pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties2", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->IsNull() ? nullptr : pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties2", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2, pQueueFamilyPropertyCount, pQueueFamilyProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkQueueFamilyProperties2* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount, VkQueueFamilyProperties2{ VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties2(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
 
-    if (pQueueFamilyProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2, *out_pQueueFamilyPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pQueueFamilyProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2, *out_pQueueFamilyPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
@@ -2533,14 +2533,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceSparseImageFormatInfo2* in_pFormatInfo = pFormatInfo->GetPointer();
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties2", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties2", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkSparseImageFormatProperties2* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkSparseImageFormatProperties2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2(in_physicalDevice, in_pFormatInfo, out_pPropertyCount, out_pProperties);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkTrimCommandPool(
@@ -2549,8 +2549,8 @@ void VulkanReplayConsumer::Process_vkTrimCommandPool(
     format::HandleId                            commandPool,
     VkCommandPoolTrimFlags                      flags)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkCommandPool in_commandPool = MapHandle<VulkanCommandPoolInfo>(commandPool, &VulkanObjectInfoTable::GetVkCommandPoolInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkCommandPool in_commandPool = MapHandle<VulkanCommandPoolInfo>(commandPool, &CommonObjectInfoTable::GetVkCommandPoolInfo);
 
     GetDeviceTable(in_device)->TrimCommandPool(in_device, in_commandPool, flags);
 }
@@ -2568,7 +2568,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceQueue2(
 
     OverrideGetDeviceQueue2(GetDeviceTable(in_device->handle)->GetDeviceQueue2, in_device, pQueueInfo, pQueue);
 
-    AddHandle<VulkanQueueInfo>(device, pQueue->GetPointer(), pQueue->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkQueueInfo);
+    AddHandle<VulkanQueueInfo>(device, pQueue->GetPointer(), pQueue->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkQueueInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversion(
@@ -2579,7 +2579,7 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversion(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkSamplerYcbcrConversionCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pYcbcrConversion->IsNull()) { pYcbcrConversion->SetHandleLength(1); }
@@ -2588,7 +2588,7 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversion(
     VkResult replay_result = GetDeviceTable(in_device)->CreateSamplerYcbcrConversion(in_device, in_pCreateInfo, in_pAllocator, out_pYcbcrConversion);
     CheckResult("vkCreateSamplerYcbcrConversion", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &VulkanObjectInfoTable::AddVkSamplerYcbcrConversionInfo);
+    AddHandle<VulkanSamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &CommonObjectInfoTable::AddVkSamplerYcbcrConversionInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversion(
@@ -2597,12 +2597,12 @@ void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversion(
     format::HandleId                            ycbcrConversion,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSamplerYcbcrConversion in_ycbcrConversion = MapHandle<VulkanSamplerYcbcrConversionInfo>(ycbcrConversion, &VulkanObjectInfoTable::GetVkSamplerYcbcrConversionInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSamplerYcbcrConversion in_ycbcrConversion = MapHandle<VulkanSamplerYcbcrConversionInfo>(ycbcrConversion, &CommonObjectInfoTable::GetVkSamplerYcbcrConversionInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroySamplerYcbcrConversion(in_device, in_ycbcrConversion, in_pAllocator);
-    RemoveHandle(ycbcrConversion, &VulkanObjectInfoTable::RemoveVkSamplerYcbcrConversionInfo);
+    RemoveHandle(ycbcrConversion, &CommonObjectInfoTable::RemoveVkSamplerYcbcrConversionInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplate(
@@ -2623,7 +2623,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplate(
     VkResult replay_result = OverrideCreateDescriptorUpdateTemplate(GetDeviceTable(in_device->handle)->CreateDescriptorUpdateTemplate, returnValue, in_device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
     CheckResult("vkCreateDescriptorUpdateTemplate", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDescriptorUpdateTemplateInfo>(device, pDescriptorUpdateTemplate->GetPointer(), pDescriptorUpdateTemplate->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkDescriptorUpdateTemplateInfo);
+    AddHandle<VulkanDescriptorUpdateTemplateInfo>(device, pDescriptorUpdateTemplate->GetPointer(), pDescriptorUpdateTemplate->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkDescriptorUpdateTemplateInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplate(
@@ -2636,7 +2636,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplate(
     auto in_descriptorUpdateTemplate = GetObjectInfoTable().GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
 
     OverrideDestroyDescriptorUpdateTemplate(GetDeviceTable(in_device->handle)->DestroyDescriptorUpdateTemplate, in_device, in_descriptorUpdateTemplate, pAllocator);
-    RemoveHandle(descriptorUpdateTemplate, &VulkanObjectInfoTable::RemoveVkDescriptorUpdateTemplateInfo);
+    RemoveHandle(descriptorUpdateTemplate, &CommonObjectInfoTable::RemoveVkDescriptorUpdateTemplateInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
@@ -2645,7 +2645,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
     StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalBufferInfo* in_pExternalBufferInfo = pExternalBufferInfo->GetPointer();
     VkExternalBufferProperties* out_pExternalBufferProperties = pExternalBufferProperties->IsNull() ? nullptr : pExternalBufferProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES, nullptr });
     InitializeOutputStructPNext(pExternalBufferProperties);
@@ -2659,7 +2659,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
     StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalFenceInfo* in_pExternalFenceInfo = pExternalFenceInfo->GetPointer();
     VkExternalFenceProperties* out_pExternalFenceProperties = pExternalFenceProperties->IsNull() ? nullptr : pExternalFenceProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, nullptr });
     InitializeOutputStructPNext(pExternalFenceProperties);
@@ -2673,7 +2673,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertie
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
     StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalSemaphoreInfo* in_pExternalSemaphoreInfo = pExternalSemaphoreInfo->GetPointer();
     VkExternalSemaphoreProperties* out_pExternalSemaphoreProperties = pExternalSemaphoreProperties->IsNull() ? nullptr : pExternalSemaphoreProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, nullptr });
     InitializeOutputStructPNext(pExternalSemaphoreProperties);
@@ -2687,7 +2687,7 @@ void VulkanReplayConsumer::Process_vkGetDescriptorSetLayoutSupport(
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDescriptorSetLayoutCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkDescriptorSetLayoutSupport* out_pSupport = pSupport->IsNull() ? nullptr : pSupport->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT, nullptr });
@@ -2706,15 +2706,15 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectCount(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCount(in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawIndirectCount(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCount, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
+        resource_dumper_.Process_vkCmdDrawIndirectCount(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCount, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -2728,15 +2728,15 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCount(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCount(in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawIndexedIndirectCount(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCount, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
+        resource_dumper_.Process_vkCmdDrawIndexedIndirectCount(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCount, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -2756,7 +2756,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass2(
     VkResult replay_result = OverrideCreateRenderPass2(GetDeviceTable(in_device->handle)->CreateRenderPass2, returnValue, in_device, pCreateInfo, pAllocator, pRenderPass);
     CheckResult("vkCreateRenderPass2", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanRenderPassInfo>(device, pRenderPass->GetPointer(), pRenderPass->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkRenderPassInfo);
+    AddHandle<VulkanRenderPassInfo>(device, pRenderPass->GetPointer(), pRenderPass->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkRenderPassInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2(
@@ -2773,7 +2773,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginRenderPass2(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass2, in_commandBuffer->handle, pRenderPassBegin, pSubpassBeginInfo);
+        resource_dumper_.Process_vkCmdBeginRenderPass2(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass2, in_commandBuffer->handle, pRenderPassBegin, pSubpassBeginInfo);
     }
 }
 
@@ -2783,7 +2783,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass2(
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkSubpassBeginInfo* in_pSubpassBeginInfo = pSubpassBeginInfo->GetPointer();
     const VkSubpassEndInfo* in_pSubpassEndInfo = pSubpassEndInfo->GetPointer();
 
@@ -2791,7 +2791,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdNextSubpass2(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass2, in_commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
+        resource_dumper_.Process_vkCmdNextSubpass2(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass2, in_commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
     }
 }
 
@@ -2800,14 +2800,14 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderPass2(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkSubpassEndInfo* in_pSubpassEndInfo = pSubpassEndInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdEndRenderPass2(in_commandBuffer, in_pSubpassEndInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndRenderPass2(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass2, in_commandBuffer, pSubpassEndInfo);
+        resource_dumper_.Process_vkCmdEndRenderPass2(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass2, in_commandBuffer, pSubpassEndInfo);
     }
 }
 
@@ -2818,8 +2818,8 @@ void VulkanReplayConsumer::Process_vkResetQueryPool(
     uint32_t                                    firstQuery,
     uint32_t                                    queryCount)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_device)->ResetQueryPool(in_device, in_queryPool, firstQuery, queryCount);
 }
@@ -2831,8 +2831,8 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreCounterValue(
     format::HandleId                            semaphore,
     PointerDecoder<uint64_t>*                   pValue)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSemaphore in_semaphore = MapHandle<VulkanSemaphoreInfo>(semaphore, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSemaphore in_semaphore = MapHandle<VulkanSemaphoreInfo>(semaphore, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     uint64_t* out_pValue = pValue->IsNull() ? nullptr : pValue->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSemaphoreCounterValue(in_device, in_semaphore, out_pValue);
@@ -2860,7 +2860,7 @@ void VulkanReplayConsumer::Process_vkSignalSemaphore(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkSemaphoreSignalInfo* in_pSignalInfo = pSignalInfo->GetPointer();
     MapStructHandles(pSignalInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -2887,7 +2887,7 @@ void VulkanReplayConsumer::Process_vkGetBufferOpaqueCaptureAddress(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkBufferDeviceAddressInfo* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -2900,7 +2900,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDeviceMemoryOpaqueCaptureAddressInfo* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -2915,13 +2915,13 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceToolProperties(
     StructPointerDecoder<Decoded_VkPhysicalDeviceToolProperties>* pToolProperties)
 {
     auto in_physicalDevice = GetObjectInfoTable().GetVkPhysicalDeviceInfo(physicalDevice);
-    pToolCount->IsNull() ? nullptr : pToolCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceToolProperties", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceToolProperties, pToolCount, pToolProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    pToolCount->IsNull() ? nullptr : pToolCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceToolProperties", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceToolProperties, pToolCount, pToolProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     if (!pToolProperties->IsNull()) { pToolProperties->AllocateOutputData(*pToolCount->GetOutputPointer(), VkPhysicalDeviceToolProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES, nullptr }); }
 
     VkResult replay_result = OverrideGetPhysicalDeviceToolProperties(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceToolProperties, returnValue, in_physicalDevice, pToolCount, pToolProperties);
     CheckResult("vkGetPhysicalDeviceToolProperties", returnValue, replay_result, call_info);
 
-    if (pToolProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceToolProperties, *pToolCount->GetOutputPointer(), &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pToolProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceToolProperties, *pToolCount->GetOutputPointer(), &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCreatePrivateDataSlot(
@@ -2932,7 +2932,7 @@ void VulkanReplayConsumer::Process_vkCreatePrivateDataSlot(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkPrivateDataSlot>*    pPrivateDataSlot)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPrivateDataSlotCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pPrivateDataSlot->IsNull()) { pPrivateDataSlot->SetHandleLength(1); }
@@ -2941,7 +2941,7 @@ void VulkanReplayConsumer::Process_vkCreatePrivateDataSlot(
     VkResult replay_result = GetDeviceTable(in_device)->CreatePrivateDataSlot(in_device, in_pCreateInfo, in_pAllocator, out_pPrivateDataSlot);
     CheckResult("vkCreatePrivateDataSlot", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanPrivateDataSlotInfo>(device, pPrivateDataSlot->GetPointer(), out_pPrivateDataSlot, &VulkanObjectInfoTable::AddVkPrivateDataSlotInfo);
+    AddHandle<VulkanPrivateDataSlotInfo>(device, pPrivateDataSlot->GetPointer(), out_pPrivateDataSlot, &CommonObjectInfoTable::AddVkPrivateDataSlotInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPrivateDataSlot(
@@ -2950,12 +2950,12 @@ void VulkanReplayConsumer::Process_vkDestroyPrivateDataSlot(
     format::HandleId                            privateDataSlot,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &VulkanObjectInfoTable::GetVkPrivateDataSlotInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &CommonObjectInfoTable::GetVkPrivateDataSlotInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyPrivateDataSlot(in_device, in_privateDataSlot, in_pAllocator);
-    RemoveHandle(privateDataSlot, &VulkanObjectInfoTable::RemoveVkPrivateDataSlotInfo);
+    RemoveHandle(privateDataSlot, &CommonObjectInfoTable::RemoveVkPrivateDataSlotInfo);
 }
 
 void VulkanReplayConsumer::Process_vkSetPrivateData(
@@ -2967,9 +2967,9 @@ void VulkanReplayConsumer::Process_vkSetPrivateData(
     format::HandleId                            privateDataSlot,
     uint64_t                                    data)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     uint64_t in_objectHandle = MapHandle(objectHandle, objectType);
-    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &VulkanObjectInfoTable::GetVkPrivateDataSlotInfo);
+    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &CommonObjectInfoTable::GetVkPrivateDataSlotInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->SetPrivateData(in_device, objectType, in_objectHandle, in_privateDataSlot, data);
     CheckResult("vkSetPrivateData", returnValue, replay_result, call_info);
@@ -2983,9 +2983,9 @@ void VulkanReplayConsumer::Process_vkGetPrivateData(
     format::HandleId                            privateDataSlot,
     PointerDecoder<uint64_t>*                   pData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     uint64_t in_objectHandle = MapHandle(objectHandle, objectType);
-    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &VulkanObjectInfoTable::GetVkPrivateDataSlotInfo);
+    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &CommonObjectInfoTable::GetVkPrivateDataSlotInfo);
     uint64_t* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     GetDeviceTable(in_device)->GetPrivateData(in_device, objectType, in_objectHandle, in_privateDataSlot, out_pData);
@@ -2997,8 +2997,8 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent2(
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &CommonObjectInfoTable::GetVkEventInfo);
     const VkDependencyInfo* in_pDependencyInfo = pDependencyInfo->GetPointer();
     MapStructHandles(pDependencyInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -3006,7 +3006,7 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetEvent2(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent2, in_commandBuffer, in_event, in_pDependencyInfo);
+        resource_dumper_.Process_vkCmdSetEvent2(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent2, in_commandBuffer, in_event, in_pDependencyInfo);
     }
 }
 
@@ -3016,14 +3016,14 @@ void VulkanReplayConsumer::Process_vkCmdResetEvent2(
     format::HandleId                            event,
     VkPipelineStageFlags2                       stageMask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &CommonObjectInfoTable::GetVkEventInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdResetEvent2(in_commandBuffer, in_event, stageMask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdResetEvent2(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent2, in_commandBuffer, in_event, stageMask);
+        resource_dumper_.Process_vkCmdResetEvent2(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent2, in_commandBuffer, in_event, stageMask);
     }
 }
 
@@ -3034,8 +3034,8 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents2(
     HandlePointerDecoder<VkEvent>*              pEvents,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfos)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkEvent* in_pEvents = MapHandles<VulkanEventInfo>(pEvents, eventCount, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkEvent* in_pEvents = MapHandles<VulkanEventInfo>(pEvents, eventCount, &CommonObjectInfoTable::GetVkEventInfo);
     const VkDependencyInfo* in_pDependencyInfos = pDependencyInfos->GetPointer();
     MapStructArrayHandles(pDependencyInfos->GetMetaStructPointer(), pDependencyInfos->GetLength(), GetObjectInfoTable());
 
@@ -3043,7 +3043,7 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWaitEvents2(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents2, in_commandBuffer, eventCount, in_pEvents, in_pDependencyInfos);
+        resource_dumper_.Process_vkCmdWaitEvents2(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents2, in_commandBuffer, eventCount, in_pEvents, in_pDependencyInfos);
     }
 }
 
@@ -3060,7 +3060,7 @@ void VulkanReplayConsumer::Process_vkCmdPipelineBarrier2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdPipelineBarrier2(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier2, in_commandBuffer->handle, pDependencyInfo->GetPointer());
+        resource_dumper_.Process_vkCmdPipelineBarrier2(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier2, in_commandBuffer->handle, pDependencyInfo->GetPointer());
     }
 }
 
@@ -3071,14 +3071,14 @@ void VulkanReplayConsumer::Process_vkCmdWriteTimestamp2(
     format::HandleId                            queryPool,
     uint32_t                                    query)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp2(in_commandBuffer, stage, in_queryPool, query);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWriteTimestamp2(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp2, in_commandBuffer, stage, in_queryPool, query);
+        resource_dumper_.Process_vkCmdWriteTimestamp2(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp2, in_commandBuffer, stage, in_queryPool, query);
     }
 }
 
@@ -3104,7 +3104,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer2(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyBufferInfo2* in_pCopyBufferInfo = pCopyBufferInfo->GetPointer();
     MapStructHandles(pCopyBufferInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -3112,7 +3112,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyBuffer2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer2, in_commandBuffer, in_pCopyBufferInfo);
+        resource_dumper_.Process_vkCmdCopyBuffer2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer2, in_commandBuffer, in_pCopyBufferInfo);
     }
 }
 
@@ -3121,7 +3121,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage2(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyImageInfo2* in_pCopyImageInfo = pCopyImageInfo->GetPointer();
     MapStructHandles(pCopyImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -3129,7 +3129,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage2, in_commandBuffer, in_pCopyImageInfo);
+        resource_dumper_.Process_vkCmdCopyImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage2, in_commandBuffer, in_pCopyImageInfo);
     }
 }
 
@@ -3138,7 +3138,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage2(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyBufferToImageInfo2* in_pCopyBufferToImageInfo = pCopyBufferToImageInfo->GetPointer();
     MapStructHandles(pCopyBufferToImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -3146,7 +3146,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyBufferToImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage2, in_commandBuffer, in_pCopyBufferToImageInfo);
+        resource_dumper_.Process_vkCmdCopyBufferToImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage2, in_commandBuffer, in_pCopyBufferToImageInfo);
     }
 }
 
@@ -3155,7 +3155,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer2(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyImageToBufferInfo2* in_pCopyImageToBufferInfo = pCopyImageToBufferInfo->GetPointer();
     MapStructHandles(pCopyImageToBufferInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -3163,7 +3163,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyImageToBuffer2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer2, in_commandBuffer, in_pCopyImageToBufferInfo);
+        resource_dumper_.Process_vkCmdCopyImageToBuffer2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer2, in_commandBuffer, in_pCopyImageToBufferInfo);
     }
 }
 
@@ -3172,7 +3172,7 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage2(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkBlitImageInfo2* in_pBlitImageInfo = pBlitImageInfo->GetPointer();
     MapStructHandles(pBlitImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -3180,7 +3180,7 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBlitImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage2, in_commandBuffer, in_pBlitImageInfo);
+        resource_dumper_.Process_vkCmdBlitImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage2, in_commandBuffer, in_pBlitImageInfo);
     }
 }
 
@@ -3189,7 +3189,7 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage2(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkResolveImageInfo2* in_pResolveImageInfo = pResolveImageInfo->GetPointer();
     MapStructHandles(pResolveImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -3197,7 +3197,7 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdResolveImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage2, in_commandBuffer, in_pResolveImageInfo);
+        resource_dumper_.Process_vkCmdResolveImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage2, in_commandBuffer, in_pResolveImageInfo);
     }
 }
 
@@ -3206,7 +3206,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRendering(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkRenderingInfo* in_pRenderingInfo = pRenderingInfo->GetPointer();
     MapStructHandles(pRenderingInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -3214,7 +3214,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRendering(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginRendering(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginRendering, in_commandBuffer, pRenderingInfo);
+        resource_dumper_.Process_vkCmdBeginRendering(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginRendering, in_commandBuffer, pRenderingInfo);
     }
 }
 
@@ -3222,13 +3222,13 @@ void VulkanReplayConsumer::Process_vkCmdEndRendering(
     const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdEndRendering(in_commandBuffer);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndRendering(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRendering, in_commandBuffer);
+        resource_dumper_.Process_vkCmdEndRendering(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRendering, in_commandBuffer);
     }
 }
 
@@ -3237,13 +3237,13 @@ void VulkanReplayConsumer::Process_vkCmdSetCullMode(
     format::HandleId                            commandBuffer,
     VkCullModeFlags                             cullMode)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetCullMode(in_commandBuffer, cullMode);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetCullMode(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCullMode, in_commandBuffer, cullMode);
+        resource_dumper_.Process_vkCmdSetCullMode(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCullMode, in_commandBuffer, cullMode);
     }
 }
 
@@ -3252,13 +3252,13 @@ void VulkanReplayConsumer::Process_vkCmdSetFrontFace(
     format::HandleId                            commandBuffer,
     VkFrontFace                                 frontFace)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetFrontFace(in_commandBuffer, frontFace);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetFrontFace(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFrontFace, in_commandBuffer, frontFace);
+        resource_dumper_.Process_vkCmdSetFrontFace(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFrontFace, in_commandBuffer, frontFace);
     }
 }
 
@@ -3267,13 +3267,13 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveTopology(
     format::HandleId                            commandBuffer,
     VkPrimitiveTopology                         primitiveTopology)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveTopology(in_commandBuffer, primitiveTopology);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetPrimitiveTopology(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveTopology, in_commandBuffer, primitiveTopology);
+        resource_dumper_.Process_vkCmdSetPrimitiveTopology(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveTopology, in_commandBuffer, primitiveTopology);
     }
 }
 
@@ -3283,14 +3283,14 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWithCount(
     uint32_t                                    viewportCount,
     StructPointerDecoder<Decoded_VkViewport>*   pViewports)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkViewport* in_pViewports = pViewports->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetViewportWithCount(in_commandBuffer, viewportCount, in_pViewports);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetViewportWithCount(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWithCount, in_commandBuffer, viewportCount, in_pViewports);
+        resource_dumper_.Process_vkCmdSetViewportWithCount(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWithCount, in_commandBuffer, viewportCount, in_pViewports);
     }
 }
 
@@ -3300,14 +3300,14 @@ void VulkanReplayConsumer::Process_vkCmdSetScissorWithCount(
     uint32_t                                    scissorCount,
     StructPointerDecoder<Decoded_VkRect2D>*     pScissors)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkRect2D* in_pScissors = pScissors->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetScissorWithCount(in_commandBuffer, scissorCount, in_pScissors);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetScissorWithCount(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissorWithCount, in_commandBuffer, scissorCount, in_pScissors);
+        resource_dumper_.Process_vkCmdSetScissorWithCount(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissorWithCount, in_commandBuffer, scissorCount, in_pScissors);
     }
 }
 
@@ -3321,8 +3321,8 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers2(
     PointerDecoder<VkDeviceSize>*               pSizes,
     PointerDecoder<VkDeviceSize>*               pStrides)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkBuffer* in_pBuffers = MapHandles<VulkanBufferInfo>(pBuffers, bindingCount, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkBuffer* in_pBuffers = MapHandles<VulkanBufferInfo>(pBuffers, bindingCount, &CommonObjectInfoTable::GetVkBufferInfo);
     const VkDeviceSize* in_pOffsets = pOffsets->GetPointer();
     const VkDeviceSize* in_pSizes = pSizes->GetPointer();
     const VkDeviceSize* in_pStrides = pStrides->GetPointer();
@@ -3331,7 +3331,7 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindVertexBuffers2(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers2, in_commandBuffer, firstBinding, bindingCount, pBuffers, in_pOffsets, in_pSizes, in_pStrides);
+        resource_dumper_.Process_vkCmdBindVertexBuffers2(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers2, in_commandBuffer, firstBinding, bindingCount, pBuffers, in_pOffsets, in_pSizes, in_pStrides);
     }
 }
 
@@ -3340,13 +3340,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthTestEnable(
     format::HandleId                            commandBuffer,
     VkBool32                                    depthTestEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthTestEnable(in_commandBuffer, depthTestEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthTestEnable, in_commandBuffer, depthTestEnable);
+        resource_dumper_.Process_vkCmdSetDepthTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthTestEnable, in_commandBuffer, depthTestEnable);
     }
 }
 
@@ -3355,13 +3355,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthWriteEnable(
     format::HandleId                            commandBuffer,
     VkBool32                                    depthWriteEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthWriteEnable(in_commandBuffer, depthWriteEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthWriteEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthWriteEnable, in_commandBuffer, depthWriteEnable);
+        resource_dumper_.Process_vkCmdSetDepthWriteEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthWriteEnable, in_commandBuffer, depthWriteEnable);
     }
 }
 
@@ -3370,13 +3370,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthCompareOp(
     format::HandleId                            commandBuffer,
     VkCompareOp                                 depthCompareOp)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthCompareOp(in_commandBuffer, depthCompareOp);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthCompareOp(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthCompareOp, in_commandBuffer, depthCompareOp);
+        resource_dumper_.Process_vkCmdSetDepthCompareOp(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthCompareOp, in_commandBuffer, depthCompareOp);
     }
 }
 
@@ -3385,13 +3385,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBoundsTestEnable(
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBoundsTestEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthBoundsTestEnable(in_commandBuffer, depthBoundsTestEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthBoundsTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBoundsTestEnable, in_commandBuffer, depthBoundsTestEnable);
+        resource_dumper_.Process_vkCmdSetDepthBoundsTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBoundsTestEnable, in_commandBuffer, depthBoundsTestEnable);
     }
 }
 
@@ -3400,13 +3400,13 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilTestEnable(
     format::HandleId                            commandBuffer,
     VkBool32                                    stencilTestEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetStencilTestEnable(in_commandBuffer, stencilTestEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetStencilTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilTestEnable, in_commandBuffer, stencilTestEnable);
+        resource_dumper_.Process_vkCmdSetStencilTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilTestEnable, in_commandBuffer, stencilTestEnable);
     }
 }
 
@@ -3419,13 +3419,13 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilOp(
     VkStencilOp                                 depthFailOp,
     VkCompareOp                                 compareOp)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetStencilOp(in_commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetStencilOp(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilOp, in_commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
+        resource_dumper_.Process_vkCmdSetStencilOp(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilOp, in_commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
     }
 }
 
@@ -3434,13 +3434,13 @@ void VulkanReplayConsumer::Process_vkCmdSetRasterizerDiscardEnable(
     format::HandleId                            commandBuffer,
     VkBool32                                    rasterizerDiscardEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetRasterizerDiscardEnable(in_commandBuffer, rasterizerDiscardEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetRasterizerDiscardEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizerDiscardEnable, in_commandBuffer, rasterizerDiscardEnable);
+        resource_dumper_.Process_vkCmdSetRasterizerDiscardEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizerDiscardEnable, in_commandBuffer, rasterizerDiscardEnable);
     }
 }
 
@@ -3449,13 +3449,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBiasEnable(
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBiasEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthBiasEnable(in_commandBuffer, depthBiasEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthBiasEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBiasEnable, in_commandBuffer, depthBiasEnable);
+        resource_dumper_.Process_vkCmdSetDepthBiasEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBiasEnable, in_commandBuffer, depthBiasEnable);
     }
 }
 
@@ -3464,13 +3464,13 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveRestartEnable(
     format::HandleId                            commandBuffer,
     VkBool32                                    primitiveRestartEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveRestartEnable(in_commandBuffer, primitiveRestartEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetPrimitiveRestartEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveRestartEnable, in_commandBuffer, primitiveRestartEnable);
+        resource_dumper_.Process_vkCmdSetPrimitiveRestartEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveRestartEnable, in_commandBuffer, primitiveRestartEnable);
     }
 }
 
@@ -3480,7 +3480,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceBufferMemoryRequirements(
     StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDeviceBufferMemoryRequirements* in_pInfo = pInfo->GetPointer();
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
     InitializeOutputStructPNext(pMemoryRequirements);
@@ -3494,7 +3494,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceImageMemoryRequirements(
     StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDeviceImageMemoryRequirements* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
@@ -3510,15 +3510,15 @@ void VulkanReplayConsumer::Process_vkGetDeviceImageSparseMemoryRequirements(
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
     StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDeviceImageMemoryRequirements* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetDeviceImageSparseMemoryRequirements", VK_SUCCESS, device, kDeviceArrayGetDeviceImageSparseMemoryRequirements, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetVkDeviceInfo));
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetDeviceImageSparseMemoryRequirements", VK_SUCCESS, device, kDeviceArrayGetDeviceImageSparseMemoryRequirements, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &CommonObjectInfoTable::GetVkDeviceInfo));
     VkSparseImageMemoryRequirements2* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetDeviceImageSparseMemoryRequirements(in_device, in_pInfo, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
 
-    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetDeviceImageSparseMemoryRequirements, *out_pSparseMemoryRequirementCount, &VulkanObjectInfoTable::GetVkDeviceInfo); }
+    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetDeviceImageSparseMemoryRequirements, *out_pSparseMemoryRequirementCount, &CommonObjectInfoTable::GetVkDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkDestroySurfaceKHR(
@@ -3532,7 +3532,7 @@ void VulkanReplayConsumer::Process_vkDestroySurfaceKHR(
     if (in_surface == nullptr || in_surface->surface_creation_skipped) { return; }
 
     OverrideDestroySurfaceKHR(GetInstanceTable(in_instance->handle)->DestroySurfaceKHR, in_instance, in_surface, pAllocator);
-    RemoveHandle(surface, &VulkanObjectInfoTable::RemoveVkSurfaceKHRInfo);
+    RemoveHandle(surface, &CommonObjectInfoTable::RemoveVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
@@ -3548,8 +3548,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
         GFXRECON_LOG_DEBUG("Skip vkGetPhysicalDeviceSurfaceSupportKHR for offscreen.");
         return;
     }
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &CommonObjectInfoTable::GetVkSurfaceKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(surface) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(surface)->surface_creation_skipped) { return; }
     VkBool32* out_pSupported = pSupported->IsNull() ? nullptr : pSupported->AllocateOutputData(1, static_cast<VkBool32>(0));
 
@@ -3591,16 +3591,16 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
         GFXRECON_LOG_DEBUG("Skip vkGetPhysicalDeviceSurfaceFormatsKHR for offscreen.");
         return;
     }
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &CommonObjectInfoTable::GetVkSurfaceKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(surface) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(surface)->surface_creation_skipped) { return; }
-    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->IsNull() ? nullptr : pSurfaceFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanSurfaceKHRInfo>("vkGetPhysicalDeviceSurfaceFormatsKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDeviceSurfaceFormatsKHR, pSurfaceFormatCount, pSurfaceFormats, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo));
+    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->IsNull() ? nullptr : pSurfaceFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanSurfaceKHRInfo>("vkGetPhysicalDeviceSurfaceFormatsKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDeviceSurfaceFormatsKHR, pSurfaceFormatCount, pSurfaceFormats, &CommonObjectInfoTable::GetVkSurfaceKHRInfo));
     VkSurfaceFormatKHR* out_pSurfaceFormats = pSurfaceFormats->IsNull() ? nullptr : pSurfaceFormats->AllocateOutputData(*out_pSurfaceFormatCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceFormatsKHR(in_physicalDevice, in_surface, out_pSurfaceFormatCount, out_pSurfaceFormats);
     CheckResult("vkGetPhysicalDeviceSurfaceFormatsKHR", returnValue, replay_result, call_info);
 
-    if (pSurfaceFormats->IsNull()) { SetOutputArrayCount<VulkanSurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDeviceSurfaceFormatsKHR, *out_pSurfaceFormatCount, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo); }
+    if (pSurfaceFormats->IsNull()) { SetOutputArrayCount<VulkanSurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDeviceSurfaceFormatsKHR, *out_pSurfaceFormatCount, &CommonObjectInfoTable::GetVkSurfaceKHRInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
@@ -3616,16 +3616,16 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
         GFXRECON_LOG_DEBUG("Skip vkGetPhysicalDeviceSurfacePresentModesKHR for offscreen.");
         return;
     }
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &CommonObjectInfoTable::GetVkSurfaceKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(surface) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(surface)->surface_creation_skipped) { return; }
-    uint32_t* out_pPresentModeCount = pPresentModeCount->IsNull() ? nullptr : pPresentModeCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanSurfaceKHRInfo>("vkGetPhysicalDeviceSurfacePresentModesKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDeviceSurfacePresentModesKHR, pPresentModeCount, pPresentModes, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo));
+    uint32_t* out_pPresentModeCount = pPresentModeCount->IsNull() ? nullptr : pPresentModeCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanSurfaceKHRInfo>("vkGetPhysicalDeviceSurfacePresentModesKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDeviceSurfacePresentModesKHR, pPresentModeCount, pPresentModes, &CommonObjectInfoTable::GetVkSurfaceKHRInfo));
     VkPresentModeKHR* out_pPresentModes = pPresentModes->IsNull() ? nullptr : pPresentModes->AllocateOutputData(*out_pPresentModeCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfacePresentModesKHR(in_physicalDevice, in_surface, out_pPresentModeCount, out_pPresentModes);
     CheckResult("vkGetPhysicalDeviceSurfacePresentModesKHR", returnValue, replay_result, call_info);
 
-    if (pPresentModes->IsNull()) { SetOutputArrayCount<VulkanSurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDeviceSurfacePresentModesKHR, *out_pPresentModeCount, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo); }
+    if (pPresentModes->IsNull()) { SetOutputArrayCount<VulkanSurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDeviceSurfacePresentModesKHR, *out_pPresentModeCount, &CommonObjectInfoTable::GetVkSurfaceKHRInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCreateSwapchainKHR(
@@ -3646,7 +3646,7 @@ void VulkanReplayConsumer::Process_vkCreateSwapchainKHR(
     VkResult replay_result = OverrideCreateSwapchainKHR(GetDeviceTable(in_device->handle)->CreateSwapchainKHR, returnValue, in_device, pCreateInfo, pAllocator, pSwapchain);
     CheckResult("vkCreateSwapchainKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSwapchainKHRInfo>(device, pSwapchain->GetPointer(), pSwapchain->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkSwapchainKHRInfo);
+    AddHandle<VulkanSwapchainKHRInfo>(device, pSwapchain->GetPointer(), pSwapchain->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSwapchainKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySwapchainKHR(
@@ -3659,7 +3659,7 @@ void VulkanReplayConsumer::Process_vkDestroySwapchainKHR(
     auto in_swapchain = GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain);
 
     OverrideDestroySwapchainKHR(GetDeviceTable(in_device->handle)->DestroySwapchainKHR, in_device, in_swapchain, pAllocator);
-    RemoveHandle(swapchain, &VulkanObjectInfoTable::RemoveVkSwapchainKHRInfo);
+    RemoveHandle(swapchain, &CommonObjectInfoTable::RemoveVkSwapchainKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
@@ -3672,7 +3672,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
 {
     auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
     auto in_swapchain = GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain);
-    pSwapchainImageCount->IsNull() ? nullptr : pSwapchainImageCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanSwapchainKHRInfo>("vkGetSwapchainImagesKHR", returnValue, swapchain, kSwapchainKHRArrayGetSwapchainImagesKHR, pSwapchainImageCount, pSwapchainImages, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo));
+    pSwapchainImageCount->IsNull() ? nullptr : pSwapchainImageCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanSwapchainKHRInfo>("vkGetSwapchainImagesKHR", returnValue, swapchain, kSwapchainKHRArrayGetSwapchainImagesKHR, pSwapchainImageCount, pSwapchainImages, &CommonObjectInfoTable::GetVkSwapchainKHRInfo));
     if (!pSwapchainImages->IsNull()) { pSwapchainImages->SetHandleLength(*pSwapchainImageCount->GetOutputPointer()); }
     std::vector<VulkanImageInfo> handle_info(*pSwapchainImageCount->GetOutputPointer());
     for (size_t i = 0; i < *pSwapchainImageCount->GetOutputPointer(); ++i) { pSwapchainImages->SetConsumerData(i, &handle_info[i]); }
@@ -3680,8 +3680,8 @@ void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
     VkResult replay_result = OverrideGetSwapchainImagesKHR(GetDeviceTable(in_device->handle)->GetSwapchainImagesKHR, returnValue, in_device, in_swapchain, pSwapchainImageCount, pSwapchainImages);
     CheckResult("vkGetSwapchainImagesKHR", returnValue, replay_result, call_info);
 
-    if (pSwapchainImages->IsNull()) { SetOutputArrayCount<VulkanSwapchainKHRInfo>(swapchain, kSwapchainKHRArrayGetSwapchainImagesKHR, *pSwapchainImageCount->GetOutputPointer(), &VulkanObjectInfoTable::GetVkSwapchainKHRInfo); }
-    AddHandles<VulkanImageInfo>(device, pSwapchainImages->GetPointer(), pSwapchainImages->GetLength(), pSwapchainImages->GetHandlePointer(), *pSwapchainImageCount->GetOutputPointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkImageInfo);
+    if (pSwapchainImages->IsNull()) { SetOutputArrayCount<VulkanSwapchainKHRInfo>(swapchain, kSwapchainKHRArrayGetSwapchainImagesKHR, *pSwapchainImageCount->GetOutputPointer(), &CommonObjectInfoTable::GetVkSwapchainKHRInfo); }
+    AddHandles<VulkanImageInfo>(device, pSwapchainImages->GetPointer(), pSwapchainImages->GetLength(), pSwapchainImages->GetHandlePointer(), *pSwapchainImageCount->GetOutputPointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkImageInfo);
 }
 
 void VulkanReplayConsumer::Process_vkAcquireNextImageKHR(
@@ -3729,7 +3729,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
         GFXRECON_LOG_DEBUG("Skip vkGetDeviceGroupPresentCapabilitiesKHR for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     VkDeviceGroupPresentCapabilitiesKHR* out_pDeviceGroupPresentCapabilities = pDeviceGroupPresentCapabilities->IsNull() ? nullptr : pDeviceGroupPresentCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR, nullptr });
     InitializeOutputStructPNext(pDeviceGroupPresentCapabilities);
 
@@ -3749,8 +3749,8 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
         GFXRECON_LOG_DEBUG("Skip vkGetDeviceGroupSurfacePresentModesKHR for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &CommonObjectInfoTable::GetVkSurfaceKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(surface) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(surface)->surface_creation_skipped) { return; }
     VkDeviceGroupPresentModeFlagsKHR* out_pModes = pModes->IsNull() ? nullptr : pModes->AllocateOutputData(1, static_cast<VkDeviceGroupPresentModeFlagsKHR>(0));
 
@@ -3771,16 +3771,16 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
         GFXRECON_LOG_DEBUG("Skip vkGetPhysicalDevicePresentRectanglesKHR for offscreen.");
         return;
     }
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &CommonObjectInfoTable::GetVkSurfaceKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(surface) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(surface)->surface_creation_skipped) { return; }
-    uint32_t* out_pRectCount = pRectCount->IsNull() ? nullptr : pRectCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanSurfaceKHRInfo>("vkGetPhysicalDevicePresentRectanglesKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR, pRectCount, pRects, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo));
+    uint32_t* out_pRectCount = pRectCount->IsNull() ? nullptr : pRectCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanSurfaceKHRInfo>("vkGetPhysicalDevicePresentRectanglesKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR, pRectCount, pRects, &CommonObjectInfoTable::GetVkSurfaceKHRInfo));
     VkRect2D* out_pRects = pRects->IsNull() ? nullptr : pRects->AllocateOutputData(*out_pRectCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDevicePresentRectanglesKHR(in_physicalDevice, in_surface, out_pRectCount, out_pRects);
     CheckResult("vkGetPhysicalDevicePresentRectanglesKHR", returnValue, replay_result, call_info);
 
-    if (pRects->IsNull()) { SetOutputArrayCount<VulkanSurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR, *out_pRectCount, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo); }
+    if (pRects->IsNull()) { SetOutputArrayCount<VulkanSurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR, *out_pRectCount, &CommonObjectInfoTable::GetVkSurfaceKHRInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkAcquireNextImage2KHR(
@@ -3806,14 +3806,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkDisplayPropertiesKHR>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkDisplayPropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, replay_result, call_info);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
@@ -3824,14 +3824,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkDisplayPlanePropertiesKHR>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkDisplayPlanePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlanePropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, replay_result, call_info);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPlanePropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
@@ -3843,16 +3843,16 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
     PointerDecoder<uint32_t>*                   pDisplayCount,
     HandlePointerDecoder<VkDisplayKHR>*         pDisplays)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pDisplayCount = pDisplayCount->IsNull() ? nullptr : pDisplayCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetDisplayPlaneSupportedDisplaysKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetDisplayPlaneSupportedDisplaysKHR, pDisplayCount, pDisplays, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pDisplayCount = pDisplayCount->IsNull() ? nullptr : pDisplayCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetDisplayPlaneSupportedDisplaysKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetDisplayPlaneSupportedDisplaysKHR, pDisplayCount, pDisplays, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     if (!pDisplays->IsNull()) { pDisplays->SetHandleLength(*out_pDisplayCount); }
     VkDisplayKHR* out_pDisplays = pDisplays->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayPlaneSupportedDisplaysKHR(in_physicalDevice, planeIndex, out_pDisplayCount, out_pDisplays);
     CheckResult("vkGetDisplayPlaneSupportedDisplaysKHR", returnValue, replay_result, call_info);
 
-    if (pDisplays->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetDisplayPlaneSupportedDisplaysKHR, *out_pDisplayCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
-    AddHandles<VulkanDisplayKHRInfo>(physicalDevice, pDisplays->GetPointer(), pDisplays->GetLength(), out_pDisplays, *out_pDisplayCount, &VulkanObjectInfoTable::AddVkDisplayKHRInfo);
+    if (pDisplays->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetDisplayPlaneSupportedDisplaysKHR, *out_pDisplayCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    AddHandles<VulkanDisplayKHRInfo>(physicalDevice, pDisplays->GetPointer(), pDisplays->GetLength(), out_pDisplays, *out_pDisplayCount, &CommonObjectInfoTable::AddVkDisplayKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
@@ -3863,15 +3863,15 @@ void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkDisplayModePropertiesKHR>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDisplayKHRInfo>("vkGetDisplayModePropertiesKHR", returnValue, display, kDisplayKHRArrayGetDisplayModePropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkDisplayKHRInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDisplayKHRInfo>("vkGetDisplayModePropertiesKHR", returnValue, display, kDisplayKHRArrayGetDisplayModePropertiesKHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkDisplayKHRInfo));
     VkDisplayModePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModePropertiesKHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetDisplayModePropertiesKHR", returnValue, replay_result, call_info);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanDisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModePropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkDisplayKHRInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanDisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModePropertiesKHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkDisplayKHRInfo); }
     AddStructArrayHandles<Decoded_VkDisplayModePropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
@@ -3884,8 +3884,8 @@ void VulkanReplayConsumer::Process_vkCreateDisplayModeKHR(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDisplayModeKHR>*     pMode)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
     const VkDisplayModeCreateInfoKHR* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pMode->IsNull()) { pMode->SetHandleLength(1); }
@@ -3894,7 +3894,7 @@ void VulkanReplayConsumer::Process_vkCreateDisplayModeKHR(
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->CreateDisplayModeKHR(in_physicalDevice, in_display, in_pCreateInfo, in_pAllocator, out_pMode);
     CheckResult("vkCreateDisplayModeKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDisplayModeKHRInfo>(physicalDevice, pMode->GetPointer(), out_pMode, &VulkanObjectInfoTable::AddVkDisplayModeKHRInfo);
+    AddHandle<VulkanDisplayModeKHRInfo>(physicalDevice, pMode->GetPointer(), out_pMode, &CommonObjectInfoTable::AddVkDisplayModeKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
@@ -3905,8 +3905,8 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
     uint32_t                                    planeIndex,
     StructPointerDecoder<Decoded_VkDisplayPlaneCapabilitiesKHR>* pCapabilities)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkDisplayModeKHR in_mode = MapHandle<VulkanDisplayModeKHRInfo>(mode, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkDisplayModeKHR in_mode = MapHandle<VulkanDisplayModeKHRInfo>(mode, &CommonObjectInfoTable::GetVkDisplayModeKHRInfo);
     VkDisplayPlaneCapabilitiesKHR* out_pCapabilities = pCapabilities->IsNull() ? nullptr : pCapabilities->AllocateOutputData(1);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayPlaneCapabilitiesKHR(in_physicalDevice, in_mode, planeIndex, out_pCapabilities);
@@ -3931,7 +3931,7 @@ void VulkanReplayConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
     VkResult replay_result = OverrideCreateDisplayPlaneSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateDisplayPlaneSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateDisplayPlaneSurfaceKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateSharedSwapchainsKHR(
@@ -3953,7 +3953,7 @@ void VulkanReplayConsumer::Process_vkCreateSharedSwapchainsKHR(
     VkResult replay_result = OverrideCreateSharedSwapchainsKHR(GetDeviceTable(in_device->handle)->CreateSharedSwapchainsKHR, returnValue, in_device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
     CheckResult("vkCreateSharedSwapchainsKHR", returnValue, replay_result, call_info);
 
-    AddHandles<VulkanSwapchainKHRInfo>(device, pSwapchains->GetPointer(), pSwapchains->GetLength(), pSwapchains->GetHandlePointer(), swapchainCount, std::move(handle_info), &VulkanObjectInfoTable::AddVkSwapchainKHRInfo);
+    AddHandles<VulkanSwapchainKHRInfo>(device, pSwapchains->GetPointer(), pSwapchains->GetLength(), pSwapchains->GetHandlePointer(), swapchainCount, std::move(handle_info), &CommonObjectInfoTable::AddVkSwapchainKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateXlibSurfaceKHR(
@@ -3972,7 +3972,7 @@ void VulkanReplayConsumer::Process_vkCreateXlibSurfaceKHR(
     VkResult replay_result = OverrideCreateXlibSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateXlibSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateXlibSurfaceKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
@@ -4005,7 +4005,7 @@ void VulkanReplayConsumer::Process_vkCreateXcbSurfaceKHR(
     VkResult replay_result = OverrideCreateXcbSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateXcbSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateXcbSurfaceKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
@@ -4038,7 +4038,7 @@ void VulkanReplayConsumer::Process_vkCreateWaylandSurfaceKHR(
     VkResult replay_result = OverrideCreateWaylandSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateWaylandSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateWaylandSurfaceKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
@@ -4070,7 +4070,7 @@ void VulkanReplayConsumer::Process_vkCreateAndroidSurfaceKHR(
     VkResult replay_result = OverrideCreateAndroidSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateAndroidSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateAndroidSurfaceKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateWin32SurfaceKHR(
@@ -4089,7 +4089,7 @@ void VulkanReplayConsumer::Process_vkCreateWin32SurfaceKHR(
     VkResult replay_result = OverrideCreateWin32SurfaceKHR(GetInstanceTable(in_instance->handle)->CreateWin32SurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateWin32SurfaceKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
@@ -4110,7 +4110,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceVideoCapabilitiesKHR(
     StructPointerDecoder<Decoded_VkVideoProfileInfoKHR>* pVideoProfile,
     StructPointerDecoder<Decoded_VkVideoCapabilitiesKHR>* pCapabilities)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkVideoProfileInfoKHR* in_pVideoProfile = pVideoProfile->GetPointer();
     VkVideoCapabilitiesKHR* out_pCapabilities = pCapabilities->IsNull() ? nullptr : pCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR, nullptr });
     InitializeOutputStructPNext(pCapabilities);
@@ -4127,15 +4127,15 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceVideoFormatPropertiesKHR(
     PointerDecoder<uint32_t>*                   pVideoFormatPropertyCount,
     StructPointerDecoder<Decoded_VkVideoFormatPropertiesKHR>* pVideoFormatProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceVideoFormatInfoKHR* in_pVideoFormatInfo = pVideoFormatInfo->GetPointer();
-    uint32_t* out_pVideoFormatPropertyCount = pVideoFormatPropertyCount->IsNull() ? nullptr : pVideoFormatPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceVideoFormatPropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceVideoFormatPropertiesKHR, pVideoFormatPropertyCount, pVideoFormatProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    uint32_t* out_pVideoFormatPropertyCount = pVideoFormatPropertyCount->IsNull() ? nullptr : pVideoFormatPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceVideoFormatPropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceVideoFormatPropertiesKHR, pVideoFormatPropertyCount, pVideoFormatProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkVideoFormatPropertiesKHR* out_pVideoFormatProperties = pVideoFormatProperties->IsNull() ? nullptr : pVideoFormatProperties->AllocateOutputData(*out_pVideoFormatPropertyCount, VkVideoFormatPropertiesKHR{ VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceVideoFormatPropertiesKHR(in_physicalDevice, in_pVideoFormatInfo, out_pVideoFormatPropertyCount, out_pVideoFormatProperties);
     CheckResult("vkGetPhysicalDeviceVideoFormatPropertiesKHR", returnValue, replay_result, call_info);
 
-    if (pVideoFormatProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceVideoFormatPropertiesKHR, *out_pVideoFormatPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pVideoFormatProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceVideoFormatPropertiesKHR, *out_pVideoFormatPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCreateVideoSessionKHR(
@@ -4154,7 +4154,7 @@ void VulkanReplayConsumer::Process_vkCreateVideoSessionKHR(
     VkResult replay_result = OverrideCreateVideoSessionKHR(GetDeviceTable(in_device->handle)->CreateVideoSessionKHR, returnValue, in_device, pCreateInfo, pAllocator, pVideoSession);
     CheckResult("vkCreateVideoSessionKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanVideoSessionKHRInfo>(device, pVideoSession->GetPointer(), pVideoSession->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkVideoSessionKHRInfo);
+    AddHandle<VulkanVideoSessionKHRInfo>(device, pVideoSession->GetPointer(), pVideoSession->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkVideoSessionKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyVideoSessionKHR(
@@ -4167,7 +4167,7 @@ void VulkanReplayConsumer::Process_vkDestroyVideoSessionKHR(
     auto in_videoSession = GetObjectInfoTable().GetVkVideoSessionKHRInfo(videoSession);
 
     OverrideDestroyVideoSessionKHR(GetDeviceTable(in_device->handle)->DestroyVideoSessionKHR, in_device, in_videoSession, pAllocator);
-    RemoveHandle(videoSession, &VulkanObjectInfoTable::RemoveVkVideoSessionKHRInfo);
+    RemoveHandle(videoSession, &CommonObjectInfoTable::RemoveVkVideoSessionKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetVideoSessionMemoryRequirementsKHR(
@@ -4178,15 +4178,15 @@ void VulkanReplayConsumer::Process_vkGetVideoSessionMemoryRequirementsKHR(
     PointerDecoder<uint32_t>*                   pMemoryRequirementsCount,
     StructPointerDecoder<Decoded_VkVideoSessionMemoryRequirementsKHR>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkVideoSessionKHR in_videoSession = MapHandle<VulkanVideoSessionKHRInfo>(videoSession, &VulkanObjectInfoTable::GetVkVideoSessionKHRInfo);
-    uint32_t* out_pMemoryRequirementsCount = pMemoryRequirementsCount->IsNull() ? nullptr : pMemoryRequirementsCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanVideoSessionKHRInfo>("vkGetVideoSessionMemoryRequirementsKHR", returnValue, videoSession, kVideoSessionKHRArrayGetVideoSessionMemoryRequirementsKHR, pMemoryRequirementsCount, pMemoryRequirements, &VulkanObjectInfoTable::GetVkVideoSessionKHRInfo));
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkVideoSessionKHR in_videoSession = MapHandle<VulkanVideoSessionKHRInfo>(videoSession, &CommonObjectInfoTable::GetVkVideoSessionKHRInfo);
+    uint32_t* out_pMemoryRequirementsCount = pMemoryRequirementsCount->IsNull() ? nullptr : pMemoryRequirementsCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanVideoSessionKHRInfo>("vkGetVideoSessionMemoryRequirementsKHR", returnValue, videoSession, kVideoSessionKHRArrayGetVideoSessionMemoryRequirementsKHR, pMemoryRequirementsCount, pMemoryRequirements, &CommonObjectInfoTable::GetVkVideoSessionKHRInfo));
     VkVideoSessionMemoryRequirementsKHR* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(*out_pMemoryRequirementsCount, VkVideoSessionMemoryRequirementsKHR{ VK_STRUCTURE_TYPE_VIDEO_SESSION_MEMORY_REQUIREMENTS_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetVideoSessionMemoryRequirementsKHR(in_device, in_videoSession, out_pMemoryRequirementsCount, out_pMemoryRequirements);
     CheckResult("vkGetVideoSessionMemoryRequirementsKHR", returnValue, replay_result, call_info);
 
-    if (pMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanVideoSessionKHRInfo>(videoSession, kVideoSessionKHRArrayGetVideoSessionMemoryRequirementsKHR, *out_pMemoryRequirementsCount, &VulkanObjectInfoTable::GetVkVideoSessionKHRInfo); }
+    if (pMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanVideoSessionKHRInfo>(videoSession, kVideoSessionKHRArrayGetVideoSessionMemoryRequirementsKHR, *out_pMemoryRequirementsCount, &CommonObjectInfoTable::GetVkVideoSessionKHRInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkBindVideoSessionMemoryKHR(
@@ -4214,7 +4214,7 @@ void VulkanReplayConsumer::Process_vkCreateVideoSessionParametersKHR(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkVideoSessionParametersKHR>* pVideoSessionParameters)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkVideoSessionParametersCreateInfoKHR* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -4224,7 +4224,7 @@ void VulkanReplayConsumer::Process_vkCreateVideoSessionParametersKHR(
     VkResult replay_result = GetDeviceTable(in_device)->CreateVideoSessionParametersKHR(in_device, in_pCreateInfo, in_pAllocator, out_pVideoSessionParameters);
     CheckResult("vkCreateVideoSessionParametersKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanVideoSessionParametersKHRInfo>(device, pVideoSessionParameters->GetPointer(), out_pVideoSessionParameters, &VulkanObjectInfoTable::AddVkVideoSessionParametersKHRInfo);
+    AddHandle<VulkanVideoSessionParametersKHRInfo>(device, pVideoSessionParameters->GetPointer(), out_pVideoSessionParameters, &CommonObjectInfoTable::AddVkVideoSessionParametersKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkUpdateVideoSessionParametersKHR(
@@ -4234,8 +4234,8 @@ void VulkanReplayConsumer::Process_vkUpdateVideoSessionParametersKHR(
     format::HandleId                            videoSessionParameters,
     StructPointerDecoder<Decoded_VkVideoSessionParametersUpdateInfoKHR>* pUpdateInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkVideoSessionParametersKHR in_videoSessionParameters = MapHandle<VulkanVideoSessionParametersKHRInfo>(videoSessionParameters, &VulkanObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkVideoSessionParametersKHR in_videoSessionParameters = MapHandle<VulkanVideoSessionParametersKHRInfo>(videoSessionParameters, &CommonObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
     const VkVideoSessionParametersUpdateInfoKHR* in_pUpdateInfo = pUpdateInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->UpdateVideoSessionParametersKHR(in_device, in_videoSessionParameters, in_pUpdateInfo);
@@ -4248,12 +4248,12 @@ void VulkanReplayConsumer::Process_vkDestroyVideoSessionParametersKHR(
     format::HandleId                            videoSessionParameters,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkVideoSessionParametersKHR in_videoSessionParameters = MapHandle<VulkanVideoSessionParametersKHRInfo>(videoSessionParameters, &VulkanObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkVideoSessionParametersKHR in_videoSessionParameters = MapHandle<VulkanVideoSessionParametersKHRInfo>(videoSessionParameters, &CommonObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyVideoSessionParametersKHR(in_device, in_videoSessionParameters, in_pAllocator);
-    RemoveHandle(videoSessionParameters, &VulkanObjectInfoTable::RemoveVkVideoSessionParametersKHRInfo);
+    RemoveHandle(videoSessionParameters, &CommonObjectInfoTable::RemoveVkVideoSessionParametersKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginVideoCodingKHR(
@@ -4261,7 +4261,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginVideoCodingKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkVideoBeginCodingInfoKHR>* pBeginInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkVideoBeginCodingInfoKHR* in_pBeginInfo = pBeginInfo->GetPointer();
     MapStructHandles(pBeginInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -4269,7 +4269,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginVideoCodingKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginVideoCodingKHR, in_commandBuffer, in_pBeginInfo);
+        resource_dumper_.Process_vkCmdBeginVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginVideoCodingKHR, in_commandBuffer, in_pBeginInfo);
     }
 }
 
@@ -4278,14 +4278,14 @@ void VulkanReplayConsumer::Process_vkCmdEndVideoCodingKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkVideoEndCodingInfoKHR>* pEndCodingInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkVideoEndCodingInfoKHR* in_pEndCodingInfo = pEndCodingInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdEndVideoCodingKHR(in_commandBuffer, in_pEndCodingInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndVideoCodingKHR, in_commandBuffer, in_pEndCodingInfo);
+        resource_dumper_.Process_vkCmdEndVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndVideoCodingKHR, in_commandBuffer, in_pEndCodingInfo);
     }
 }
 
@@ -4294,14 +4294,14 @@ void VulkanReplayConsumer::Process_vkCmdControlVideoCodingKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkVideoCodingControlInfoKHR>* pCodingControlInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkVideoCodingControlInfoKHR* in_pCodingControlInfo = pCodingControlInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdControlVideoCodingKHR(in_commandBuffer, in_pCodingControlInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdControlVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdControlVideoCodingKHR, in_commandBuffer, in_pCodingControlInfo);
+        resource_dumper_.Process_vkCmdControlVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdControlVideoCodingKHR, in_commandBuffer, in_pCodingControlInfo);
     }
 }
 
@@ -4310,7 +4310,7 @@ void VulkanReplayConsumer::Process_vkCmdDecodeVideoKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkVideoDecodeInfoKHR>* pDecodeInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkVideoDecodeInfoKHR* in_pDecodeInfo = pDecodeInfo->GetPointer();
     MapStructHandles(pDecodeInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -4318,7 +4318,7 @@ void VulkanReplayConsumer::Process_vkCmdDecodeVideoKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDecodeVideoKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDecodeVideoKHR, in_commandBuffer, in_pDecodeInfo);
+        resource_dumper_.Process_vkCmdDecodeVideoKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDecodeVideoKHR, in_commandBuffer, in_pDecodeInfo);
     }
 }
 
@@ -4327,7 +4327,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderingKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkRenderingInfo* in_pRenderingInfo = pRenderingInfo->GetPointer();
     MapStructHandles(pRenderingInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -4335,7 +4335,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderingKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginRenderingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginRenderingKHR, in_commandBuffer, pRenderingInfo);
+        resource_dumper_.Process_vkCmdBeginRenderingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginRenderingKHR, in_commandBuffer, pRenderingInfo);
     }
 }
 
@@ -4343,13 +4343,13 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderingKHR(
     const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdEndRenderingKHR(in_commandBuffer);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndRenderingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderingKHR, in_commandBuffer);
+        resource_dumper_.Process_vkCmdEndRenderingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderingKHR, in_commandBuffer);
     }
 }
 
@@ -4358,7 +4358,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures2KHR(
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     VkPhysicalDeviceFeatures2* out_pFeatures = pFeatures->IsNull() ? nullptr : pFeatures->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, nullptr });
     InitializeOutputStructPNext(pFeatures);
 
@@ -4383,7 +4383,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(
     VkFormat                                    format,
     StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     VkFormatProperties2* out_pFormatProperties = pFormatProperties->IsNull() ? nullptr : pFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, nullptr });
     InitializeOutputStructPNext(pFormatProperties);
 
@@ -4397,7 +4397,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
     StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
     StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceImageFormatInfo2* in_pImageFormatInfo = pImageFormatInfo->GetPointer();
     VkImageFormatProperties2* out_pImageFormatProperties = pImageFormatProperties->IsNull() ? nullptr : pImageFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
     InitializeOutputStructPNext(pImageFormatProperties);
@@ -4412,13 +4412,13 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
     StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->IsNull() ? nullptr : pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties2KHR", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2KHR, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->IsNull() ? nullptr : pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties2KHR", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2KHR, pQueueFamilyPropertyCount, pQueueFamilyProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkQueueFamilyProperties2* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount, VkQueueFamilyProperties2{ VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties2KHR(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
 
-    if (pQueueFamilyProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2KHR, *out_pQueueFamilyPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pQueueFamilyProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2KHR, *out_pQueueFamilyPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
@@ -4440,14 +4440,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceSparseImageFormatInfo2* in_pFormatInfo = pFormatInfo->GetPointer();
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties2KHR", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties2KHR", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2KHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkSparseImageFormatProperties2* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkSparseImageFormatProperties2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2KHR(in_physicalDevice, in_pFormatInfo, out_pPropertyCount, out_pProperties);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2KHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
@@ -4458,7 +4458,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
     uint32_t                                    remoteDeviceIndex,
     PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     VkPeerMemoryFeatureFlags* out_pPeerMemoryFeatures = pPeerMemoryFeatures->IsNull() ? nullptr : pPeerMemoryFeatures->AllocateOutputData(1, static_cast<VkPeerMemoryFeatureFlags>(0));
 
     GetDeviceTable(in_device)->GetDeviceGroupPeerMemoryFeaturesKHR(in_device, heapIndex, localDeviceIndex, remoteDeviceIndex, out_pPeerMemoryFeatures);
@@ -4469,13 +4469,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDeviceMaskKHR(
     format::HandleId                            commandBuffer,
     uint32_t                                    deviceMask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDeviceMaskKHR(in_commandBuffer, deviceMask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDeviceMaskKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDeviceMaskKHR, in_commandBuffer, deviceMask);
+        resource_dumper_.Process_vkCmdSetDeviceMaskKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDeviceMaskKHR, in_commandBuffer, deviceMask);
     }
 }
 
@@ -4489,13 +4489,13 @@ void VulkanReplayConsumer::Process_vkCmdDispatchBaseKHR(
     uint32_t                                    groupCountY,
     uint32_t                                    groupCountZ)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDispatchBaseKHR(in_commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDispatchBaseKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchBaseKHR, in_commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+        resource_dumper_.Process_vkCmdDispatchBaseKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchBaseKHR, in_commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
     }
 }
 
@@ -4505,8 +4505,8 @@ void VulkanReplayConsumer::Process_vkTrimCommandPoolKHR(
     format::HandleId                            commandPool,
     VkCommandPoolTrimFlags                      flags)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkCommandPool in_commandPool = MapHandle<VulkanCommandPoolInfo>(commandPool, &VulkanObjectInfoTable::GetVkCommandPoolInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkCommandPool in_commandPool = MapHandle<VulkanCommandPoolInfo>(commandPool, &CommonObjectInfoTable::GetVkCommandPoolInfo);
 
     GetDeviceTable(in_device)->TrimCommandPoolKHR(in_device, in_commandPool, flags);
 }
@@ -4519,14 +4519,14 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties)
 {
     auto in_instance = GetObjectInfoTable().GetVkInstanceInfo(instance);
-    pPhysicalDeviceGroupCount->IsNull() ? nullptr : pPhysicalDeviceGroupCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanInstanceInfo>("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, &VulkanObjectInfoTable::GetVkInstanceInfo));
+    pPhysicalDeviceGroupCount->IsNull() ? nullptr : pPhysicalDeviceGroupCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanInstanceInfo>("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, &CommonObjectInfoTable::GetVkInstanceInfo));
     SetStructArrayHandleLengths<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength());
     if (!pPhysicalDeviceGroupProperties->IsNull()) { pPhysicalDeviceGroupProperties->AllocateOutputData(*pPhysicalDeviceGroupCount->GetOutputPointer(), VkPhysicalDeviceGroupProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, nullptr }); }
 
     VkResult replay_result = OverrideEnumeratePhysicalDeviceGroups(GetInstanceTable(in_instance->handle)->EnumeratePhysicalDeviceGroupsKHR, returnValue, in_instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
     CheckResult("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, replay_result, call_info);
 
-    if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<VulkanInstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, *pPhysicalDeviceGroupCount->GetOutputPointer(), &VulkanObjectInfoTable::GetVkInstanceInfo); }
+    if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<VulkanInstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, *pPhysicalDeviceGroupCount->GetOutputPointer(), &CommonObjectInfoTable::GetVkInstanceInfo); }
     AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(instance, pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), pPhysicalDeviceGroupProperties->GetOutputPointer(), *pPhysicalDeviceGroupCount->GetOutputPointer(), &GetObjectInfoTable());
 }
 
@@ -4536,7 +4536,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKH
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
     StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalBufferInfo* in_pExternalBufferInfo = pExternalBufferInfo->GetPointer();
     VkExternalBufferProperties* out_pExternalBufferProperties = pExternalBufferProperties->IsNull() ? nullptr : pExternalBufferProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES, nullptr });
     InitializeOutputStructPNext(pExternalBufferProperties);
@@ -4551,7 +4551,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleKHR(
     StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
     PointerDecoder<uint64_t, void*>*            pHandle)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkMemoryGetWin32HandleInfoKHR* in_pGetWin32HandleInfo = pGetWin32HandleInfo->GetPointer();
     MapStructHandles(pGetWin32HandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
     HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
@@ -4570,7 +4570,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
     uint64_t                                    handle,
     StructPointerDecoder<Decoded_VkMemoryWin32HandlePropertiesKHR>* pMemoryWin32HandleProperties)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     HANDLE in_handle = static_cast<HANDLE>(PreProcessExternalObject(handle, format::ApiCallId::ApiCall_vkGetMemoryWin32HandlePropertiesKHR, "vkGetMemoryWin32HandlePropertiesKHR"));
     VkMemoryWin32HandlePropertiesKHR* out_pMemoryWin32HandleProperties = pMemoryWin32HandleProperties->IsNull() ? nullptr : pMemoryWin32HandleProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR, nullptr });
     InitializeOutputStructPNext(pMemoryWin32HandleProperties);
@@ -4586,7 +4586,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryFdKHR(
     StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
     PointerDecoder<int>*                        pFd)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkMemoryGetFdInfoKHR* in_pGetFdInfo = pGetFdInfo->GetPointer();
     MapStructHandles(pGetFdInfo->GetMetaStructPointer(), GetObjectInfoTable());
     int* out_pFd = pFd->IsNull() ? nullptr : pFd->AllocateOutputData(1, static_cast<int>(0));
@@ -4603,7 +4603,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryFdPropertiesKHR(
     int                                         fd,
     StructPointerDecoder<Decoded_VkMemoryFdPropertiesKHR>* pMemoryFdProperties)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     VkMemoryFdPropertiesKHR* out_pMemoryFdProperties = pMemoryFdProperties->IsNull() ? nullptr : pMemoryFdProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR, nullptr });
     InitializeOutputStructPNext(pMemoryFdProperties);
 
@@ -4617,7 +4617,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertie
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
     StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalSemaphoreInfo* in_pExternalSemaphoreInfo = pExternalSemaphoreInfo->GetPointer();
     VkExternalSemaphoreProperties* out_pExternalSemaphoreProperties = pExternalSemaphoreProperties->IsNull() ? nullptr : pExternalSemaphoreProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, nullptr });
     InitializeOutputStructPNext(pExternalSemaphoreProperties);
@@ -4646,7 +4646,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreWin32HandleKHR(
     StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
     PointerDecoder<uint64_t, void*>*            pHandle)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkSemaphoreGetWin32HandleInfoKHR* in_pGetWin32HandleInfo = pGetWin32HandleInfo->GetPointer();
     MapStructHandles(pGetWin32HandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
     HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
@@ -4696,8 +4696,8 @@ void VulkanReplayConsumer::Process_vkCmdPushDescriptorSetKHR(
     uint32_t                                    descriptorWriteCount,
     StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkPipelineLayout in_layout = MapHandle<VulkanPipelineLayoutInfo>(layout, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkPipelineLayout in_layout = MapHandle<VulkanPipelineLayoutInfo>(layout, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
     const VkWriteDescriptorSet* in_pDescriptorWrites = pDescriptorWrites->GetPointer();
     MapStructArrayHandles(pDescriptorWrites->GetMetaStructPointer(), pDescriptorWrites->GetLength(), GetObjectInfoTable());
 
@@ -4705,7 +4705,7 @@ void VulkanReplayConsumer::Process_vkCmdPushDescriptorSetKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdPushDescriptorSetKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSetKHR, in_commandBuffer, pipelineBindPoint, in_layout, set, descriptorWriteCount, in_pDescriptorWrites);
+        resource_dumper_.Process_vkCmdPushDescriptorSetKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSetKHR, in_commandBuffer, pipelineBindPoint, in_layout, set, descriptorWriteCount, in_pDescriptorWrites);
     }
 }
 
@@ -4727,7 +4727,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
     VkResult replay_result = OverrideCreateDescriptorUpdateTemplate(GetDeviceTable(in_device->handle)->CreateDescriptorUpdateTemplateKHR, returnValue, in_device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
     CheckResult("vkCreateDescriptorUpdateTemplateKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDescriptorUpdateTemplateInfo>(device, pDescriptorUpdateTemplate->GetPointer(), pDescriptorUpdateTemplate->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkDescriptorUpdateTemplateInfo);
+    AddHandle<VulkanDescriptorUpdateTemplateInfo>(device, pDescriptorUpdateTemplate->GetPointer(), pDescriptorUpdateTemplate->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkDescriptorUpdateTemplateInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
@@ -4740,7 +4740,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
     auto in_descriptorUpdateTemplate = GetObjectInfoTable().GetVkDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
 
     OverrideDestroyDescriptorUpdateTemplate(GetDeviceTable(in_device->handle)->DestroyDescriptorUpdateTemplateKHR, in_device, in_descriptorUpdateTemplate, pAllocator);
-    RemoveHandle(descriptorUpdateTemplate, &VulkanObjectInfoTable::RemoveVkDescriptorUpdateTemplateInfo);
+    RemoveHandle(descriptorUpdateTemplate, &CommonObjectInfoTable::RemoveVkDescriptorUpdateTemplateInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateRenderPass2KHR(
@@ -4759,7 +4759,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass2KHR(
     VkResult replay_result = OverrideCreateRenderPass2(GetDeviceTable(in_device->handle)->CreateRenderPass2KHR, returnValue, in_device, pCreateInfo, pAllocator, pRenderPass);
     CheckResult("vkCreateRenderPass2KHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanRenderPassInfo>(device, pRenderPass->GetPointer(), pRenderPass->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkRenderPassInfo);
+    AddHandle<VulkanRenderPassInfo>(device, pRenderPass->GetPointer(), pRenderPass->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkRenderPassInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2KHR(
@@ -4776,7 +4776,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginRenderPass2KHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass2KHR, in_commandBuffer->handle, pRenderPassBegin, pSubpassBeginInfo);
+        resource_dumper_.Process_vkCmdBeginRenderPass2KHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass2KHR, in_commandBuffer->handle, pRenderPassBegin, pSubpassBeginInfo);
     }
 }
 
@@ -4786,7 +4786,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass2KHR(
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkSubpassBeginInfo* in_pSubpassBeginInfo = pSubpassBeginInfo->GetPointer();
     const VkSubpassEndInfo* in_pSubpassEndInfo = pSubpassEndInfo->GetPointer();
 
@@ -4794,7 +4794,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdNextSubpass2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass2KHR, in_commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
+        resource_dumper_.Process_vkCmdNextSubpass2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass2KHR, in_commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
     }
 }
 
@@ -4803,14 +4803,14 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderPass2KHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkSubpassEndInfo* in_pSubpassEndInfo = pSubpassEndInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdEndRenderPass2KHR(in_commandBuffer, in_pSubpassEndInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndRenderPass2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass2KHR, in_commandBuffer, pSubpassEndInfo);
+        resource_dumper_.Process_vkCmdEndRenderPass2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass2KHR, in_commandBuffer, pSubpassEndInfo);
     }
 }
 
@@ -4825,8 +4825,8 @@ void VulkanReplayConsumer::Process_vkGetSwapchainStatusKHR(
         GFXRECON_LOG_DEBUG("Skip vkGetSwapchainStatusKHR for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSwapchainStatusKHR(in_device, in_swapchain);
@@ -4839,7 +4839,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
     StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalFenceInfo* in_pExternalFenceInfo = pExternalFenceInfo->GetPointer();
     VkExternalFenceProperties* out_pExternalFenceProperties = pExternalFenceProperties->IsNull() ? nullptr : pExternalFenceProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, nullptr });
     InitializeOutputStructPNext(pExternalFenceProperties);
@@ -4853,7 +4853,7 @@ void VulkanReplayConsumer::Process_vkImportFenceWin32HandleKHR(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>* pImportFenceWin32HandleInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkImportFenceWin32HandleInfoKHR* in_pImportFenceWin32HandleInfo = pImportFenceWin32HandleInfo->GetPointer();
     MapStructHandles(pImportFenceWin32HandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -4868,7 +4868,7 @@ void VulkanReplayConsumer::Process_vkGetFenceWin32HandleKHR(
     StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
     PointerDecoder<uint64_t, void*>*            pHandle)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkFenceGetWin32HandleInfoKHR* in_pGetWin32HandleInfo = pGetWin32HandleInfo->GetPointer();
     MapStructHandles(pGetWin32HandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
     HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
@@ -4885,7 +4885,7 @@ void VulkanReplayConsumer::Process_vkImportFenceFdKHR(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>* pImportFenceFdInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkImportFenceFdInfoKHR* in_pImportFenceFdInfo = pImportFenceFdInfo->GetPointer();
     MapStructHandles(pImportFenceFdInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -4900,7 +4900,7 @@ void VulkanReplayConsumer::Process_vkGetFenceFdKHR(
     StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>* pGetFdInfo,
     PointerDecoder<int>*                        pFd)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkFenceGetFdInfoKHR* in_pGetFdInfo = pGetFdInfo->GetPointer();
     MapStructHandles(pGetFdInfo->GetMetaStructPointer(), GetObjectInfoTable());
     int* out_pFd = pFd->IsNull() ? nullptr : pFd->AllocateOutputData(1, static_cast<int>(0));
@@ -4918,16 +4918,16 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerforman
     StructPointerDecoder<Decoded_VkPerformanceCounterKHR>* pCounters,
     StructPointerDecoder<Decoded_VkPerformanceCounterDescriptionKHR>* pCounterDescriptions)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pCounterCount = pCounterCount->IsNull() ? nullptr : pCounterCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", returnValue, physicalDevice, kPhysicalDeviceArrayEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, pCounterCount, pCounterDescriptions, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pCounterCount = pCounterCount->IsNull() ? nullptr : pCounterCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", returnValue, physicalDevice, kPhysicalDeviceArrayEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, pCounterCount, pCounterDescriptions, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkPerformanceCounterKHR* out_pCounters = pCounters->IsNull() ? nullptr : pCounters->AllocateOutputData(*out_pCounterCount, VkPerformanceCounterKHR{ VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_KHR, nullptr });
     VkPerformanceCounterDescriptionKHR* out_pCounterDescriptions = pCounterDescriptions->IsNull() ? nullptr : pCounterDescriptions->AllocateOutputData(*out_pCounterCount, VkPerformanceCounterDescriptionKHR{ VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_DESCRIPTION_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(in_physicalDevice, queueFamilyIndex, out_pCounterCount, out_pCounters, out_pCounterDescriptions);
     CheckResult("vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", returnValue, replay_result, call_info);
 
-    if (pCounters->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, *out_pCounterCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
-    if (pCounterDescriptions->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, *out_pCounterCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pCounters->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, *out_pCounterCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pCounterDescriptions->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, *out_pCounterCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(
@@ -4936,7 +4936,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyPerformanceQuer
     StructPointerDecoder<Decoded_VkQueryPoolPerformanceCreateInfoKHR>* pPerformanceQueryCreateInfo,
     PointerDecoder<uint32_t>*                   pNumPasses)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkQueryPoolPerformanceCreateInfoKHR* in_pPerformanceQueryCreateInfo = pPerformanceQueryCreateInfo->GetPointer();
     uint32_t* out_pNumPasses = pNumPasses->IsNull() ? nullptr : pNumPasses->AllocateOutputData(1, static_cast<uint32_t>(0));
 
@@ -4959,7 +4959,7 @@ void VulkanReplayConsumer::Process_vkReleaseProfilingLockKHR(
     const ApiCallInfo&                          call_info,
     format::HandleId                            device)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
 
     GetDeviceTable(in_device)->ReleaseProfilingLockKHR(in_device);
 }
@@ -5002,19 +5002,19 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
         GFXRECON_LOG_DEBUG("Skip vkGetPhysicalDeviceSurfaceFormats2KHR for offscreen.");
         return;
     }
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceSurfaceInfo2KHR* in_pSurfaceInfo = pSurfaceInfo->GetPointer();
     if (pSurfaceInfo->GetPointer()->surface == VK_NULL_HANDLE) { return; }
     MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
     auto in_pSurfaceInfo_meta = pSurfaceInfo->GetMetaStructPointer();
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(in_pSurfaceInfo_meta->surface) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(in_pSurfaceInfo_meta->surface)->surface_creation_skipped) { return; }
-    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->IsNull() ? nullptr : pSurfaceFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSurfaceFormats2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfaceFormats2KHR, pSurfaceFormatCount, pSurfaceFormats, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->IsNull() ? nullptr : pSurfaceFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSurfaceFormats2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfaceFormats2KHR, pSurfaceFormatCount, pSurfaceFormats, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkSurfaceFormat2KHR* out_pSurfaceFormats = pSurfaceFormats->IsNull() ? nullptr : pSurfaceFormats->AllocateOutputData(*out_pSurfaceFormatCount, VkSurfaceFormat2KHR{ VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceFormats2KHR(in_physicalDevice, in_pSurfaceInfo, out_pSurfaceFormatCount, out_pSurfaceFormats);
     CheckResult("vkGetPhysicalDeviceSurfaceFormats2KHR", returnValue, replay_result, call_info);
 
-    if (pSurfaceFormats->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfaceFormats2KHR, *out_pSurfaceFormatCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pSurfaceFormats->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfaceFormats2KHR, *out_pSurfaceFormatCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
@@ -5024,14 +5024,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkDisplayProperties2KHR>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkDisplayProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, replay_result, call_info);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
@@ -5042,14 +5042,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkDisplayPlaneProperties2KHR>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkDisplayPlaneProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayPlaneProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlaneProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, replay_result, call_info);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPlaneProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
@@ -5061,15 +5061,15 @@ void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkDisplayModeProperties2KHR>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDisplayKHRInfo>("vkGetDisplayModeProperties2KHR", returnValue, display, kDisplayKHRArrayGetDisplayModeProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkDisplayKHRInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDisplayKHRInfo>("vkGetDisplayModeProperties2KHR", returnValue, display, kDisplayKHRArrayGetDisplayModeProperties2KHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkDisplayKHRInfo));
     VkDisplayModeProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayModeProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModeProperties2KHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetDisplayModeProperties2KHR", returnValue, replay_result, call_info);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanDisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModeProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkDisplayKHRInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanDisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModeProperties2KHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkDisplayKHRInfo); }
     AddStructArrayHandles<Decoded_VkDisplayModeProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
@@ -5080,7 +5080,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
     StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>* pDisplayPlaneInfo,
     StructPointerDecoder<Decoded_VkDisplayPlaneCapabilities2KHR>* pCapabilities)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkDisplayPlaneInfo2KHR* in_pDisplayPlaneInfo = pDisplayPlaneInfo->GetPointer();
     MapStructHandles(pDisplayPlaneInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkDisplayPlaneCapabilities2KHR* out_pCapabilities = pCapabilities->IsNull() ? nullptr : pCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DISPLAY_PLANE_CAPABILITIES_2_KHR, nullptr });
@@ -5096,7 +5096,7 @@ void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2KHR(
     StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkImageMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
@@ -5111,7 +5111,7 @@ void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements2KHR(
     StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkBufferMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
@@ -5127,15 +5127,15 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
     StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkImageSparseMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetImageSparseMemoryRequirements2KHR", VK_SUCCESS, device, kDeviceArrayGetImageSparseMemoryRequirements2KHR, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetVkDeviceInfo));
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetImageSparseMemoryRequirements2KHR", VK_SUCCESS, device, kDeviceArrayGetImageSparseMemoryRequirements2KHR, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &CommonObjectInfoTable::GetVkDeviceInfo));
     VkSparseImageMemoryRequirements2* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements2KHR(in_device, in_pInfo, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
 
-    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetImageSparseMemoryRequirements2KHR, *out_pSparseMemoryRequirementCount, &VulkanObjectInfoTable::GetVkDeviceInfo); }
+    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetImageSparseMemoryRequirements2KHR, *out_pSparseMemoryRequirementCount, &CommonObjectInfoTable::GetVkDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
@@ -5146,7 +5146,7 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkSamplerYcbcrConversionCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pYcbcrConversion->IsNull()) { pYcbcrConversion->SetHandleLength(1); }
@@ -5155,7 +5155,7 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
     VkResult replay_result = GetDeviceTable(in_device)->CreateSamplerYcbcrConversionKHR(in_device, in_pCreateInfo, in_pAllocator, out_pYcbcrConversion);
     CheckResult("vkCreateSamplerYcbcrConversionKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &VulkanObjectInfoTable::AddVkSamplerYcbcrConversionInfo);
+    AddHandle<VulkanSamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &CommonObjectInfoTable::AddVkSamplerYcbcrConversionInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
@@ -5164,12 +5164,12 @@ void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
     format::HandleId                            ycbcrConversion,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSamplerYcbcrConversion in_ycbcrConversion = MapHandle<VulkanSamplerYcbcrConversionInfo>(ycbcrConversion, &VulkanObjectInfoTable::GetVkSamplerYcbcrConversionInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSamplerYcbcrConversion in_ycbcrConversion = MapHandle<VulkanSamplerYcbcrConversionInfo>(ycbcrConversion, &CommonObjectInfoTable::GetVkSamplerYcbcrConversionInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroySamplerYcbcrConversionKHR(in_device, in_ycbcrConversion, in_pAllocator);
-    RemoveHandle(ycbcrConversion, &VulkanObjectInfoTable::RemoveVkSamplerYcbcrConversionInfo);
+    RemoveHandle(ycbcrConversion, &CommonObjectInfoTable::RemoveVkSamplerYcbcrConversionInfo);
 }
 
 void VulkanReplayConsumer::Process_vkBindBufferMemory2KHR(
@@ -5208,7 +5208,7 @@ void VulkanReplayConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDescriptorSetLayoutCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkDescriptorSetLayoutSupport* out_pSupport = pSupport->IsNull() ? nullptr : pSupport->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT, nullptr });
@@ -5227,15 +5227,15 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectCountKHR(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCountKHR(in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawIndirectCountKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCountKHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
+        resource_dumper_.Process_vkCmdDrawIndirectCountKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCountKHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -5249,15 +5249,15 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCountKHR(in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawIndexedIndirectCountKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCountKHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
+        resource_dumper_.Process_vkCmdDrawIndexedIndirectCountKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCountKHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -5268,8 +5268,8 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreCounterValueKHR(
     format::HandleId                            semaphore,
     PointerDecoder<uint64_t>*                   pValue)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSemaphore in_semaphore = MapHandle<VulkanSemaphoreInfo>(semaphore, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSemaphore in_semaphore = MapHandle<VulkanSemaphoreInfo>(semaphore, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     uint64_t* out_pValue = pValue->IsNull() ? nullptr : pValue->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSemaphoreCounterValueKHR(in_device, in_semaphore, out_pValue);
@@ -5283,7 +5283,7 @@ void VulkanReplayConsumer::Process_vkWaitSemaphoresKHR(
     StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
     uint64_t                                    timeout)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkSemaphoreWaitInfo* in_pWaitInfo = pWaitInfo->GetPointer();
     MapStructHandles(pWaitInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5297,7 +5297,7 @@ void VulkanReplayConsumer::Process_vkSignalSemaphoreKHR(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkSemaphoreSignalInfo* in_pSignalInfo = pSignalInfo->GetPointer();
     MapStructHandles(pSignalInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5312,14 +5312,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
     PointerDecoder<uint32_t>*                   pFragmentShadingRateCount,
     StructPointerDecoder<Decoded_VkPhysicalDeviceFragmentShadingRateKHR>* pFragmentShadingRates)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pFragmentShadingRateCount = pFragmentShadingRateCount->IsNull() ? nullptr : pFragmentShadingRateCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceFragmentShadingRatesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceFragmentShadingRatesKHR, pFragmentShadingRateCount, pFragmentShadingRates, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pFragmentShadingRateCount = pFragmentShadingRateCount->IsNull() ? nullptr : pFragmentShadingRateCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceFragmentShadingRatesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceFragmentShadingRatesKHR, pFragmentShadingRateCount, pFragmentShadingRates, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkPhysicalDeviceFragmentShadingRateKHR* out_pFragmentShadingRates = pFragmentShadingRates->IsNull() ? nullptr : pFragmentShadingRates->AllocateOutputData(*out_pFragmentShadingRateCount, VkPhysicalDeviceFragmentShadingRateKHR{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceFragmentShadingRatesKHR(in_physicalDevice, out_pFragmentShadingRateCount, out_pFragmentShadingRates);
     CheckResult("vkGetPhysicalDeviceFragmentShadingRatesKHR", returnValue, replay_result, call_info);
 
-    if (pFragmentShadingRates->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceFragmentShadingRatesKHR, *out_pFragmentShadingRateCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pFragmentShadingRates->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceFragmentShadingRatesKHR, *out_pFragmentShadingRateCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetFragmentShadingRateKHR(
@@ -5328,7 +5328,7 @@ void VulkanReplayConsumer::Process_vkCmdSetFragmentShadingRateKHR(
     StructPointerDecoder<Decoded_VkExtent2D>*   pFragmentSize,
     PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkExtent2D* in_pFragmentSize = pFragmentSize->GetPointer();
     const VkFragmentShadingRateCombinerOpKHR* in_combinerOps = combinerOps->GetPointer();
 
@@ -5336,7 +5336,7 @@ void VulkanReplayConsumer::Process_vkCmdSetFragmentShadingRateKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetFragmentShadingRateKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFragmentShadingRateKHR, in_commandBuffer, in_pFragmentSize, in_combinerOps);
+        resource_dumper_.Process_vkCmdSetFragmentShadingRateKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFragmentShadingRateKHR, in_commandBuffer, in_pFragmentSize, in_combinerOps);
     }
 }
 
@@ -5345,14 +5345,14 @@ void VulkanReplayConsumer::Process_vkCmdSetRenderingAttachmentLocationsKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingAttachmentLocationInfoKHR>* pLocationInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkRenderingAttachmentLocationInfoKHR* in_pLocationInfo = pLocationInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetRenderingAttachmentLocationsKHR(in_commandBuffer, in_pLocationInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetRenderingAttachmentLocationsKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRenderingAttachmentLocationsKHR, in_commandBuffer, in_pLocationInfo);
+        resource_dumper_.Process_vkCmdSetRenderingAttachmentLocationsKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRenderingAttachmentLocationsKHR, in_commandBuffer, in_pLocationInfo);
     }
 }
 
@@ -5361,14 +5361,14 @@ void VulkanReplayConsumer::Process_vkCmdSetRenderingInputAttachmentIndicesKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInputAttachmentIndexInfoKHR>* pInputAttachmentIndexInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkRenderingInputAttachmentIndexInfoKHR* in_pInputAttachmentIndexInfo = pInputAttachmentIndexInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetRenderingInputAttachmentIndicesKHR(in_commandBuffer, in_pInputAttachmentIndexInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetRenderingInputAttachmentIndicesKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRenderingInputAttachmentIndicesKHR, in_commandBuffer, in_pInputAttachmentIndexInfo);
+        resource_dumper_.Process_vkCmdSetRenderingInputAttachmentIndicesKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRenderingInputAttachmentIndicesKHR, in_commandBuffer, in_pInputAttachmentIndexInfo);
     }
 }
 
@@ -5411,7 +5411,7 @@ void VulkanReplayConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkBufferDeviceAddressInfo* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5424,7 +5424,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDeviceMemoryOpaqueCaptureAddressInfo* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5438,7 +5438,7 @@ void VulkanReplayConsumer::Process_vkCreateDeferredOperationKHR(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDeferredOperationKHR>* pDeferredOperation)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pDeferredOperation->IsNull()) { pDeferredOperation->SetHandleLength(1); }
     VkDeferredOperationKHR* out_pDeferredOperation = pDeferredOperation->GetHandlePointer();
@@ -5446,7 +5446,7 @@ void VulkanReplayConsumer::Process_vkCreateDeferredOperationKHR(
     VkResult replay_result = GetDeviceTable(in_device)->CreateDeferredOperationKHR(in_device, in_pAllocator, out_pDeferredOperation);
     CheckResult("vkCreateDeferredOperationKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDeferredOperationKHRInfo>(device, pDeferredOperation->GetPointer(), out_pDeferredOperation, &VulkanObjectInfoTable::AddVkDeferredOperationKHRInfo);
+    AddHandle<VulkanDeferredOperationKHRInfo>(device, pDeferredOperation->GetPointer(), out_pDeferredOperation, &CommonObjectInfoTable::AddVkDeferredOperationKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDeferredOperationKHR(
@@ -5455,12 +5455,12 @@ void VulkanReplayConsumer::Process_vkDestroyDeferredOperationKHR(
     format::HandleId                            operation,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeferredOperationKHR in_operation = MapHandle<VulkanDeferredOperationKHRInfo>(operation, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeferredOperationKHR in_operation = MapHandle<VulkanDeferredOperationKHRInfo>(operation, &CommonObjectInfoTable::GetVkDeferredOperationKHRInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyDeferredOperationKHR(in_device, in_operation, in_pAllocator);
-    RemoveHandle(operation, &VulkanObjectInfoTable::RemoveVkDeferredOperationKHRInfo);
+    RemoveHandle(operation, &CommonObjectInfoTable::RemoveVkDeferredOperationKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
@@ -5469,8 +5469,8 @@ void VulkanReplayConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
     format::HandleId                            device,
     format::HandleId                            operation)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeferredOperationKHR in_operation = MapHandle<VulkanDeferredOperationKHRInfo>(operation, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeferredOperationKHR in_operation = MapHandle<VulkanDeferredOperationKHRInfo>(operation, &CommonObjectInfoTable::GetVkDeferredOperationKHRInfo);
 
     GetDeviceTable(in_device)->GetDeferredOperationMaxConcurrencyKHR(in_device, in_operation);
 }
@@ -5481,8 +5481,8 @@ void VulkanReplayConsumer::Process_vkGetDeferredOperationResultKHR(
     format::HandleId                            device,
     format::HandleId                            operation)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeferredOperationKHR in_operation = MapHandle<VulkanDeferredOperationKHRInfo>(operation, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeferredOperationKHR in_operation = MapHandle<VulkanDeferredOperationKHRInfo>(operation, &CommonObjectInfoTable::GetVkDeferredOperationKHRInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetDeferredOperationResultKHR(in_device, in_operation);
     CheckResult("vkGetDeferredOperationResultKHR", returnValue, replay_result, call_info);
@@ -5509,16 +5509,16 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
     PointerDecoder<uint32_t>*                   pExecutableCount,
     StructPointerDecoder<Decoded_VkPipelineExecutablePropertiesKHR>* pProperties)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPipelineInfoKHR* in_pPipelineInfo = pPipelineInfo->GetPointer();
     MapStructHandles(pPipelineInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pExecutableCount = pExecutableCount->IsNull() ? nullptr : pExecutableCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetPipelineExecutablePropertiesKHR", returnValue, device, kDeviceArrayGetPipelineExecutablePropertiesKHR, pExecutableCount, pProperties, &VulkanObjectInfoTable::GetVkDeviceInfo));
+    uint32_t* out_pExecutableCount = pExecutableCount->IsNull() ? nullptr : pExecutableCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetPipelineExecutablePropertiesKHR", returnValue, device, kDeviceArrayGetPipelineExecutablePropertiesKHR, pExecutableCount, pProperties, &CommonObjectInfoTable::GetVkDeviceInfo));
     VkPipelineExecutablePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pExecutableCount, VkPipelineExecutablePropertiesKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_PROPERTIES_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutablePropertiesKHR(in_device, in_pPipelineInfo, out_pExecutableCount, out_pProperties);
     CheckResult("vkGetPipelineExecutablePropertiesKHR", returnValue, replay_result, call_info);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetPipelineExecutablePropertiesKHR, *out_pExecutableCount, &VulkanObjectInfoTable::GetVkDeviceInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetPipelineExecutablePropertiesKHR, *out_pExecutableCount, &CommonObjectInfoTable::GetVkDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
@@ -5529,16 +5529,16 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
     PointerDecoder<uint32_t>*                   pStatisticCount,
     StructPointerDecoder<Decoded_VkPipelineExecutableStatisticKHR>* pStatistics)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPipelineExecutableInfoKHR* in_pExecutableInfo = pExecutableInfo->GetPointer();
     MapStructHandles(pExecutableInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pStatisticCount = pStatisticCount->IsNull() ? nullptr : pStatisticCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetPipelineExecutableStatisticsKHR", returnValue, device, kDeviceArrayGetPipelineExecutableStatisticsKHR, pStatisticCount, pStatistics, &VulkanObjectInfoTable::GetVkDeviceInfo));
+    uint32_t* out_pStatisticCount = pStatisticCount->IsNull() ? nullptr : pStatisticCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetPipelineExecutableStatisticsKHR", returnValue, device, kDeviceArrayGetPipelineExecutableStatisticsKHR, pStatisticCount, pStatistics, &CommonObjectInfoTable::GetVkDeviceInfo));
     VkPipelineExecutableStatisticKHR* out_pStatistics = pStatistics->IsNull() ? nullptr : pStatistics->AllocateOutputData(*out_pStatisticCount, VkPipelineExecutableStatisticKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutableStatisticsKHR(in_device, in_pExecutableInfo, out_pStatisticCount, out_pStatistics);
     CheckResult("vkGetPipelineExecutableStatisticsKHR", returnValue, replay_result, call_info);
 
-    if (pStatistics->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetPipelineExecutableStatisticsKHR, *out_pStatisticCount, &VulkanObjectInfoTable::GetVkDeviceInfo); }
+    if (pStatistics->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetPipelineExecutableStatisticsKHR, *out_pStatisticCount, &CommonObjectInfoTable::GetVkDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineExecutableInternalRepresentationsKHR(
@@ -5549,16 +5549,16 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableInternalRepresentation
     PointerDecoder<uint32_t>*                   pInternalRepresentationCount,
     StructPointerDecoder<Decoded_VkPipelineExecutableInternalRepresentationKHR>* pInternalRepresentations)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPipelineExecutableInfoKHR* in_pExecutableInfo = pExecutableInfo->GetPointer();
     MapStructHandles(pExecutableInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pInternalRepresentationCount = pInternalRepresentationCount->IsNull() ? nullptr : pInternalRepresentationCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetPipelineExecutableInternalRepresentationsKHR", returnValue, device, kDeviceArrayGetPipelineExecutableInternalRepresentationsKHR, pInternalRepresentationCount, pInternalRepresentations, &VulkanObjectInfoTable::GetVkDeviceInfo));
+    uint32_t* out_pInternalRepresentationCount = pInternalRepresentationCount->IsNull() ? nullptr : pInternalRepresentationCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetPipelineExecutableInternalRepresentationsKHR", returnValue, device, kDeviceArrayGetPipelineExecutableInternalRepresentationsKHR, pInternalRepresentationCount, pInternalRepresentations, &CommonObjectInfoTable::GetVkDeviceInfo));
     VkPipelineExecutableInternalRepresentationKHR* out_pInternalRepresentations = pInternalRepresentations->IsNull() ? nullptr : pInternalRepresentations->AllocateOutputData(*out_pInternalRepresentationCount, VkPipelineExecutableInternalRepresentationKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutableInternalRepresentationsKHR(in_device, in_pExecutableInfo, out_pInternalRepresentationCount, out_pInternalRepresentations);
     CheckResult("vkGetPipelineExecutableInternalRepresentationsKHR", returnValue, replay_result, call_info);
 
-    if (pInternalRepresentations->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetPipelineExecutableInternalRepresentationsKHR, *out_pInternalRepresentationCount, &VulkanObjectInfoTable::GetVkDeviceInfo); }
+    if (pInternalRepresentations->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetPipelineExecutableInternalRepresentationsKHR, *out_pInternalRepresentationCount, &CommonObjectInfoTable::GetVkDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkMapMemory2KHR(
@@ -5568,7 +5568,7 @@ void VulkanReplayConsumer::Process_vkMapMemory2KHR(
     StructPointerDecoder<Decoded_VkMemoryMapInfoKHR>* pMemoryMapInfo,
     PointerDecoder<uint64_t, void*>*            ppData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkMemoryMapInfoKHR* in_pMemoryMapInfo = pMemoryMapInfo->GetPointer();
     MapStructHandles(pMemoryMapInfo->GetMetaStructPointer(), GetObjectInfoTable());
     void** out_ppData = ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
@@ -5585,7 +5585,7 @@ void VulkanReplayConsumer::Process_vkUnmapMemory2KHR(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryUnmapInfoKHR>* pMemoryUnmapInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkMemoryUnmapInfoKHR* in_pMemoryUnmapInfo = pMemoryUnmapInfo->GetPointer();
     MapStructHandles(pMemoryUnmapInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5600,7 +5600,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceVideoEncodeQualityLevelPro
     StructPointerDecoder<Decoded_VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR>* pQualityLevelInfo,
     StructPointerDecoder<Decoded_VkVideoEncodeQualityLevelPropertiesKHR>* pQualityLevelProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR* in_pQualityLevelInfo = pQualityLevelInfo->GetPointer();
     VkVideoEncodeQualityLevelPropertiesKHR* out_pQualityLevelProperties = pQualityLevelProperties->IsNull() ? nullptr : pQualityLevelProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_PROPERTIES_KHR, nullptr });
     InitializeOutputStructPNext(pQualityLevelProperties);
@@ -5618,18 +5618,18 @@ void VulkanReplayConsumer::Process_vkGetEncodedVideoSessionParametersKHR(
     PointerDecoder<size_t>*                     pDataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkVideoEncodeSessionParametersGetInfoKHR* in_pVideoSessionParametersInfo = pVideoSessionParametersInfo->GetPointer();
     MapStructHandles(pVideoSessionParametersInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkVideoEncodeSessionParametersFeedbackInfoKHR* out_pFeedbackInfo = pFeedbackInfo->IsNull() ? nullptr : pFeedbackInfo->AllocateOutputData(1, { VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_FEEDBACK_INFO_KHR, nullptr });
     InitializeOutputStructPNext(pFeedbackInfo);
-    size_t* out_pDataSize = pDataSize->IsNull() ? nullptr : pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanDeviceInfo>("vkGetEncodedVideoSessionParametersKHR", returnValue, device, kDeviceArrayGetEncodedVideoSessionParametersKHR, pDataSize, pData, &VulkanObjectInfoTable::GetVkDeviceInfo));
+    size_t* out_pDataSize = pDataSize->IsNull() ? nullptr : pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanDeviceInfo>("vkGetEncodedVideoSessionParametersKHR", returnValue, device, kDeviceArrayGetEncodedVideoSessionParametersKHR, pDataSize, pData, &CommonObjectInfoTable::GetVkDeviceInfo));
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(*out_pDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetEncodedVideoSessionParametersKHR(in_device, in_pVideoSessionParametersInfo, out_pFeedbackInfo, out_pDataSize, out_pData);
     CheckResult("vkGetEncodedVideoSessionParametersKHR", returnValue, replay_result, call_info);
 
-    if (pData->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetEncodedVideoSessionParametersKHR, *out_pDataSize, &VulkanObjectInfoTable::GetVkDeviceInfo); }
+    if (pData->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetEncodedVideoSessionParametersKHR, *out_pDataSize, &CommonObjectInfoTable::GetVkDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCmdEncodeVideoKHR(
@@ -5637,7 +5637,7 @@ void VulkanReplayConsumer::Process_vkCmdEncodeVideoKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkVideoEncodeInfoKHR>* pEncodeInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkVideoEncodeInfoKHR* in_pEncodeInfo = pEncodeInfo->GetPointer();
     MapStructHandles(pEncodeInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5645,7 +5645,7 @@ void VulkanReplayConsumer::Process_vkCmdEncodeVideoKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEncodeVideoKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEncodeVideoKHR, in_commandBuffer, in_pEncodeInfo);
+        resource_dumper_.Process_vkCmdEncodeVideoKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEncodeVideoKHR, in_commandBuffer, in_pEncodeInfo);
     }
 }
 
@@ -5655,8 +5655,8 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent2KHR(
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &CommonObjectInfoTable::GetVkEventInfo);
     const VkDependencyInfo* in_pDependencyInfo = pDependencyInfo->GetPointer();
     MapStructHandles(pDependencyInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5664,7 +5664,7 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetEvent2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent2KHR, in_commandBuffer, in_event, in_pDependencyInfo);
+        resource_dumper_.Process_vkCmdSetEvent2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent2KHR, in_commandBuffer, in_event, in_pDependencyInfo);
     }
 }
 
@@ -5674,14 +5674,14 @@ void VulkanReplayConsumer::Process_vkCmdResetEvent2KHR(
     format::HandleId                            event,
     VkPipelineStageFlags2                       stageMask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &CommonObjectInfoTable::GetVkEventInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdResetEvent2KHR(in_commandBuffer, in_event, stageMask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdResetEvent2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent2KHR, in_commandBuffer, in_event, stageMask);
+        resource_dumper_.Process_vkCmdResetEvent2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent2KHR, in_commandBuffer, in_event, stageMask);
     }
 }
 
@@ -5692,8 +5692,8 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents2KHR(
     HandlePointerDecoder<VkEvent>*              pEvents,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfos)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkEvent* in_pEvents = MapHandles<VulkanEventInfo>(pEvents, eventCount, &VulkanObjectInfoTable::GetVkEventInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkEvent* in_pEvents = MapHandles<VulkanEventInfo>(pEvents, eventCount, &CommonObjectInfoTable::GetVkEventInfo);
     const VkDependencyInfo* in_pDependencyInfos = pDependencyInfos->GetPointer();
     MapStructArrayHandles(pDependencyInfos->GetMetaStructPointer(), pDependencyInfos->GetLength(), GetObjectInfoTable());
 
@@ -5701,7 +5701,7 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWaitEvents2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents2KHR, in_commandBuffer, eventCount, in_pEvents, in_pDependencyInfos);
+        resource_dumper_.Process_vkCmdWaitEvents2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents2KHR, in_commandBuffer, eventCount, in_pEvents, in_pDependencyInfos);
     }
 }
 
@@ -5718,7 +5718,7 @@ void VulkanReplayConsumer::Process_vkCmdPipelineBarrier2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdPipelineBarrier2KHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier2KHR, in_commandBuffer->handle, pDependencyInfo->GetPointer());
+        resource_dumper_.Process_vkCmdPipelineBarrier2KHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier2KHR, in_commandBuffer->handle, pDependencyInfo->GetPointer());
     }
 }
 
@@ -5729,14 +5729,14 @@ void VulkanReplayConsumer::Process_vkCmdWriteTimestamp2KHR(
     format::HandleId                            queryPool,
     uint32_t                                    query)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp2KHR(in_commandBuffer, stage, in_queryPool, query);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWriteTimestamp2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp2KHR, in_commandBuffer, stage, in_queryPool, query);
+        resource_dumper_.Process_vkCmdWriteTimestamp2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp2KHR, in_commandBuffer, stage, in_queryPool, query);
     }
 }
 
@@ -5765,14 +5765,14 @@ void VulkanReplayConsumer::Process_vkCmdWriteBufferMarker2AMD(
     VkDeviceSize                                dstOffset,
     uint32_t                                    marker)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdWriteBufferMarker2AMD(in_commandBuffer, stage, in_dstBuffer, dstOffset, marker);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWriteBufferMarker2AMD(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteBufferMarker2AMD, in_commandBuffer, stage, in_dstBuffer, dstOffset, marker);
+        resource_dumper_.Process_vkCmdWriteBufferMarker2AMD(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteBufferMarker2AMD, in_commandBuffer, stage, in_dstBuffer, dstOffset, marker);
     }
 }
 
@@ -5782,13 +5782,13 @@ void VulkanReplayConsumer::Process_vkGetQueueCheckpointData2NV(
     PointerDecoder<uint32_t>*                   pCheckpointDataCount,
     StructPointerDecoder<Decoded_VkCheckpointData2NV>* pCheckpointData)
 {
-    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &VulkanObjectInfoTable::GetVkQueueInfo);
-    uint32_t* out_pCheckpointDataCount = pCheckpointDataCount->IsNull() ? nullptr : pCheckpointDataCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanQueueInfo>("vkGetQueueCheckpointData2NV", VK_SUCCESS, queue, kQueueArrayGetQueueCheckpointData2NV, pCheckpointDataCount, pCheckpointData, &VulkanObjectInfoTable::GetVkQueueInfo));
+    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &CommonObjectInfoTable::GetVkQueueInfo);
+    uint32_t* out_pCheckpointDataCount = pCheckpointDataCount->IsNull() ? nullptr : pCheckpointDataCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanQueueInfo>("vkGetQueueCheckpointData2NV", VK_SUCCESS, queue, kQueueArrayGetQueueCheckpointData2NV, pCheckpointDataCount, pCheckpointData, &CommonObjectInfoTable::GetVkQueueInfo));
     VkCheckpointData2NV* out_pCheckpointData = pCheckpointData->IsNull() ? nullptr : pCheckpointData->AllocateOutputData(*out_pCheckpointDataCount, VkCheckpointData2NV{ VK_STRUCTURE_TYPE_CHECKPOINT_DATA_2_NV, nullptr });
 
     GetDeviceTable(in_queue)->GetQueueCheckpointData2NV(in_queue, out_pCheckpointDataCount, out_pCheckpointData);
 
-    if (pCheckpointData->IsNull()) { SetOutputArrayCount<VulkanQueueInfo>(queue, kQueueArrayGetQueueCheckpointData2NV, *out_pCheckpointDataCount, &VulkanObjectInfoTable::GetVkQueueInfo); }
+    if (pCheckpointData->IsNull()) { SetOutputArrayCount<VulkanQueueInfo>(queue, kQueueArrayGetQueueCheckpointData2NV, *out_pCheckpointDataCount, &CommonObjectInfoTable::GetVkQueueInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyBuffer2KHR(
@@ -5796,7 +5796,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer2KHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyBufferInfo2* in_pCopyBufferInfo = pCopyBufferInfo->GetPointer();
     MapStructHandles(pCopyBufferInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5804,7 +5804,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer2KHR, in_commandBuffer, in_pCopyBufferInfo);
+        resource_dumper_.Process_vkCmdCopyBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer2KHR, in_commandBuffer, in_pCopyBufferInfo);
     }
 }
 
@@ -5813,7 +5813,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage2KHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyImageInfo2* in_pCopyImageInfo = pCopyImageInfo->GetPointer();
     MapStructHandles(pCopyImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5821,7 +5821,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage2KHR, in_commandBuffer, in_pCopyImageInfo);
+        resource_dumper_.Process_vkCmdCopyImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage2KHR, in_commandBuffer, in_pCopyImageInfo);
     }
 }
 
@@ -5830,7 +5830,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage2KHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyBufferToImageInfo2* in_pCopyBufferToImageInfo = pCopyBufferToImageInfo->GetPointer();
     MapStructHandles(pCopyBufferToImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5838,7 +5838,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyBufferToImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage2KHR, in_commandBuffer, in_pCopyBufferToImageInfo);
+        resource_dumper_.Process_vkCmdCopyBufferToImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage2KHR, in_commandBuffer, in_pCopyBufferToImageInfo);
     }
 }
 
@@ -5847,7 +5847,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer2KHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyImageToBufferInfo2* in_pCopyImageToBufferInfo = pCopyImageToBufferInfo->GetPointer();
     MapStructHandles(pCopyImageToBufferInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5855,7 +5855,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyImageToBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer2KHR, in_commandBuffer, in_pCopyImageToBufferInfo);
+        resource_dumper_.Process_vkCmdCopyImageToBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer2KHR, in_commandBuffer, in_pCopyImageToBufferInfo);
     }
 }
 
@@ -5864,7 +5864,7 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage2KHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkBlitImageInfo2* in_pBlitImageInfo = pBlitImageInfo->GetPointer();
     MapStructHandles(pBlitImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5872,7 +5872,7 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBlitImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage2KHR, in_commandBuffer, in_pBlitImageInfo);
+        resource_dumper_.Process_vkCmdBlitImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage2KHR, in_commandBuffer, in_pBlitImageInfo);
     }
 }
 
@@ -5881,7 +5881,7 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage2KHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkResolveImageInfo2* in_pResolveImageInfo = pResolveImageInfo->GetPointer();
     MapStructHandles(pResolveImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -5889,7 +5889,7 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdResolveImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage2KHR, in_commandBuffer, in_pResolveImageInfo);
+        resource_dumper_.Process_vkCmdResolveImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage2KHR, in_commandBuffer, in_pResolveImageInfo);
     }
 }
 
@@ -5898,13 +5898,13 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysIndirect2KHR(
     format::HandleId                            commandBuffer,
     VkDeviceAddress                             indirectDeviceAddress)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdTraceRaysIndirect2KHR(in_commandBuffer, indirectDeviceAddress);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdTraceRaysIndirect2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysIndirect2KHR, in_commandBuffer, indirectDeviceAddress);
+        resource_dumper_.Process_vkCmdTraceRaysIndirect2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysIndirect2KHR, in_commandBuffer, indirectDeviceAddress);
     }
 }
 
@@ -5914,7 +5914,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceBufferMemoryRequirementsKHR(
     StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDeviceBufferMemoryRequirements* in_pInfo = pInfo->GetPointer();
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
     InitializeOutputStructPNext(pMemoryRequirements);
@@ -5928,7 +5928,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceImageMemoryRequirementsKHR(
     StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDeviceImageMemoryRequirements* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
@@ -5944,15 +5944,15 @@ void VulkanReplayConsumer::Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
     StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDeviceImageMemoryRequirements* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetDeviceImageSparseMemoryRequirementsKHR", VK_SUCCESS, device, kDeviceArrayGetDeviceImageSparseMemoryRequirementsKHR, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetVkDeviceInfo));
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDeviceInfo>("vkGetDeviceImageSparseMemoryRequirementsKHR", VK_SUCCESS, device, kDeviceArrayGetDeviceImageSparseMemoryRequirementsKHR, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &CommonObjectInfoTable::GetVkDeviceInfo));
     VkSparseImageMemoryRequirements2* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetDeviceImageSparseMemoryRequirementsKHR(in_device, in_pInfo, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
 
-    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetDeviceImageSparseMemoryRequirementsKHR, *out_pSparseMemoryRequirementCount, &VulkanObjectInfoTable::GetVkDeviceInfo); }
+    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetDeviceImageSparseMemoryRequirementsKHR, *out_pSparseMemoryRequirementCount, &CommonObjectInfoTable::GetVkDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindIndexBuffer2KHR(
@@ -5963,14 +5963,14 @@ void VulkanReplayConsumer::Process_vkCmdBindIndexBuffer2KHR(
     VkDeviceSize                                size,
     VkIndexType                                 indexType)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdBindIndexBuffer2KHR(in_commandBuffer, in_buffer, offset, size, indexType);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindIndexBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBindIndexBuffer2KHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, size, indexType);
+        resource_dumper_.Process_vkCmdBindIndexBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBindIndexBuffer2KHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, size, indexType);
     }
 }
 
@@ -5980,7 +5980,7 @@ void VulkanReplayConsumer::Process_vkGetRenderingAreaGranularityKHR(
     StructPointerDecoder<Decoded_VkRenderingAreaInfoKHR>* pRenderingAreaInfo,
     StructPointerDecoder<Decoded_VkExtent2D>*   pGranularity)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkRenderingAreaInfoKHR* in_pRenderingAreaInfo = pRenderingAreaInfo->GetPointer();
     VkExtent2D* out_pGranularity = pGranularity->IsNull() ? nullptr : pGranularity->AllocateOutputData(1);
 
@@ -5993,7 +5993,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceImageSubresourceLayoutKHR(
     StructPointerDecoder<Decoded_VkDeviceImageSubresourceInfoKHR>* pInfo,
     StructPointerDecoder<Decoded_VkSubresourceLayout2KHR>* pLayout)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDeviceImageSubresourceInfoKHR* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkSubresourceLayout2KHR* out_pLayout = pLayout->IsNull() ? nullptr : pLayout->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR, nullptr });
@@ -6009,8 +6009,8 @@ void VulkanReplayConsumer::Process_vkGetImageSubresourceLayout2KHR(
     StructPointerDecoder<Decoded_VkImageSubresource2KHR>* pSubresource,
     StructPointerDecoder<Decoded_VkSubresourceLayout2KHR>* pLayout)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkImage in_image = MapHandle<VulkanImageInfo>(image, &VulkanObjectInfoTable::GetVkImageInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkImage in_image = MapHandle<VulkanImageInfo>(image, &CommonObjectInfoTable::GetVkImageInfo);
     const VkImageSubresource2KHR* in_pSubresource = pSubresource->GetPointer();
     VkSubresourceLayout2KHR* out_pLayout = pLayout->IsNull() ? nullptr : pLayout->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR, nullptr });
     InitializeOutputStructPNext(pLayout);
@@ -6026,7 +6026,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineBinariesKHR(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     StructPointerDecoder<Decoded_VkPipelineBinaryHandlesInfoKHR>* pBinaries)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPipelineBinaryCreateInfoKHR* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -6046,12 +6046,12 @@ void VulkanReplayConsumer::Process_vkDestroyPipelineBinaryKHR(
     format::HandleId                            pipelineBinary,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPipelineBinaryKHR in_pipelineBinary = MapHandle<VulkanPipelineBinaryKHRInfo>(pipelineBinary, &VulkanObjectInfoTable::GetVkPipelineBinaryKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPipelineBinaryKHR in_pipelineBinary = MapHandle<VulkanPipelineBinaryKHRInfo>(pipelineBinary, &CommonObjectInfoTable::GetVkPipelineBinaryKHRInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyPipelineBinaryKHR(in_device, in_pipelineBinary, in_pAllocator);
-    RemoveHandle(pipelineBinary, &VulkanObjectInfoTable::RemoveVkPipelineBinaryKHRInfo);
+    RemoveHandle(pipelineBinary, &CommonObjectInfoTable::RemoveVkPipelineBinaryKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineKeyKHR(
@@ -6061,7 +6061,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineKeyKHR(
     StructPointerDecoder<Decoded_VkPipelineCreateInfoKHR>* pPipelineCreateInfo,
     StructPointerDecoder<Decoded_VkPipelineBinaryKeyKHR>* pPipelineKey)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPipelineCreateInfoKHR* in_pPipelineCreateInfo = pPipelineCreateInfo->GetPointer();
     VkPipelineBinaryKeyKHR* out_pPipelineKey = pPipelineKey->IsNull() ? nullptr : pPipelineKey->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR, nullptr });
     InitializeOutputStructPNext(pPipelineKey);
@@ -6079,18 +6079,18 @@ void VulkanReplayConsumer::Process_vkGetPipelineBinaryDataKHR(
     PointerDecoder<size_t>*                     pPipelineBinaryDataSize,
     PointerDecoder<uint8_t>*                    pPipelineBinaryData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPipelineBinaryDataInfoKHR* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkPipelineBinaryKeyKHR* out_pPipelineBinaryKey = pPipelineBinaryKey->IsNull() ? nullptr : pPipelineBinaryKey->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR, nullptr });
     InitializeOutputStructPNext(pPipelineBinaryKey);
-    size_t* out_pPipelineBinaryDataSize = pPipelineBinaryDataSize->IsNull() ? nullptr : pPipelineBinaryDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanDeviceInfo>("vkGetPipelineBinaryDataKHR", returnValue, device, kDeviceArrayGetPipelineBinaryDataKHR, pPipelineBinaryDataSize, pPipelineBinaryData, &VulkanObjectInfoTable::GetVkDeviceInfo));
+    size_t* out_pPipelineBinaryDataSize = pPipelineBinaryDataSize->IsNull() ? nullptr : pPipelineBinaryDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanDeviceInfo>("vkGetPipelineBinaryDataKHR", returnValue, device, kDeviceArrayGetPipelineBinaryDataKHR, pPipelineBinaryDataSize, pPipelineBinaryData, &CommonObjectInfoTable::GetVkDeviceInfo));
     void* out_pPipelineBinaryData = pPipelineBinaryData->IsNull() ? nullptr : pPipelineBinaryData->AllocateOutputData(*out_pPipelineBinaryDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineBinaryDataKHR(in_device, in_pInfo, out_pPipelineBinaryKey, out_pPipelineBinaryDataSize, out_pPipelineBinaryData);
     CheckResult("vkGetPipelineBinaryDataKHR", returnValue, replay_result, call_info);
 
-    if (pPipelineBinaryData->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetPipelineBinaryDataKHR, *out_pPipelineBinaryDataSize, &VulkanObjectInfoTable::GetVkDeviceInfo); }
+    if (pPipelineBinaryData->IsNull()) { SetOutputArrayCount<VulkanDeviceInfo>(device, kDeviceArrayGetPipelineBinaryDataKHR, *out_pPipelineBinaryDataSize, &CommonObjectInfoTable::GetVkDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkReleaseCapturedPipelineDataKHR(
@@ -6100,7 +6100,7 @@ void VulkanReplayConsumer::Process_vkReleaseCapturedPipelineDataKHR(
     StructPointerDecoder<Decoded_VkReleaseCapturedPipelineDataInfoKHR>* pInfo,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkReleaseCapturedPipelineDataInfoKHR* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -6116,14 +6116,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertie
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesKHR>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesKHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkCooperativeMatrixPropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkCooperativeMatrixPropertiesKHR{ VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR", returnValue, replay_result, call_info);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesKHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetLineStippleKHR(
@@ -6132,13 +6132,13 @@ void VulkanReplayConsumer::Process_vkCmdSetLineStippleKHR(
     uint32_t                                    lineStippleFactor,
     uint16_t                                    lineStipplePattern)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetLineStippleKHR(in_commandBuffer, lineStippleFactor, lineStipplePattern);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetLineStippleKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleKHR, in_commandBuffer, lineStippleFactor, lineStipplePattern);
+        resource_dumper_.Process_vkCmdSetLineStippleKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleKHR, in_commandBuffer, lineStippleFactor, lineStipplePattern);
     }
 }
 
@@ -6149,14 +6149,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsKH
     PointerDecoder<uint32_t>*                   pTimeDomainCount,
     PointerDecoder<VkTimeDomainKHR>*            pTimeDomains)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pTimeDomainCount = pTimeDomainCount->IsNull() ? nullptr : pTimeDomainCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceCalibrateableTimeDomainsKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsKHR, pTimeDomainCount, pTimeDomains, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pTimeDomainCount = pTimeDomainCount->IsNull() ? nullptr : pTimeDomainCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceCalibrateableTimeDomainsKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsKHR, pTimeDomainCount, pTimeDomains, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkTimeDomainKHR* out_pTimeDomains = pTimeDomains->IsNull() ? nullptr : pTimeDomains->AllocateOutputData(*out_pTimeDomainCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCalibrateableTimeDomainsKHR(in_physicalDevice, out_pTimeDomainCount, out_pTimeDomains);
     CheckResult("vkGetPhysicalDeviceCalibrateableTimeDomainsKHR", returnValue, replay_result, call_info);
 
-    if (pTimeDomains->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsKHR, *out_pTimeDomainCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pTimeDomains->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsKHR, *out_pTimeDomainCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetCalibratedTimestampsKHR(
@@ -6168,7 +6168,7 @@ void VulkanReplayConsumer::Process_vkGetCalibratedTimestampsKHR(
     PointerDecoder<uint64_t>*                   pTimestamps,
     PointerDecoder<uint64_t>*                   pMaxDeviation)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkCalibratedTimestampInfoKHR* in_pTimestampInfos = pTimestampInfos->GetPointer();
     uint64_t* out_pTimestamps = pTimestamps->IsNull() ? nullptr : pTimestamps->AllocateOutputData(timestampCount);
     uint64_t* out_pMaxDeviation = pMaxDeviation->IsNull() ? nullptr : pMaxDeviation->AllocateOutputData(1, static_cast<uint64_t>(0));
@@ -6182,7 +6182,7 @@ void VulkanReplayConsumer::Process_vkCmdBindDescriptorSets2KHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkBindDescriptorSetsInfoKHR>* pBindDescriptorSetsInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkBindDescriptorSetsInfoKHR* in_pBindDescriptorSetsInfo = pBindDescriptorSetsInfo->GetPointer();
     MapStructHandles(pBindDescriptorSetsInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -6190,7 +6190,7 @@ void VulkanReplayConsumer::Process_vkCmdBindDescriptorSets2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindDescriptorSets2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorSets2KHR, in_commandBuffer, in_pBindDescriptorSetsInfo);
+        resource_dumper_.Process_vkCmdBindDescriptorSets2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorSets2KHR, in_commandBuffer, in_pBindDescriptorSetsInfo);
     }
 }
 
@@ -6199,7 +6199,7 @@ void VulkanReplayConsumer::Process_vkCmdPushConstants2KHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPushConstantsInfoKHR>* pPushConstantsInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkPushConstantsInfoKHR* in_pPushConstantsInfo = pPushConstantsInfo->GetPointer();
     MapStructHandles(pPushConstantsInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -6207,7 +6207,7 @@ void VulkanReplayConsumer::Process_vkCmdPushConstants2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdPushConstants2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushConstants2KHR, in_commandBuffer, in_pPushConstantsInfo);
+        resource_dumper_.Process_vkCmdPushConstants2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushConstants2KHR, in_commandBuffer, in_pPushConstantsInfo);
     }
 }
 
@@ -6216,7 +6216,7 @@ void VulkanReplayConsumer::Process_vkCmdPushDescriptorSet2KHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPushDescriptorSetInfoKHR>* pPushDescriptorSetInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkPushDescriptorSetInfoKHR* in_pPushDescriptorSetInfo = pPushDescriptorSetInfo->GetPointer();
     MapStructHandles(pPushDescriptorSetInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -6224,7 +6224,7 @@ void VulkanReplayConsumer::Process_vkCmdPushDescriptorSet2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdPushDescriptorSet2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSet2KHR, in_commandBuffer, in_pPushDescriptorSetInfo);
+        resource_dumper_.Process_vkCmdPushDescriptorSet2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSet2KHR, in_commandBuffer, in_pPushDescriptorSetInfo);
     }
 }
 
@@ -6233,7 +6233,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDescriptorBufferOffsets2EXT(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSetDescriptorBufferOffsetsInfoEXT>* pSetDescriptorBufferOffsetsInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkSetDescriptorBufferOffsetsInfoEXT* in_pSetDescriptorBufferOffsetsInfo = pSetDescriptorBufferOffsetsInfo->GetPointer();
     MapStructHandles(pSetDescriptorBufferOffsetsInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -6241,7 +6241,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDescriptorBufferOffsets2EXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDescriptorBufferOffsets2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDescriptorBufferOffsets2EXT, in_commandBuffer, in_pSetDescriptorBufferOffsetsInfo);
+        resource_dumper_.Process_vkCmdSetDescriptorBufferOffsets2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDescriptorBufferOffsets2EXT, in_commandBuffer, in_pSetDescriptorBufferOffsetsInfo);
     }
 }
 
@@ -6250,7 +6250,7 @@ void VulkanReplayConsumer::Process_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT>* pBindDescriptorBufferEmbeddedSamplersInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* in_pBindDescriptorBufferEmbeddedSamplersInfo = pBindDescriptorBufferEmbeddedSamplersInfo->GetPointer();
     MapStructHandles(pBindDescriptorBufferEmbeddedSamplersInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -6258,7 +6258,7 @@ void VulkanReplayConsumer::Process_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorBufferEmbeddedSamplers2EXT, in_commandBuffer, in_pBindDescriptorBufferEmbeddedSamplersInfo);
+        resource_dumper_.Process_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorBufferEmbeddedSamplers2EXT, in_commandBuffer, in_pBindDescriptorBufferEmbeddedSamplersInfo);
     }
 }
 
@@ -6291,7 +6291,7 @@ void VulkanReplayConsumer::Process_vkCreateDebugReportCallbackEXT(
     VkResult replay_result = OverrideCreateDebugReportCallbackEXT(GetInstanceTable(in_instance->handle)->CreateDebugReportCallbackEXT, returnValue, in_instance, pCreateInfo, pAllocator, pCallback);
     CheckResult("vkCreateDebugReportCallbackEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDebugReportCallbackEXTInfo>(instance, pCallback->GetPointer(), pCallback->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkDebugReportCallbackEXTInfo);
+    AddHandle<VulkanDebugReportCallbackEXTInfo>(instance, pCallback->GetPointer(), pCallback->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkDebugReportCallbackEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDebugReportCallbackEXT(
@@ -6300,12 +6300,12 @@ void VulkanReplayConsumer::Process_vkDestroyDebugReportCallbackEXT(
     format::HandleId                            callback,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
-    VkDebugReportCallbackEXT in_callback = MapHandle<VulkanDebugReportCallbackEXTInfo>(callback, &VulkanObjectInfoTable::GetVkDebugReportCallbackEXTInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
+    VkDebugReportCallbackEXT in_callback = MapHandle<VulkanDebugReportCallbackEXTInfo>(callback, &CommonObjectInfoTable::GetVkDebugReportCallbackEXTInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetInstanceTable(in_instance)->DestroyDebugReportCallbackEXT(in_instance, in_callback, in_pAllocator);
-    RemoveHandle(callback, &VulkanObjectInfoTable::RemoveVkDebugReportCallbackEXTInfo);
+    RemoveHandle(callback, &CommonObjectInfoTable::RemoveVkDebugReportCallbackEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDebugReportMessageEXT(
@@ -6319,7 +6319,7 @@ void VulkanReplayConsumer::Process_vkDebugReportMessageEXT(
     StringDecoder*                              pLayerPrefix,
     StringDecoder*                              pMessage)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
     uint64_t in_object = MapHandle(object, objectType);
     const char* in_pLayerPrefix = pLayerPrefix->GetPointer();
     const char* in_pMessage = pMessage->GetPointer();
@@ -6333,7 +6333,7 @@ void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectTagEXT(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>* pTagInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDebugMarkerObjectTagInfoEXT* in_pTagInfo = pTagInfo->GetPointer();
     MapStructHandles(pTagInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -6347,7 +6347,7 @@ void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectNameEXT(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>* pNameInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDebugMarkerObjectNameInfoEXT* in_pNameInfo = pNameInfo->GetPointer();
     MapStructHandles(pNameInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -6360,14 +6360,14 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerBeginEXT(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkDebugMarkerMarkerInfoEXT* in_pMarkerInfo = pMarkerInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdDebugMarkerBeginEXT(in_commandBuffer, in_pMarkerInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDebugMarkerBeginEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDebugMarkerBeginEXT, in_commandBuffer, in_pMarkerInfo);
+        resource_dumper_.Process_vkCmdDebugMarkerBeginEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDebugMarkerBeginEXT, in_commandBuffer, in_pMarkerInfo);
     }
 }
 
@@ -6375,13 +6375,13 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerEndEXT(
     const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDebugMarkerEndEXT(in_commandBuffer);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDebugMarkerEndEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDebugMarkerEndEXT, in_commandBuffer);
+        resource_dumper_.Process_vkCmdDebugMarkerEndEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDebugMarkerEndEXT, in_commandBuffer);
     }
 }
 
@@ -6396,7 +6396,7 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerInsertEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDebugMarkerInsertEXT(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdDebugMarkerInsertEXT, in_commandBuffer->handle, pMarkerInfo->GetPointer());
+        resource_dumper_.Process_vkCmdDebugMarkerInsertEXT(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdDebugMarkerInsertEXT, in_commandBuffer->handle, pMarkerInfo->GetPointer());
     }
 }
 
@@ -6409,8 +6409,8 @@ void VulkanReplayConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
     PointerDecoder<VkDeviceSize>*               pOffsets,
     PointerDecoder<VkDeviceSize>*               pSizes)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkBuffer* in_pBuffers = MapHandles<VulkanBufferInfo>(pBuffers, bindingCount, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkBuffer* in_pBuffers = MapHandles<VulkanBufferInfo>(pBuffers, bindingCount, &CommonObjectInfoTable::GetVkBufferInfo);
     const VkDeviceSize* in_pOffsets = pOffsets->GetPointer();
     const VkDeviceSize* in_pSizes = pSizes->GetPointer();
 
@@ -6418,7 +6418,7 @@ void VulkanReplayConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindTransformFeedbackBuffersEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindTransformFeedbackBuffersEXT, in_commandBuffer, firstBinding, bindingCount, in_pBuffers, in_pOffsets, in_pSizes);
+        resource_dumper_.Process_vkCmdBindTransformFeedbackBuffersEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindTransformFeedbackBuffersEXT, in_commandBuffer, firstBinding, bindingCount, in_pBuffers, in_pOffsets, in_pSizes);
     }
 }
 
@@ -6430,15 +6430,15 @@ void VulkanReplayConsumer::Process_vkCmdBeginTransformFeedbackEXT(
     HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
     PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkBuffer* in_pCounterBuffers = MapHandles<VulkanBufferInfo>(pCounterBuffers, counterBufferCount, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkBuffer* in_pCounterBuffers = MapHandles<VulkanBufferInfo>(pCounterBuffers, counterBufferCount, &CommonObjectInfoTable::GetVkBufferInfo);
     const VkDeviceSize* in_pCounterBufferOffsets = pCounterBufferOffsets->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdBeginTransformFeedbackEXT(in_commandBuffer, firstCounterBuffer, counterBufferCount, in_pCounterBuffers, in_pCounterBufferOffsets);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginTransformFeedbackEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginTransformFeedbackEXT, in_commandBuffer, firstCounterBuffer, counterBufferCount, in_pCounterBuffers, in_pCounterBufferOffsets);
+        resource_dumper_.Process_vkCmdBeginTransformFeedbackEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginTransformFeedbackEXT, in_commandBuffer, firstCounterBuffer, counterBufferCount, in_pCounterBuffers, in_pCounterBufferOffsets);
     }
 }
 
@@ -6450,15 +6450,15 @@ void VulkanReplayConsumer::Process_vkCmdEndTransformFeedbackEXT(
     HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
     PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkBuffer* in_pCounterBuffers = MapHandles<VulkanBufferInfo>(pCounterBuffers, counterBufferCount, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkBuffer* in_pCounterBuffers = MapHandles<VulkanBufferInfo>(pCounterBuffers, counterBufferCount, &CommonObjectInfoTable::GetVkBufferInfo);
     const VkDeviceSize* in_pCounterBufferOffsets = pCounterBufferOffsets->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdEndTransformFeedbackEXT(in_commandBuffer, firstCounterBuffer, counterBufferCount, in_pCounterBuffers, in_pCounterBufferOffsets);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndTransformFeedbackEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndTransformFeedbackEXT, in_commandBuffer, firstCounterBuffer, counterBufferCount, in_pCounterBuffers, in_pCounterBufferOffsets);
+        resource_dumper_.Process_vkCmdEndTransformFeedbackEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndTransformFeedbackEXT, in_commandBuffer, firstCounterBuffer, counterBufferCount, in_pCounterBuffers, in_pCounterBufferOffsets);
     }
 }
 
@@ -6470,14 +6470,14 @@ void VulkanReplayConsumer::Process_vkCmdBeginQueryIndexedEXT(
     VkQueryControlFlags                         flags,
     uint32_t                                    index)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdBeginQueryIndexedEXT(in_commandBuffer, in_queryPool, query, flags, index);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginQueryIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginQueryIndexedEXT, in_commandBuffer, in_queryPool, query, flags, index);
+        resource_dumper_.Process_vkCmdBeginQueryIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginQueryIndexedEXT, in_commandBuffer, in_queryPool, query, flags, index);
     }
 }
 
@@ -6488,14 +6488,14 @@ void VulkanReplayConsumer::Process_vkCmdEndQueryIndexedEXT(
     uint32_t                                    query,
     uint32_t                                    index)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdEndQueryIndexedEXT(in_commandBuffer, in_queryPool, query, index);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndQueryIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndQueryIndexedEXT, in_commandBuffer, in_queryPool, query, index);
+        resource_dumper_.Process_vkCmdEndQueryIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndQueryIndexedEXT, in_commandBuffer, in_queryPool, query, index);
     }
 }
 
@@ -6509,14 +6509,14 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectByteCountEXT(
     uint32_t                                    counterOffset,
     uint32_t                                    vertexStride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_counterBuffer = MapHandle<VulkanBufferInfo>(counterBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_counterBuffer = MapHandle<VulkanBufferInfo>(counterBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawIndirectByteCountEXT(in_commandBuffer, instanceCount, firstInstance, in_counterBuffer, counterBufferOffset, counterOffset, vertexStride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawIndirectByteCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectByteCountEXT, in_commandBuffer, instanceCount, firstInstance, in_counterBuffer, counterBufferOffset, counterOffset, vertexStride);
+        resource_dumper_.Process_vkCmdDrawIndirectByteCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectByteCountEXT, in_commandBuffer, instanceCount, firstInstance, in_counterBuffer, counterBufferOffset, counterOffset, vertexStride);
     }
 }
 
@@ -6526,7 +6526,7 @@ void VulkanReplayConsumer::Process_vkGetImageViewHandleNVX(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkImageViewHandleInfoNVX* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -6540,8 +6540,8 @@ void VulkanReplayConsumer::Process_vkGetImageViewAddressNVX(
     format::HandleId                            imageView,
     StructPointerDecoder<Decoded_VkImageViewAddressPropertiesNVX>* pProperties)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkImageView in_imageView = MapHandle<VulkanImageViewInfo>(imageView, &VulkanObjectInfoTable::GetVkImageViewInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkImageView in_imageView = MapHandle<VulkanImageViewInfo>(imageView, &CommonObjectInfoTable::GetVkImageViewInfo);
     VkImageViewAddressPropertiesNVX* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_IMAGE_VIEW_ADDRESS_PROPERTIES_NVX, nullptr });
     InitializeOutputStructPNext(pProperties);
 
@@ -6559,15 +6559,15 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectCountAMD(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCountAMD(in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawIndirectCountAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCountAMD, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
+        resource_dumper_.Process_vkCmdDrawIndirectCountAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCountAMD, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -6581,15 +6581,15 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCountAMD(in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawIndexedIndirectCountAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCountAMD, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
+        resource_dumper_.Process_vkCmdDrawIndexedIndirectCountAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCountAMD, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -6603,15 +6603,15 @@ void VulkanReplayConsumer::Process_vkGetShaderInfoAMD(
     PointerDecoder<size_t>*                     pInfoSize,
     PointerDecoder<uint8_t>*                    pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &VulkanObjectInfoTable::GetVkPipelineInfo);
-    size_t* out_pInfoSize = pInfoSize->IsNull() ? nullptr : pInfoSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanPipelineInfo>("vkGetShaderInfoAMD", returnValue, pipeline, kPipelineArrayGetShaderInfoAMD, pInfoSize, pInfo, &VulkanObjectInfoTable::GetVkPipelineInfo));
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &CommonObjectInfoTable::GetVkPipelineInfo);
+    size_t* out_pInfoSize = pInfoSize->IsNull() ? nullptr : pInfoSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanPipelineInfo>("vkGetShaderInfoAMD", returnValue, pipeline, kPipelineArrayGetShaderInfoAMD, pInfoSize, pInfo, &CommonObjectInfoTable::GetVkPipelineInfo));
     void* out_pInfo = pInfo->IsNull() ? nullptr : pInfo->AllocateOutputData(*out_pInfoSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetShaderInfoAMD(in_device, in_pipeline, shaderStage, infoType, out_pInfoSize, out_pInfo);
     CheckResult("vkGetShaderInfoAMD", returnValue, replay_result, call_info);
 
-    if (pInfo->IsNull()) { SetOutputArrayCount<VulkanPipelineInfo>(pipeline, kPipelineArrayGetShaderInfoAMD, *out_pInfoSize, &VulkanObjectInfoTable::GetVkPipelineInfo); }
+    if (pInfo->IsNull()) { SetOutputArrayCount<VulkanPipelineInfo>(pipeline, kPipelineArrayGetShaderInfoAMD, *out_pInfoSize, &CommonObjectInfoTable::GetVkPipelineInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
@@ -6622,7 +6622,7 @@ void VulkanReplayConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
     const VkStreamDescriptorSurfaceCreateInfoGGP* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pSurface->IsNull()) { pSurface->SetHandleLength(1); }
@@ -6631,7 +6631,7 @@ void VulkanReplayConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateStreamDescriptorSurfaceGGP(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateStreamDescriptorSurfaceGGP", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
@@ -6646,7 +6646,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalImageFormatPropert
     VkExternalMemoryHandleTypeFlagsNV           externalHandleType,
     StructPointerDecoder<Decoded_VkExternalImageFormatPropertiesNV>* pExternalImageFormatProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     VkExternalImageFormatPropertiesNV* out_pExternalImageFormatProperties = pExternalImageFormatProperties->IsNull() ? nullptr : pExternalImageFormatProperties->AllocateOutputData(1);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceExternalImageFormatPropertiesNV(in_physicalDevice, format, type, tiling, usage, flags, externalHandleType, out_pExternalImageFormatProperties);
@@ -6661,8 +6661,8 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleNV(
     VkExternalMemoryHandleTypeFlagsNV           handleType,
     PointerDecoder<uint64_t, void*>*            pHandle)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeviceMemory in_memory = MapHandle<VulkanDeviceMemoryInfo>(memory, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeviceMemory in_memory = MapHandle<VulkanDeviceMemoryInfo>(memory, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryWin32HandleNV(in_device, in_memory, handleType, out_pHandle);
@@ -6679,7 +6679,7 @@ void VulkanReplayConsumer::Process_vkCreateViSurfaceNN(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
     const VkViSurfaceCreateInfoNN* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pSurface->IsNull()) { pSurface->SetHandleLength(1); }
@@ -6688,7 +6688,7 @@ void VulkanReplayConsumer::Process_vkCreateViSurfaceNN(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateViSurfaceNN(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateViSurfaceNN", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginConditionalRenderingEXT(
@@ -6696,7 +6696,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginConditionalRenderingEXT(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkConditionalRenderingBeginInfoEXT* in_pConditionalRenderingBegin = pConditionalRenderingBegin->GetPointer();
     MapStructHandles(pConditionalRenderingBegin->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -6704,7 +6704,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginConditionalRenderingEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginConditionalRenderingEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginConditionalRenderingEXT, in_commandBuffer, in_pConditionalRenderingBegin);
+        resource_dumper_.Process_vkCmdBeginConditionalRenderingEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginConditionalRenderingEXT, in_commandBuffer, in_pConditionalRenderingBegin);
     }
 }
 
@@ -6712,13 +6712,13 @@ void VulkanReplayConsumer::Process_vkCmdEndConditionalRenderingEXT(
     const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdEndConditionalRenderingEXT(in_commandBuffer);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndConditionalRenderingEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndConditionalRenderingEXT, in_commandBuffer);
+        resource_dumper_.Process_vkCmdEndConditionalRenderingEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndConditionalRenderingEXT, in_commandBuffer);
     }
 }
 
@@ -6729,14 +6729,14 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWScalingNV(
     uint32_t                                    viewportCount,
     StructPointerDecoder<Decoded_VkViewportWScalingNV>* pViewportWScalings)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkViewportWScalingNV* in_pViewportWScalings = pViewportWScalings->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetViewportWScalingNV(in_commandBuffer, firstViewport, viewportCount, in_pViewportWScalings);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetViewportWScalingNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWScalingNV, in_commandBuffer, firstViewport, viewportCount, in_pViewportWScalings);
+        resource_dumper_.Process_vkCmdSetViewportWScalingNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWScalingNV, in_commandBuffer, firstViewport, viewportCount, in_pViewportWScalings);
     }
 }
 
@@ -6746,8 +6746,8 @@ void VulkanReplayConsumer::Process_vkReleaseDisplayEXT(
     format::HandleId                            physicalDevice,
     format::HandleId                            display)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->ReleaseDisplayEXT(in_physicalDevice, in_display);
     CheckResult("vkReleaseDisplayEXT", returnValue, replay_result, call_info);
@@ -6760,9 +6760,9 @@ void VulkanReplayConsumer::Process_vkAcquireXlibDisplayEXT(
     uint64_t                                    dpy,
     format::HandleId                            display)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     Display* in_dpy = static_cast<Display*>(PreProcessExternalObject(dpy, format::ApiCallId::ApiCall_vkAcquireXlibDisplayEXT, "vkAcquireXlibDisplayEXT"));
-    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
+    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->AcquireXlibDisplayEXT(in_physicalDevice, in_dpy, in_display);
     CheckResult("vkAcquireXlibDisplayEXT", returnValue, replay_result, call_info);
@@ -6785,7 +6785,7 @@ void VulkanReplayConsumer::Process_vkGetRandROutputDisplayEXT(
     VkResult replay_result = OverrideGetRandROutputDisplayEXT(GetInstanceTable(in_physicalDevice->handle)->GetRandROutputDisplayEXT, returnValue, in_physicalDevice, in_dpy, rrOutput, pDisplay);
     CheckResult("vkGetRandROutputDisplayEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDisplayKHRInfo>(physicalDevice, pDisplay->GetPointer(), pDisplay->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkDisplayKHRInfo);
+    AddHandle<VulkanDisplayKHRInfo>(physicalDevice, pDisplay->GetPointer(), pDisplay->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkDisplayKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
@@ -6800,8 +6800,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
         GFXRECON_LOG_DEBUG("Skip vkGetPhysicalDeviceSurfaceCapabilities2EXT for offscreen.");
         return;
     }
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkSurfaceKHR in_surface = MapHandle<VulkanSurfaceKHRInfo>(surface, &CommonObjectInfoTable::GetVkSurfaceKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(surface) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(surface)->surface_creation_skipped) { return; }
     VkSurfaceCapabilities2EXT* out_pSurfaceCapabilities = pSurfaceCapabilities->IsNull() ? nullptr : pSurfaceCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT, nullptr });
     InitializeOutputStructPNext(pSurfaceCapabilities);
@@ -6817,8 +6817,8 @@ void VulkanReplayConsumer::Process_vkDisplayPowerControlEXT(
     format::HandleId                            display,
     StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>* pDisplayPowerInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
     const VkDisplayPowerInfoEXT* in_pDisplayPowerInfo = pDisplayPowerInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->DisplayPowerControlEXT(in_device, in_display, in_pDisplayPowerInfo);
@@ -6833,7 +6833,7 @@ void VulkanReplayConsumer::Process_vkRegisterDeviceEventEXT(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkFence>*              pFence)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDeviceEventInfoEXT* in_pDeviceEventInfo = pDeviceEventInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pFence->IsNull()) { pFence->SetHandleLength(1); }
@@ -6842,7 +6842,7 @@ void VulkanReplayConsumer::Process_vkRegisterDeviceEventEXT(
     VkResult replay_result = GetDeviceTable(in_device)->RegisterDeviceEventEXT(in_device, in_pDeviceEventInfo, in_pAllocator, out_pFence);
     CheckResult("vkRegisterDeviceEventEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanFenceInfo>(device, pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddVkFenceInfo);
+    AddHandle<VulkanFenceInfo>(device, pFence->GetPointer(), out_pFence, &CommonObjectInfoTable::AddVkFenceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkRegisterDisplayEventEXT(
@@ -6854,8 +6854,8 @@ void VulkanReplayConsumer::Process_vkRegisterDisplayEventEXT(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkFence>*              pFence)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
     const VkDisplayEventInfoEXT* in_pDisplayEventInfo = pDisplayEventInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pFence->IsNull()) { pFence->SetHandleLength(1); }
@@ -6864,7 +6864,7 @@ void VulkanReplayConsumer::Process_vkRegisterDisplayEventEXT(
     VkResult replay_result = GetDeviceTable(in_device)->RegisterDisplayEventEXT(in_device, in_display, in_pDisplayEventInfo, in_pAllocator, out_pFence);
     CheckResult("vkRegisterDisplayEventEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanFenceInfo>(device, pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddVkFenceInfo);
+    AddHandle<VulkanFenceInfo>(device, pFence->GetPointer(), out_pFence, &CommonObjectInfoTable::AddVkFenceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetSwapchainCounterEXT(
@@ -6880,8 +6880,8 @@ void VulkanReplayConsumer::Process_vkGetSwapchainCounterEXT(
         GFXRECON_LOG_DEBUG("Skip vkGetSwapchainCounterEXT for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
     uint64_t* out_pCounterValue = pCounterValue->IsNull() ? nullptr : pCounterValue->AllocateOutputData(1, static_cast<uint64_t>(0));
 
@@ -6901,8 +6901,8 @@ void VulkanReplayConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
         GFXRECON_LOG_DEBUG("Skip vkGetRefreshCycleDurationGOOGLE for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
     VkRefreshCycleDurationGOOGLE* out_pDisplayTimingProperties = pDisplayTimingProperties->IsNull() ? nullptr : pDisplayTimingProperties->AllocateOutputData(1);
 
@@ -6923,16 +6923,16 @@ void VulkanReplayConsumer::Process_vkGetPastPresentationTimingGOOGLE(
         GFXRECON_LOG_DEBUG("Skip vkGetPastPresentationTimingGOOGLE for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
-    uint32_t* out_pPresentationTimingCount = pPresentationTimingCount->IsNull() ? nullptr : pPresentationTimingCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanSwapchainKHRInfo>("vkGetPastPresentationTimingGOOGLE", returnValue, swapchain, kSwapchainKHRArrayGetPastPresentationTimingGOOGLE, pPresentationTimingCount, pPresentationTimings, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo));
+    uint32_t* out_pPresentationTimingCount = pPresentationTimingCount->IsNull() ? nullptr : pPresentationTimingCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanSwapchainKHRInfo>("vkGetPastPresentationTimingGOOGLE", returnValue, swapchain, kSwapchainKHRArrayGetPastPresentationTimingGOOGLE, pPresentationTimingCount, pPresentationTimings, &CommonObjectInfoTable::GetVkSwapchainKHRInfo));
     VkPastPresentationTimingGOOGLE* out_pPresentationTimings = pPresentationTimings->IsNull() ? nullptr : pPresentationTimings->AllocateOutputData(*out_pPresentationTimingCount);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPastPresentationTimingGOOGLE(in_device, in_swapchain, out_pPresentationTimingCount, out_pPresentationTimings);
     CheckResult("vkGetPastPresentationTimingGOOGLE", returnValue, replay_result, call_info);
 
-    if (pPresentationTimings->IsNull()) { SetOutputArrayCount<VulkanSwapchainKHRInfo>(swapchain, kSwapchainKHRArrayGetPastPresentationTimingGOOGLE, *out_pPresentationTimingCount, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo); }
+    if (pPresentationTimings->IsNull()) { SetOutputArrayCount<VulkanSwapchainKHRInfo>(swapchain, kSwapchainKHRArrayGetPastPresentationTimingGOOGLE, *out_pPresentationTimingCount, &CommonObjectInfoTable::GetVkSwapchainKHRInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDiscardRectangleEXT(
@@ -6942,14 +6942,14 @@ void VulkanReplayConsumer::Process_vkCmdSetDiscardRectangleEXT(
     uint32_t                                    discardRectangleCount,
     StructPointerDecoder<Decoded_VkRect2D>*     pDiscardRectangles)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkRect2D* in_pDiscardRectangles = pDiscardRectangles->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleEXT(in_commandBuffer, firstDiscardRectangle, discardRectangleCount, in_pDiscardRectangles);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDiscardRectangleEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleEXT, in_commandBuffer, firstDiscardRectangle, discardRectangleCount, in_pDiscardRectangles);
+        resource_dumper_.Process_vkCmdSetDiscardRectangleEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleEXT, in_commandBuffer, firstDiscardRectangle, discardRectangleCount, in_pDiscardRectangles);
     }
 }
 
@@ -6958,13 +6958,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDiscardRectangleEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    discardRectangleEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleEnableEXT(in_commandBuffer, discardRectangleEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDiscardRectangleEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleEnableEXT, in_commandBuffer, discardRectangleEnable);
+        resource_dumper_.Process_vkCmdSetDiscardRectangleEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleEnableEXT, in_commandBuffer, discardRectangleEnable);
     }
 }
 
@@ -6973,13 +6973,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDiscardRectangleModeEXT(
     format::HandleId                            commandBuffer,
     VkDiscardRectangleModeEXT                   discardRectangleMode)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleModeEXT(in_commandBuffer, discardRectangleMode);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDiscardRectangleModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleModeEXT, in_commandBuffer, discardRectangleMode);
+        resource_dumper_.Process_vkCmdSetDiscardRectangleModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleModeEXT, in_commandBuffer, discardRectangleMode);
     }
 }
 
@@ -6995,8 +6995,8 @@ void VulkanReplayConsumer::Process_vkSetHdrMetadataEXT(
         GFXRECON_LOG_DEBUG("Skip vkSetHdrMetadataEXT for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    const VkSwapchainKHR* in_pSwapchains = MapHandles<VulkanSwapchainKHRInfo>(pSwapchains, swapchainCount, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    const VkSwapchainKHR* in_pSwapchains = MapHandles<VulkanSwapchainKHRInfo>(pSwapchains, swapchainCount, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     const VkHdrMetadataEXT* in_pMetadata = pMetadata->GetPointer();
 
     GetDeviceTable(in_device)->SetHdrMetadataEXT(in_device, swapchainCount, in_pSwapchains, in_pMetadata);
@@ -7010,7 +7010,7 @@ void VulkanReplayConsumer::Process_vkCreateIOSSurfaceMVK(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
     const VkIOSSurfaceCreateInfoMVK* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pSurface->IsNull()) { pSurface->SetHandleLength(1); }
@@ -7019,7 +7019,7 @@ void VulkanReplayConsumer::Process_vkCreateIOSSurfaceMVK(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateIOSSurfaceMVK(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateIOSSurfaceMVK", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateMacOSSurfaceMVK(
@@ -7030,7 +7030,7 @@ void VulkanReplayConsumer::Process_vkCreateMacOSSurfaceMVK(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
     const VkMacOSSurfaceCreateInfoMVK* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pSurface->IsNull()) { pSurface->SetHandleLength(1); }
@@ -7039,7 +7039,7 @@ void VulkanReplayConsumer::Process_vkCreateMacOSSurfaceMVK(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateMacOSSurfaceMVK(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateMacOSSurfaceMVK", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectNameEXT(
@@ -7048,10 +7048,10 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectNameEXT(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDebugUtilsObjectNameInfoEXT* in_pNameInfo = pNameInfo->GetPointer();
     MapStructHandles(pNameInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(device);
+    VulkanDeviceInfo* device_info     = GetObjectInfoTable().GetVkDeviceInfo(device);
     VkPhysicalDevice  physical_device = device_info->parent;
 
     VkResult replay_result = GetInstanceTable(physical_device)->SetDebugUtilsObjectNameEXT(in_device, in_pNameInfo);
@@ -7064,10 +7064,10 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectTagEXT(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDebugUtilsObjectTagInfoEXT* in_pTagInfo = pTagInfo->GetPointer();
     MapStructHandles(pTagInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(device);
+    VulkanDeviceInfo* device_info     = GetObjectInfoTable().GetVkDeviceInfo(device);
     VkPhysicalDevice  physical_device = device_info->parent;
 
     VkResult replay_result = GetInstanceTable(physical_device)->SetDebugUtilsObjectTagEXT(in_device, in_pTagInfo);
@@ -7079,7 +7079,7 @@ void VulkanReplayConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
     format::HandleId                            queue,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
-    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &VulkanObjectInfoTable::GetVkQueueInfo);
+    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &CommonObjectInfoTable::GetVkQueueInfo);
     const VkDebugUtilsLabelEXT* in_pLabelInfo = pLabelInfo->GetPointer();
 
     GetDeviceTable(in_queue)->QueueBeginDebugUtilsLabelEXT(in_queue, in_pLabelInfo);
@@ -7089,7 +7089,7 @@ void VulkanReplayConsumer::Process_vkQueueEndDebugUtilsLabelEXT(
     const ApiCallInfo&                          call_info,
     format::HandleId                            queue)
 {
-    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &VulkanObjectInfoTable::GetVkQueueInfo);
+    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &CommonObjectInfoTable::GetVkQueueInfo);
 
     GetDeviceTable(in_queue)->QueueEndDebugUtilsLabelEXT(in_queue);
 }
@@ -7099,7 +7099,7 @@ void VulkanReplayConsumer::Process_vkQueueInsertDebugUtilsLabelEXT(
     format::HandleId                            queue,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
-    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &VulkanObjectInfoTable::GetVkQueueInfo);
+    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &CommonObjectInfoTable::GetVkQueueInfo);
     const VkDebugUtilsLabelEXT* in_pLabelInfo = pLabelInfo->GetPointer();
 
     GetDeviceTable(in_queue)->QueueInsertDebugUtilsLabelEXT(in_queue, in_pLabelInfo);
@@ -7110,14 +7110,14 @@ void VulkanReplayConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkDebugUtilsLabelEXT* in_pLabelInfo = pLabelInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdBeginDebugUtilsLabelEXT(in_commandBuffer, in_pLabelInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBeginDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginDebugUtilsLabelEXT, in_commandBuffer, in_pLabelInfo);
+        resource_dumper_.Process_vkCmdBeginDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginDebugUtilsLabelEXT, in_commandBuffer, in_pLabelInfo);
     }
 }
 
@@ -7125,13 +7125,13 @@ void VulkanReplayConsumer::Process_vkCmdEndDebugUtilsLabelEXT(
     const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdEndDebugUtilsLabelEXT(in_commandBuffer);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdEndDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndDebugUtilsLabelEXT, in_commandBuffer);
+        resource_dumper_.Process_vkCmdEndDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndDebugUtilsLabelEXT, in_commandBuffer);
     }
 }
 
@@ -7146,7 +7146,7 @@ void VulkanReplayConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdInsertDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdInsertDebugUtilsLabelEXT, in_commandBuffer->handle, pLabelInfo->GetPointer());
+        resource_dumper_.Process_vkCmdInsertDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdInsertDebugUtilsLabelEXT, in_commandBuffer->handle, pLabelInfo->GetPointer());
     }
 }
 
@@ -7166,7 +7166,7 @@ void VulkanReplayConsumer::Process_vkCreateDebugUtilsMessengerEXT(
     VkResult replay_result = OverrideCreateDebugUtilsMessengerEXT(GetInstanceTable(in_instance->handle)->CreateDebugUtilsMessengerEXT, returnValue, in_instance, pCreateInfo, pAllocator, pMessenger);
     CheckResult("vkCreateDebugUtilsMessengerEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDebugUtilsMessengerEXTInfo>(instance, pMessenger->GetPointer(), pMessenger->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkDebugUtilsMessengerEXTInfo);
+    AddHandle<VulkanDebugUtilsMessengerEXTInfo>(instance, pMessenger->GetPointer(), pMessenger->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkDebugUtilsMessengerEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
@@ -7175,12 +7175,12 @@ void VulkanReplayConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
     format::HandleId                            messenger,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
-    VkDebugUtilsMessengerEXT in_messenger = MapHandle<VulkanDebugUtilsMessengerEXTInfo>(messenger, &VulkanObjectInfoTable::GetVkDebugUtilsMessengerEXTInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
+    VkDebugUtilsMessengerEXT in_messenger = MapHandle<VulkanDebugUtilsMessengerEXTInfo>(messenger, &CommonObjectInfoTable::GetVkDebugUtilsMessengerEXTInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetInstanceTable(in_instance)->DestroyDebugUtilsMessengerEXT(in_instance, in_messenger, in_pAllocator);
-    RemoveHandle(messenger, &VulkanObjectInfoTable::RemoveVkDebugUtilsMessengerEXTInfo);
+    RemoveHandle(messenger, &CommonObjectInfoTable::RemoveVkDebugUtilsMessengerEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkSubmitDebugUtilsMessageEXT(
@@ -7190,7 +7190,7 @@ void VulkanReplayConsumer::Process_vkSubmitDebugUtilsMessageEXT(
     VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
     StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>* pCallbackData)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
     const VkDebugUtilsMessengerCallbackDataEXT* in_pCallbackData = pCallbackData->GetPointer();
 
     GetInstanceTable(in_instance)->SubmitDebugUtilsMessageEXT(in_instance, messageSeverity, messageTypes, in_pCallbackData);
@@ -7219,7 +7219,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
     StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>* pInfo,
     PointerDecoder<uint64_t, void*>*            pBuffer)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkMemoryGetAndroidHardwareBufferInfoANDROID* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     struct AHardwareBuffer** out_pBuffer = pBuffer->IsNull() ? nullptr : reinterpret_cast<struct AHardwareBuffer**>(pBuffer->AllocateOutputData(1));
@@ -7235,14 +7235,14 @@ void VulkanReplayConsumer::Process_vkCmdSetSampleLocationsEXT(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>* pSampleLocationsInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkSampleLocationsInfoEXT* in_pSampleLocationsInfo = pSampleLocationsInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetSampleLocationsEXT(in_commandBuffer, in_pSampleLocationsInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetSampleLocationsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleLocationsEXT, in_commandBuffer, in_pSampleLocationsInfo);
+        resource_dumper_.Process_vkCmdSetSampleLocationsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleLocationsEXT, in_commandBuffer, in_pSampleLocationsInfo);
     }
 }
 
@@ -7252,7 +7252,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
     VkSampleCountFlagBits                       samples,
     StructPointerDecoder<Decoded_VkMultisamplePropertiesEXT>* pMultisampleProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     VkMultisamplePropertiesEXT* out_pMultisampleProperties = pMultisampleProperties->IsNull() ? nullptr : pMultisampleProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT, nullptr });
     InitializeOutputStructPNext(pMultisampleProperties);
 
@@ -7266,8 +7266,8 @@ void VulkanReplayConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
     format::HandleId                            image,
     StructPointerDecoder<Decoded_VkImageDrmFormatModifierPropertiesEXT>* pProperties)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkImage in_image = MapHandle<VulkanImageInfo>(image, &VulkanObjectInfoTable::GetVkImageInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkImage in_image = MapHandle<VulkanImageInfo>(image, &CommonObjectInfoTable::GetVkImageInfo);
     VkImageDrmFormatModifierPropertiesEXT* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT, nullptr });
     InitializeOutputStructPNext(pProperties);
 
@@ -7283,7 +7283,7 @@ void VulkanReplayConsumer::Process_vkCreateValidationCacheEXT(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkValidationCacheEXT>* pValidationCache)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkValidationCacheCreateInfoEXT* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pValidationCache->IsNull()) { pValidationCache->SetHandleLength(1); }
@@ -7292,7 +7292,7 @@ void VulkanReplayConsumer::Process_vkCreateValidationCacheEXT(
     VkResult replay_result = GetDeviceTable(in_device)->CreateValidationCacheEXT(in_device, in_pCreateInfo, in_pAllocator, out_pValidationCache);
     CheckResult("vkCreateValidationCacheEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanValidationCacheEXTInfo>(device, pValidationCache->GetPointer(), out_pValidationCache, &VulkanObjectInfoTable::AddVkValidationCacheEXTInfo);
+    AddHandle<VulkanValidationCacheEXTInfo>(device, pValidationCache->GetPointer(), out_pValidationCache, &CommonObjectInfoTable::AddVkValidationCacheEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyValidationCacheEXT(
@@ -7301,12 +7301,12 @@ void VulkanReplayConsumer::Process_vkDestroyValidationCacheEXT(
     format::HandleId                            validationCache,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkValidationCacheEXT in_validationCache = MapHandle<VulkanValidationCacheEXTInfo>(validationCache, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkValidationCacheEXT in_validationCache = MapHandle<VulkanValidationCacheEXTInfo>(validationCache, &CommonObjectInfoTable::GetVkValidationCacheEXTInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyValidationCacheEXT(in_device, in_validationCache, in_pAllocator);
-    RemoveHandle(validationCache, &VulkanObjectInfoTable::RemoveVkValidationCacheEXTInfo);
+    RemoveHandle(validationCache, &CommonObjectInfoTable::RemoveVkValidationCacheEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkMergeValidationCachesEXT(
@@ -7317,9 +7317,9 @@ void VulkanReplayConsumer::Process_vkMergeValidationCachesEXT(
     uint32_t                                    srcCacheCount,
     HandlePointerDecoder<VkValidationCacheEXT>* pSrcCaches)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkValidationCacheEXT in_dstCache = MapHandle<VulkanValidationCacheEXTInfo>(dstCache, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo);
-    const VkValidationCacheEXT* in_pSrcCaches = MapHandles<VulkanValidationCacheEXTInfo>(pSrcCaches, srcCacheCount, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkValidationCacheEXT in_dstCache = MapHandle<VulkanValidationCacheEXTInfo>(dstCache, &CommonObjectInfoTable::GetVkValidationCacheEXTInfo);
+    const VkValidationCacheEXT* in_pSrcCaches = MapHandles<VulkanValidationCacheEXTInfo>(pSrcCaches, srcCacheCount, &CommonObjectInfoTable::GetVkValidationCacheEXTInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->MergeValidationCachesEXT(in_device, in_dstCache, srcCacheCount, in_pSrcCaches);
     CheckResult("vkMergeValidationCachesEXT", returnValue, replay_result, call_info);
@@ -7333,15 +7333,15 @@ void VulkanReplayConsumer::Process_vkGetValidationCacheDataEXT(
     PointerDecoder<size_t>*                     pDataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkValidationCacheEXT in_validationCache = MapHandle<VulkanValidationCacheEXTInfo>(validationCache, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo);
-    size_t* out_pDataSize = pDataSize->IsNull() ? nullptr : pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanValidationCacheEXTInfo>("vkGetValidationCacheDataEXT", returnValue, validationCache, kValidationCacheEXTArrayGetValidationCacheDataEXT, pDataSize, pData, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo));
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkValidationCacheEXT in_validationCache = MapHandle<VulkanValidationCacheEXTInfo>(validationCache, &CommonObjectInfoTable::GetVkValidationCacheEXTInfo);
+    size_t* out_pDataSize = pDataSize->IsNull() ? nullptr : pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanValidationCacheEXTInfo>("vkGetValidationCacheDataEXT", returnValue, validationCache, kValidationCacheEXTArrayGetValidationCacheDataEXT, pDataSize, pData, &CommonObjectInfoTable::GetVkValidationCacheEXTInfo));
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(*out_pDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetValidationCacheDataEXT(in_device, in_validationCache, out_pDataSize, out_pData);
     CheckResult("vkGetValidationCacheDataEXT", returnValue, replay_result, call_info);
 
-    if (pData->IsNull()) { SetOutputArrayCount<VulkanValidationCacheEXTInfo>(validationCache, kValidationCacheEXTArrayGetValidationCacheDataEXT, *out_pDataSize, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo); }
+    if (pData->IsNull()) { SetOutputArrayCount<VulkanValidationCacheEXTInfo>(validationCache, kValidationCacheEXTArrayGetValidationCacheDataEXT, *out_pDataSize, &CommonObjectInfoTable::GetVkValidationCacheEXTInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindShadingRateImageNV(
@@ -7350,14 +7350,14 @@ void VulkanReplayConsumer::Process_vkCmdBindShadingRateImageNV(
     format::HandleId                            imageView,
     VkImageLayout                               imageLayout)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkImageView in_imageView = MapHandle<VulkanImageViewInfo>(imageView, &VulkanObjectInfoTable::GetVkImageViewInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkImageView in_imageView = MapHandle<VulkanImageViewInfo>(imageView, &CommonObjectInfoTable::GetVkImageViewInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdBindShadingRateImageNV(in_commandBuffer, in_imageView, imageLayout);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindShadingRateImageNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBindShadingRateImageNV, in_commandBuffer, in_imageView, imageLayout);
+        resource_dumper_.Process_vkCmdBindShadingRateImageNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBindShadingRateImageNV, in_commandBuffer, in_imageView, imageLayout);
     }
 }
 
@@ -7368,14 +7368,14 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportShadingRatePaletteNV(
     uint32_t                                    viewportCount,
     StructPointerDecoder<Decoded_VkShadingRatePaletteNV>* pShadingRatePalettes)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkShadingRatePaletteNV* in_pShadingRatePalettes = pShadingRatePalettes->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetViewportShadingRatePaletteNV(in_commandBuffer, firstViewport, viewportCount, in_pShadingRatePalettes);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetViewportShadingRatePaletteNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportShadingRatePaletteNV, in_commandBuffer, firstViewport, viewportCount, in_pShadingRatePalettes);
+        resource_dumper_.Process_vkCmdSetViewportShadingRatePaletteNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportShadingRatePaletteNV, in_commandBuffer, firstViewport, viewportCount, in_pShadingRatePalettes);
     }
 }
 
@@ -7386,14 +7386,14 @@ void VulkanReplayConsumer::Process_vkCmdSetCoarseSampleOrderNV(
     uint32_t                                    customSampleOrderCount,
     StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>* pCustomSampleOrders)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCoarseSampleOrderCustomNV* in_pCustomSampleOrders = pCustomSampleOrders->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetCoarseSampleOrderNV(in_commandBuffer, sampleOrderType, customSampleOrderCount, in_pCustomSampleOrders);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetCoarseSampleOrderNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoarseSampleOrderNV, in_commandBuffer, sampleOrderType, customSampleOrderCount, in_pCustomSampleOrders);
+        resource_dumper_.Process_vkCmdSetCoarseSampleOrderNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoarseSampleOrderNV, in_commandBuffer, sampleOrderType, customSampleOrderCount, in_pCustomSampleOrders);
     }
 }
 
@@ -7405,7 +7405,7 @@ void VulkanReplayConsumer::Process_vkCreateAccelerationStructureNV(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructure)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkAccelerationStructureCreateInfoNV* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -7415,7 +7415,7 @@ void VulkanReplayConsumer::Process_vkCreateAccelerationStructureNV(
     VkResult replay_result = GetDeviceTable(in_device)->CreateAccelerationStructureNV(in_device, in_pCreateInfo, in_pAllocator, out_pAccelerationStructure);
     CheckResult("vkCreateAccelerationStructureNV", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanAccelerationStructureNVInfo>(device, pAccelerationStructure->GetPointer(), out_pAccelerationStructure, &VulkanObjectInfoTable::AddVkAccelerationStructureNVInfo);
+    AddHandle<VulkanAccelerationStructureNVInfo>(device, pAccelerationStructure->GetPointer(), out_pAccelerationStructure, &CommonObjectInfoTable::AddVkAccelerationStructureNVInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureNV(
@@ -7424,12 +7424,12 @@ void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureNV(
     format::HandleId                            accelerationStructure,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkAccelerationStructureNV in_accelerationStructure = MapHandle<VulkanAccelerationStructureNVInfo>(accelerationStructure, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkAccelerationStructureNV in_accelerationStructure = MapHandle<VulkanAccelerationStructureNVInfo>(accelerationStructure, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyAccelerationStructureNV(in_device, in_accelerationStructure, in_pAllocator);
-    RemoveHandle(accelerationStructure, &VulkanObjectInfoTable::RemoveVkAccelerationStructureNVInfo);
+    RemoveHandle(accelerationStructure, &CommonObjectInfoTable::RemoveVkAccelerationStructureNVInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetAccelerationStructureMemoryRequirementsNV(
@@ -7438,7 +7438,7 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureMemoryRequirementsN
     StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkAccelerationStructureMemoryRequirementsInfoNV* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMemoryRequirements2KHR* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1);
@@ -7453,7 +7453,7 @@ void VulkanReplayConsumer::Process_vkBindAccelerationStructureMemoryNV(
     uint32_t                                    bindInfoCount,
     StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>* pBindInfos)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkBindAccelerationStructureMemoryInfoNV* in_pBindInfos = pBindInfos->GetPointer();
     MapStructArrayHandles(pBindInfos->GetMetaStructPointer(), pBindInfos->GetLength(), GetObjectInfoTable());
 
@@ -7473,19 +7473,19 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructureNV(
     format::HandleId                            scratch,
     VkDeviceSize                                scratchOffset)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkAccelerationStructureInfoNV* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkBuffer in_instanceData = MapHandle<VulkanBufferInfo>(instanceData, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkAccelerationStructureNV in_dst = MapHandle<VulkanAccelerationStructureNVInfo>(dst, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
-    VkAccelerationStructureNV in_src = MapHandle<VulkanAccelerationStructureNVInfo>(src, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
-    VkBuffer in_scratch = MapHandle<VulkanBufferInfo>(scratch, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_instanceData = MapHandle<VulkanBufferInfo>(instanceData, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkAccelerationStructureNV in_dst = MapHandle<VulkanAccelerationStructureNVInfo>(dst, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo);
+    VkAccelerationStructureNV in_src = MapHandle<VulkanAccelerationStructureNVInfo>(src, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo);
+    VkBuffer in_scratch = MapHandle<VulkanBufferInfo>(scratch, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdBuildAccelerationStructureNV(in_commandBuffer, in_pInfo, in_instanceData, instanceOffset, update, in_dst, in_src, in_scratch, scratchOffset);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBuildAccelerationStructureNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildAccelerationStructureNV, in_commandBuffer, in_pInfo, in_instanceData, instanceOffset, update, in_dst, in_src, in_scratch, scratchOffset);
+        resource_dumper_.Process_vkCmdBuildAccelerationStructureNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildAccelerationStructureNV, in_commandBuffer, in_pInfo, in_instanceData, instanceOffset, update, in_dst, in_src, in_scratch, scratchOffset);
     }
 }
 
@@ -7496,15 +7496,15 @@ void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureNV(
     format::HandleId                            src,
     VkCopyAccelerationStructureModeKHR          mode)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkAccelerationStructureNV in_dst = MapHandle<VulkanAccelerationStructureNVInfo>(dst, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
-    VkAccelerationStructureNV in_src = MapHandle<VulkanAccelerationStructureNVInfo>(src, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkAccelerationStructureNV in_dst = MapHandle<VulkanAccelerationStructureNVInfo>(dst, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo);
+    VkAccelerationStructureNV in_src = MapHandle<VulkanAccelerationStructureNVInfo>(src, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdCopyAccelerationStructureNV(in_commandBuffer, in_dst, in_src, mode);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyAccelerationStructureNV(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyAccelerationStructureNV, in_commandBuffer, in_dst, in_src, mode);
+        resource_dumper_.Process_vkCmdCopyAccelerationStructureNV(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyAccelerationStructureNV, in_commandBuffer, in_dst, in_src, mode);
     }
 }
 
@@ -7526,17 +7526,17 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysNV(
     uint32_t                                    height,
     uint32_t                                    depth)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_raygenShaderBindingTableBuffer = MapHandle<VulkanBufferInfo>(raygenShaderBindingTableBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_missShaderBindingTableBuffer = MapHandle<VulkanBufferInfo>(missShaderBindingTableBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_hitShaderBindingTableBuffer = MapHandle<VulkanBufferInfo>(hitShaderBindingTableBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_callableShaderBindingTableBuffer = MapHandle<VulkanBufferInfo>(callableShaderBindingTableBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_raygenShaderBindingTableBuffer = MapHandle<VulkanBufferInfo>(raygenShaderBindingTableBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_missShaderBindingTableBuffer = MapHandle<VulkanBufferInfo>(missShaderBindingTableBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_hitShaderBindingTableBuffer = MapHandle<VulkanBufferInfo>(hitShaderBindingTableBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_callableShaderBindingTableBuffer = MapHandle<VulkanBufferInfo>(callableShaderBindingTableBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdTraceRaysNV(in_commandBuffer, in_raygenShaderBindingTableBuffer, raygenShaderBindingOffset, in_missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, in_hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, in_callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdTraceRaysNV(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysNV, in_commandBuffer, in_raygenShaderBindingTableBuffer, raygenShaderBindingOffset, in_missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, in_hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, in_callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
+        resource_dumper_.Process_vkCmdTraceRaysNV(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysNV, in_commandBuffer, in_raygenShaderBindingTableBuffer, raygenShaderBindingOffset, in_missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, in_hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, in_callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
     }
 }
 
@@ -7550,8 +7550,8 @@ void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesNV(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkPipeline>*           pPipelines)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPipelineCache in_pipelineCache = MapHandle<VulkanPipelineCacheInfo>(pipelineCache, &VulkanObjectInfoTable::GetVkPipelineCacheInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPipelineCache in_pipelineCache = MapHandle<VulkanPipelineCacheInfo>(pipelineCache, &CommonObjectInfoTable::GetVkPipelineCacheInfo);
     const VkRayTracingPipelineCreateInfoNV* in_pCreateInfos = pCreateInfos->GetPointer();
     MapStructArrayHandles(pCreateInfos->GetMetaStructPointer(), pCreateInfos->GetLength(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -7562,7 +7562,7 @@ void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesNV(
     VkResult replay_result = GetDeviceTable(in_device)->CreateRayTracingPipelinesNV(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);
     CheckResult("vkCreateRayTracingPipelinesNV", returnValue, replay_result, call_info);
 
-    AddHandles<VulkanPipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddVkPipelineInfo);
+    AddHandles<VulkanPipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &CommonObjectInfoTable::AddVkPipelineInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
@@ -7593,8 +7593,8 @@ void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
     size_t                                      dataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &VulkanObjectInfoTable::GetVkPipelineInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &CommonObjectInfoTable::GetVkPipelineInfo);
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetRayTracingShaderGroupHandlesNV(in_device, in_pipeline, firstGroup, groupCount, dataSize, out_pData);
@@ -7609,8 +7609,8 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureHandleNV(
     size_t                                      dataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkAccelerationStructureNV in_accelerationStructure = MapHandle<VulkanAccelerationStructureNVInfo>(accelerationStructure, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkAccelerationStructureNV in_accelerationStructure = MapHandle<VulkanAccelerationStructureNVInfo>(accelerationStructure, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo);
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetAccelerationStructureHandleNV(in_device, in_accelerationStructure, dataSize, out_pData);
@@ -7626,15 +7626,15 @@ void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkAccelerationStructureNV* in_pAccelerationStructures = MapHandles<VulkanAccelerationStructureNVInfo>(pAccelerationStructures, accelerationStructureCount, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkAccelerationStructureNV* in_pAccelerationStructures = MapHandles<VulkanAccelerationStructureNVInfo>(pAccelerationStructures, accelerationStructureCount, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdWriteAccelerationStructuresPropertiesNV(in_commandBuffer, accelerationStructureCount, in_pAccelerationStructures, queryType, in_queryPool, firstQuery);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWriteAccelerationStructuresPropertiesNV(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteAccelerationStructuresPropertiesNV, in_commandBuffer, accelerationStructureCount, in_pAccelerationStructures, queryType, in_queryPool, firstQuery);
+        resource_dumper_.Process_vkCmdWriteAccelerationStructuresPropertiesNV(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteAccelerationStructuresPropertiesNV, in_commandBuffer, accelerationStructureCount, in_pAccelerationStructures, queryType, in_queryPool, firstQuery);
     }
 }
 
@@ -7645,8 +7645,8 @@ void VulkanReplayConsumer::Process_vkCompileDeferredNV(
     format::HandleId                            pipeline,
     uint32_t                                    shader)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &VulkanObjectInfoTable::GetVkPipelineInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &CommonObjectInfoTable::GetVkPipelineInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->CompileDeferredNV(in_device, in_pipeline, shader);
     CheckResult("vkCompileDeferredNV", returnValue, replay_result, call_info);
@@ -7660,7 +7660,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
     uint64_t                                    pHostPointer,
     StructPointerDecoder<Decoded_VkMemoryHostPointerPropertiesEXT>* pMemoryHostPointerProperties)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const void* in_pHostPointer = PreProcessExternalObject(pHostPointer, format::ApiCallId::ApiCall_vkGetMemoryHostPointerPropertiesEXT, "vkGetMemoryHostPointerPropertiesEXT");
     VkMemoryHostPointerPropertiesEXT* out_pMemoryHostPointerProperties = pMemoryHostPointerProperties->IsNull() ? nullptr : pMemoryHostPointerProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT, nullptr });
     InitializeOutputStructPNext(pMemoryHostPointerProperties);
@@ -7677,14 +7677,14 @@ void VulkanReplayConsumer::Process_vkCmdWriteBufferMarkerAMD(
     VkDeviceSize                                dstOffset,
     uint32_t                                    marker)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_dstBuffer = MapHandle<VulkanBufferInfo>(dstBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdWriteBufferMarkerAMD(in_commandBuffer, pipelineStage, in_dstBuffer, dstOffset, marker);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWriteBufferMarkerAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteBufferMarkerAMD, in_commandBuffer, pipelineStage, in_dstBuffer, dstOffset, marker);
+        resource_dumper_.Process_vkCmdWriteBufferMarkerAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteBufferMarkerAMD, in_commandBuffer, pipelineStage, in_dstBuffer, dstOffset, marker);
     }
 }
 
@@ -7695,14 +7695,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEX
     PointerDecoder<uint32_t>*                   pTimeDomainCount,
     PointerDecoder<VkTimeDomainKHR>*            pTimeDomains)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pTimeDomainCount = pTimeDomainCount->IsNull() ? nullptr : pTimeDomainCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsEXT, pTimeDomainCount, pTimeDomains, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pTimeDomainCount = pTimeDomainCount->IsNull() ? nullptr : pTimeDomainCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsEXT, pTimeDomainCount, pTimeDomains, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkTimeDomainKHR* out_pTimeDomains = pTimeDomains->IsNull() ? nullptr : pTimeDomains->AllocateOutputData(*out_pTimeDomainCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCalibrateableTimeDomainsEXT(in_physicalDevice, out_pTimeDomainCount, out_pTimeDomains);
     CheckResult("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", returnValue, replay_result, call_info);
 
-    if (pTimeDomains->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsEXT, *out_pTimeDomainCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pTimeDomains->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsEXT, *out_pTimeDomainCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetCalibratedTimestampsEXT(
@@ -7714,7 +7714,7 @@ void VulkanReplayConsumer::Process_vkGetCalibratedTimestampsEXT(
     PointerDecoder<uint64_t>*                   pTimestamps,
     PointerDecoder<uint64_t>*                   pMaxDeviation)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkCalibratedTimestampInfoKHR* in_pTimestampInfos = pTimestampInfos->GetPointer();
     uint64_t* out_pTimestamps = pTimestamps->IsNull() ? nullptr : pTimestamps->AllocateOutputData(timestampCount);
     uint64_t* out_pMaxDeviation = pMaxDeviation->IsNull() ? nullptr : pMaxDeviation->AllocateOutputData(1, static_cast<uint64_t>(0));
@@ -7729,13 +7729,13 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksNV(
     uint32_t                                    taskCount,
     uint32_t                                    firstTask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksNV(in_commandBuffer, taskCount, firstTask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawMeshTasksNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksNV, in_commandBuffer, taskCount, firstTask);
+        resource_dumper_.Process_vkCmdDrawMeshTasksNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksNV, in_commandBuffer, taskCount, firstTask);
     }
 }
 
@@ -7747,14 +7747,14 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
     uint32_t                                    drawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectNV(in_commandBuffer, in_buffer, offset, drawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawMeshTasksIndirectNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectNV, in_commandBuffer, in_buffer, offset, drawCount, stride);
+        resource_dumper_.Process_vkCmdDrawMeshTasksIndirectNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectNV, in_commandBuffer, in_buffer, offset, drawCount, stride);
     }
 }
 
@@ -7768,15 +7768,15 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectCountNV(in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawMeshTasksIndirectCountNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectCountNV, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
+        resource_dumper_.Process_vkCmdDrawMeshTasksIndirectCountNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectCountNV, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -7787,14 +7787,14 @@ void VulkanReplayConsumer::Process_vkCmdSetExclusiveScissorEnableNV(
     uint32_t                                    exclusiveScissorCount,
     PointerDecoder<VkBool32>*                   pExclusiveScissorEnables)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkBool32* in_pExclusiveScissorEnables = pExclusiveScissorEnables->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetExclusiveScissorEnableNV(in_commandBuffer, firstExclusiveScissor, exclusiveScissorCount, in_pExclusiveScissorEnables);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetExclusiveScissorEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExclusiveScissorEnableNV, in_commandBuffer, firstExclusiveScissor, exclusiveScissorCount, in_pExclusiveScissorEnables);
+        resource_dumper_.Process_vkCmdSetExclusiveScissorEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExclusiveScissorEnableNV, in_commandBuffer, firstExclusiveScissor, exclusiveScissorCount, in_pExclusiveScissorEnables);
     }
 }
 
@@ -7805,14 +7805,14 @@ void VulkanReplayConsumer::Process_vkCmdSetExclusiveScissorNV(
     uint32_t                                    exclusiveScissorCount,
     StructPointerDecoder<Decoded_VkRect2D>*     pExclusiveScissors)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkRect2D* in_pExclusiveScissors = pExclusiveScissors->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetExclusiveScissorNV(in_commandBuffer, firstExclusiveScissor, exclusiveScissorCount, in_pExclusiveScissors);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetExclusiveScissorNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExclusiveScissorNV, in_commandBuffer, firstExclusiveScissor, exclusiveScissorCount, in_pExclusiveScissors);
+        resource_dumper_.Process_vkCmdSetExclusiveScissorNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExclusiveScissorNV, in_commandBuffer, firstExclusiveScissor, exclusiveScissorCount, in_pExclusiveScissors);
     }
 }
 
@@ -7821,14 +7821,14 @@ void VulkanReplayConsumer::Process_vkCmdSetCheckpointNV(
     format::HandleId                            commandBuffer,
     uint64_t                                    pCheckpointMarker)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const void* in_pCheckpointMarker = PreProcessExternalObject(pCheckpointMarker, format::ApiCallId::ApiCall_vkCmdSetCheckpointNV, "vkCmdSetCheckpointNV");
 
     GetDeviceTable(in_commandBuffer)->CmdSetCheckpointNV(in_commandBuffer, in_pCheckpointMarker);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetCheckpointNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCheckpointNV, in_commandBuffer, in_pCheckpointMarker);
+        resource_dumper_.Process_vkCmdSetCheckpointNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCheckpointNV, in_commandBuffer, in_pCheckpointMarker);
     }
 }
 
@@ -7838,13 +7838,13 @@ void VulkanReplayConsumer::Process_vkGetQueueCheckpointDataNV(
     PointerDecoder<uint32_t>*                   pCheckpointDataCount,
     StructPointerDecoder<Decoded_VkCheckpointDataNV>* pCheckpointData)
 {
-    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &VulkanObjectInfoTable::GetVkQueueInfo);
-    uint32_t* out_pCheckpointDataCount = pCheckpointDataCount->IsNull() ? nullptr : pCheckpointDataCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanQueueInfo>("vkGetQueueCheckpointDataNV", VK_SUCCESS, queue, kQueueArrayGetQueueCheckpointDataNV, pCheckpointDataCount, pCheckpointData, &VulkanObjectInfoTable::GetVkQueueInfo));
+    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &CommonObjectInfoTable::GetVkQueueInfo);
+    uint32_t* out_pCheckpointDataCount = pCheckpointDataCount->IsNull() ? nullptr : pCheckpointDataCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanQueueInfo>("vkGetQueueCheckpointDataNV", VK_SUCCESS, queue, kQueueArrayGetQueueCheckpointDataNV, pCheckpointDataCount, pCheckpointData, &CommonObjectInfoTable::GetVkQueueInfo));
     VkCheckpointDataNV* out_pCheckpointData = pCheckpointData->IsNull() ? nullptr : pCheckpointData->AllocateOutputData(*out_pCheckpointDataCount, VkCheckpointDataNV{ VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV, nullptr });
 
     GetDeviceTable(in_queue)->GetQueueCheckpointDataNV(in_queue, out_pCheckpointDataCount, out_pCheckpointData);
 
-    if (pCheckpointData->IsNull()) { SetOutputArrayCount<VulkanQueueInfo>(queue, kQueueArrayGetQueueCheckpointDataNV, *out_pCheckpointDataCount, &VulkanObjectInfoTable::GetVkQueueInfo); }
+    if (pCheckpointData->IsNull()) { SetOutputArrayCount<VulkanQueueInfo>(queue, kQueueArrayGetQueueCheckpointDataNV, *out_pCheckpointDataCount, &CommonObjectInfoTable::GetVkQueueInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkInitializePerformanceApiINTEL(
@@ -7853,7 +7853,7 @@ void VulkanReplayConsumer::Process_vkInitializePerformanceApiINTEL(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>* pInitializeInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkInitializePerformanceApiInfoINTEL* in_pInitializeInfo = pInitializeInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->InitializePerformanceApiINTEL(in_device, in_pInitializeInfo);
@@ -7864,7 +7864,7 @@ void VulkanReplayConsumer::Process_vkUninitializePerformanceApiINTEL(
     const ApiCallInfo&                          call_info,
     format::HandleId                            device)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
 
     GetDeviceTable(in_device)->UninitializePerformanceApiINTEL(in_device);
 }
@@ -7875,7 +7875,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>* pMarkerInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkPerformanceMarkerInfoINTEL* in_pMarkerInfo = pMarkerInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_commandBuffer)->CmdSetPerformanceMarkerINTEL(in_commandBuffer, in_pMarkerInfo);
@@ -7883,7 +7883,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetPerformanceMarkerINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceMarkerINTEL, returnValue, in_commandBuffer, in_pMarkerInfo);
+        resource_dumper_.Process_vkCmdSetPerformanceMarkerINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceMarkerINTEL, returnValue, in_commandBuffer, in_pMarkerInfo);
     }
 }
 
@@ -7893,7 +7893,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>* pMarkerInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkPerformanceStreamMarkerInfoINTEL* in_pMarkerInfo = pMarkerInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_commandBuffer)->CmdSetPerformanceStreamMarkerINTEL(in_commandBuffer, in_pMarkerInfo);
@@ -7901,7 +7901,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetPerformanceStreamMarkerINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceStreamMarkerINTEL, returnValue, in_commandBuffer, in_pMarkerInfo);
+        resource_dumper_.Process_vkCmdSetPerformanceStreamMarkerINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceStreamMarkerINTEL, returnValue, in_commandBuffer, in_pMarkerInfo);
     }
 }
 
@@ -7911,7 +7911,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>* pOverrideInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkPerformanceOverrideInfoINTEL* in_pOverrideInfo = pOverrideInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_commandBuffer)->CmdSetPerformanceOverrideINTEL(in_commandBuffer, in_pOverrideInfo);
@@ -7919,7 +7919,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetPerformanceOverrideINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceOverrideINTEL, returnValue, in_commandBuffer, in_pOverrideInfo);
+        resource_dumper_.Process_vkCmdSetPerformanceOverrideINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceOverrideINTEL, returnValue, in_commandBuffer, in_pOverrideInfo);
     }
 }
 
@@ -7930,7 +7930,7 @@ void VulkanReplayConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
     StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>* pAcquireInfo,
     HandlePointerDecoder<VkPerformanceConfigurationINTEL>* pConfiguration)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPerformanceConfigurationAcquireInfoINTEL* in_pAcquireInfo = pAcquireInfo->GetPointer();
     if (!pConfiguration->IsNull()) { pConfiguration->SetHandleLength(1); }
     VkPerformanceConfigurationINTEL* out_pConfiguration = pConfiguration->GetHandlePointer();
@@ -7938,7 +7938,7 @@ void VulkanReplayConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
     VkResult replay_result = GetDeviceTable(in_device)->AcquirePerformanceConfigurationINTEL(in_device, in_pAcquireInfo, out_pConfiguration);
     CheckResult("vkAcquirePerformanceConfigurationINTEL", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanPerformanceConfigurationINTELInfo>(device, pConfiguration->GetPointer(), out_pConfiguration, &VulkanObjectInfoTable::AddVkPerformanceConfigurationINTELInfo);
+    AddHandle<VulkanPerformanceConfigurationINTELInfo>(device, pConfiguration->GetPointer(), out_pConfiguration, &CommonObjectInfoTable::AddVkPerformanceConfigurationINTELInfo);
 }
 
 void VulkanReplayConsumer::Process_vkReleasePerformanceConfigurationINTEL(
@@ -7947,8 +7947,8 @@ void VulkanReplayConsumer::Process_vkReleasePerformanceConfigurationINTEL(
     format::HandleId                            device,
     format::HandleId                            configuration)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPerformanceConfigurationINTEL in_configuration = MapHandle<VulkanPerformanceConfigurationINTELInfo>(configuration, &VulkanObjectInfoTable::GetVkPerformanceConfigurationINTELInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPerformanceConfigurationINTEL in_configuration = MapHandle<VulkanPerformanceConfigurationINTELInfo>(configuration, &CommonObjectInfoTable::GetVkPerformanceConfigurationINTELInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->ReleasePerformanceConfigurationINTEL(in_device, in_configuration);
     CheckResult("vkReleasePerformanceConfigurationINTEL", returnValue, replay_result, call_info);
@@ -7960,8 +7960,8 @@ void VulkanReplayConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
     format::HandleId                            queue,
     format::HandleId                            configuration)
 {
-    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &VulkanObjectInfoTable::GetVkQueueInfo);
-    VkPerformanceConfigurationINTEL in_configuration = MapHandle<VulkanPerformanceConfigurationINTELInfo>(configuration, &VulkanObjectInfoTable::GetVkPerformanceConfigurationINTELInfo);
+    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &CommonObjectInfoTable::GetVkQueueInfo);
+    VkPerformanceConfigurationINTEL in_configuration = MapHandle<VulkanPerformanceConfigurationINTELInfo>(configuration, &CommonObjectInfoTable::GetVkPerformanceConfigurationINTELInfo);
 
     VkResult replay_result = GetDeviceTable(in_queue)->QueueSetPerformanceConfigurationINTEL(in_queue, in_configuration);
     CheckResult("vkQueueSetPerformanceConfigurationINTEL", returnValue, replay_result, call_info);
@@ -7974,7 +7974,7 @@ void VulkanReplayConsumer::Process_vkGetPerformanceParameterINTEL(
     VkPerformanceParameterTypeINTEL             parameter,
     StructPointerDecoder<Decoded_VkPerformanceValueINTEL>* pValue)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     VkPerformanceValueINTEL* out_pValue = pValue->IsNull() ? nullptr : pValue->AllocateOutputData(1);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPerformanceParameterINTEL(in_device, parameter, out_pValue);
@@ -7992,8 +7992,8 @@ void VulkanReplayConsumer::Process_vkSetLocalDimmingAMD(
         GFXRECON_LOG_DEBUG("Skip vkSetLocalDimmingAMD for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapChain = MapHandle<VulkanSwapchainKHRInfo>(swapChain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapChain = MapHandle<VulkanSwapchainKHRInfo>(swapChain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
 
     GetDeviceTable(in_device)->SetLocalDimmingAMD(in_device, in_swapChain, localDimmingEnable);
 }
@@ -8006,7 +8006,7 @@ void VulkanReplayConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
     const VkImagePipeSurfaceCreateInfoFUCHSIA* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pSurface->IsNull()) { pSurface->SetHandleLength(1); }
@@ -8015,7 +8015,7 @@ void VulkanReplayConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateImagePipeSurfaceFUCHSIA(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateImagePipeSurfaceFUCHSIA", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateMetalSurfaceEXT(
@@ -8034,7 +8034,7 @@ void VulkanReplayConsumer::Process_vkCreateMetalSurfaceEXT(
     VkResult replay_result = OverrideCreateMetalSurfaceEXT(GetInstanceTable(in_instance->handle)->CreateMetalSurfaceEXT, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateMetalSurfaceEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressEXT(
@@ -8058,13 +8058,13 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
     StructPointerDecoder<Decoded_VkPhysicalDeviceToolProperties>* pToolProperties)
 {
     auto in_physicalDevice = GetObjectInfoTable().GetVkPhysicalDeviceInfo(physicalDevice);
-    pToolCount->IsNull() ? nullptr : pToolCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceToolPropertiesEXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceToolPropertiesEXT, pToolCount, pToolProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    pToolCount->IsNull() ? nullptr : pToolCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceToolPropertiesEXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceToolPropertiesEXT, pToolCount, pToolProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     if (!pToolProperties->IsNull()) { pToolProperties->AllocateOutputData(*pToolCount->GetOutputPointer(), VkPhysicalDeviceToolProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES, nullptr }); }
 
     VkResult replay_result = OverrideGetPhysicalDeviceToolProperties(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceToolPropertiesEXT, returnValue, in_physicalDevice, pToolCount, pToolProperties);
     CheckResult("vkGetPhysicalDeviceToolPropertiesEXT", returnValue, replay_result, call_info);
 
-    if (pToolProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceToolPropertiesEXT, *pToolCount->GetOutputPointer(), &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pToolProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceToolPropertiesEXT, *pToolCount->GetOutputPointer(), &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
@@ -8074,14 +8074,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertie
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>* pProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesNV, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesNV, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkCooperativeMatrixPropertiesNV* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkCooperativeMatrixPropertiesNV{ VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesNV(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", returnValue, replay_result, call_info);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesNV, *out_pPropertyCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesNV, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(
@@ -8091,14 +8091,14 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedS
     PointerDecoder<uint32_t>*                   pCombinationCount,
     StructPointerDecoder<Decoded_VkFramebufferMixedSamplesCombinationNV>* pCombinations)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    uint32_t* out_pCombinationCount = pCombinationCount->IsNull() ? nullptr : pCombinationCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, pCombinationCount, pCombinations, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    uint32_t* out_pCombinationCount = pCombinationCount->IsNull() ? nullptr : pCombinationCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, pCombinationCount, pCombinations, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkFramebufferMixedSamplesCombinationNV* out_pCombinations = pCombinations->IsNull() ? nullptr : pCombinations->AllocateOutputData(*out_pCombinationCount, VkFramebufferMixedSamplesCombinationNV{ VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(in_physicalDevice, out_pCombinationCount, out_pCombinations);
     CheckResult("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", returnValue, replay_result, call_info);
 
-    if (pCombinations->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, *out_pCombinationCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pCombinations->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, *out_pCombinationCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
@@ -8114,19 +8114,19 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
         GFXRECON_LOG_DEBUG("Skip vkGetPhysicalDeviceSurfacePresentModes2EXT for offscreen.");
         return;
     }
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkPhysicalDeviceSurfaceInfo2KHR* in_pSurfaceInfo = pSurfaceInfo->GetPointer();
     if (pSurfaceInfo->GetPointer()->surface == VK_NULL_HANDLE) { return; }
     MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
     auto in_pSurfaceInfo_meta = pSurfaceInfo->GetMetaStructPointer();
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(in_pSurfaceInfo_meta->surface) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(in_pSurfaceInfo_meta->surface)->surface_creation_skipped) { return; }
-    uint32_t* out_pPresentModeCount = pPresentModeCount->IsNull() ? nullptr : pPresentModeCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSurfacePresentModes2EXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfacePresentModes2EXT, pPresentModeCount, pPresentModes, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    uint32_t* out_pPresentModeCount = pPresentModeCount->IsNull() ? nullptr : pPresentModeCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceSurfacePresentModes2EXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfacePresentModes2EXT, pPresentModeCount, pPresentModes, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkPresentModeKHR* out_pPresentModes = pPresentModes->IsNull() ? nullptr : pPresentModes->AllocateOutputData(*out_pPresentModeCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfacePresentModes2EXT(in_physicalDevice, in_pSurfaceInfo, out_pPresentModeCount, out_pPresentModes);
     CheckResult("vkGetPhysicalDeviceSurfacePresentModes2EXT", returnValue, replay_result, call_info);
 
-    if (pPresentModes->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfacePresentModes2EXT, *out_pPresentModeCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pPresentModes->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfacePresentModes2EXT, *out_pPresentModeCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
@@ -8140,8 +8140,8 @@ void VulkanReplayConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
         GFXRECON_LOG_DEBUG("Skip vkAcquireFullScreenExclusiveModeEXT for offscreen or force windowed mode.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
 
     VkResult replay_result = GetDeviceTable(in_device)->AcquireFullScreenExclusiveModeEXT(in_device, in_swapchain);
@@ -8159,8 +8159,8 @@ void VulkanReplayConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
         GFXRECON_LOG_DEBUG("Skip vkReleaseFullScreenExclusiveModeEXT for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
 
     VkResult replay_result = GetDeviceTable(in_device)->ReleaseFullScreenExclusiveModeEXT(in_device, in_swapchain);
@@ -8179,7 +8179,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
         GFXRECON_LOG_DEBUG("Skip vkGetDeviceGroupSurfacePresentModes2EXT for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPhysicalDeviceSurfaceInfo2KHR* in_pSurfaceInfo = pSurfaceInfo->GetPointer();
     if (pSurfaceInfo->GetPointer()->surface == VK_NULL_HANDLE) { return; }
     MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
@@ -8207,7 +8207,7 @@ void VulkanReplayConsumer::Process_vkCreateHeadlessSurfaceEXT(
     VkResult replay_result = OverrideCreateHeadlessSurfaceEXT(GetInstanceTable(in_instance->handle)->CreateHeadlessSurfaceEXT, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateHeadlessSurfaceEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetLineStippleEXT(
@@ -8216,13 +8216,13 @@ void VulkanReplayConsumer::Process_vkCmdSetLineStippleEXT(
     uint32_t                                    lineStippleFactor,
     uint16_t                                    lineStipplePattern)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetLineStippleEXT(in_commandBuffer, lineStippleFactor, lineStipplePattern);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetLineStippleEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleEXT, in_commandBuffer, lineStippleFactor, lineStipplePattern);
+        resource_dumper_.Process_vkCmdSetLineStippleEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleEXT, in_commandBuffer, lineStippleFactor, lineStipplePattern);
     }
 }
 
@@ -8233,8 +8233,8 @@ void VulkanReplayConsumer::Process_vkResetQueryPoolEXT(
     uint32_t                                    firstQuery,
     uint32_t                                    queryCount)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_device)->ResetQueryPoolEXT(in_device, in_queryPool, firstQuery, queryCount);
 }
@@ -8244,13 +8244,13 @@ void VulkanReplayConsumer::Process_vkCmdSetCullModeEXT(
     format::HandleId                            commandBuffer,
     VkCullModeFlags                             cullMode)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetCullModeEXT(in_commandBuffer, cullMode);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetCullModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCullModeEXT, in_commandBuffer, cullMode);
+        resource_dumper_.Process_vkCmdSetCullModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCullModeEXT, in_commandBuffer, cullMode);
     }
 }
 
@@ -8259,13 +8259,13 @@ void VulkanReplayConsumer::Process_vkCmdSetFrontFaceEXT(
     format::HandleId                            commandBuffer,
     VkFrontFace                                 frontFace)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetFrontFaceEXT(in_commandBuffer, frontFace);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetFrontFaceEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFrontFaceEXT, in_commandBuffer, frontFace);
+        resource_dumper_.Process_vkCmdSetFrontFaceEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFrontFaceEXT, in_commandBuffer, frontFace);
     }
 }
 
@@ -8274,13 +8274,13 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveTopologyEXT(
     format::HandleId                            commandBuffer,
     VkPrimitiveTopology                         primitiveTopology)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveTopologyEXT(in_commandBuffer, primitiveTopology);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetPrimitiveTopologyEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveTopologyEXT, in_commandBuffer, primitiveTopology);
+        resource_dumper_.Process_vkCmdSetPrimitiveTopologyEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveTopologyEXT, in_commandBuffer, primitiveTopology);
     }
 }
 
@@ -8290,14 +8290,14 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWithCountEXT(
     uint32_t                                    viewportCount,
     StructPointerDecoder<Decoded_VkViewport>*   pViewports)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkViewport* in_pViewports = pViewports->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetViewportWithCountEXT(in_commandBuffer, viewportCount, in_pViewports);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetViewportWithCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWithCountEXT, in_commandBuffer, viewportCount, in_pViewports);
+        resource_dumper_.Process_vkCmdSetViewportWithCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWithCountEXT, in_commandBuffer, viewportCount, in_pViewports);
     }
 }
 
@@ -8307,14 +8307,14 @@ void VulkanReplayConsumer::Process_vkCmdSetScissorWithCountEXT(
     uint32_t                                    scissorCount,
     StructPointerDecoder<Decoded_VkRect2D>*     pScissors)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkRect2D* in_pScissors = pScissors->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetScissorWithCountEXT(in_commandBuffer, scissorCount, in_pScissors);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetScissorWithCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissorWithCountEXT, in_commandBuffer, scissorCount, in_pScissors);
+        resource_dumper_.Process_vkCmdSetScissorWithCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissorWithCountEXT, in_commandBuffer, scissorCount, in_pScissors);
     }
 }
 
@@ -8328,8 +8328,8 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers2EXT(
     PointerDecoder<VkDeviceSize>*               pSizes,
     PointerDecoder<VkDeviceSize>*               pStrides)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkBuffer* in_pBuffers = MapHandles<VulkanBufferInfo>(pBuffers, bindingCount, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkBuffer* in_pBuffers = MapHandles<VulkanBufferInfo>(pBuffers, bindingCount, &CommonObjectInfoTable::GetVkBufferInfo);
     const VkDeviceSize* in_pOffsets = pOffsets->GetPointer();
     const VkDeviceSize* in_pSizes = pSizes->GetPointer();
     const VkDeviceSize* in_pStrides = pStrides->GetPointer();
@@ -8338,7 +8338,7 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers2EXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindVertexBuffers2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers2EXT, in_commandBuffer, firstBinding, bindingCount, in_pBuffers, in_pOffsets, in_pSizes, in_pStrides);
+        resource_dumper_.Process_vkCmdBindVertexBuffers2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers2EXT, in_commandBuffer, firstBinding, bindingCount, in_pBuffers, in_pOffsets, in_pSizes, in_pStrides);
     }
 }
 
@@ -8347,13 +8347,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthTestEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    depthTestEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthTestEnableEXT(in_commandBuffer, depthTestEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthTestEnableEXT, in_commandBuffer, depthTestEnable);
+        resource_dumper_.Process_vkCmdSetDepthTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthTestEnableEXT, in_commandBuffer, depthTestEnable);
     }
 }
 
@@ -8362,13 +8362,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthWriteEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    depthWriteEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthWriteEnableEXT(in_commandBuffer, depthWriteEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthWriteEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthWriteEnableEXT, in_commandBuffer, depthWriteEnable);
+        resource_dumper_.Process_vkCmdSetDepthWriteEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthWriteEnableEXT, in_commandBuffer, depthWriteEnable);
     }
 }
 
@@ -8377,13 +8377,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthCompareOpEXT(
     format::HandleId                            commandBuffer,
     VkCompareOp                                 depthCompareOp)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthCompareOpEXT(in_commandBuffer, depthCompareOp);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthCompareOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthCompareOpEXT, in_commandBuffer, depthCompareOp);
+        resource_dumper_.Process_vkCmdSetDepthCompareOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthCompareOpEXT, in_commandBuffer, depthCompareOp);
     }
 }
 
@@ -8392,13 +8392,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBoundsTestEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBoundsTestEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthBoundsTestEnableEXT(in_commandBuffer, depthBoundsTestEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthBoundsTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBoundsTestEnableEXT, in_commandBuffer, depthBoundsTestEnable);
+        resource_dumper_.Process_vkCmdSetDepthBoundsTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBoundsTestEnableEXT, in_commandBuffer, depthBoundsTestEnable);
     }
 }
 
@@ -8407,13 +8407,13 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilTestEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    stencilTestEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetStencilTestEnableEXT(in_commandBuffer, stencilTestEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetStencilTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilTestEnableEXT, in_commandBuffer, stencilTestEnable);
+        resource_dumper_.Process_vkCmdSetStencilTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilTestEnableEXT, in_commandBuffer, stencilTestEnable);
     }
 }
 
@@ -8426,13 +8426,13 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilOpEXT(
     VkStencilOp                                 depthFailOp,
     VkCompareOp                                 compareOp)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetStencilOpEXT(in_commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetStencilOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilOpEXT, in_commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
+        resource_dumper_.Process_vkCmdSetStencilOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilOpEXT, in_commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
     }
 }
 
@@ -8442,7 +8442,7 @@ void VulkanReplayConsumer::Process_vkCopyMemoryToImageEXT(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkCopyMemoryToImageInfoEXT>* pCopyMemoryToImageInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkCopyMemoryToImageInfoEXT* in_pCopyMemoryToImageInfo = pCopyMemoryToImageInfo->GetPointer();
     MapStructHandles(pCopyMemoryToImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -8456,7 +8456,7 @@ void VulkanReplayConsumer::Process_vkCopyImageToMemoryEXT(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkCopyImageToMemoryInfoEXT>* pCopyImageToMemoryInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkCopyImageToMemoryInfoEXT* in_pCopyImageToMemoryInfo = pCopyImageToMemoryInfo->GetPointer();
     MapStructHandles(pCopyImageToMemoryInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -8470,7 +8470,7 @@ void VulkanReplayConsumer::Process_vkCopyImageToImageEXT(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkCopyImageToImageInfoEXT>* pCopyImageToImageInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkCopyImageToImageInfoEXT* in_pCopyImageToImageInfo = pCopyImageToImageInfo->GetPointer();
     MapStructHandles(pCopyImageToImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -8485,7 +8485,7 @@ void VulkanReplayConsumer::Process_vkTransitionImageLayoutEXT(
     uint32_t                                    transitionCount,
     StructPointerDecoder<Decoded_VkHostImageLayoutTransitionInfoEXT>* pTransitions)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkHostImageLayoutTransitionInfoEXT* in_pTransitions = pTransitions->GetPointer();
     MapStructArrayHandles(pTransitions->GetMetaStructPointer(), pTransitions->GetLength(), GetObjectInfoTable());
 
@@ -8500,8 +8500,8 @@ void VulkanReplayConsumer::Process_vkGetImageSubresourceLayout2EXT(
     StructPointerDecoder<Decoded_VkImageSubresource2KHR>* pSubresource,
     StructPointerDecoder<Decoded_VkSubresourceLayout2KHR>* pLayout)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkImage in_image = MapHandle<VulkanImageInfo>(image, &VulkanObjectInfoTable::GetVkImageInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkImage in_image = MapHandle<VulkanImageInfo>(image, &CommonObjectInfoTable::GetVkImageInfo);
     const VkImageSubresource2KHR* in_pSubresource = pSubresource->GetPointer();
     VkSubresourceLayout2KHR* out_pLayout = pLayout->IsNull() ? nullptr : pLayout->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR, nullptr });
     InitializeOutputStructPNext(pLayout);
@@ -8520,7 +8520,7 @@ void VulkanReplayConsumer::Process_vkReleaseSwapchainImagesEXT(
         GFXRECON_LOG_DEBUG("Skip vkReleaseSwapchainImagesEXT for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkReleaseSwapchainImagesInfoEXT* in_pReleaseInfo = pReleaseInfo->GetPointer();
     MapStructHandles(pReleaseInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -8534,7 +8534,7 @@ void VulkanReplayConsumer::Process_vkGetGeneratedCommandsMemoryRequirementsNV(
     StructPointerDecoder<Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkGeneratedCommandsMemoryRequirementsInfoNV* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
@@ -8548,7 +8548,7 @@ void VulkanReplayConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkGeneratedCommandsInfoNV* in_pGeneratedCommandsInfo = pGeneratedCommandsInfo->GetPointer();
     MapStructHandles(pGeneratedCommandsInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -8556,7 +8556,7 @@ void VulkanReplayConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdPreprocessGeneratedCommandsNV(call_info, GetDeviceTable(in_commandBuffer)->CmdPreprocessGeneratedCommandsNV, in_commandBuffer, in_pGeneratedCommandsInfo);
+        resource_dumper_.Process_vkCmdPreprocessGeneratedCommandsNV(call_info, GetDeviceTable(in_commandBuffer)->CmdPreprocessGeneratedCommandsNV, in_commandBuffer, in_pGeneratedCommandsInfo);
     }
 }
 
@@ -8566,7 +8566,7 @@ void VulkanReplayConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
     VkBool32                                    isPreprocessed,
     StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkGeneratedCommandsInfoNV* in_pGeneratedCommandsInfo = pGeneratedCommandsInfo->GetPointer();
     MapStructHandles(pGeneratedCommandsInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -8574,7 +8574,7 @@ void VulkanReplayConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdExecuteGeneratedCommandsNV(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteGeneratedCommandsNV, in_commandBuffer, isPreprocessed, in_pGeneratedCommandsInfo);
+        resource_dumper_.Process_vkCmdExecuteGeneratedCommandsNV(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteGeneratedCommandsNV, in_commandBuffer, isPreprocessed, in_pGeneratedCommandsInfo);
     }
 }
 
@@ -8585,14 +8585,14 @@ void VulkanReplayConsumer::Process_vkCmdBindPipelineShaderGroupNV(
     format::HandleId                            pipeline,
     uint32_t                                    groupIndex)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &VulkanObjectInfoTable::GetVkPipelineInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &CommonObjectInfoTable::GetVkPipelineInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdBindPipelineShaderGroupNV(in_commandBuffer, pipelineBindPoint, in_pipeline, groupIndex);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindPipelineShaderGroupNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBindPipelineShaderGroupNV, in_commandBuffer, pipelineBindPoint, in_pipeline, groupIndex);
+        resource_dumper_.Process_vkCmdBindPipelineShaderGroupNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBindPipelineShaderGroupNV, in_commandBuffer, pipelineBindPoint, in_pipeline, groupIndex);
     }
 }
 
@@ -8604,7 +8604,7 @@ void VulkanReplayConsumer::Process_vkCreateIndirectCommandsLayoutNV(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkIndirectCommandsLayoutNV>* pIndirectCommandsLayout)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkIndirectCommandsLayoutCreateInfoNV* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -8614,7 +8614,7 @@ void VulkanReplayConsumer::Process_vkCreateIndirectCommandsLayoutNV(
     VkResult replay_result = GetDeviceTable(in_device)->CreateIndirectCommandsLayoutNV(in_device, in_pCreateInfo, in_pAllocator, out_pIndirectCommandsLayout);
     CheckResult("vkCreateIndirectCommandsLayoutNV", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanIndirectCommandsLayoutNVInfo>(device, pIndirectCommandsLayout->GetPointer(), out_pIndirectCommandsLayout, &VulkanObjectInfoTable::AddVkIndirectCommandsLayoutNVInfo);
+    AddHandle<VulkanIndirectCommandsLayoutNVInfo>(device, pIndirectCommandsLayout->GetPointer(), out_pIndirectCommandsLayout, &CommonObjectInfoTable::AddVkIndirectCommandsLayoutNVInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
@@ -8623,12 +8623,12 @@ void VulkanReplayConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
     format::HandleId                            indirectCommandsLayout,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkIndirectCommandsLayoutNV in_indirectCommandsLayout = MapHandle<VulkanIndirectCommandsLayoutNVInfo>(indirectCommandsLayout, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkIndirectCommandsLayoutNV in_indirectCommandsLayout = MapHandle<VulkanIndirectCommandsLayoutNVInfo>(indirectCommandsLayout, &CommonObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyIndirectCommandsLayoutNV(in_device, in_indirectCommandsLayout, in_pAllocator);
-    RemoveHandle(indirectCommandsLayout, &VulkanObjectInfoTable::RemoveVkIndirectCommandsLayoutNVInfo);
+    RemoveHandle(indirectCommandsLayout, &CommonObjectInfoTable::RemoveVkIndirectCommandsLayoutNVInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthBias2EXT(
@@ -8636,14 +8636,14 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBias2EXT(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDepthBiasInfoEXT>* pDepthBiasInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkDepthBiasInfoEXT* in_pDepthBiasInfo = pDepthBiasInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthBias2EXT(in_commandBuffer, in_pDepthBiasInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthBias2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBias2EXT, in_commandBuffer, in_pDepthBiasInfo);
+        resource_dumper_.Process_vkCmdSetDepthBias2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBias2EXT, in_commandBuffer, in_pDepthBiasInfo);
     }
 }
 
@@ -8654,8 +8654,8 @@ void VulkanReplayConsumer::Process_vkAcquireDrmDisplayEXT(
     int32_t                                     drmFd,
     format::HandleId                            display)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->AcquireDrmDisplayEXT(in_physicalDevice, drmFd, in_display);
     CheckResult("vkAcquireDrmDisplayEXT", returnValue, replay_result, call_info);
@@ -8669,14 +8669,14 @@ void VulkanReplayConsumer::Process_vkGetDrmDisplayEXT(
     uint32_t                                    connectorId,
     HandlePointerDecoder<VkDisplayKHR>*         display)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     if (!display->IsNull()) { display->SetHandleLength(1); }
     VkDisplayKHR* out_display = display->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDrmDisplayEXT(in_physicalDevice, drmFd, connectorId, out_display);
     CheckResult("vkGetDrmDisplayEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDisplayKHRInfo>(physicalDevice, display->GetPointer(), out_display, &VulkanObjectInfoTable::AddVkDisplayKHRInfo);
+    AddHandle<VulkanDisplayKHRInfo>(physicalDevice, display->GetPointer(), out_display, &CommonObjectInfoTable::AddVkDisplayKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreatePrivateDataSlotEXT(
@@ -8687,7 +8687,7 @@ void VulkanReplayConsumer::Process_vkCreatePrivateDataSlotEXT(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkPrivateDataSlot>*    pPrivateDataSlot)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPrivateDataSlotCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pPrivateDataSlot->IsNull()) { pPrivateDataSlot->SetHandleLength(1); }
@@ -8696,7 +8696,7 @@ void VulkanReplayConsumer::Process_vkCreatePrivateDataSlotEXT(
     VkResult replay_result = GetDeviceTable(in_device)->CreatePrivateDataSlotEXT(in_device, in_pCreateInfo, in_pAllocator, out_pPrivateDataSlot);
     CheckResult("vkCreatePrivateDataSlotEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanPrivateDataSlotInfo>(device, pPrivateDataSlot->GetPointer(), out_pPrivateDataSlot, &VulkanObjectInfoTable::AddVkPrivateDataSlotInfo);
+    AddHandle<VulkanPrivateDataSlotInfo>(device, pPrivateDataSlot->GetPointer(), out_pPrivateDataSlot, &CommonObjectInfoTable::AddVkPrivateDataSlotInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPrivateDataSlotEXT(
@@ -8705,12 +8705,12 @@ void VulkanReplayConsumer::Process_vkDestroyPrivateDataSlotEXT(
     format::HandleId                            privateDataSlot,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &VulkanObjectInfoTable::GetVkPrivateDataSlotInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &CommonObjectInfoTable::GetVkPrivateDataSlotInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyPrivateDataSlotEXT(in_device, in_privateDataSlot, in_pAllocator);
-    RemoveHandle(privateDataSlot, &VulkanObjectInfoTable::RemoveVkPrivateDataSlotInfo);
+    RemoveHandle(privateDataSlot, &CommonObjectInfoTable::RemoveVkPrivateDataSlotInfo);
 }
 
 void VulkanReplayConsumer::Process_vkSetPrivateDataEXT(
@@ -8722,9 +8722,9 @@ void VulkanReplayConsumer::Process_vkSetPrivateDataEXT(
     format::HandleId                            privateDataSlot,
     uint64_t                                    data)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     uint64_t in_objectHandle = MapHandle(objectHandle, objectType);
-    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &VulkanObjectInfoTable::GetVkPrivateDataSlotInfo);
+    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &CommonObjectInfoTable::GetVkPrivateDataSlotInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->SetPrivateDataEXT(in_device, objectType, in_objectHandle, in_privateDataSlot, data);
     CheckResult("vkSetPrivateDataEXT", returnValue, replay_result, call_info);
@@ -8738,9 +8738,9 @@ void VulkanReplayConsumer::Process_vkGetPrivateDataEXT(
     format::HandleId                            privateDataSlot,
     PointerDecoder<uint64_t>*                   pData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     uint64_t in_objectHandle = MapHandle(objectHandle, objectType);
-    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &VulkanObjectInfoTable::GetVkPrivateDataSlotInfo);
+    VkPrivateDataSlot in_privateDataSlot = MapHandle<VulkanPrivateDataSlotInfo>(privateDataSlot, &CommonObjectInfoTable::GetVkPrivateDataSlotInfo);
     uint64_t* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     GetDeviceTable(in_device)->GetPrivateDataEXT(in_device, objectType, in_objectHandle, in_privateDataSlot, out_pData);
@@ -8752,14 +8752,14 @@ void VulkanReplayConsumer::Process_vkCmdSetFragmentShadingRateEnumNV(
     VkFragmentShadingRateNV                     shadingRate,
     PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkFragmentShadingRateCombinerOpKHR* in_combinerOps = combinerOps->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetFragmentShadingRateEnumNV(in_commandBuffer, shadingRate, in_combinerOps);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetFragmentShadingRateEnumNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFragmentShadingRateEnumNV, in_commandBuffer, shadingRate, in_combinerOps);
+        resource_dumper_.Process_vkCmdSetFragmentShadingRateEnumNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFragmentShadingRateEnumNV, in_commandBuffer, shadingRate, in_combinerOps);
     }
 }
 
@@ -8770,7 +8770,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceFaultInfoEXT(
     StructPointerDecoder<Decoded_VkDeviceFaultCountsEXT>* pFaultCounts,
     StructPointerDecoder<Decoded_VkDeviceFaultInfoEXT>* pFaultInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     VkDeviceFaultCountsEXT* out_pFaultCounts = pFaultCounts->IsNull() ? nullptr : pFaultCounts->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DEVICE_FAULT_COUNTS_EXT, nullptr });
     InitializeOutputStructPNext(pFaultCounts);
     VkDeviceFaultInfoEXT* out_pFaultInfo = pFaultInfo->IsNull() ? nullptr : pFaultInfo->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DEVICE_FAULT_INFO_EXT, nullptr });
@@ -8786,8 +8786,8 @@ void VulkanReplayConsumer::Process_vkAcquireWinrtDisplayNV(
     format::HandleId                            physicalDevice,
     format::HandleId                            display)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
-    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkDisplayKHR in_display = MapHandle<VulkanDisplayKHRInfo>(display, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->AcquireWinrtDisplayNV(in_physicalDevice, in_display);
     CheckResult("vkAcquireWinrtDisplayNV", returnValue, replay_result, call_info);
@@ -8800,14 +8800,14 @@ void VulkanReplayConsumer::Process_vkGetWinrtDisplayNV(
     uint32_t                                    deviceRelativeId,
     HandlePointerDecoder<VkDisplayKHR>*         pDisplay)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     if (!pDisplay->IsNull()) { pDisplay->SetHandleLength(1); }
     VkDisplayKHR* out_pDisplay = pDisplay->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetWinrtDisplayNV(in_physicalDevice, deviceRelativeId, out_pDisplay);
     CheckResult("vkGetWinrtDisplayNV", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanDisplayKHRInfo>(physicalDevice, pDisplay->GetPointer(), out_pDisplay, &VulkanObjectInfoTable::AddVkDisplayKHRInfo);
+    AddHandle<VulkanDisplayKHRInfo>(physicalDevice, pDisplay->GetPointer(), out_pDisplay, &CommonObjectInfoTable::AddVkDisplayKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDirectFBSurfaceEXT(
@@ -8818,7 +8818,7 @@ void VulkanReplayConsumer::Process_vkCreateDirectFBSurfaceEXT(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
     const VkDirectFBSurfaceCreateInfoEXT* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pSurface->IsNull()) { pSurface->SetHandleLength(1); }
@@ -8827,7 +8827,7 @@ void VulkanReplayConsumer::Process_vkCreateDirectFBSurfaceEXT(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateDirectFBSurfaceEXT(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateDirectFBSurfaceEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(
@@ -8837,7 +8837,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSuppor
     uint32_t                                    queueFamilyIndex,
     uint64_t                                    dfb)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     IDirectFB* in_dfb = static_cast<IDirectFB*>(PreProcessExternalObject(dfb, format::ApiCallId::ApiCall_vkGetPhysicalDeviceDirectFBPresentationSupportEXT, "vkGetPhysicalDeviceDirectFBPresentationSupportEXT"));
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDirectFBPresentationSupportEXT(in_physicalDevice, queueFamilyIndex, in_dfb);
@@ -8851,7 +8851,7 @@ void VulkanReplayConsumer::Process_vkCmdSetVertexInputEXT(
     uint32_t                                    vertexAttributeDescriptionCount,
     StructPointerDecoder<Decoded_VkVertexInputAttributeDescription2EXT>* pVertexAttributeDescriptions)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkVertexInputBindingDescription2EXT* in_pVertexBindingDescriptions = pVertexBindingDescriptions->GetPointer();
     const VkVertexInputAttributeDescription2EXT* in_pVertexAttributeDescriptions = pVertexAttributeDescriptions->GetPointer();
 
@@ -8859,7 +8859,7 @@ void VulkanReplayConsumer::Process_vkCmdSetVertexInputEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetVertexInputEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetVertexInputEXT, in_commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions);
+        resource_dumper_.Process_vkCmdSetVertexInputEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetVertexInputEXT, in_commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions);
     }
 }
 
@@ -8870,7 +8870,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
     StructPointerDecoder<Decoded_VkMemoryGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
     PointerDecoder<uint32_t>*                   pZirconHandle)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkMemoryGetZirconHandleInfoFUCHSIA* in_pGetZirconHandleInfo = pGetZirconHandleInfo->GetPointer();
     MapStructHandles(pGetZirconHandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
     zx_handle_t* out_pZirconHandle = pZirconHandle->IsNull() ? nullptr : pZirconHandle->AllocateOutputData(1, static_cast<uint32_t>(0));
@@ -8887,7 +8887,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
     uint32_t                                    zirconHandle,
     StructPointerDecoder<Decoded_VkMemoryZirconHandlePropertiesFUCHSIA>* pMemoryZirconHandleProperties)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     VkMemoryZirconHandlePropertiesFUCHSIA* out_pMemoryZirconHandleProperties = pMemoryZirconHandleProperties->IsNull() ? nullptr : pMemoryZirconHandleProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_ZIRCON_HANDLE_PROPERTIES_FUCHSIA, nullptr });
     InitializeOutputStructPNext(pMemoryZirconHandleProperties);
 
@@ -8901,7 +8901,7 @@ void VulkanReplayConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA>* pImportSemaphoreZirconHandleInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkImportSemaphoreZirconHandleInfoFUCHSIA* in_pImportSemaphoreZirconHandleInfo = pImportSemaphoreZirconHandleInfo->GetPointer();
     MapStructHandles(pImportSemaphoreZirconHandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -8916,7 +8916,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
     StructPointerDecoder<Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
     PointerDecoder<uint32_t>*                   pZirconHandle)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkSemaphoreGetZirconHandleInfoFUCHSIA* in_pGetZirconHandleInfo = pGetZirconHandleInfo->GetPointer();
     MapStructHandles(pGetZirconHandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
     zx_handle_t* out_pZirconHandle = pZirconHandle->IsNull() ? nullptr : pZirconHandle->AllocateOutputData(1, static_cast<uint32_t>(0));
@@ -8931,14 +8931,14 @@ void VulkanReplayConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
     format::HandleId                            imageView,
     VkImageLayout                               imageLayout)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkImageView in_imageView = MapHandle<VulkanImageViewInfo>(imageView, &VulkanObjectInfoTable::GetVkImageViewInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkImageView in_imageView = MapHandle<VulkanImageViewInfo>(imageView, &CommonObjectInfoTable::GetVkImageViewInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdBindInvocationMaskHUAWEI(in_commandBuffer, in_imageView, imageLayout);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindInvocationMaskHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdBindInvocationMaskHUAWEI, in_commandBuffer, in_imageView, imageLayout);
+        resource_dumper_.Process_vkCmdBindInvocationMaskHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdBindInvocationMaskHUAWEI, in_commandBuffer, in_imageView, imageLayout);
     }
 }
 
@@ -8949,7 +8949,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryRemoteAddressNV(
     StructPointerDecoder<Decoded_VkMemoryGetRemoteAddressInfoNV>* pMemoryGetRemoteAddressInfo,
     PointerDecoder<uint64_t, void*>*            pAddress)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkMemoryGetRemoteAddressInfoNV* in_pMemoryGetRemoteAddressInfo = pMemoryGetRemoteAddressInfo->GetPointer();
     MapStructHandles(pMemoryGetRemoteAddressInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkRemoteAddressNV* out_pAddress = pAddress->IsNull() ? nullptr : reinterpret_cast<VkRemoteAddressNV*>(pAddress->AllocateOutputData(1));
@@ -8965,13 +8965,13 @@ void VulkanReplayConsumer::Process_vkCmdSetPatchControlPointsEXT(
     format::HandleId                            commandBuffer,
     uint32_t                                    patchControlPoints)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetPatchControlPointsEXT(in_commandBuffer, patchControlPoints);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetPatchControlPointsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPatchControlPointsEXT, in_commandBuffer, patchControlPoints);
+        resource_dumper_.Process_vkCmdSetPatchControlPointsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPatchControlPointsEXT, in_commandBuffer, patchControlPoints);
     }
 }
 
@@ -8980,13 +8980,13 @@ void VulkanReplayConsumer::Process_vkCmdSetRasterizerDiscardEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    rasterizerDiscardEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetRasterizerDiscardEnableEXT(in_commandBuffer, rasterizerDiscardEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetRasterizerDiscardEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizerDiscardEnableEXT, in_commandBuffer, rasterizerDiscardEnable);
+        resource_dumper_.Process_vkCmdSetRasterizerDiscardEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizerDiscardEnableEXT, in_commandBuffer, rasterizerDiscardEnable);
     }
 }
 
@@ -8995,13 +8995,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBiasEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBiasEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthBiasEnableEXT(in_commandBuffer, depthBiasEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthBiasEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBiasEnableEXT, in_commandBuffer, depthBiasEnable);
+        resource_dumper_.Process_vkCmdSetDepthBiasEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBiasEnableEXT, in_commandBuffer, depthBiasEnable);
     }
 }
 
@@ -9010,13 +9010,13 @@ void VulkanReplayConsumer::Process_vkCmdSetLogicOpEXT(
     format::HandleId                            commandBuffer,
     VkLogicOp                                   logicOp)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetLogicOpEXT(in_commandBuffer, logicOp);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetLogicOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLogicOpEXT, in_commandBuffer, logicOp);
+        resource_dumper_.Process_vkCmdSetLogicOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLogicOpEXT, in_commandBuffer, logicOp);
     }
 }
 
@@ -9025,13 +9025,13 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveRestartEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    primitiveRestartEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveRestartEnableEXT(in_commandBuffer, primitiveRestartEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetPrimitiveRestartEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveRestartEnableEXT, in_commandBuffer, primitiveRestartEnable);
+        resource_dumper_.Process_vkCmdSetPrimitiveRestartEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveRestartEnableEXT, in_commandBuffer, primitiveRestartEnable);
     }
 }
 
@@ -9043,7 +9043,7 @@ void VulkanReplayConsumer::Process_vkCreateScreenSurfaceQNX(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
-    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &VulkanObjectInfoTable::GetVkInstanceInfo);
+    VkInstance in_instance = MapHandle<VulkanInstanceInfo>(instance, &CommonObjectInfoTable::GetVkInstanceInfo);
     const VkScreenSurfaceCreateInfoQNX* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pSurface->IsNull()) { pSurface->SetHandleLength(1); }
@@ -9052,7 +9052,7 @@ void VulkanReplayConsumer::Process_vkCreateScreenSurfaceQNX(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateScreenSurfaceQNX(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateScreenSurfaceQNX", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddVkSurfaceKHRInfo);
+    AddHandle<VulkanSurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &CommonObjectInfoTable::AddVkSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQNX(
@@ -9062,7 +9062,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQ
     uint32_t                                    queueFamilyIndex,
     uint64_t                                    window)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     struct _screen_window* in_window = static_cast<struct _screen_window*>(PreProcessExternalObject(window, format::ApiCallId::ApiCall_vkGetPhysicalDeviceScreenPresentationSupportQNX, "vkGetPhysicalDeviceScreenPresentationSupportQNX"));
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceScreenPresentationSupportQNX(in_physicalDevice, queueFamilyIndex, in_window);
@@ -9074,14 +9074,14 @@ void VulkanReplayConsumer::Process_vkCmdSetColorWriteEnableEXT(
     uint32_t                                    attachmentCount,
     PointerDecoder<VkBool32>*                   pColorWriteEnables)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkBool32* in_pColorWriteEnables = pColorWriteEnables->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetColorWriteEnableEXT(in_commandBuffer, attachmentCount, in_pColorWriteEnables);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetColorWriteEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorWriteEnableEXT, in_commandBuffer, attachmentCount, in_pColorWriteEnables);
+        resource_dumper_.Process_vkCmdSetColorWriteEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorWriteEnableEXT, in_commandBuffer, attachmentCount, in_pColorWriteEnables);
     }
 }
 
@@ -9094,14 +9094,14 @@ void VulkanReplayConsumer::Process_vkCmdDrawMultiEXT(
     uint32_t                                    firstInstance,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkMultiDrawInfoEXT* in_pVertexInfo = pVertexInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdDrawMultiEXT(in_commandBuffer, drawCount, in_pVertexInfo, instanceCount, firstInstance, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawMultiEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMultiEXT, in_commandBuffer, drawCount, in_pVertexInfo, instanceCount, firstInstance, stride);
+        resource_dumper_.Process_vkCmdDrawMultiEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMultiEXT, in_commandBuffer, drawCount, in_pVertexInfo, instanceCount, firstInstance, stride);
     }
 }
 
@@ -9115,7 +9115,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMultiIndexedEXT(
     uint32_t                                    stride,
     PointerDecoder<int32_t>*                    pVertexOffset)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkMultiDrawIndexedInfoEXT* in_pIndexInfo = pIndexInfo->GetPointer();
     const int32_t* in_pVertexOffset = pVertexOffset->GetPointer();
 
@@ -9123,7 +9123,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMultiIndexedEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawMultiIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMultiIndexedEXT, in_commandBuffer, drawCount, in_pIndexInfo, instanceCount, firstInstance, stride, in_pVertexOffset);
+        resource_dumper_.Process_vkCmdDrawMultiIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMultiIndexedEXT, in_commandBuffer, drawCount, in_pIndexInfo, instanceCount, firstInstance, stride, in_pVertexOffset);
     }
 }
 
@@ -9135,7 +9135,7 @@ void VulkanReplayConsumer::Process_vkCreateMicromapEXT(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkMicromapEXT>*        pMicromap)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkMicromapCreateInfoEXT* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -9145,7 +9145,7 @@ void VulkanReplayConsumer::Process_vkCreateMicromapEXT(
     VkResult replay_result = GetDeviceTable(in_device)->CreateMicromapEXT(in_device, in_pCreateInfo, in_pAllocator, out_pMicromap);
     CheckResult("vkCreateMicromapEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanMicromapEXTInfo>(device, pMicromap->GetPointer(), out_pMicromap, &VulkanObjectInfoTable::AddVkMicromapEXTInfo);
+    AddHandle<VulkanMicromapEXTInfo>(device, pMicromap->GetPointer(), out_pMicromap, &CommonObjectInfoTable::AddVkMicromapEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyMicromapEXT(
@@ -9154,12 +9154,12 @@ void VulkanReplayConsumer::Process_vkDestroyMicromapEXT(
     format::HandleId                            micromap,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkMicromapEXT in_micromap = MapHandle<VulkanMicromapEXTInfo>(micromap, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkMicromapEXT in_micromap = MapHandle<VulkanMicromapEXTInfo>(micromap, &CommonObjectInfoTable::GetVkMicromapEXTInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyMicromapEXT(in_device, in_micromap, in_pAllocator);
-    RemoveHandle(micromap, &VulkanObjectInfoTable::RemoveVkMicromapEXTInfo);
+    RemoveHandle(micromap, &CommonObjectInfoTable::RemoveVkMicromapEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBuildMicromapsEXT(
@@ -9168,7 +9168,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildMicromapsEXT(
     uint32_t                                    infoCount,
     StructPointerDecoder<Decoded_VkMicromapBuildInfoEXT>* pInfos)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkMicromapBuildInfoEXT* in_pInfos = pInfos->GetPointer();
     MapStructArrayHandles(pInfos->GetMetaStructPointer(), pInfos->GetLength(), GetObjectInfoTable());
 
@@ -9176,7 +9176,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildMicromapsEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBuildMicromapsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildMicromapsEXT, in_commandBuffer, infoCount, in_pInfos);
+        resource_dumper_.Process_vkCmdBuildMicromapsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildMicromapsEXT, in_commandBuffer, infoCount, in_pInfos);
     }
 }
 
@@ -9188,8 +9188,8 @@ void VulkanReplayConsumer::Process_vkBuildMicromapsEXT(
     uint32_t                                    infoCount,
     StructPointerDecoder<Decoded_VkMicromapBuildInfoEXT>* pInfos)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &CommonObjectInfoTable::GetVkDeferredOperationKHRInfo);
     const VkMicromapBuildInfoEXT* in_pInfos = pInfos->GetPointer();
     MapStructArrayHandles(pInfos->GetMetaStructPointer(), pInfos->GetLength(), GetObjectInfoTable());
 
@@ -9204,8 +9204,8 @@ void VulkanReplayConsumer::Process_vkCopyMicromapEXT(
     format::HandleId                            deferredOperation,
     StructPointerDecoder<Decoded_VkCopyMicromapInfoEXT>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &CommonObjectInfoTable::GetVkDeferredOperationKHRInfo);
     const VkCopyMicromapInfoEXT* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -9220,8 +9220,8 @@ void VulkanReplayConsumer::Process_vkCopyMicromapToMemoryEXT(
     format::HandleId                            deferredOperation,
     StructPointerDecoder<Decoded_VkCopyMicromapToMemoryInfoEXT>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &CommonObjectInfoTable::GetVkDeferredOperationKHRInfo);
     const VkCopyMicromapToMemoryInfoEXT* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -9236,8 +9236,8 @@ void VulkanReplayConsumer::Process_vkCopyMemoryToMicromapEXT(
     format::HandleId                            deferredOperation,
     StructPointerDecoder<Decoded_VkCopyMemoryToMicromapInfoEXT>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &CommonObjectInfoTable::GetVkDeferredOperationKHRInfo);
     const VkCopyMemoryToMicromapInfoEXT* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -9256,8 +9256,8 @@ void VulkanReplayConsumer::Process_vkWriteMicromapsPropertiesEXT(
     PointerDecoder<uint8_t>*                    pData,
     size_t                                      stride)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    const VkMicromapEXT* in_pMicromaps = MapHandles<VulkanMicromapEXTInfo>(pMicromaps, micromapCount, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    const VkMicromapEXT* in_pMicromaps = MapHandles<VulkanMicromapEXTInfo>(pMicromaps, micromapCount, &CommonObjectInfoTable::GetVkMicromapEXTInfo);
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->WriteMicromapsPropertiesEXT(in_device, micromapCount, in_pMicromaps, queryType, dataSize, out_pData, stride);
@@ -9269,7 +9269,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMicromapEXT(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyMicromapInfoEXT>* pInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyMicromapInfoEXT* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -9277,7 +9277,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMicromapEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyMicromapEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMicromapEXT, in_commandBuffer, in_pInfo);
+        resource_dumper_.Process_vkCmdCopyMicromapEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMicromapEXT, in_commandBuffer, in_pInfo);
     }
 }
 
@@ -9286,7 +9286,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMicromapToMemoryEXT(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyMicromapToMemoryInfoEXT>* pInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyMicromapToMemoryInfoEXT* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -9294,7 +9294,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMicromapToMemoryEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyMicromapToMemoryEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMicromapToMemoryEXT, in_commandBuffer, in_pInfo);
+        resource_dumper_.Process_vkCmdCopyMicromapToMemoryEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMicromapToMemoryEXT, in_commandBuffer, in_pInfo);
     }
 }
 
@@ -9303,7 +9303,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMemoryToMicromapEXT(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyMemoryToMicromapInfoEXT>* pInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyMemoryToMicromapInfoEXT* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -9311,7 +9311,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMemoryToMicromapEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyMemoryToMicromapEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMemoryToMicromapEXT, in_commandBuffer, in_pInfo);
+        resource_dumper_.Process_vkCmdCopyMemoryToMicromapEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMemoryToMicromapEXT, in_commandBuffer, in_pInfo);
     }
 }
 
@@ -9324,15 +9324,15 @@ void VulkanReplayConsumer::Process_vkCmdWriteMicromapsPropertiesEXT(
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    const VkMicromapEXT* in_pMicromaps = MapHandles<VulkanMicromapEXTInfo>(pMicromaps, micromapCount, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
-    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    const VkMicromapEXT* in_pMicromaps = MapHandles<VulkanMicromapEXTInfo>(pMicromaps, micromapCount, &CommonObjectInfoTable::GetVkMicromapEXTInfo);
+    VkQueryPool in_queryPool = MapHandle<VulkanQueryPoolInfo>(queryPool, &CommonObjectInfoTable::GetVkQueryPoolInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdWriteMicromapsPropertiesEXT(in_commandBuffer, micromapCount, in_pMicromaps, queryType, in_queryPool, firstQuery);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWriteMicromapsPropertiesEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteMicromapsPropertiesEXT, in_commandBuffer, micromapCount, in_pMicromaps, queryType, in_queryPool, firstQuery);
+        resource_dumper_.Process_vkCmdWriteMicromapsPropertiesEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteMicromapsPropertiesEXT, in_commandBuffer, micromapCount, in_pMicromaps, queryType, in_queryPool, firstQuery);
     }
 }
 
@@ -9342,7 +9342,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceMicromapCompatibilityEXT(
     StructPointerDecoder<Decoded_VkMicromapVersionInfoEXT>* pVersionInfo,
     PointerDecoder<VkAccelerationStructureCompatibilityKHR>* pCompatibility)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkMicromapVersionInfoEXT* in_pVersionInfo = pVersionInfo->GetPointer();
     VkAccelerationStructureCompatibilityKHR* out_pCompatibility = pCompatibility->IsNull() ? nullptr : pCompatibility->AllocateOutputData(1, static_cast<VkAccelerationStructureCompatibilityKHR>(0));
 
@@ -9356,7 +9356,7 @@ void VulkanReplayConsumer::Process_vkGetMicromapBuildSizesEXT(
     StructPointerDecoder<Decoded_VkMicromapBuildInfoEXT>* pBuildInfo,
     StructPointerDecoder<Decoded_VkMicromapBuildSizesInfoEXT>* pSizeInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkMicromapBuildInfoEXT* in_pBuildInfo = pBuildInfo->GetPointer();
     MapStructHandles(pBuildInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMicromapBuildSizesInfoEXT* out_pSizeInfo = pSizeInfo->IsNull() ? nullptr : pSizeInfo->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MICROMAP_BUILD_SIZES_INFO_EXT, nullptr });
@@ -9372,13 +9372,13 @@ void VulkanReplayConsumer::Process_vkCmdDrawClusterHUAWEI(
     uint32_t                                    groupCountY,
     uint32_t                                    groupCountZ)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawClusterHUAWEI(in_commandBuffer, groupCountX, groupCountY, groupCountZ);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawClusterHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawClusterHUAWEI, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
+        resource_dumper_.Process_vkCmdDrawClusterHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawClusterHUAWEI, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
     }
 }
 
@@ -9388,14 +9388,14 @@ void VulkanReplayConsumer::Process_vkCmdDrawClusterIndirectHUAWEI(
     format::HandleId                            buffer,
     VkDeviceSize                                offset)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawClusterIndirectHUAWEI(in_commandBuffer, in_buffer, offset);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawClusterIndirectHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawClusterIndirectHUAWEI, in_commandBuffer, in_buffer, offset);
+        resource_dumper_.Process_vkCmdDrawClusterIndirectHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawClusterIndirectHUAWEI, in_commandBuffer, in_buffer, offset);
     }
 }
 
@@ -9405,8 +9405,8 @@ void VulkanReplayConsumer::Process_vkSetDeviceMemoryPriorityEXT(
     format::HandleId                            memory,
     float                                       priority)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeviceMemory in_memory = MapHandle<VulkanDeviceMemoryInfo>(memory, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeviceMemory in_memory = MapHandle<VulkanDeviceMemoryInfo>(memory, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
 
     GetDeviceTable(in_device)->SetDeviceMemoryPriorityEXT(in_device, in_memory, priority);
 }
@@ -9417,7 +9417,7 @@ void VulkanReplayConsumer::Process_vkGetDescriptorSetLayoutHostMappingInfoVALVE(
     StructPointerDecoder<Decoded_VkDescriptorSetBindingReferenceVALVE>* pBindingReference,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutHostMappingInfoVALVE>* pHostMapping)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkDescriptorSetBindingReferenceVALVE* in_pBindingReference = pBindingReference->GetPointer();
     MapStructHandles(pBindingReference->GetMetaStructPointer(), GetObjectInfoTable());
     VkDescriptorSetLayoutHostMappingInfoVALVE* out_pHostMapping = pHostMapping->IsNull() ? nullptr : pHostMapping->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_HOST_MAPPING_INFO_VALVE, nullptr });
@@ -9432,8 +9432,8 @@ void VulkanReplayConsumer::Process_vkGetDescriptorSetHostMappingVALVE(
     format::HandleId                            descriptorSet,
     PointerDecoder<uint64_t, void*>*            ppData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDescriptorSet in_descriptorSet = MapHandle<VulkanDescriptorSetInfo>(descriptorSet, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDescriptorSet in_descriptorSet = MapHandle<VulkanDescriptorSetInfo>(descriptorSet, &CommonObjectInfoTable::GetVkDescriptorSetInfo);
     void** out_ppData = ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
 
     GetDeviceTable(in_device)->GetDescriptorSetHostMappingVALVE(in_device, in_descriptorSet, out_ppData);
@@ -9447,7 +9447,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineIndirectMemoryRequirementsNV(
     StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkComputePipelineCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
@@ -9462,14 +9462,14 @@ void VulkanReplayConsumer::Process_vkCmdUpdatePipelineIndirectBufferNV(
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            pipeline)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &VulkanObjectInfoTable::GetVkPipelineInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &CommonObjectInfoTable::GetVkPipelineInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdUpdatePipelineIndirectBufferNV(in_commandBuffer, pipelineBindPoint, in_pipeline);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdUpdatePipelineIndirectBufferNV(call_info, GetDeviceTable(in_commandBuffer)->CmdUpdatePipelineIndirectBufferNV, in_commandBuffer, pipelineBindPoint, in_pipeline);
+        resource_dumper_.Process_vkCmdUpdatePipelineIndirectBufferNV(call_info, GetDeviceTable(in_commandBuffer)->CmdUpdatePipelineIndirectBufferNV, in_commandBuffer, pipelineBindPoint, in_pipeline);
     }
 }
 
@@ -9479,7 +9479,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineIndirectDeviceAddressNV(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineIndirectDeviceAddressInfoNV>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkPipelineIndirectDeviceAddressInfoNV* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -9491,13 +9491,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthClampEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    depthClampEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthClampEnableEXT(in_commandBuffer, depthClampEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthClampEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClampEnableEXT, in_commandBuffer, depthClampEnable);
+        resource_dumper_.Process_vkCmdSetDepthClampEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClampEnableEXT, in_commandBuffer, depthClampEnable);
     }
 }
 
@@ -9506,13 +9506,13 @@ void VulkanReplayConsumer::Process_vkCmdSetPolygonModeEXT(
     format::HandleId                            commandBuffer,
     VkPolygonMode                               polygonMode)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetPolygonModeEXT(in_commandBuffer, polygonMode);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetPolygonModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPolygonModeEXT, in_commandBuffer, polygonMode);
+        resource_dumper_.Process_vkCmdSetPolygonModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPolygonModeEXT, in_commandBuffer, polygonMode);
     }
 }
 
@@ -9521,13 +9521,13 @@ void VulkanReplayConsumer::Process_vkCmdSetRasterizationSamplesEXT(
     format::HandleId                            commandBuffer,
     VkSampleCountFlagBits                       rasterizationSamples)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetRasterizationSamplesEXT(in_commandBuffer, rasterizationSamples);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetRasterizationSamplesEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizationSamplesEXT, in_commandBuffer, rasterizationSamples);
+        resource_dumper_.Process_vkCmdSetRasterizationSamplesEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizationSamplesEXT, in_commandBuffer, rasterizationSamples);
     }
 }
 
@@ -9537,14 +9537,14 @@ void VulkanReplayConsumer::Process_vkCmdSetSampleMaskEXT(
     VkSampleCountFlagBits                       samples,
     PointerDecoder<VkSampleMask>*               pSampleMask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkSampleMask* in_pSampleMask = pSampleMask->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetSampleMaskEXT(in_commandBuffer, samples, in_pSampleMask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetSampleMaskEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleMaskEXT, in_commandBuffer, samples, in_pSampleMask);
+        resource_dumper_.Process_vkCmdSetSampleMaskEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleMaskEXT, in_commandBuffer, samples, in_pSampleMask);
     }
 }
 
@@ -9553,13 +9553,13 @@ void VulkanReplayConsumer::Process_vkCmdSetAlphaToCoverageEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    alphaToCoverageEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetAlphaToCoverageEnableEXT(in_commandBuffer, alphaToCoverageEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetAlphaToCoverageEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAlphaToCoverageEnableEXT, in_commandBuffer, alphaToCoverageEnable);
+        resource_dumper_.Process_vkCmdSetAlphaToCoverageEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAlphaToCoverageEnableEXT, in_commandBuffer, alphaToCoverageEnable);
     }
 }
 
@@ -9568,13 +9568,13 @@ void VulkanReplayConsumer::Process_vkCmdSetAlphaToOneEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    alphaToOneEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetAlphaToOneEnableEXT(in_commandBuffer, alphaToOneEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetAlphaToOneEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAlphaToOneEnableEXT, in_commandBuffer, alphaToOneEnable);
+        resource_dumper_.Process_vkCmdSetAlphaToOneEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAlphaToOneEnableEXT, in_commandBuffer, alphaToOneEnable);
     }
 }
 
@@ -9583,13 +9583,13 @@ void VulkanReplayConsumer::Process_vkCmdSetLogicOpEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    logicOpEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetLogicOpEnableEXT(in_commandBuffer, logicOpEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetLogicOpEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLogicOpEnableEXT, in_commandBuffer, logicOpEnable);
+        resource_dumper_.Process_vkCmdSetLogicOpEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLogicOpEnableEXT, in_commandBuffer, logicOpEnable);
     }
 }
 
@@ -9600,14 +9600,14 @@ void VulkanReplayConsumer::Process_vkCmdSetColorBlendEnableEXT(
     uint32_t                                    attachmentCount,
     PointerDecoder<VkBool32>*                   pColorBlendEnables)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkBool32* in_pColorBlendEnables = pColorBlendEnables->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetColorBlendEnableEXT(in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendEnables);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetColorBlendEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendEnableEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendEnables);
+        resource_dumper_.Process_vkCmdSetColorBlendEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendEnableEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendEnables);
     }
 }
 
@@ -9618,14 +9618,14 @@ void VulkanReplayConsumer::Process_vkCmdSetColorBlendEquationEXT(
     uint32_t                                    attachmentCount,
     StructPointerDecoder<Decoded_VkColorBlendEquationEXT>* pColorBlendEquations)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkColorBlendEquationEXT* in_pColorBlendEquations = pColorBlendEquations->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetColorBlendEquationEXT(in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendEquations);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetColorBlendEquationEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendEquationEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendEquations);
+        resource_dumper_.Process_vkCmdSetColorBlendEquationEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendEquationEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendEquations);
     }
 }
 
@@ -9636,14 +9636,14 @@ void VulkanReplayConsumer::Process_vkCmdSetColorWriteMaskEXT(
     uint32_t                                    attachmentCount,
     PointerDecoder<VkColorComponentFlags>*      pColorWriteMasks)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkColorComponentFlags* in_pColorWriteMasks = pColorWriteMasks->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetColorWriteMaskEXT(in_commandBuffer, firstAttachment, attachmentCount, in_pColorWriteMasks);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetColorWriteMaskEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorWriteMaskEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorWriteMasks);
+        resource_dumper_.Process_vkCmdSetColorWriteMaskEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorWriteMaskEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorWriteMasks);
     }
 }
 
@@ -9652,13 +9652,13 @@ void VulkanReplayConsumer::Process_vkCmdSetTessellationDomainOriginEXT(
     format::HandleId                            commandBuffer,
     VkTessellationDomainOrigin                  domainOrigin)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetTessellationDomainOriginEXT(in_commandBuffer, domainOrigin);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetTessellationDomainOriginEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetTessellationDomainOriginEXT, in_commandBuffer, domainOrigin);
+        resource_dumper_.Process_vkCmdSetTessellationDomainOriginEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetTessellationDomainOriginEXT, in_commandBuffer, domainOrigin);
     }
 }
 
@@ -9667,13 +9667,13 @@ void VulkanReplayConsumer::Process_vkCmdSetRasterizationStreamEXT(
     format::HandleId                            commandBuffer,
     uint32_t                                    rasterizationStream)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetRasterizationStreamEXT(in_commandBuffer, rasterizationStream);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetRasterizationStreamEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizationStreamEXT, in_commandBuffer, rasterizationStream);
+        resource_dumper_.Process_vkCmdSetRasterizationStreamEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizationStreamEXT, in_commandBuffer, rasterizationStream);
     }
 }
 
@@ -9682,13 +9682,13 @@ void VulkanReplayConsumer::Process_vkCmdSetConservativeRasterizationModeEXT(
     format::HandleId                            commandBuffer,
     VkConservativeRasterizationModeEXT          conservativeRasterizationMode)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetConservativeRasterizationModeEXT(in_commandBuffer, conservativeRasterizationMode);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetConservativeRasterizationModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetConservativeRasterizationModeEXT, in_commandBuffer, conservativeRasterizationMode);
+        resource_dumper_.Process_vkCmdSetConservativeRasterizationModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetConservativeRasterizationModeEXT, in_commandBuffer, conservativeRasterizationMode);
     }
 }
 
@@ -9697,13 +9697,13 @@ void VulkanReplayConsumer::Process_vkCmdSetExtraPrimitiveOverestimationSizeEXT(
     format::HandleId                            commandBuffer,
     float                                       extraPrimitiveOverestimationSize)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetExtraPrimitiveOverestimationSizeEXT(in_commandBuffer, extraPrimitiveOverestimationSize);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetExtraPrimitiveOverestimationSizeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExtraPrimitiveOverestimationSizeEXT, in_commandBuffer, extraPrimitiveOverestimationSize);
+        resource_dumper_.Process_vkCmdSetExtraPrimitiveOverestimationSizeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExtraPrimitiveOverestimationSizeEXT, in_commandBuffer, extraPrimitiveOverestimationSize);
     }
 }
 
@@ -9712,13 +9712,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthClipEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    depthClipEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthClipEnableEXT(in_commandBuffer, depthClipEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthClipEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClipEnableEXT, in_commandBuffer, depthClipEnable);
+        resource_dumper_.Process_vkCmdSetDepthClipEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClipEnableEXT, in_commandBuffer, depthClipEnable);
     }
 }
 
@@ -9727,13 +9727,13 @@ void VulkanReplayConsumer::Process_vkCmdSetSampleLocationsEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    sampleLocationsEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetSampleLocationsEnableEXT(in_commandBuffer, sampleLocationsEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetSampleLocationsEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleLocationsEnableEXT, in_commandBuffer, sampleLocationsEnable);
+        resource_dumper_.Process_vkCmdSetSampleLocationsEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleLocationsEnableEXT, in_commandBuffer, sampleLocationsEnable);
     }
 }
 
@@ -9744,14 +9744,14 @@ void VulkanReplayConsumer::Process_vkCmdSetColorBlendAdvancedEXT(
     uint32_t                                    attachmentCount,
     StructPointerDecoder<Decoded_VkColorBlendAdvancedEXT>* pColorBlendAdvanced)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkColorBlendAdvancedEXT* in_pColorBlendAdvanced = pColorBlendAdvanced->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetColorBlendAdvancedEXT(in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendAdvanced);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetColorBlendAdvancedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendAdvancedEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendAdvanced);
+        resource_dumper_.Process_vkCmdSetColorBlendAdvancedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendAdvancedEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendAdvanced);
     }
 }
 
@@ -9760,13 +9760,13 @@ void VulkanReplayConsumer::Process_vkCmdSetProvokingVertexModeEXT(
     format::HandleId                            commandBuffer,
     VkProvokingVertexModeEXT                    provokingVertexMode)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetProvokingVertexModeEXT(in_commandBuffer, provokingVertexMode);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetProvokingVertexModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetProvokingVertexModeEXT, in_commandBuffer, provokingVertexMode);
+        resource_dumper_.Process_vkCmdSetProvokingVertexModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetProvokingVertexModeEXT, in_commandBuffer, provokingVertexMode);
     }
 }
 
@@ -9775,13 +9775,13 @@ void VulkanReplayConsumer::Process_vkCmdSetLineRasterizationModeEXT(
     format::HandleId                            commandBuffer,
     VkLineRasterizationModeEXT                  lineRasterizationMode)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetLineRasterizationModeEXT(in_commandBuffer, lineRasterizationMode);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetLineRasterizationModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineRasterizationModeEXT, in_commandBuffer, lineRasterizationMode);
+        resource_dumper_.Process_vkCmdSetLineRasterizationModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineRasterizationModeEXT, in_commandBuffer, lineRasterizationMode);
     }
 }
 
@@ -9790,13 +9790,13 @@ void VulkanReplayConsumer::Process_vkCmdSetLineStippleEnableEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    stippledLineEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetLineStippleEnableEXT(in_commandBuffer, stippledLineEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetLineStippleEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleEnableEXT, in_commandBuffer, stippledLineEnable);
+        resource_dumper_.Process_vkCmdSetLineStippleEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleEnableEXT, in_commandBuffer, stippledLineEnable);
     }
 }
 
@@ -9805,13 +9805,13 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthClipNegativeOneToOneEXT(
     format::HandleId                            commandBuffer,
     VkBool32                                    negativeOneToOne)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthClipNegativeOneToOneEXT(in_commandBuffer, negativeOneToOne);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthClipNegativeOneToOneEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClipNegativeOneToOneEXT, in_commandBuffer, negativeOneToOne);
+        resource_dumper_.Process_vkCmdSetDepthClipNegativeOneToOneEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClipNegativeOneToOneEXT, in_commandBuffer, negativeOneToOne);
     }
 }
 
@@ -9820,13 +9820,13 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWScalingEnableNV(
     format::HandleId                            commandBuffer,
     VkBool32                                    viewportWScalingEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetViewportWScalingEnableNV(in_commandBuffer, viewportWScalingEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetViewportWScalingEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWScalingEnableNV, in_commandBuffer, viewportWScalingEnable);
+        resource_dumper_.Process_vkCmdSetViewportWScalingEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWScalingEnableNV, in_commandBuffer, viewportWScalingEnable);
     }
 }
 
@@ -9837,14 +9837,14 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportSwizzleNV(
     uint32_t                                    viewportCount,
     StructPointerDecoder<Decoded_VkViewportSwizzleNV>* pViewportSwizzles)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkViewportSwizzleNV* in_pViewportSwizzles = pViewportSwizzles->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetViewportSwizzleNV(in_commandBuffer, firstViewport, viewportCount, in_pViewportSwizzles);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetViewportSwizzleNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportSwizzleNV, in_commandBuffer, firstViewport, viewportCount, in_pViewportSwizzles);
+        resource_dumper_.Process_vkCmdSetViewportSwizzleNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportSwizzleNV, in_commandBuffer, firstViewport, viewportCount, in_pViewportSwizzles);
     }
 }
 
@@ -9853,13 +9853,13 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageToColorEnableNV(
     format::HandleId                            commandBuffer,
     VkBool32                                    coverageToColorEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetCoverageToColorEnableNV(in_commandBuffer, coverageToColorEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetCoverageToColorEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageToColorEnableNV, in_commandBuffer, coverageToColorEnable);
+        resource_dumper_.Process_vkCmdSetCoverageToColorEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageToColorEnableNV, in_commandBuffer, coverageToColorEnable);
     }
 }
 
@@ -9868,13 +9868,13 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageToColorLocationNV(
     format::HandleId                            commandBuffer,
     uint32_t                                    coverageToColorLocation)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetCoverageToColorLocationNV(in_commandBuffer, coverageToColorLocation);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetCoverageToColorLocationNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageToColorLocationNV, in_commandBuffer, coverageToColorLocation);
+        resource_dumper_.Process_vkCmdSetCoverageToColorLocationNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageToColorLocationNV, in_commandBuffer, coverageToColorLocation);
     }
 }
 
@@ -9883,13 +9883,13 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageModulationModeNV(
     format::HandleId                            commandBuffer,
     VkCoverageModulationModeNV                  coverageModulationMode)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationModeNV(in_commandBuffer, coverageModulationMode);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetCoverageModulationModeNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationModeNV, in_commandBuffer, coverageModulationMode);
+        resource_dumper_.Process_vkCmdSetCoverageModulationModeNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationModeNV, in_commandBuffer, coverageModulationMode);
     }
 }
 
@@ -9898,13 +9898,13 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageModulationTableEnableNV(
     format::HandleId                            commandBuffer,
     VkBool32                                    coverageModulationTableEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationTableEnableNV(in_commandBuffer, coverageModulationTableEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetCoverageModulationTableEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationTableEnableNV, in_commandBuffer, coverageModulationTableEnable);
+        resource_dumper_.Process_vkCmdSetCoverageModulationTableEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationTableEnableNV, in_commandBuffer, coverageModulationTableEnable);
     }
 }
 
@@ -9914,14 +9914,14 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageModulationTableNV(
     uint32_t                                    coverageModulationTableCount,
     PointerDecoder<float>*                      pCoverageModulationTable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const float* in_pCoverageModulationTable = pCoverageModulationTable->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationTableNV(in_commandBuffer, coverageModulationTableCount, in_pCoverageModulationTable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetCoverageModulationTableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationTableNV, in_commandBuffer, coverageModulationTableCount, in_pCoverageModulationTable);
+        resource_dumper_.Process_vkCmdSetCoverageModulationTableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationTableNV, in_commandBuffer, coverageModulationTableCount, in_pCoverageModulationTable);
     }
 }
 
@@ -9930,13 +9930,13 @@ void VulkanReplayConsumer::Process_vkCmdSetShadingRateImageEnableNV(
     format::HandleId                            commandBuffer,
     VkBool32                                    shadingRateImageEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetShadingRateImageEnableNV(in_commandBuffer, shadingRateImageEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetShadingRateImageEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetShadingRateImageEnableNV, in_commandBuffer, shadingRateImageEnable);
+        resource_dumper_.Process_vkCmdSetShadingRateImageEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetShadingRateImageEnableNV, in_commandBuffer, shadingRateImageEnable);
     }
 }
 
@@ -9945,13 +9945,13 @@ void VulkanReplayConsumer::Process_vkCmdSetRepresentativeFragmentTestEnableNV(
     format::HandleId                            commandBuffer,
     VkBool32                                    representativeFragmentTestEnable)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetRepresentativeFragmentTestEnableNV(in_commandBuffer, representativeFragmentTestEnable);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetRepresentativeFragmentTestEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRepresentativeFragmentTestEnableNV, in_commandBuffer, representativeFragmentTestEnable);
+        resource_dumper_.Process_vkCmdSetRepresentativeFragmentTestEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRepresentativeFragmentTestEnableNV, in_commandBuffer, representativeFragmentTestEnable);
     }
 }
 
@@ -9960,13 +9960,13 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageReductionModeNV(
     format::HandleId                            commandBuffer,
     VkCoverageReductionModeNV                   coverageReductionMode)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetCoverageReductionModeNV(in_commandBuffer, coverageReductionMode);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetCoverageReductionModeNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageReductionModeNV, in_commandBuffer, coverageReductionMode);
+        resource_dumper_.Process_vkCmdSetCoverageReductionModeNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageReductionModeNV, in_commandBuffer, coverageReductionMode);
     }
 }
 
@@ -9976,8 +9976,8 @@ void VulkanReplayConsumer::Process_vkGetShaderModuleIdentifierEXT(
     format::HandleId                            shaderModule,
     StructPointerDecoder<Decoded_VkShaderModuleIdentifierEXT>* pIdentifier)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkShaderModule in_shaderModule = MapHandle<VulkanShaderModuleInfo>(shaderModule, &VulkanObjectInfoTable::GetVkShaderModuleInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkShaderModule in_shaderModule = MapHandle<VulkanShaderModuleInfo>(shaderModule, &CommonObjectInfoTable::GetVkShaderModuleInfo);
     VkShaderModuleIdentifierEXT* out_pIdentifier = pIdentifier->IsNull() ? nullptr : pIdentifier->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT, nullptr });
     InitializeOutputStructPNext(pIdentifier);
 
@@ -9990,7 +9990,7 @@ void VulkanReplayConsumer::Process_vkGetShaderModuleCreateInfoIdentifierEXT(
     StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkShaderModuleIdentifierEXT>* pIdentifier)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkShaderModuleCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkShaderModuleIdentifierEXT* out_pIdentifier = pIdentifier->IsNull() ? nullptr : pIdentifier->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT, nullptr });
@@ -10007,15 +10007,15 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceOpticalFlowImageFormatsNV(
     PointerDecoder<uint32_t>*                   pFormatCount,
     StructPointerDecoder<Decoded_VkOpticalFlowImageFormatPropertiesNV>* pImageFormatProperties)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+    VkPhysicalDevice in_physicalDevice = MapHandle<VulkanPhysicalDeviceInfo>(physicalDevice, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     const VkOpticalFlowImageFormatInfoNV* in_pOpticalFlowImageFormatInfo = pOpticalFlowImageFormatInfo->GetPointer();
-    uint32_t* out_pFormatCount = pFormatCount->IsNull() ? nullptr : pFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceOpticalFlowImageFormatsNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceOpticalFlowImageFormatsNV, pFormatCount, pImageFormatProperties, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo));
+    uint32_t* out_pFormatCount = pFormatCount->IsNull() ? nullptr : pFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceOpticalFlowImageFormatsNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceOpticalFlowImageFormatsNV, pFormatCount, pImageFormatProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkOpticalFlowImageFormatPropertiesNV* out_pImageFormatProperties = pImageFormatProperties->IsNull() ? nullptr : pImageFormatProperties->AllocateOutputData(*out_pFormatCount, VkOpticalFlowImageFormatPropertiesNV{ VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_NV, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceOpticalFlowImageFormatsNV(in_physicalDevice, in_pOpticalFlowImageFormatInfo, out_pFormatCount, out_pImageFormatProperties);
     CheckResult("vkGetPhysicalDeviceOpticalFlowImageFormatsNV", returnValue, replay_result, call_info);
 
-    if (pImageFormatProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceOpticalFlowImageFormatsNV, *out_pFormatCount, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo); }
+    if (pImageFormatProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceOpticalFlowImageFormatsNV, *out_pFormatCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCreateOpticalFlowSessionNV(
@@ -10026,7 +10026,7 @@ void VulkanReplayConsumer::Process_vkCreateOpticalFlowSessionNV(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkOpticalFlowSessionNV>* pSession)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkOpticalFlowSessionCreateInfoNV* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pSession->IsNull()) { pSession->SetHandleLength(1); }
@@ -10035,7 +10035,7 @@ void VulkanReplayConsumer::Process_vkCreateOpticalFlowSessionNV(
     VkResult replay_result = GetDeviceTable(in_device)->CreateOpticalFlowSessionNV(in_device, in_pCreateInfo, in_pAllocator, out_pSession);
     CheckResult("vkCreateOpticalFlowSessionNV", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanOpticalFlowSessionNVInfo>(device, pSession->GetPointer(), out_pSession, &VulkanObjectInfoTable::AddVkOpticalFlowSessionNVInfo);
+    AddHandle<VulkanOpticalFlowSessionNVInfo>(device, pSession->GetPointer(), out_pSession, &CommonObjectInfoTable::AddVkOpticalFlowSessionNVInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyOpticalFlowSessionNV(
@@ -10044,12 +10044,12 @@ void VulkanReplayConsumer::Process_vkDestroyOpticalFlowSessionNV(
     format::HandleId                            session,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkOpticalFlowSessionNV in_session = MapHandle<VulkanOpticalFlowSessionNVInfo>(session, &VulkanObjectInfoTable::GetVkOpticalFlowSessionNVInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkOpticalFlowSessionNV in_session = MapHandle<VulkanOpticalFlowSessionNVInfo>(session, &CommonObjectInfoTable::GetVkOpticalFlowSessionNVInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyOpticalFlowSessionNV(in_device, in_session, in_pAllocator);
-    RemoveHandle(session, &VulkanObjectInfoTable::RemoveVkOpticalFlowSessionNVInfo);
+    RemoveHandle(session, &CommonObjectInfoTable::RemoveVkOpticalFlowSessionNVInfo);
 }
 
 void VulkanReplayConsumer::Process_vkBindOpticalFlowSessionImageNV(
@@ -10061,9 +10061,9 @@ void VulkanReplayConsumer::Process_vkBindOpticalFlowSessionImageNV(
     format::HandleId                            view,
     VkImageLayout                               layout)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkOpticalFlowSessionNV in_session = MapHandle<VulkanOpticalFlowSessionNVInfo>(session, &VulkanObjectInfoTable::GetVkOpticalFlowSessionNVInfo);
-    VkImageView in_view = MapHandle<VulkanImageViewInfo>(view, &VulkanObjectInfoTable::GetVkImageViewInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkOpticalFlowSessionNV in_session = MapHandle<VulkanOpticalFlowSessionNVInfo>(session, &CommonObjectInfoTable::GetVkOpticalFlowSessionNVInfo);
+    VkImageView in_view = MapHandle<VulkanImageViewInfo>(view, &CommonObjectInfoTable::GetVkImageViewInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->BindOpticalFlowSessionImageNV(in_device, in_session, bindingPoint, in_view, layout);
     CheckResult("vkBindOpticalFlowSessionImageNV", returnValue, replay_result, call_info);
@@ -10075,15 +10075,15 @@ void VulkanReplayConsumer::Process_vkCmdOpticalFlowExecuteNV(
     format::HandleId                            session,
     StructPointerDecoder<Decoded_VkOpticalFlowExecuteInfoNV>* pExecuteInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkOpticalFlowSessionNV in_session = MapHandle<VulkanOpticalFlowSessionNVInfo>(session, &VulkanObjectInfoTable::GetVkOpticalFlowSessionNVInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkOpticalFlowSessionNV in_session = MapHandle<VulkanOpticalFlowSessionNVInfo>(session, &CommonObjectInfoTable::GetVkOpticalFlowSessionNVInfo);
     const VkOpticalFlowExecuteInfoNV* in_pExecuteInfo = pExecuteInfo->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdOpticalFlowExecuteNV(in_commandBuffer, in_session, in_pExecuteInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdOpticalFlowExecuteNV(call_info, GetDeviceTable(in_commandBuffer)->CmdOpticalFlowExecuteNV, in_commandBuffer, in_session, in_pExecuteInfo);
+        resource_dumper_.Process_vkCmdOpticalFlowExecuteNV(call_info, GetDeviceTable(in_commandBuffer)->CmdOpticalFlowExecuteNV, in_commandBuffer, in_session, in_pExecuteInfo);
     }
 }
 
@@ -10092,7 +10092,7 @@ void VulkanReplayConsumer::Process_vkAntiLagUpdateAMD(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAntiLagDataAMD>* pData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkAntiLagDataAMD* in_pData = pData->GetPointer();
 
     GetDeviceTable(in_device)->AntiLagUpdateAMD(in_device, in_pData);
@@ -10126,7 +10126,7 @@ void VulkanReplayConsumer::Process_vkCreateShadersEXT(
     VkResult replay_result = OverrideCreateShadersEXT(GetDeviceTable(in_device->handle)->CreateShadersEXT, returnValue, in_device, createInfoCount, pCreateInfos, pAllocator, pShaders);
     CheckResult("vkCreateShadersEXT", returnValue, replay_result, call_info);
 
-    AddHandles<VulkanShaderEXTInfo>(device, pShaders->GetPointer(), pShaders->GetLength(), pShaders->GetHandlePointer(), createInfoCount, std::move(handle_info), &VulkanObjectInfoTable::AddVkShaderEXTInfo);
+    AddHandles<VulkanShaderEXTInfo>(device, pShaders->GetPointer(), pShaders->GetLength(), pShaders->GetHandlePointer(), createInfoCount, std::move(handle_info), &CommonObjectInfoTable::AddVkShaderEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyShaderEXT(
@@ -10135,12 +10135,12 @@ void VulkanReplayConsumer::Process_vkDestroyShaderEXT(
     format::HandleId                            shader,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkShaderEXT in_shader = MapHandle<VulkanShaderEXTInfo>(shader, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkShaderEXT in_shader = MapHandle<VulkanShaderEXTInfo>(shader, &CommonObjectInfoTable::GetVkShaderEXTInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyShaderEXT(in_device, in_shader, in_pAllocator);
-    RemoveHandle(shader, &VulkanObjectInfoTable::RemoveVkShaderEXTInfo);
+    RemoveHandle(shader, &CommonObjectInfoTable::RemoveVkShaderEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetShaderBinaryDataEXT(
@@ -10151,15 +10151,15 @@ void VulkanReplayConsumer::Process_vkGetShaderBinaryDataEXT(
     PointerDecoder<size_t>*                     pDataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkShaderEXT in_shader = MapHandle<VulkanShaderEXTInfo>(shader, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
-    size_t* out_pDataSize = pDataSize->IsNull() ? nullptr : pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanShaderEXTInfo>("vkGetShaderBinaryDataEXT", returnValue, shader, kShaderEXTArrayGetShaderBinaryDataEXT, pDataSize, pData, &VulkanObjectInfoTable::GetVkShaderEXTInfo));
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkShaderEXT in_shader = MapHandle<VulkanShaderEXTInfo>(shader, &CommonObjectInfoTable::GetVkShaderEXTInfo);
+    size_t* out_pDataSize = pDataSize->IsNull() ? nullptr : pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, VulkanShaderEXTInfo>("vkGetShaderBinaryDataEXT", returnValue, shader, kShaderEXTArrayGetShaderBinaryDataEXT, pDataSize, pData, &CommonObjectInfoTable::GetVkShaderEXTInfo));
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(*out_pDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetShaderBinaryDataEXT(in_device, in_shader, out_pDataSize, out_pData);
     CheckResult("vkGetShaderBinaryDataEXT", returnValue, replay_result, call_info);
 
-    if (pData->IsNull()) { SetOutputArrayCount<VulkanShaderEXTInfo>(shader, kShaderEXTArrayGetShaderBinaryDataEXT, *out_pDataSize, &VulkanObjectInfoTable::GetVkShaderEXTInfo); }
+    if (pData->IsNull()) { SetOutputArrayCount<VulkanShaderEXTInfo>(shader, kShaderEXTArrayGetShaderBinaryDataEXT, *out_pDataSize, &CommonObjectInfoTable::GetVkShaderEXTInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindShadersEXT(
@@ -10169,15 +10169,15 @@ void VulkanReplayConsumer::Process_vkCmdBindShadersEXT(
     PointerDecoder<VkShaderStageFlagBits>*      pStages,
     HandlePointerDecoder<VkShaderEXT>*          pShaders)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkShaderStageFlagBits* in_pStages = pStages->GetPointer();
-    const VkShaderEXT* in_pShaders = MapHandles<VulkanShaderEXTInfo>(pShaders, stageCount, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
+    const VkShaderEXT* in_pShaders = MapHandles<VulkanShaderEXTInfo>(pShaders, stageCount, &CommonObjectInfoTable::GetVkShaderEXTInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdBindShadersEXT(in_commandBuffer, stageCount, in_pStages, in_pShaders);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBindShadersEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindShadersEXT, in_commandBuffer, stageCount, in_pStages, in_pShaders);
+        resource_dumper_.Process_vkCmdBindShadersEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindShadersEXT, in_commandBuffer, stageCount, in_pStages, in_pShaders);
     }
 }
 
@@ -10187,14 +10187,14 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthClampRangeEXT(
     VkDepthClampModeEXT                         depthClampMode,
     StructPointerDecoder<Decoded_VkDepthClampRangeEXT>* pDepthClampRange)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkDepthClampRangeEXT* in_pDepthClampRange = pDepthClampRange->GetPointer();
 
     GetDeviceTable(in_commandBuffer)->CmdSetDepthClampRangeEXT(in_commandBuffer, depthClampMode, in_pDepthClampRange);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetDepthClampRangeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClampRangeEXT, in_commandBuffer, depthClampMode, in_pDepthClampRange);
+        resource_dumper_.Process_vkCmdSetDepthClampRangeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClampRangeEXT, in_commandBuffer, depthClampMode, in_pDepthClampRange);
     }
 }
 
@@ -10206,15 +10206,15 @@ void VulkanReplayConsumer::Process_vkGetFramebufferTilePropertiesQCOM(
     PointerDecoder<uint32_t>*                   pPropertiesCount,
     StructPointerDecoder<Decoded_VkTilePropertiesQCOM>* pProperties)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkFramebuffer in_framebuffer = MapHandle<VulkanFramebufferInfo>(framebuffer, &VulkanObjectInfoTable::GetVkFramebufferInfo);
-    uint32_t* out_pPropertiesCount = pPropertiesCount->IsNull() ? nullptr : pPropertiesCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanFramebufferInfo>("vkGetFramebufferTilePropertiesQCOM", returnValue, framebuffer, kFramebufferArrayGetFramebufferTilePropertiesQCOM, pPropertiesCount, pProperties, &VulkanObjectInfoTable::GetVkFramebufferInfo));
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkFramebuffer in_framebuffer = MapHandle<VulkanFramebufferInfo>(framebuffer, &CommonObjectInfoTable::GetVkFramebufferInfo);
+    uint32_t* out_pPropertiesCount = pPropertiesCount->IsNull() ? nullptr : pPropertiesCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanFramebufferInfo>("vkGetFramebufferTilePropertiesQCOM", returnValue, framebuffer, kFramebufferArrayGetFramebufferTilePropertiesQCOM, pPropertiesCount, pProperties, &CommonObjectInfoTable::GetVkFramebufferInfo));
     VkTilePropertiesQCOM* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertiesCount, VkTilePropertiesQCOM{ VK_STRUCTURE_TYPE_TILE_PROPERTIES_QCOM, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetFramebufferTilePropertiesQCOM(in_device, in_framebuffer, out_pPropertiesCount, out_pProperties);
     CheckResult("vkGetFramebufferTilePropertiesQCOM", returnValue, replay_result, call_info);
 
-    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanFramebufferInfo>(framebuffer, kFramebufferArrayGetFramebufferTilePropertiesQCOM, *out_pPropertiesCount, &VulkanObjectInfoTable::GetVkFramebufferInfo); }
+    if (pProperties->IsNull()) { SetOutputArrayCount<VulkanFramebufferInfo>(framebuffer, kFramebufferArrayGetFramebufferTilePropertiesQCOM, *out_pPropertiesCount, &CommonObjectInfoTable::GetVkFramebufferInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetDynamicRenderingTilePropertiesQCOM(
@@ -10224,7 +10224,7 @@ void VulkanReplayConsumer::Process_vkGetDynamicRenderingTilePropertiesQCOM(
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo,
     StructPointerDecoder<Decoded_VkTilePropertiesQCOM>* pProperties)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkRenderingInfo* in_pRenderingInfo = pRenderingInfo->GetPointer();
     MapStructHandles(pRenderingInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkTilePropertiesQCOM* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_TILE_PROPERTIES_QCOM, nullptr });
@@ -10246,8 +10246,8 @@ void VulkanReplayConsumer::Process_vkSetLatencySleepModeNV(
         GFXRECON_LOG_DEBUG("Skip vkSetLatencySleepModeNV for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
     const VkLatencySleepModeInfoNV* in_pSleepModeInfo = pSleepModeInfo->GetPointer();
 
@@ -10267,8 +10267,8 @@ void VulkanReplayConsumer::Process_vkLatencySleepNV(
         GFXRECON_LOG_DEBUG("Skip vkLatencySleepNV for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
     const VkLatencySleepInfoNV* in_pSleepInfo = pSleepInfo->GetPointer();
     MapStructHandles(pSleepInfo->GetMetaStructPointer(), GetObjectInfoTable());
@@ -10288,8 +10288,8 @@ void VulkanReplayConsumer::Process_vkSetLatencyMarkerNV(
         GFXRECON_LOG_DEBUG("Skip vkSetLatencyMarkerNV for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
     const VkSetLatencyMarkerInfoNV* in_pLatencyMarkerInfo = pLatencyMarkerInfo->GetPointer();
 
@@ -10307,8 +10307,8 @@ void VulkanReplayConsumer::Process_vkGetLatencyTimingsNV(
         GFXRECON_LOG_DEBUG("Skip vkGetLatencyTimingsNV for offscreen.");
         return;
     }
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkSwapchainKHR in_swapchain = MapHandle<VulkanSwapchainKHRInfo>(swapchain, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().GetVkSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
     VkGetLatencyMarkerInfoNV* out_pLatencyMarkerInfo = pLatencyMarkerInfo->IsNull() ? nullptr : pLatencyMarkerInfo->AllocateOutputData(1, { VK_STRUCTURE_TYPE_GET_LATENCY_MARKER_INFO_NV, nullptr });
     InitializeOutputStructPNext(pLatencyMarkerInfo);
@@ -10321,7 +10321,7 @@ void VulkanReplayConsumer::Process_vkQueueNotifyOutOfBandNV(
     format::HandleId                            queue,
     StructPointerDecoder<Decoded_VkOutOfBandQueueTypeInfoNV>* pQueueTypeInfo)
 {
-    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &VulkanObjectInfoTable::GetVkQueueInfo);
+    VkQueue in_queue = MapHandle<VulkanQueueInfo>(queue, &CommonObjectInfoTable::GetVkQueueInfo);
     const VkOutOfBandQueueTypeInfoNV* in_pQueueTypeInfo = pQueueTypeInfo->GetPointer();
 
     GetDeviceTable(in_queue)->QueueNotifyOutOfBandNV(in_queue, in_pQueueTypeInfo);
@@ -10332,13 +10332,13 @@ void VulkanReplayConsumer::Process_vkCmdSetAttachmentFeedbackLoopEnableEXT(
     format::HandleId                            commandBuffer,
     VkImageAspectFlags                          aspectMask)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetAttachmentFeedbackLoopEnableEXT(in_commandBuffer, aspectMask);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetAttachmentFeedbackLoopEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAttachmentFeedbackLoopEnableEXT, in_commandBuffer, aspectMask);
+        resource_dumper_.Process_vkCmdSetAttachmentFeedbackLoopEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAttachmentFeedbackLoopEnableEXT, in_commandBuffer, aspectMask);
     }
 }
 
@@ -10348,7 +10348,7 @@ void VulkanReplayConsumer::Process_vkGetGeneratedCommandsMemoryRequirementsEXT(
     StructPointerDecoder<Decoded_VkGeneratedCommandsMemoryRequirementsInfoEXT>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkGeneratedCommandsMemoryRequirementsInfoEXT* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
@@ -10363,16 +10363,16 @@ void VulkanReplayConsumer::Process_vkCmdPreprocessGeneratedCommandsEXT(
     StructPointerDecoder<Decoded_VkGeneratedCommandsInfoEXT>* pGeneratedCommandsInfo,
     format::HandleId                            stateCommandBuffer)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkGeneratedCommandsInfoEXT* in_pGeneratedCommandsInfo = pGeneratedCommandsInfo->GetPointer();
     MapStructHandles(pGeneratedCommandsInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkCommandBuffer in_stateCommandBuffer = MapHandle<VulkanCommandBufferInfo>(stateCommandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_stateCommandBuffer = MapHandle<VulkanCommandBufferInfo>(stateCommandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdPreprocessGeneratedCommandsEXT(in_commandBuffer, in_pGeneratedCommandsInfo, in_stateCommandBuffer);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdPreprocessGeneratedCommandsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdPreprocessGeneratedCommandsEXT, in_commandBuffer, in_pGeneratedCommandsInfo, in_stateCommandBuffer);
+        resource_dumper_.Process_vkCmdPreprocessGeneratedCommandsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdPreprocessGeneratedCommandsEXT, in_commandBuffer, in_pGeneratedCommandsInfo, in_stateCommandBuffer);
     }
 }
 
@@ -10382,7 +10382,7 @@ void VulkanReplayConsumer::Process_vkCmdExecuteGeneratedCommandsEXT(
     VkBool32                                    isPreprocessed,
     StructPointerDecoder<Decoded_VkGeneratedCommandsInfoEXT>* pGeneratedCommandsInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkGeneratedCommandsInfoEXT* in_pGeneratedCommandsInfo = pGeneratedCommandsInfo->GetPointer();
     MapStructHandles(pGeneratedCommandsInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -10390,7 +10390,7 @@ void VulkanReplayConsumer::Process_vkCmdExecuteGeneratedCommandsEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdExecuteGeneratedCommandsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteGeneratedCommandsEXT, in_commandBuffer, isPreprocessed, in_pGeneratedCommandsInfo);
+        resource_dumper_.Process_vkCmdExecuteGeneratedCommandsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteGeneratedCommandsEXT, in_commandBuffer, isPreprocessed, in_pGeneratedCommandsInfo);
     }
 }
 
@@ -10402,7 +10402,7 @@ void VulkanReplayConsumer::Process_vkCreateIndirectCommandsLayoutEXT(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkIndirectCommandsLayoutEXT>* pIndirectCommandsLayout)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkIndirectCommandsLayoutCreateInfoEXT* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
@@ -10412,7 +10412,7 @@ void VulkanReplayConsumer::Process_vkCreateIndirectCommandsLayoutEXT(
     VkResult replay_result = GetDeviceTable(in_device)->CreateIndirectCommandsLayoutEXT(in_device, in_pCreateInfo, in_pAllocator, out_pIndirectCommandsLayout);
     CheckResult("vkCreateIndirectCommandsLayoutEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanIndirectCommandsLayoutEXTInfo>(device, pIndirectCommandsLayout->GetPointer(), out_pIndirectCommandsLayout, &VulkanObjectInfoTable::AddVkIndirectCommandsLayoutEXTInfo);
+    AddHandle<VulkanIndirectCommandsLayoutEXTInfo>(device, pIndirectCommandsLayout->GetPointer(), out_pIndirectCommandsLayout, &CommonObjectInfoTable::AddVkIndirectCommandsLayoutEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyIndirectCommandsLayoutEXT(
@@ -10421,12 +10421,12 @@ void VulkanReplayConsumer::Process_vkDestroyIndirectCommandsLayoutEXT(
     format::HandleId                            indirectCommandsLayout,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkIndirectCommandsLayoutEXT in_indirectCommandsLayout = MapHandle<VulkanIndirectCommandsLayoutEXTInfo>(indirectCommandsLayout, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutEXTInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkIndirectCommandsLayoutEXT in_indirectCommandsLayout = MapHandle<VulkanIndirectCommandsLayoutEXTInfo>(indirectCommandsLayout, &CommonObjectInfoTable::GetVkIndirectCommandsLayoutEXTInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyIndirectCommandsLayoutEXT(in_device, in_indirectCommandsLayout, in_pAllocator);
-    RemoveHandle(indirectCommandsLayout, &VulkanObjectInfoTable::RemoveVkIndirectCommandsLayoutEXTInfo);
+    RemoveHandle(indirectCommandsLayout, &CommonObjectInfoTable::RemoveVkIndirectCommandsLayoutEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateIndirectExecutionSetEXT(
@@ -10437,7 +10437,7 @@ void VulkanReplayConsumer::Process_vkCreateIndirectExecutionSetEXT(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkIndirectExecutionSetEXT>* pIndirectExecutionSet)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkIndirectExecutionSetCreateInfoEXT* in_pCreateInfo = pCreateInfo->GetPointer();
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pIndirectExecutionSet->IsNull()) { pIndirectExecutionSet->SetHandleLength(1); }
@@ -10446,7 +10446,7 @@ void VulkanReplayConsumer::Process_vkCreateIndirectExecutionSetEXT(
     VkResult replay_result = GetDeviceTable(in_device)->CreateIndirectExecutionSetEXT(in_device, in_pCreateInfo, in_pAllocator, out_pIndirectExecutionSet);
     CheckResult("vkCreateIndirectExecutionSetEXT", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanIndirectExecutionSetEXTInfo>(device, pIndirectExecutionSet->GetPointer(), out_pIndirectExecutionSet, &VulkanObjectInfoTable::AddVkIndirectExecutionSetEXTInfo);
+    AddHandle<VulkanIndirectExecutionSetEXTInfo>(device, pIndirectExecutionSet->GetPointer(), out_pIndirectExecutionSet, &CommonObjectInfoTable::AddVkIndirectExecutionSetEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyIndirectExecutionSetEXT(
@@ -10455,12 +10455,12 @@ void VulkanReplayConsumer::Process_vkDestroyIndirectExecutionSetEXT(
     format::HandleId                            indirectExecutionSet,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkIndirectExecutionSetEXT in_indirectExecutionSet = MapHandle<VulkanIndirectExecutionSetEXTInfo>(indirectExecutionSet, &VulkanObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkIndirectExecutionSetEXT in_indirectExecutionSet = MapHandle<VulkanIndirectExecutionSetEXTInfo>(indirectExecutionSet, &CommonObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyIndirectExecutionSetEXT(in_device, in_indirectExecutionSet, in_pAllocator);
-    RemoveHandle(indirectExecutionSet, &VulkanObjectInfoTable::RemoveVkIndirectExecutionSetEXTInfo);
+    RemoveHandle(indirectExecutionSet, &CommonObjectInfoTable::RemoveVkIndirectExecutionSetEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkUpdateIndirectExecutionSetPipelineEXT(
@@ -10470,8 +10470,8 @@ void VulkanReplayConsumer::Process_vkUpdateIndirectExecutionSetPipelineEXT(
     uint32_t                                    executionSetWriteCount,
     StructPointerDecoder<Decoded_VkWriteIndirectExecutionSetPipelineEXT>* pExecutionSetWrites)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkIndirectExecutionSetEXT in_indirectExecutionSet = MapHandle<VulkanIndirectExecutionSetEXTInfo>(indirectExecutionSet, &VulkanObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkIndirectExecutionSetEXT in_indirectExecutionSet = MapHandle<VulkanIndirectExecutionSetEXTInfo>(indirectExecutionSet, &CommonObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
     const VkWriteIndirectExecutionSetPipelineEXT* in_pExecutionSetWrites = pExecutionSetWrites->GetPointer();
     MapStructArrayHandles(pExecutionSetWrites->GetMetaStructPointer(), pExecutionSetWrites->GetLength(), GetObjectInfoTable());
 
@@ -10485,8 +10485,8 @@ void VulkanReplayConsumer::Process_vkUpdateIndirectExecutionSetShaderEXT(
     uint32_t                                    executionSetWriteCount,
     StructPointerDecoder<Decoded_VkWriteIndirectExecutionSetShaderEXT>* pExecutionSetWrites)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkIndirectExecutionSetEXT in_indirectExecutionSet = MapHandle<VulkanIndirectExecutionSetEXTInfo>(indirectExecutionSet, &VulkanObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkIndirectExecutionSetEXT in_indirectExecutionSet = MapHandle<VulkanIndirectExecutionSetEXTInfo>(indirectExecutionSet, &CommonObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
     const VkWriteIndirectExecutionSetShaderEXT* in_pExecutionSetWrites = pExecutionSetWrites->GetPointer();
     MapStructArrayHandles(pExecutionSetWrites->GetMetaStructPointer(), pExecutionSetWrites->GetLength(), GetObjectInfoTable());
 
@@ -10511,7 +10511,7 @@ void VulkanReplayConsumer::Process_vkCreateAccelerationStructureKHR(
     VkResult replay_result = OverrideCreateAccelerationStructureKHR(GetDeviceTable(in_device->handle)->CreateAccelerationStructureKHR, returnValue, in_device, pCreateInfo, pAllocator, pAccelerationStructure);
     CheckResult("vkCreateAccelerationStructureKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanAccelerationStructureKHRInfo>(device, pAccelerationStructure->GetPointer(), pAccelerationStructure->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVkAccelerationStructureKHRInfo);
+    AddHandle<VulkanAccelerationStructureKHRInfo>(device, pAccelerationStructure->GetPointer(), pAccelerationStructure->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkAccelerationStructureKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureKHR(
@@ -10524,7 +10524,7 @@ void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureKHR(
     auto in_accelerationStructure = GetObjectInfoTable().GetVkAccelerationStructureKHRInfo(accelerationStructure);
 
     OverrideDestroyAccelerationStructureKHR(GetDeviceTable(in_device->handle)->DestroyAccelerationStructureKHR, in_device, in_accelerationStructure, pAllocator);
-    RemoveHandle(accelerationStructure, &VulkanObjectInfoTable::RemoveVkAccelerationStructureKHRInfo);
+    RemoveHandle(accelerationStructure, &CommonObjectInfoTable::RemoveVkAccelerationStructureKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresKHR(
@@ -10542,7 +10542,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBuildAccelerationStructuresKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBuildAccelerationStructuresKHR, in_commandBuffer->handle, infoCount, pInfos->GetPointer(), ppBuildRangeInfos->GetPointer());
+        resource_dumper_.Process_vkCmdBuildAccelerationStructuresKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBuildAccelerationStructuresKHR, in_commandBuffer->handle, infoCount, pInfos->GetPointer(), ppBuildRangeInfos->GetPointer());
     }
 }
 
@@ -10555,7 +10555,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
     PointerDecoder<uint32_t>*                   pIndirectStrides,
     PointerDecoder<uint32_t*>*                  ppMaxPrimitiveCounts)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkAccelerationStructureBuildGeometryInfoKHR* in_pInfos = pInfos->GetPointer();
     MapStructArrayHandles(pInfos->GetMetaStructPointer(), pInfos->GetLength(), GetObjectInfoTable());
     const VkDeviceAddress* in_pIndirectDeviceAddresses = pIndirectDeviceAddresses->GetPointer();
@@ -10566,7 +10566,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdBuildAccelerationStructuresIndirectKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildAccelerationStructuresIndirectKHR, in_commandBuffer, infoCount, in_pInfos, in_pIndirectDeviceAddresses, in_pIndirectStrides, in_ppMaxPrimitiveCounts);
+        resource_dumper_.Process_vkCmdBuildAccelerationStructuresIndirectKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildAccelerationStructuresIndirectKHR, in_commandBuffer, infoCount, in_pInfos, in_pIndirectDeviceAddresses, in_pIndirectStrides, in_ppMaxPrimitiveCounts);
     }
 }
 
@@ -10577,8 +10577,8 @@ void VulkanReplayConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
     format::HandleId                            deferredOperation,
     StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &CommonObjectInfoTable::GetVkDeferredOperationKHRInfo);
     const VkCopyAccelerationStructureToMemoryInfoKHR* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -10593,8 +10593,8 @@ void VulkanReplayConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
     format::HandleId                            deferredOperation,
     StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &VulkanObjectInfoTable::GetVkDeferredOperationKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkDeferredOperationKHR in_deferredOperation = MapHandle<VulkanDeferredOperationKHRInfo>(deferredOperation, &CommonObjectInfoTable::GetVkDeferredOperationKHRInfo);
     const VkCopyMemoryToAccelerationStructureInfoKHR* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -10613,8 +10613,8 @@ void VulkanReplayConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
     PointerDecoder<uint8_t>*                    pData,
     size_t                                      stride)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    const VkAccelerationStructureKHR* in_pAccelerationStructures = MapHandles<VulkanAccelerationStructureKHRInfo>(pAccelerationStructures, accelerationStructureCount, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    const VkAccelerationStructureKHR* in_pAccelerationStructures = MapHandles<VulkanAccelerationStructureKHRInfo>(pAccelerationStructures, accelerationStructureCount, &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->WriteAccelerationStructuresPropertiesKHR(in_device, accelerationStructureCount, in_pAccelerationStructures, queryType, dataSize, out_pData, stride);
@@ -10634,7 +10634,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyAccelerationStructureKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdCopyAccelerationStructureKHR, in_commandBuffer->handle, pInfo->GetPointer());
+        resource_dumper_.Process_vkCmdCopyAccelerationStructureKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdCopyAccelerationStructureKHR, in_commandBuffer->handle, pInfo->GetPointer());
     }
 }
 
@@ -10643,7 +10643,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyAccelerationStructureToMemoryInfoKHR* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -10651,7 +10651,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyAccelerationStructureToMemoryKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyAccelerationStructureToMemoryKHR, in_commandBuffer, in_pInfo);
+        resource_dumper_.Process_vkCmdCopyAccelerationStructureToMemoryKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyAccelerationStructureToMemoryKHR, in_commandBuffer, in_pInfo);
     }
 }
 
@@ -10660,7 +10660,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkCopyMemoryToAccelerationStructureInfoKHR* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
@@ -10668,7 +10668,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdCopyMemoryToAccelerationStructureKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMemoryToAccelerationStructureKHR, in_commandBuffer, in_pInfo);
+        resource_dumper_.Process_vkCmdCopyMemoryToAccelerationStructureKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMemoryToAccelerationStructureKHR, in_commandBuffer, in_pInfo);
     }
 }
 
@@ -10695,14 +10695,14 @@ void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR
     uint32_t                                    firstQuery)
 {
     auto in_commandBuffer = GetObjectInfoTable().GetVkCommandBufferInfo(commandBuffer);
-    MapHandles<VulkanAccelerationStructureKHRInfo>(pAccelerationStructures, accelerationStructureCount, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
+    MapHandles<VulkanAccelerationStructureKHRInfo>(pAccelerationStructures, accelerationStructureCount, &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     auto in_queryPool = GetObjectInfoTable().GetVkQueryPoolInfo(queryPool);
 
     OverrideCmdWriteAccelerationStructuresPropertiesKHR(GetDeviceTable(in_commandBuffer->handle)->CmdWriteAccelerationStructuresPropertiesKHR, in_commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, in_queryPool, firstQuery);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdWriteAccelerationStructuresPropertiesKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdWriteAccelerationStructuresPropertiesKHR, in_commandBuffer->handle, accelerationStructureCount, pAccelerationStructures->GetHandlePointer(), queryType, in_queryPool->handle, firstQuery);
+        resource_dumper_.Process_vkCmdWriteAccelerationStructuresPropertiesKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdWriteAccelerationStructuresPropertiesKHR, in_commandBuffer->handle, accelerationStructureCount, pAccelerationStructures->GetHandlePointer(), queryType, in_queryPool->handle, firstQuery);
     }
 }
 
@@ -10712,7 +10712,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceAccelerationStructureCompatibility
     StructPointerDecoder<Decoded_VkAccelerationStructureVersionInfoKHR>* pVersionInfo,
     PointerDecoder<VkAccelerationStructureCompatibilityKHR>* pCompatibility)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkAccelerationStructureVersionInfoKHR* in_pVersionInfo = pVersionInfo->GetPointer();
     VkAccelerationStructureCompatibilityKHR* out_pCompatibility = pCompatibility->IsNull() ? nullptr : pCompatibility->AllocateOutputData(1, static_cast<VkAccelerationStructureCompatibilityKHR>(0));
 
@@ -10727,7 +10727,7 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureBuildSizesKHR(
     PointerDecoder<uint32_t>*                   pMaxPrimitiveCounts,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildSizesInfoKHR>* pSizeInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
     const VkAccelerationStructureBuildGeometryInfoKHR* in_pBuildInfo = pBuildInfo->GetPointer();
     MapStructHandles(pBuildInfo->GetMetaStructPointer(), GetObjectInfoTable());
     const uint32_t* in_pMaxPrimitiveCounts = pMaxPrimitiveCounts->GetPointer();
@@ -10754,7 +10754,7 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdTraceRaysKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdTraceRaysKHR, in_commandBuffer->handle, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
+        resource_dumper_.Process_vkCmdTraceRaysKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdTraceRaysKHR, in_commandBuffer->handle, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
     }
 }
 
@@ -10768,8 +10768,8 @@ void VulkanReplayConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandle
     size_t                                      dataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &VulkanObjectInfoTable::GetVkPipelineInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &CommonObjectInfoTable::GetVkPipelineInfo);
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetRayTracingCaptureReplayShaderGroupHandlesKHR(in_device, in_pipeline, firstGroup, groupCount, dataSize, out_pData);
@@ -10785,7 +10785,7 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysIndirectKHR(
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pCallableShaderBindingTable,
     VkDeviceAddress                             indirectDeviceAddress)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     const VkStridedDeviceAddressRegionKHR* in_pRaygenShaderBindingTable = pRaygenShaderBindingTable->GetPointer();
     const VkStridedDeviceAddressRegionKHR* in_pMissShaderBindingTable = pMissShaderBindingTable->GetPointer();
     const VkStridedDeviceAddressRegionKHR* in_pHitShaderBindingTable = pHitShaderBindingTable->GetPointer();
@@ -10795,7 +10795,7 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysIndirectKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdTraceRaysIndirectKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysIndirectKHR, in_commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress);
+        resource_dumper_.Process_vkCmdTraceRaysIndirectKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysIndirectKHR, in_commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress);
     }
 }
 
@@ -10807,8 +10807,8 @@ void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
     uint32_t                                    group,
     VkShaderGroupShaderKHR                      groupShader)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &VulkanObjectInfoTable::GetVkDeviceInfo);
-    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &VulkanObjectInfoTable::GetVkPipelineInfo);
+    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
+    VkPipeline in_pipeline = MapHandle<VulkanPipelineInfo>(pipeline, &CommonObjectInfoTable::GetVkPipelineInfo);
 
     GetDeviceTable(in_device)->GetRayTracingShaderGroupStackSizeKHR(in_device, in_pipeline, group, groupShader);
 }
@@ -10818,13 +10818,13 @@ void VulkanReplayConsumer::Process_vkCmdSetRayTracingPipelineStackSizeKHR(
     format::HandleId                            commandBuffer,
     uint32_t                                    pipelineStackSize)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdSetRayTracingPipelineStackSizeKHR(in_commandBuffer, pipelineStackSize);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdSetRayTracingPipelineStackSizeKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRayTracingPipelineStackSizeKHR, in_commandBuffer, pipelineStackSize);
+        resource_dumper_.Process_vkCmdSetRayTracingPipelineStackSizeKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRayTracingPipelineStackSizeKHR, in_commandBuffer, pipelineStackSize);
     }
 }
 
@@ -10835,13 +10835,13 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksEXT(
     uint32_t                                    groupCountY,
     uint32_t                                    groupCountZ)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksEXT(in_commandBuffer, groupCountX, groupCountY, groupCountZ);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawMeshTasksEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksEXT, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
+        resource_dumper_.Process_vkCmdDrawMeshTasksEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksEXT, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
     }
 }
 
@@ -10853,14 +10853,14 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectEXT(
     uint32_t                                    drawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectEXT(in_commandBuffer, in_buffer, offset, drawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawMeshTasksIndirectEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectEXT, in_commandBuffer, in_buffer, offset, drawCount, stride);
+        resource_dumper_.Process_vkCmdDrawMeshTasksIndirectEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectEXT, in_commandBuffer, in_buffer, offset, drawCount, stride);
     }
 }
 
@@ -10874,15 +10874,15 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectCountEXT(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
-    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &VulkanObjectInfoTable::GetVkBufferInfo);
-    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &VulkanObjectInfoTable::GetVkBufferInfo);
+    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
+    VkBuffer in_buffer = MapHandle<VulkanBufferInfo>(buffer, &CommonObjectInfoTable::GetVkBufferInfo);
+    VkBuffer in_countBuffer = MapHandle<VulkanBufferInfo>(countBuffer, &CommonObjectInfoTable::GetVkBufferInfo);
 
     GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectCountEXT(in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
 
     if (options_.dumping_resources)
     {
-        resource_dumper.Process_vkCmdDrawMeshTasksIndirectCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectCountEXT, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
+        resource_dumper_.Process_vkCmdDrawMeshTasksIndirectCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectCountEXT, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 }
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -1440,7 +1440,7 @@ void VulkanReplayConsumer::Process_vkEndCommandBuffer(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkEndCommandBuffer(call_info, GetDeviceTable(in_commandBuffer)->EndCommandBuffer, returnValue, in_commandBuffer);
+        resource_dumper_->Process_vkEndCommandBuffer(call_info, GetDeviceTable(in_commandBuffer)->EndCommandBuffer, returnValue, in_commandBuffer);
     }
 }
 
@@ -1469,7 +1469,7 @@ void VulkanReplayConsumer::Process_vkCmdBindPipeline(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindPipeline(call_info, GetDeviceTable(in_commandBuffer)->CmdBindPipeline, in_commandBuffer, pipelineBindPoint, GetObjectInfoTable().GetVkPipelineInfo(pipeline));
+        resource_dumper_->Process_vkCmdBindPipeline(call_info, GetDeviceTable(in_commandBuffer)->CmdBindPipeline, in_commandBuffer, pipelineBindPoint, GetObjectInfoTable().GetVkPipelineInfo(pipeline));
     }
 }
 
@@ -1487,7 +1487,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewport(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetViewport(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewport, in_commandBuffer, firstViewport, viewportCount, in_pViewports);
+        resource_dumper_->Process_vkCmdSetViewport(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewport, in_commandBuffer, firstViewport, viewportCount, in_pViewports);
     }
 }
 
@@ -1505,7 +1505,7 @@ void VulkanReplayConsumer::Process_vkCmdSetScissor(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetScissor(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissor, in_commandBuffer, firstScissor, scissorCount, in_pScissors);
+        resource_dumper_->Process_vkCmdSetScissor(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissor, in_commandBuffer, firstScissor, scissorCount, in_pScissors);
     }
 }
 
@@ -1520,7 +1520,7 @@ void VulkanReplayConsumer::Process_vkCmdSetLineWidth(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetLineWidth(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineWidth, in_commandBuffer, lineWidth);
+        resource_dumper_->Process_vkCmdSetLineWidth(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineWidth, in_commandBuffer, lineWidth);
     }
 }
 
@@ -1537,7 +1537,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBias(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthBias(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBias, in_commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
+        resource_dumper_->Process_vkCmdSetDepthBias(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBias, in_commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
     }
 }
 
@@ -1553,7 +1553,7 @@ void VulkanReplayConsumer::Process_vkCmdSetBlendConstants(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetBlendConstants(call_info, GetDeviceTable(in_commandBuffer)->CmdSetBlendConstants, in_commandBuffer, in_blendConstants);
+        resource_dumper_->Process_vkCmdSetBlendConstants(call_info, GetDeviceTable(in_commandBuffer)->CmdSetBlendConstants, in_commandBuffer, in_blendConstants);
     }
 }
 
@@ -1569,7 +1569,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBounds(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthBounds(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBounds, in_commandBuffer, minDepthBounds, maxDepthBounds);
+        resource_dumper_->Process_vkCmdSetDepthBounds(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBounds, in_commandBuffer, minDepthBounds, maxDepthBounds);
     }
 }
 
@@ -1585,7 +1585,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilCompareMask(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetStencilCompareMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilCompareMask, in_commandBuffer, faceMask, compareMask);
+        resource_dumper_->Process_vkCmdSetStencilCompareMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilCompareMask, in_commandBuffer, faceMask, compareMask);
     }
 }
 
@@ -1601,7 +1601,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilWriteMask(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetStencilWriteMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilWriteMask, in_commandBuffer, faceMask, writeMask);
+        resource_dumper_->Process_vkCmdSetStencilWriteMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilWriteMask, in_commandBuffer, faceMask, writeMask);
     }
 }
 
@@ -1617,7 +1617,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilReference(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetStencilReference(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilReference, in_commandBuffer, faceMask, reference);
+        resource_dumper_->Process_vkCmdSetStencilReference(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilReference, in_commandBuffer, faceMask, reference);
     }
 }
 
@@ -1641,7 +1641,7 @@ void VulkanReplayConsumer::Process_vkCmdBindDescriptorSets(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindDescriptorSets(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorSets, in_commandBuffer, pipelineBindPoint, GetObjectInfoTable().GetVkPipelineLayoutInfo(layout), firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, in_pDynamicOffsets);
+        resource_dumper_->Process_vkCmdBindDescriptorSets(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorSets, in_commandBuffer, pipelineBindPoint, GetObjectInfoTable().GetVkPipelineLayoutInfo(layout), firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, in_pDynamicOffsets);
     }
 }
 
@@ -1659,7 +1659,7 @@ void VulkanReplayConsumer::Process_vkCmdBindIndexBuffer(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindIndexBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdBindIndexBuffer, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, indexType);
+        resource_dumper_->Process_vkCmdBindIndexBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdBindIndexBuffer, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, indexType);
     }
 }
 
@@ -1679,7 +1679,7 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindVertexBuffers(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers, in_commandBuffer, firstBinding, bindingCount, pBuffers, in_pOffsets);
+        resource_dumper_->Process_vkCmdBindVertexBuffers(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers, in_commandBuffer, firstBinding, bindingCount, pBuffers, in_pOffsets);
     }
 }
 
@@ -1697,7 +1697,7 @@ void VulkanReplayConsumer::Process_vkCmdDraw(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDraw(call_info, GetDeviceTable(in_commandBuffer)->CmdDraw, in_commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
+        resource_dumper_->Process_vkCmdDraw(call_info, GetDeviceTable(in_commandBuffer)->CmdDraw, in_commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
     }
 }
 
@@ -1716,7 +1716,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexed(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawIndexed(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexed, in_commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
+        resource_dumper_->Process_vkCmdDrawIndexed(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexed, in_commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
     }
 }
 
@@ -1735,7 +1735,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirect(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, drawCount, stride);
+        resource_dumper_->Process_vkCmdDrawIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, drawCount, stride);
     }
 }
 
@@ -1754,7 +1754,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirect(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawIndexedIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, drawCount, stride);
+        resource_dumper_->Process_vkCmdDrawIndexedIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, drawCount, stride);
     }
 }
 
@@ -1771,7 +1771,7 @@ void VulkanReplayConsumer::Process_vkCmdDispatch(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDispatch(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatch, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
+        resource_dumper_->Process_vkCmdDispatch(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatch, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
     }
 }
 
@@ -1788,7 +1788,7 @@ void VulkanReplayConsumer::Process_vkCmdDispatchIndirect(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDispatchIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset);
+        resource_dumper_->Process_vkCmdDispatchIndirect(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchIndirect, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset);
     }
 }
 
@@ -1809,7 +1809,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer, in_commandBuffer, in_srcBuffer, in_dstBuffer, regionCount, in_pRegions);
+        resource_dumper_->Process_vkCmdCopyBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer, in_commandBuffer, in_srcBuffer, in_dstBuffer, regionCount, in_pRegions);
     }
 }
 
@@ -1832,7 +1832,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyImage(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions);
+        resource_dumper_->Process_vkCmdCopyImage(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions);
     }
 }
 
@@ -1856,7 +1856,7 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBlitImage(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions, filter);
+        resource_dumper_->Process_vkCmdBlitImage(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions, filter);
     }
 }
 
@@ -1878,7 +1878,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyBufferToImage(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage, in_commandBuffer, in_srcBuffer, in_dstImage, dstImageLayout, regionCount, in_pRegions);
+        resource_dumper_->Process_vkCmdCopyBufferToImage(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage, in_commandBuffer, in_srcBuffer, in_dstImage, dstImageLayout, regionCount, in_pRegions);
     }
 }
 
@@ -1900,7 +1900,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyImageToBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer, in_commandBuffer, in_srcImage, srcImageLayout, in_dstBuffer, regionCount, in_pRegions);
+        resource_dumper_->Process_vkCmdCopyImageToBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer, in_commandBuffer, in_srcImage, srcImageLayout, in_dstBuffer, regionCount, in_pRegions);
     }
 }
 
@@ -1920,7 +1920,7 @@ void VulkanReplayConsumer::Process_vkCmdUpdateBuffer(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdUpdateBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdUpdateBuffer, in_commandBuffer, in_dstBuffer, dstOffset, dataSize, in_pData);
+        resource_dumper_->Process_vkCmdUpdateBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdUpdateBuffer, in_commandBuffer, in_dstBuffer, dstOffset, dataSize, in_pData);
     }
 }
 
@@ -1939,7 +1939,7 @@ void VulkanReplayConsumer::Process_vkCmdFillBuffer(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdFillBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdFillBuffer, in_commandBuffer, in_dstBuffer, dstOffset, size, data);
+        resource_dumper_->Process_vkCmdFillBuffer(call_info, GetDeviceTable(in_commandBuffer)->CmdFillBuffer, in_commandBuffer, in_dstBuffer, dstOffset, size, data);
     }
 }
 
@@ -1961,7 +1961,7 @@ void VulkanReplayConsumer::Process_vkCmdClearColorImage(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdClearColorImage(call_info, GetDeviceTable(in_commandBuffer)->CmdClearColorImage, in_commandBuffer, in_image, imageLayout, in_pColor, rangeCount, in_pRanges);
+        resource_dumper_->Process_vkCmdClearColorImage(call_info, GetDeviceTable(in_commandBuffer)->CmdClearColorImage, in_commandBuffer, in_image, imageLayout, in_pColor, rangeCount, in_pRanges);
     }
 }
 
@@ -1983,7 +1983,7 @@ void VulkanReplayConsumer::Process_vkCmdClearDepthStencilImage(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdClearDepthStencilImage(call_info, GetDeviceTable(in_commandBuffer)->CmdClearDepthStencilImage, in_commandBuffer, in_image, imageLayout, in_pDepthStencil, rangeCount, in_pRanges);
+        resource_dumper_->Process_vkCmdClearDepthStencilImage(call_info, GetDeviceTable(in_commandBuffer)->CmdClearDepthStencilImage, in_commandBuffer, in_image, imageLayout, in_pDepthStencil, rangeCount, in_pRanges);
     }
 }
 
@@ -2003,7 +2003,7 @@ void VulkanReplayConsumer::Process_vkCmdClearAttachments(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdClearAttachments(call_info, GetDeviceTable(in_commandBuffer)->CmdClearAttachments, in_commandBuffer, attachmentCount, in_pAttachments, rectCount, in_pRects);
+        resource_dumper_->Process_vkCmdClearAttachments(call_info, GetDeviceTable(in_commandBuffer)->CmdClearAttachments, in_commandBuffer, attachmentCount, in_pAttachments, rectCount, in_pRects);
     }
 }
 
@@ -2026,7 +2026,7 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdResolveImage(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions);
+        resource_dumper_->Process_vkCmdResolveImage(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage, in_commandBuffer, in_srcImage, srcImageLayout, in_dstImage, dstImageLayout, regionCount, in_pRegions);
     }
 }
 
@@ -2043,7 +2043,7 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetEvent(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent, in_commandBuffer, in_event, stageMask);
+        resource_dumper_->Process_vkCmdSetEvent(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent, in_commandBuffer, in_event, stageMask);
     }
 }
 
@@ -2060,7 +2060,7 @@ void VulkanReplayConsumer::Process_vkCmdResetEvent(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdResetEvent(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent, in_commandBuffer, in_event, stageMask);
+        resource_dumper_->Process_vkCmdResetEvent(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent, in_commandBuffer, in_event, stageMask);
     }
 }
 
@@ -2090,7 +2090,7 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWaitEvents(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents, in_commandBuffer, eventCount, in_pEvents, srcStageMask, dstStageMask, memoryBarrierCount, in_pMemoryBarriers, bufferMemoryBarrierCount, in_pBufferMemoryBarriers, imageMemoryBarrierCount, in_pImageMemoryBarriers);
+        resource_dumper_->Process_vkCmdWaitEvents(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents, in_commandBuffer, eventCount, in_pEvents, srcStageMask, dstStageMask, memoryBarrierCount, in_pMemoryBarriers, bufferMemoryBarrierCount, in_pBufferMemoryBarriers, imageMemoryBarrierCount, in_pImageMemoryBarriers);
     }
 }
 
@@ -2117,7 +2117,7 @@ void VulkanReplayConsumer::Process_vkCmdPipelineBarrier(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPipelineBarrier(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier, in_commandBuffer->handle, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers->GetPointer(), bufferMemoryBarrierCount, pBufferMemoryBarriers->GetPointer(), imageMemoryBarrierCount, pImageMemoryBarriers->GetPointer());
+        resource_dumper_->Process_vkCmdPipelineBarrier(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier, in_commandBuffer->handle, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers->GetPointer(), bufferMemoryBarrierCount, pBufferMemoryBarriers->GetPointer(), imageMemoryBarrierCount, pImageMemoryBarriers->GetPointer());
     }
 }
 
@@ -2135,7 +2135,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginQuery(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginQuery(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginQuery, in_commandBuffer, in_queryPool, query, flags);
+        resource_dumper_->Process_vkCmdBeginQuery(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginQuery, in_commandBuffer, in_queryPool, query, flags);
     }
 }
 
@@ -2152,7 +2152,7 @@ void VulkanReplayConsumer::Process_vkCmdEndQuery(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndQuery(call_info, GetDeviceTable(in_commandBuffer)->CmdEndQuery, in_commandBuffer, in_queryPool, query);
+        resource_dumper_->Process_vkCmdEndQuery(call_info, GetDeviceTable(in_commandBuffer)->CmdEndQuery, in_commandBuffer, in_queryPool, query);
     }
 }
 
@@ -2170,7 +2170,7 @@ void VulkanReplayConsumer::Process_vkCmdResetQueryPool(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdResetQueryPool(call_info, GetDeviceTable(in_commandBuffer)->CmdResetQueryPool, in_commandBuffer, in_queryPool, firstQuery, queryCount);
+        resource_dumper_->Process_vkCmdResetQueryPool(call_info, GetDeviceTable(in_commandBuffer)->CmdResetQueryPool, in_commandBuffer, in_queryPool, firstQuery, queryCount);
     }
 }
 
@@ -2188,7 +2188,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteTimestamp(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWriteTimestamp(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp, in_commandBuffer, pipelineStage, in_queryPool, query);
+        resource_dumper_->Process_vkCmdWriteTimestamp(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp, in_commandBuffer, pipelineStage, in_queryPool, query);
     }
 }
 
@@ -2211,7 +2211,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyQueryPoolResults(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyQueryPoolResults(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyQueryPoolResults, in_commandBuffer, in_queryPool, firstQuery, queryCount, in_dstBuffer, dstOffset, stride, flags);
+        resource_dumper_->Process_vkCmdCopyQueryPoolResults(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyQueryPoolResults, in_commandBuffer, in_queryPool, firstQuery, queryCount, in_dstBuffer, dstOffset, stride, flags);
     }
 }
 
@@ -2232,7 +2232,7 @@ void VulkanReplayConsumer::Process_vkCmdPushConstants(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPushConstants(call_info, GetDeviceTable(in_commandBuffer)->CmdPushConstants, in_commandBuffer, in_layout, stageFlags, offset, size, in_pValues);
+        resource_dumper_->Process_vkCmdPushConstants(call_info, GetDeviceTable(in_commandBuffer)->CmdPushConstants, in_commandBuffer, in_layout, stageFlags, offset, size, in_pValues);
     }
 }
 
@@ -2250,7 +2250,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginRenderPass(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass, in_commandBuffer->handle, pRenderPassBegin, contents);
+        resource_dumper_->Process_vkCmdBeginRenderPass(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass, in_commandBuffer->handle, pRenderPassBegin, contents);
     }
 }
 
@@ -2265,7 +2265,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdNextSubpass(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass, in_commandBuffer, contents);
+        resource_dumper_->Process_vkCmdNextSubpass(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass, in_commandBuffer, contents);
     }
 }
 
@@ -2279,7 +2279,7 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderPass(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndRenderPass(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass, in_commandBuffer);
+        resource_dumper_->Process_vkCmdEndRenderPass(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass, in_commandBuffer);
     }
 }
 
@@ -2296,7 +2296,7 @@ void VulkanReplayConsumer::Process_vkCmdExecuteCommands(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdExecuteCommands(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteCommands, in_commandBuffer, commandBufferCount, in_pCommandBuffers);
+        resource_dumper_->Process_vkCmdExecuteCommands(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteCommands, in_commandBuffer, commandBufferCount, in_pCommandBuffers);
     }
 }
 
@@ -2355,7 +2355,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDeviceMask(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDeviceMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDeviceMask, in_commandBuffer, deviceMask);
+        resource_dumper_->Process_vkCmdSetDeviceMask(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDeviceMask, in_commandBuffer, deviceMask);
     }
 }
 
@@ -2375,7 +2375,7 @@ void VulkanReplayConsumer::Process_vkCmdDispatchBase(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDispatchBase(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchBase, in_commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+        resource_dumper_->Process_vkCmdDispatchBase(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchBase, in_commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
     }
 }
 
@@ -2714,7 +2714,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectCount(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawIndirectCount(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCount, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
+        resource_dumper_->Process_vkCmdDrawIndirectCount(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCount, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -2736,7 +2736,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCount(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawIndexedIndirectCount(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCount, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
+        resource_dumper_->Process_vkCmdDrawIndexedIndirectCount(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCount, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -2773,7 +2773,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginRenderPass2(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass2, in_commandBuffer->handle, pRenderPassBegin, pSubpassBeginInfo);
+        resource_dumper_->Process_vkCmdBeginRenderPass2(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass2, in_commandBuffer->handle, pRenderPassBegin, pSubpassBeginInfo);
     }
 }
 
@@ -2791,7 +2791,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdNextSubpass2(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass2, in_commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
+        resource_dumper_->Process_vkCmdNextSubpass2(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass2, in_commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
     }
 }
 
@@ -2807,7 +2807,7 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderPass2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndRenderPass2(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass2, in_commandBuffer, pSubpassEndInfo);
+        resource_dumper_->Process_vkCmdEndRenderPass2(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass2, in_commandBuffer, pSubpassEndInfo);
     }
 }
 
@@ -3006,7 +3006,7 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetEvent2(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent2, in_commandBuffer, in_event, in_pDependencyInfo);
+        resource_dumper_->Process_vkCmdSetEvent2(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent2, in_commandBuffer, in_event, in_pDependencyInfo);
     }
 }
 
@@ -3023,7 +3023,7 @@ void VulkanReplayConsumer::Process_vkCmdResetEvent2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdResetEvent2(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent2, in_commandBuffer, in_event, stageMask);
+        resource_dumper_->Process_vkCmdResetEvent2(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent2, in_commandBuffer, in_event, stageMask);
     }
 }
 
@@ -3043,7 +3043,7 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWaitEvents2(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents2, in_commandBuffer, eventCount, in_pEvents, in_pDependencyInfos);
+        resource_dumper_->Process_vkCmdWaitEvents2(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents2, in_commandBuffer, eventCount, in_pEvents, in_pDependencyInfos);
     }
 }
 
@@ -3060,7 +3060,7 @@ void VulkanReplayConsumer::Process_vkCmdPipelineBarrier2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPipelineBarrier2(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier2, in_commandBuffer->handle, pDependencyInfo->GetPointer());
+        resource_dumper_->Process_vkCmdPipelineBarrier2(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier2, in_commandBuffer->handle, pDependencyInfo->GetPointer());
     }
 }
 
@@ -3078,7 +3078,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteTimestamp2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWriteTimestamp2(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp2, in_commandBuffer, stage, in_queryPool, query);
+        resource_dumper_->Process_vkCmdWriteTimestamp2(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp2, in_commandBuffer, stage, in_queryPool, query);
     }
 }
 
@@ -3112,7 +3112,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyBuffer2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer2, in_commandBuffer, in_pCopyBufferInfo);
+        resource_dumper_->Process_vkCmdCopyBuffer2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer2, in_commandBuffer, in_pCopyBufferInfo);
     }
 }
 
@@ -3129,7 +3129,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage2, in_commandBuffer, in_pCopyImageInfo);
+        resource_dumper_->Process_vkCmdCopyImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage2, in_commandBuffer, in_pCopyImageInfo);
     }
 }
 
@@ -3146,7 +3146,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyBufferToImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage2, in_commandBuffer, in_pCopyBufferToImageInfo);
+        resource_dumper_->Process_vkCmdCopyBufferToImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage2, in_commandBuffer, in_pCopyBufferToImageInfo);
     }
 }
 
@@ -3163,7 +3163,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyImageToBuffer2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer2, in_commandBuffer, in_pCopyImageToBufferInfo);
+        resource_dumper_->Process_vkCmdCopyImageToBuffer2(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer2, in_commandBuffer, in_pCopyImageToBufferInfo);
     }
 }
 
@@ -3180,7 +3180,7 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBlitImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage2, in_commandBuffer, in_pBlitImageInfo);
+        resource_dumper_->Process_vkCmdBlitImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage2, in_commandBuffer, in_pBlitImageInfo);
     }
 }
 
@@ -3197,7 +3197,7 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdResolveImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage2, in_commandBuffer, in_pResolveImageInfo);
+        resource_dumper_->Process_vkCmdResolveImage2(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage2, in_commandBuffer, in_pResolveImageInfo);
     }
 }
 
@@ -3214,7 +3214,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRendering(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginRendering(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginRendering, in_commandBuffer, pRenderingInfo);
+        resource_dumper_->Process_vkCmdBeginRendering(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginRendering, in_commandBuffer, pRenderingInfo);
     }
 }
 
@@ -3228,7 +3228,7 @@ void VulkanReplayConsumer::Process_vkCmdEndRendering(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndRendering(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRendering, in_commandBuffer);
+        resource_dumper_->Process_vkCmdEndRendering(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRendering, in_commandBuffer);
     }
 }
 
@@ -3243,7 +3243,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCullMode(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetCullMode(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCullMode, in_commandBuffer, cullMode);
+        resource_dumper_->Process_vkCmdSetCullMode(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCullMode, in_commandBuffer, cullMode);
     }
 }
 
@@ -3258,7 +3258,7 @@ void VulkanReplayConsumer::Process_vkCmdSetFrontFace(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetFrontFace(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFrontFace, in_commandBuffer, frontFace);
+        resource_dumper_->Process_vkCmdSetFrontFace(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFrontFace, in_commandBuffer, frontFace);
     }
 }
 
@@ -3273,7 +3273,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveTopology(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetPrimitiveTopology(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveTopology, in_commandBuffer, primitiveTopology);
+        resource_dumper_->Process_vkCmdSetPrimitiveTopology(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveTopology, in_commandBuffer, primitiveTopology);
     }
 }
 
@@ -3290,7 +3290,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWithCount(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetViewportWithCount(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWithCount, in_commandBuffer, viewportCount, in_pViewports);
+        resource_dumper_->Process_vkCmdSetViewportWithCount(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWithCount, in_commandBuffer, viewportCount, in_pViewports);
     }
 }
 
@@ -3307,7 +3307,7 @@ void VulkanReplayConsumer::Process_vkCmdSetScissorWithCount(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetScissorWithCount(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissorWithCount, in_commandBuffer, scissorCount, in_pScissors);
+        resource_dumper_->Process_vkCmdSetScissorWithCount(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissorWithCount, in_commandBuffer, scissorCount, in_pScissors);
     }
 }
 
@@ -3331,7 +3331,7 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers2(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindVertexBuffers2(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers2, in_commandBuffer, firstBinding, bindingCount, pBuffers, in_pOffsets, in_pSizes, in_pStrides);
+        resource_dumper_->Process_vkCmdBindVertexBuffers2(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers2, in_commandBuffer, firstBinding, bindingCount, pBuffers, in_pOffsets, in_pSizes, in_pStrides);
     }
 }
 
@@ -3346,7 +3346,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthTestEnable(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthTestEnable, in_commandBuffer, depthTestEnable);
+        resource_dumper_->Process_vkCmdSetDepthTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthTestEnable, in_commandBuffer, depthTestEnable);
     }
 }
 
@@ -3361,7 +3361,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthWriteEnable(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthWriteEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthWriteEnable, in_commandBuffer, depthWriteEnable);
+        resource_dumper_->Process_vkCmdSetDepthWriteEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthWriteEnable, in_commandBuffer, depthWriteEnable);
     }
 }
 
@@ -3376,7 +3376,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthCompareOp(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthCompareOp(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthCompareOp, in_commandBuffer, depthCompareOp);
+        resource_dumper_->Process_vkCmdSetDepthCompareOp(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthCompareOp, in_commandBuffer, depthCompareOp);
     }
 }
 
@@ -3391,7 +3391,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBoundsTestEnable(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthBoundsTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBoundsTestEnable, in_commandBuffer, depthBoundsTestEnable);
+        resource_dumper_->Process_vkCmdSetDepthBoundsTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBoundsTestEnable, in_commandBuffer, depthBoundsTestEnable);
     }
 }
 
@@ -3406,7 +3406,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilTestEnable(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetStencilTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilTestEnable, in_commandBuffer, stencilTestEnable);
+        resource_dumper_->Process_vkCmdSetStencilTestEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilTestEnable, in_commandBuffer, stencilTestEnable);
     }
 }
 
@@ -3425,7 +3425,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilOp(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetStencilOp(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilOp, in_commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
+        resource_dumper_->Process_vkCmdSetStencilOp(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilOp, in_commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
     }
 }
 
@@ -3440,7 +3440,7 @@ void VulkanReplayConsumer::Process_vkCmdSetRasterizerDiscardEnable(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetRasterizerDiscardEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizerDiscardEnable, in_commandBuffer, rasterizerDiscardEnable);
+        resource_dumper_->Process_vkCmdSetRasterizerDiscardEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizerDiscardEnable, in_commandBuffer, rasterizerDiscardEnable);
     }
 }
 
@@ -3455,7 +3455,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBiasEnable(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthBiasEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBiasEnable, in_commandBuffer, depthBiasEnable);
+        resource_dumper_->Process_vkCmdSetDepthBiasEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBiasEnable, in_commandBuffer, depthBiasEnable);
     }
 }
 
@@ -3470,7 +3470,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveRestartEnable(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetPrimitiveRestartEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveRestartEnable, in_commandBuffer, primitiveRestartEnable);
+        resource_dumper_->Process_vkCmdSetPrimitiveRestartEnable(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveRestartEnable, in_commandBuffer, primitiveRestartEnable);
     }
 }
 
@@ -4269,7 +4269,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginVideoCodingKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginVideoCodingKHR, in_commandBuffer, in_pBeginInfo);
+        resource_dumper_->Process_vkCmdBeginVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginVideoCodingKHR, in_commandBuffer, in_pBeginInfo);
     }
 }
 
@@ -4285,7 +4285,7 @@ void VulkanReplayConsumer::Process_vkCmdEndVideoCodingKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndVideoCodingKHR, in_commandBuffer, in_pEndCodingInfo);
+        resource_dumper_->Process_vkCmdEndVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndVideoCodingKHR, in_commandBuffer, in_pEndCodingInfo);
     }
 }
 
@@ -4301,7 +4301,7 @@ void VulkanReplayConsumer::Process_vkCmdControlVideoCodingKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdControlVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdControlVideoCodingKHR, in_commandBuffer, in_pCodingControlInfo);
+        resource_dumper_->Process_vkCmdControlVideoCodingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdControlVideoCodingKHR, in_commandBuffer, in_pCodingControlInfo);
     }
 }
 
@@ -4318,7 +4318,7 @@ void VulkanReplayConsumer::Process_vkCmdDecodeVideoKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDecodeVideoKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDecodeVideoKHR, in_commandBuffer, in_pDecodeInfo);
+        resource_dumper_->Process_vkCmdDecodeVideoKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDecodeVideoKHR, in_commandBuffer, in_pDecodeInfo);
     }
 }
 
@@ -4335,7 +4335,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderingKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginRenderingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginRenderingKHR, in_commandBuffer, pRenderingInfo);
+        resource_dumper_->Process_vkCmdBeginRenderingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginRenderingKHR, in_commandBuffer, pRenderingInfo);
     }
 }
 
@@ -4349,7 +4349,7 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderingKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndRenderingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderingKHR, in_commandBuffer);
+        resource_dumper_->Process_vkCmdEndRenderingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderingKHR, in_commandBuffer);
     }
 }
 
@@ -4475,7 +4475,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDeviceMaskKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDeviceMaskKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDeviceMaskKHR, in_commandBuffer, deviceMask);
+        resource_dumper_->Process_vkCmdSetDeviceMaskKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDeviceMaskKHR, in_commandBuffer, deviceMask);
     }
 }
 
@@ -4495,7 +4495,7 @@ void VulkanReplayConsumer::Process_vkCmdDispatchBaseKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDispatchBaseKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchBaseKHR, in_commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+        resource_dumper_->Process_vkCmdDispatchBaseKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDispatchBaseKHR, in_commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
     }
 }
 
@@ -4705,7 +4705,7 @@ void VulkanReplayConsumer::Process_vkCmdPushDescriptorSetKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPushDescriptorSetKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSetKHR, in_commandBuffer, pipelineBindPoint, in_layout, set, descriptorWriteCount, in_pDescriptorWrites);
+        resource_dumper_->Process_vkCmdPushDescriptorSetKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSetKHR, in_commandBuffer, pipelineBindPoint, in_layout, set, descriptorWriteCount, in_pDescriptorWrites);
     }
 }
 
@@ -4776,7 +4776,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginRenderPass2KHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass2KHR, in_commandBuffer->handle, pRenderPassBegin, pSubpassBeginInfo);
+        resource_dumper_->Process_vkCmdBeginRenderPass2KHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass2KHR, in_commandBuffer->handle, pRenderPassBegin, pSubpassBeginInfo);
     }
 }
 
@@ -4794,7 +4794,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdNextSubpass2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass2KHR, in_commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
+        resource_dumper_->Process_vkCmdNextSubpass2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdNextSubpass2KHR, in_commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
     }
 }
 
@@ -4810,7 +4810,7 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderPass2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndRenderPass2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass2KHR, in_commandBuffer, pSubpassEndInfo);
+        resource_dumper_->Process_vkCmdEndRenderPass2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEndRenderPass2KHR, in_commandBuffer, pSubpassEndInfo);
     }
 }
 
@@ -5235,7 +5235,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectCountKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawIndirectCountKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCountKHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
+        resource_dumper_->Process_vkCmdDrawIndirectCountKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCountKHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -5257,7 +5257,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawIndexedIndirectCountKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCountKHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
+        resource_dumper_->Process_vkCmdDrawIndexedIndirectCountKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCountKHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, GetObjectInfoTable().GetVkBufferInfo(countBuffer), countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -5336,7 +5336,7 @@ void VulkanReplayConsumer::Process_vkCmdSetFragmentShadingRateKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetFragmentShadingRateKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFragmentShadingRateKHR, in_commandBuffer, in_pFragmentSize, in_combinerOps);
+        resource_dumper_->Process_vkCmdSetFragmentShadingRateKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFragmentShadingRateKHR, in_commandBuffer, in_pFragmentSize, in_combinerOps);
     }
 }
 
@@ -5352,7 +5352,7 @@ void VulkanReplayConsumer::Process_vkCmdSetRenderingAttachmentLocationsKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetRenderingAttachmentLocationsKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRenderingAttachmentLocationsKHR, in_commandBuffer, in_pLocationInfo);
+        resource_dumper_->Process_vkCmdSetRenderingAttachmentLocationsKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRenderingAttachmentLocationsKHR, in_commandBuffer, in_pLocationInfo);
     }
 }
 
@@ -5368,7 +5368,7 @@ void VulkanReplayConsumer::Process_vkCmdSetRenderingInputAttachmentIndicesKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetRenderingInputAttachmentIndicesKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRenderingInputAttachmentIndicesKHR, in_commandBuffer, in_pInputAttachmentIndexInfo);
+        resource_dumper_->Process_vkCmdSetRenderingInputAttachmentIndicesKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRenderingInputAttachmentIndicesKHR, in_commandBuffer, in_pInputAttachmentIndexInfo);
     }
 }
 
@@ -5645,7 +5645,7 @@ void VulkanReplayConsumer::Process_vkCmdEncodeVideoKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEncodeVideoKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEncodeVideoKHR, in_commandBuffer, in_pEncodeInfo);
+        resource_dumper_->Process_vkCmdEncodeVideoKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdEncodeVideoKHR, in_commandBuffer, in_pEncodeInfo);
     }
 }
 
@@ -5664,7 +5664,7 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetEvent2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent2KHR, in_commandBuffer, in_event, in_pDependencyInfo);
+        resource_dumper_->Process_vkCmdSetEvent2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetEvent2KHR, in_commandBuffer, in_event, in_pDependencyInfo);
     }
 }
 
@@ -5681,7 +5681,7 @@ void VulkanReplayConsumer::Process_vkCmdResetEvent2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdResetEvent2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent2KHR, in_commandBuffer, in_event, stageMask);
+        resource_dumper_->Process_vkCmdResetEvent2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdResetEvent2KHR, in_commandBuffer, in_event, stageMask);
     }
 }
 
@@ -5701,7 +5701,7 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWaitEvents2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents2KHR, in_commandBuffer, eventCount, in_pEvents, in_pDependencyInfos);
+        resource_dumper_->Process_vkCmdWaitEvents2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdWaitEvents2KHR, in_commandBuffer, eventCount, in_pEvents, in_pDependencyInfos);
     }
 }
 
@@ -5718,7 +5718,7 @@ void VulkanReplayConsumer::Process_vkCmdPipelineBarrier2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPipelineBarrier2KHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier2KHR, in_commandBuffer->handle, pDependencyInfo->GetPointer());
+        resource_dumper_->Process_vkCmdPipelineBarrier2KHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPipelineBarrier2KHR, in_commandBuffer->handle, pDependencyInfo->GetPointer());
     }
 }
 
@@ -5736,7 +5736,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteTimestamp2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWriteTimestamp2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp2KHR, in_commandBuffer, stage, in_queryPool, query);
+        resource_dumper_->Process_vkCmdWriteTimestamp2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteTimestamp2KHR, in_commandBuffer, stage, in_queryPool, query);
     }
 }
 
@@ -5772,7 +5772,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteBufferMarker2AMD(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWriteBufferMarker2AMD(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteBufferMarker2AMD, in_commandBuffer, stage, in_dstBuffer, dstOffset, marker);
+        resource_dumper_->Process_vkCmdWriteBufferMarker2AMD(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteBufferMarker2AMD, in_commandBuffer, stage, in_dstBuffer, dstOffset, marker);
     }
 }
 
@@ -5804,7 +5804,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer2KHR, in_commandBuffer, in_pCopyBufferInfo);
+        resource_dumper_->Process_vkCmdCopyBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBuffer2KHR, in_commandBuffer, in_pCopyBufferInfo);
     }
 }
 
@@ -5821,7 +5821,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage2KHR, in_commandBuffer, in_pCopyImageInfo);
+        resource_dumper_->Process_vkCmdCopyImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImage2KHR, in_commandBuffer, in_pCopyImageInfo);
     }
 }
 
@@ -5838,7 +5838,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyBufferToImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage2KHR, in_commandBuffer, in_pCopyBufferToImageInfo);
+        resource_dumper_->Process_vkCmdCopyBufferToImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyBufferToImage2KHR, in_commandBuffer, in_pCopyBufferToImageInfo);
     }
 }
 
@@ -5855,7 +5855,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyImageToBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer2KHR, in_commandBuffer, in_pCopyImageToBufferInfo);
+        resource_dumper_->Process_vkCmdCopyImageToBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyImageToBuffer2KHR, in_commandBuffer, in_pCopyImageToBufferInfo);
     }
 }
 
@@ -5872,7 +5872,7 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBlitImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage2KHR, in_commandBuffer, in_pBlitImageInfo);
+        resource_dumper_->Process_vkCmdBlitImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBlitImage2KHR, in_commandBuffer, in_pBlitImageInfo);
     }
 }
 
@@ -5889,7 +5889,7 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdResolveImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage2KHR, in_commandBuffer, in_pResolveImageInfo);
+        resource_dumper_->Process_vkCmdResolveImage2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdResolveImage2KHR, in_commandBuffer, in_pResolveImageInfo);
     }
 }
 
@@ -5904,7 +5904,7 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysIndirect2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdTraceRaysIndirect2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysIndirect2KHR, in_commandBuffer, indirectDeviceAddress);
+        resource_dumper_->Process_vkCmdTraceRaysIndirect2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysIndirect2KHR, in_commandBuffer, indirectDeviceAddress);
     }
 }
 
@@ -5970,7 +5970,7 @@ void VulkanReplayConsumer::Process_vkCmdBindIndexBuffer2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindIndexBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBindIndexBuffer2KHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, size, indexType);
+        resource_dumper_->Process_vkCmdBindIndexBuffer2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBindIndexBuffer2KHR, in_commandBuffer, GetObjectInfoTable().GetVkBufferInfo(buffer), offset, size, indexType);
     }
 }
 
@@ -6138,7 +6138,7 @@ void VulkanReplayConsumer::Process_vkCmdSetLineStippleKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetLineStippleKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleKHR, in_commandBuffer, lineStippleFactor, lineStipplePattern);
+        resource_dumper_->Process_vkCmdSetLineStippleKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleKHR, in_commandBuffer, lineStippleFactor, lineStipplePattern);
     }
 }
 
@@ -6190,7 +6190,7 @@ void VulkanReplayConsumer::Process_vkCmdBindDescriptorSets2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindDescriptorSets2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorSets2KHR, in_commandBuffer, in_pBindDescriptorSetsInfo);
+        resource_dumper_->Process_vkCmdBindDescriptorSets2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorSets2KHR, in_commandBuffer, in_pBindDescriptorSetsInfo);
     }
 }
 
@@ -6207,7 +6207,7 @@ void VulkanReplayConsumer::Process_vkCmdPushConstants2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPushConstants2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushConstants2KHR, in_commandBuffer, in_pPushConstantsInfo);
+        resource_dumper_->Process_vkCmdPushConstants2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushConstants2KHR, in_commandBuffer, in_pPushConstantsInfo);
     }
 }
 
@@ -6224,7 +6224,7 @@ void VulkanReplayConsumer::Process_vkCmdPushDescriptorSet2KHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPushDescriptorSet2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSet2KHR, in_commandBuffer, in_pPushDescriptorSetInfo);
+        resource_dumper_->Process_vkCmdPushDescriptorSet2KHR(call_info, GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSet2KHR, in_commandBuffer, in_pPushDescriptorSetInfo);
     }
 }
 
@@ -6241,7 +6241,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDescriptorBufferOffsets2EXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDescriptorBufferOffsets2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDescriptorBufferOffsets2EXT, in_commandBuffer, in_pSetDescriptorBufferOffsetsInfo);
+        resource_dumper_->Process_vkCmdSetDescriptorBufferOffsets2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDescriptorBufferOffsets2EXT, in_commandBuffer, in_pSetDescriptorBufferOffsetsInfo);
     }
 }
 
@@ -6258,7 +6258,7 @@ void VulkanReplayConsumer::Process_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorBufferEmbeddedSamplers2EXT, in_commandBuffer, in_pBindDescriptorBufferEmbeddedSamplersInfo);
+        resource_dumper_->Process_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindDescriptorBufferEmbeddedSamplers2EXT, in_commandBuffer, in_pBindDescriptorBufferEmbeddedSamplersInfo);
     }
 }
 
@@ -6367,7 +6367,7 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerBeginEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDebugMarkerBeginEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDebugMarkerBeginEXT, in_commandBuffer, in_pMarkerInfo);
+        resource_dumper_->Process_vkCmdDebugMarkerBeginEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDebugMarkerBeginEXT, in_commandBuffer, in_pMarkerInfo);
     }
 }
 
@@ -6381,7 +6381,7 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerEndEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDebugMarkerEndEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDebugMarkerEndEXT, in_commandBuffer);
+        resource_dumper_->Process_vkCmdDebugMarkerEndEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDebugMarkerEndEXT, in_commandBuffer);
     }
 }
 
@@ -6396,7 +6396,7 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerInsertEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDebugMarkerInsertEXT(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdDebugMarkerInsertEXT, in_commandBuffer->handle, pMarkerInfo->GetPointer());
+        resource_dumper_->Process_vkCmdDebugMarkerInsertEXT(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdDebugMarkerInsertEXT, in_commandBuffer->handle, pMarkerInfo->GetPointer());
     }
 }
 
@@ -6418,7 +6418,7 @@ void VulkanReplayConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindTransformFeedbackBuffersEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindTransformFeedbackBuffersEXT, in_commandBuffer, firstBinding, bindingCount, in_pBuffers, in_pOffsets, in_pSizes);
+        resource_dumper_->Process_vkCmdBindTransformFeedbackBuffersEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindTransformFeedbackBuffersEXT, in_commandBuffer, firstBinding, bindingCount, in_pBuffers, in_pOffsets, in_pSizes);
     }
 }
 
@@ -6438,7 +6438,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginTransformFeedbackEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginTransformFeedbackEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginTransformFeedbackEXT, in_commandBuffer, firstCounterBuffer, counterBufferCount, in_pCounterBuffers, in_pCounterBufferOffsets);
+        resource_dumper_->Process_vkCmdBeginTransformFeedbackEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginTransformFeedbackEXT, in_commandBuffer, firstCounterBuffer, counterBufferCount, in_pCounterBuffers, in_pCounterBufferOffsets);
     }
 }
 
@@ -6458,7 +6458,7 @@ void VulkanReplayConsumer::Process_vkCmdEndTransformFeedbackEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndTransformFeedbackEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndTransformFeedbackEXT, in_commandBuffer, firstCounterBuffer, counterBufferCount, in_pCounterBuffers, in_pCounterBufferOffsets);
+        resource_dumper_->Process_vkCmdEndTransformFeedbackEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndTransformFeedbackEXT, in_commandBuffer, firstCounterBuffer, counterBufferCount, in_pCounterBuffers, in_pCounterBufferOffsets);
     }
 }
 
@@ -6477,7 +6477,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginQueryIndexedEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginQueryIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginQueryIndexedEXT, in_commandBuffer, in_queryPool, query, flags, index);
+        resource_dumper_->Process_vkCmdBeginQueryIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginQueryIndexedEXT, in_commandBuffer, in_queryPool, query, flags, index);
     }
 }
 
@@ -6495,7 +6495,7 @@ void VulkanReplayConsumer::Process_vkCmdEndQueryIndexedEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndQueryIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndQueryIndexedEXT, in_commandBuffer, in_queryPool, query, index);
+        resource_dumper_->Process_vkCmdEndQueryIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndQueryIndexedEXT, in_commandBuffer, in_queryPool, query, index);
     }
 }
 
@@ -6516,7 +6516,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectByteCountEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawIndirectByteCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectByteCountEXT, in_commandBuffer, instanceCount, firstInstance, in_counterBuffer, counterBufferOffset, counterOffset, vertexStride);
+        resource_dumper_->Process_vkCmdDrawIndirectByteCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectByteCountEXT, in_commandBuffer, instanceCount, firstInstance, in_counterBuffer, counterBufferOffset, counterOffset, vertexStride);
     }
 }
 
@@ -6567,7 +6567,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectCountAMD(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawIndirectCountAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCountAMD, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
+        resource_dumper_->Process_vkCmdDrawIndirectCountAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndirectCountAMD, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -6589,7 +6589,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawIndexedIndirectCountAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCountAMD, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
+        resource_dumper_->Process_vkCmdDrawIndexedIndirectCountAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawIndexedIndirectCountAMD, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -6704,7 +6704,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginConditionalRenderingEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginConditionalRenderingEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginConditionalRenderingEXT, in_commandBuffer, in_pConditionalRenderingBegin);
+        resource_dumper_->Process_vkCmdBeginConditionalRenderingEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginConditionalRenderingEXT, in_commandBuffer, in_pConditionalRenderingBegin);
     }
 }
 
@@ -6718,7 +6718,7 @@ void VulkanReplayConsumer::Process_vkCmdEndConditionalRenderingEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndConditionalRenderingEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndConditionalRenderingEXT, in_commandBuffer);
+        resource_dumper_->Process_vkCmdEndConditionalRenderingEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndConditionalRenderingEXT, in_commandBuffer);
     }
 }
 
@@ -6736,7 +6736,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWScalingNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetViewportWScalingNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWScalingNV, in_commandBuffer, firstViewport, viewportCount, in_pViewportWScalings);
+        resource_dumper_->Process_vkCmdSetViewportWScalingNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWScalingNV, in_commandBuffer, firstViewport, viewportCount, in_pViewportWScalings);
     }
 }
 
@@ -6949,7 +6949,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDiscardRectangleEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDiscardRectangleEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleEXT, in_commandBuffer, firstDiscardRectangle, discardRectangleCount, in_pDiscardRectangles);
+        resource_dumper_->Process_vkCmdSetDiscardRectangleEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleEXT, in_commandBuffer, firstDiscardRectangle, discardRectangleCount, in_pDiscardRectangles);
     }
 }
 
@@ -6964,7 +6964,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDiscardRectangleEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDiscardRectangleEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleEnableEXT, in_commandBuffer, discardRectangleEnable);
+        resource_dumper_->Process_vkCmdSetDiscardRectangleEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleEnableEXT, in_commandBuffer, discardRectangleEnable);
     }
 }
 
@@ -6979,7 +6979,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDiscardRectangleModeEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDiscardRectangleModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleModeEXT, in_commandBuffer, discardRectangleMode);
+        resource_dumper_->Process_vkCmdSetDiscardRectangleModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDiscardRectangleModeEXT, in_commandBuffer, discardRectangleMode);
     }
 }
 
@@ -7117,7 +7117,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBeginDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginDebugUtilsLabelEXT, in_commandBuffer, in_pLabelInfo);
+        resource_dumper_->Process_vkCmdBeginDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginDebugUtilsLabelEXT, in_commandBuffer, in_pLabelInfo);
     }
 }
 
@@ -7131,7 +7131,7 @@ void VulkanReplayConsumer::Process_vkCmdEndDebugUtilsLabelEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdEndDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndDebugUtilsLabelEXT, in_commandBuffer);
+        resource_dumper_->Process_vkCmdEndDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdEndDebugUtilsLabelEXT, in_commandBuffer);
     }
 }
 
@@ -7146,7 +7146,7 @@ void VulkanReplayConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdInsertDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdInsertDebugUtilsLabelEXT, in_commandBuffer->handle, pLabelInfo->GetPointer());
+        resource_dumper_->Process_vkCmdInsertDebugUtilsLabelEXT(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdInsertDebugUtilsLabelEXT, in_commandBuffer->handle, pLabelInfo->GetPointer());
     }
 }
 
@@ -7242,7 +7242,7 @@ void VulkanReplayConsumer::Process_vkCmdSetSampleLocationsEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetSampleLocationsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleLocationsEXT, in_commandBuffer, in_pSampleLocationsInfo);
+        resource_dumper_->Process_vkCmdSetSampleLocationsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleLocationsEXT, in_commandBuffer, in_pSampleLocationsInfo);
     }
 }
 
@@ -7357,7 +7357,7 @@ void VulkanReplayConsumer::Process_vkCmdBindShadingRateImageNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindShadingRateImageNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBindShadingRateImageNV, in_commandBuffer, in_imageView, imageLayout);
+        resource_dumper_->Process_vkCmdBindShadingRateImageNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBindShadingRateImageNV, in_commandBuffer, in_imageView, imageLayout);
     }
 }
 
@@ -7375,7 +7375,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportShadingRatePaletteNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetViewportShadingRatePaletteNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportShadingRatePaletteNV, in_commandBuffer, firstViewport, viewportCount, in_pShadingRatePalettes);
+        resource_dumper_->Process_vkCmdSetViewportShadingRatePaletteNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportShadingRatePaletteNV, in_commandBuffer, firstViewport, viewportCount, in_pShadingRatePalettes);
     }
 }
 
@@ -7393,7 +7393,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCoarseSampleOrderNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetCoarseSampleOrderNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoarseSampleOrderNV, in_commandBuffer, sampleOrderType, customSampleOrderCount, in_pCustomSampleOrders);
+        resource_dumper_->Process_vkCmdSetCoarseSampleOrderNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoarseSampleOrderNV, in_commandBuffer, sampleOrderType, customSampleOrderCount, in_pCustomSampleOrders);
     }
 }
 
@@ -7485,7 +7485,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructureNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBuildAccelerationStructureNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildAccelerationStructureNV, in_commandBuffer, in_pInfo, in_instanceData, instanceOffset, update, in_dst, in_src, in_scratch, scratchOffset);
+        resource_dumper_->Process_vkCmdBuildAccelerationStructureNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildAccelerationStructureNV, in_commandBuffer, in_pInfo, in_instanceData, instanceOffset, update, in_dst, in_src, in_scratch, scratchOffset);
     }
 }
 
@@ -7504,7 +7504,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyAccelerationStructureNV(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyAccelerationStructureNV, in_commandBuffer, in_dst, in_src, mode);
+        resource_dumper_->Process_vkCmdCopyAccelerationStructureNV(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyAccelerationStructureNV, in_commandBuffer, in_dst, in_src, mode);
     }
 }
 
@@ -7536,7 +7536,7 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdTraceRaysNV(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysNV, in_commandBuffer, in_raygenShaderBindingTableBuffer, raygenShaderBindingOffset, in_missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, in_hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, in_callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
+        resource_dumper_->Process_vkCmdTraceRaysNV(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysNV, in_commandBuffer, in_raygenShaderBindingTableBuffer, raygenShaderBindingOffset, in_missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, in_hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, in_callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
     }
 }
 
@@ -7634,7 +7634,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWriteAccelerationStructuresPropertiesNV(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteAccelerationStructuresPropertiesNV, in_commandBuffer, accelerationStructureCount, in_pAccelerationStructures, queryType, in_queryPool, firstQuery);
+        resource_dumper_->Process_vkCmdWriteAccelerationStructuresPropertiesNV(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteAccelerationStructuresPropertiesNV, in_commandBuffer, accelerationStructureCount, in_pAccelerationStructures, queryType, in_queryPool, firstQuery);
     }
 }
 
@@ -7684,7 +7684,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteBufferMarkerAMD(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWriteBufferMarkerAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteBufferMarkerAMD, in_commandBuffer, pipelineStage, in_dstBuffer, dstOffset, marker);
+        resource_dumper_->Process_vkCmdWriteBufferMarkerAMD(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteBufferMarkerAMD, in_commandBuffer, pipelineStage, in_dstBuffer, dstOffset, marker);
     }
 }
 
@@ -7735,7 +7735,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawMeshTasksNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksNV, in_commandBuffer, taskCount, firstTask);
+        resource_dumper_->Process_vkCmdDrawMeshTasksNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksNV, in_commandBuffer, taskCount, firstTask);
     }
 }
 
@@ -7754,7 +7754,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawMeshTasksIndirectNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectNV, in_commandBuffer, in_buffer, offset, drawCount, stride);
+        resource_dumper_->Process_vkCmdDrawMeshTasksIndirectNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectNV, in_commandBuffer, in_buffer, offset, drawCount, stride);
     }
 }
 
@@ -7776,7 +7776,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawMeshTasksIndirectCountNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectCountNV, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
+        resource_dumper_->Process_vkCmdDrawMeshTasksIndirectCountNV(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectCountNV, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 }
 
@@ -7794,7 +7794,7 @@ void VulkanReplayConsumer::Process_vkCmdSetExclusiveScissorEnableNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetExclusiveScissorEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExclusiveScissorEnableNV, in_commandBuffer, firstExclusiveScissor, exclusiveScissorCount, in_pExclusiveScissorEnables);
+        resource_dumper_->Process_vkCmdSetExclusiveScissorEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExclusiveScissorEnableNV, in_commandBuffer, firstExclusiveScissor, exclusiveScissorCount, in_pExclusiveScissorEnables);
     }
 }
 
@@ -7812,7 +7812,7 @@ void VulkanReplayConsumer::Process_vkCmdSetExclusiveScissorNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetExclusiveScissorNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExclusiveScissorNV, in_commandBuffer, firstExclusiveScissor, exclusiveScissorCount, in_pExclusiveScissors);
+        resource_dumper_->Process_vkCmdSetExclusiveScissorNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExclusiveScissorNV, in_commandBuffer, firstExclusiveScissor, exclusiveScissorCount, in_pExclusiveScissors);
     }
 }
 
@@ -7828,7 +7828,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCheckpointNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetCheckpointNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCheckpointNV, in_commandBuffer, in_pCheckpointMarker);
+        resource_dumper_->Process_vkCmdSetCheckpointNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCheckpointNV, in_commandBuffer, in_pCheckpointMarker);
     }
 }
 
@@ -7883,7 +7883,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetPerformanceMarkerINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceMarkerINTEL, returnValue, in_commandBuffer, in_pMarkerInfo);
+        resource_dumper_->Process_vkCmdSetPerformanceMarkerINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceMarkerINTEL, returnValue, in_commandBuffer, in_pMarkerInfo);
     }
 }
 
@@ -7901,7 +7901,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetPerformanceStreamMarkerINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceStreamMarkerINTEL, returnValue, in_commandBuffer, in_pMarkerInfo);
+        resource_dumper_->Process_vkCmdSetPerformanceStreamMarkerINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceStreamMarkerINTEL, returnValue, in_commandBuffer, in_pMarkerInfo);
     }
 }
 
@@ -7919,7 +7919,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetPerformanceOverrideINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceOverrideINTEL, returnValue, in_commandBuffer, in_pOverrideInfo);
+        resource_dumper_->Process_vkCmdSetPerformanceOverrideINTEL(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPerformanceOverrideINTEL, returnValue, in_commandBuffer, in_pOverrideInfo);
     }
 }
 
@@ -8222,7 +8222,7 @@ void VulkanReplayConsumer::Process_vkCmdSetLineStippleEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetLineStippleEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleEXT, in_commandBuffer, lineStippleFactor, lineStipplePattern);
+        resource_dumper_->Process_vkCmdSetLineStippleEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleEXT, in_commandBuffer, lineStippleFactor, lineStipplePattern);
     }
 }
 
@@ -8250,7 +8250,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCullModeEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetCullModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCullModeEXT, in_commandBuffer, cullMode);
+        resource_dumper_->Process_vkCmdSetCullModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCullModeEXT, in_commandBuffer, cullMode);
     }
 }
 
@@ -8265,7 +8265,7 @@ void VulkanReplayConsumer::Process_vkCmdSetFrontFaceEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetFrontFaceEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFrontFaceEXT, in_commandBuffer, frontFace);
+        resource_dumper_->Process_vkCmdSetFrontFaceEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFrontFaceEXT, in_commandBuffer, frontFace);
     }
 }
 
@@ -8280,7 +8280,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveTopologyEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetPrimitiveTopologyEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveTopologyEXT, in_commandBuffer, primitiveTopology);
+        resource_dumper_->Process_vkCmdSetPrimitiveTopologyEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveTopologyEXT, in_commandBuffer, primitiveTopology);
     }
 }
 
@@ -8297,7 +8297,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWithCountEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetViewportWithCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWithCountEXT, in_commandBuffer, viewportCount, in_pViewports);
+        resource_dumper_->Process_vkCmdSetViewportWithCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWithCountEXT, in_commandBuffer, viewportCount, in_pViewports);
     }
 }
 
@@ -8314,7 +8314,7 @@ void VulkanReplayConsumer::Process_vkCmdSetScissorWithCountEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetScissorWithCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissorWithCountEXT, in_commandBuffer, scissorCount, in_pScissors);
+        resource_dumper_->Process_vkCmdSetScissorWithCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetScissorWithCountEXT, in_commandBuffer, scissorCount, in_pScissors);
     }
 }
 
@@ -8338,7 +8338,7 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers2EXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindVertexBuffers2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers2EXT, in_commandBuffer, firstBinding, bindingCount, in_pBuffers, in_pOffsets, in_pSizes, in_pStrides);
+        resource_dumper_->Process_vkCmdBindVertexBuffers2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindVertexBuffers2EXT, in_commandBuffer, firstBinding, bindingCount, in_pBuffers, in_pOffsets, in_pSizes, in_pStrides);
     }
 }
 
@@ -8353,7 +8353,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthTestEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthTestEnableEXT, in_commandBuffer, depthTestEnable);
+        resource_dumper_->Process_vkCmdSetDepthTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthTestEnableEXT, in_commandBuffer, depthTestEnable);
     }
 }
 
@@ -8368,7 +8368,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthWriteEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthWriteEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthWriteEnableEXT, in_commandBuffer, depthWriteEnable);
+        resource_dumper_->Process_vkCmdSetDepthWriteEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthWriteEnableEXT, in_commandBuffer, depthWriteEnable);
     }
 }
 
@@ -8383,7 +8383,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthCompareOpEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthCompareOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthCompareOpEXT, in_commandBuffer, depthCompareOp);
+        resource_dumper_->Process_vkCmdSetDepthCompareOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthCompareOpEXT, in_commandBuffer, depthCompareOp);
     }
 }
 
@@ -8398,7 +8398,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBoundsTestEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthBoundsTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBoundsTestEnableEXT, in_commandBuffer, depthBoundsTestEnable);
+        resource_dumper_->Process_vkCmdSetDepthBoundsTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBoundsTestEnableEXT, in_commandBuffer, depthBoundsTestEnable);
     }
 }
 
@@ -8413,7 +8413,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilTestEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetStencilTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilTestEnableEXT, in_commandBuffer, stencilTestEnable);
+        resource_dumper_->Process_vkCmdSetStencilTestEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilTestEnableEXT, in_commandBuffer, stencilTestEnable);
     }
 }
 
@@ -8432,7 +8432,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilOpEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetStencilOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilOpEXT, in_commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
+        resource_dumper_->Process_vkCmdSetStencilOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetStencilOpEXT, in_commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
     }
 }
 
@@ -8556,7 +8556,7 @@ void VulkanReplayConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPreprocessGeneratedCommandsNV(call_info, GetDeviceTable(in_commandBuffer)->CmdPreprocessGeneratedCommandsNV, in_commandBuffer, in_pGeneratedCommandsInfo);
+        resource_dumper_->Process_vkCmdPreprocessGeneratedCommandsNV(call_info, GetDeviceTable(in_commandBuffer)->CmdPreprocessGeneratedCommandsNV, in_commandBuffer, in_pGeneratedCommandsInfo);
     }
 }
 
@@ -8574,7 +8574,7 @@ void VulkanReplayConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdExecuteGeneratedCommandsNV(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteGeneratedCommandsNV, in_commandBuffer, isPreprocessed, in_pGeneratedCommandsInfo);
+        resource_dumper_->Process_vkCmdExecuteGeneratedCommandsNV(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteGeneratedCommandsNV, in_commandBuffer, isPreprocessed, in_pGeneratedCommandsInfo);
     }
 }
 
@@ -8592,7 +8592,7 @@ void VulkanReplayConsumer::Process_vkCmdBindPipelineShaderGroupNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindPipelineShaderGroupNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBindPipelineShaderGroupNV, in_commandBuffer, pipelineBindPoint, in_pipeline, groupIndex);
+        resource_dumper_->Process_vkCmdBindPipelineShaderGroupNV(call_info, GetDeviceTable(in_commandBuffer)->CmdBindPipelineShaderGroupNV, in_commandBuffer, pipelineBindPoint, in_pipeline, groupIndex);
     }
 }
 
@@ -8643,7 +8643,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBias2EXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthBias2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBias2EXT, in_commandBuffer, in_pDepthBiasInfo);
+        resource_dumper_->Process_vkCmdSetDepthBias2EXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBias2EXT, in_commandBuffer, in_pDepthBiasInfo);
     }
 }
 
@@ -8759,7 +8759,7 @@ void VulkanReplayConsumer::Process_vkCmdSetFragmentShadingRateEnumNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetFragmentShadingRateEnumNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFragmentShadingRateEnumNV, in_commandBuffer, shadingRate, in_combinerOps);
+        resource_dumper_->Process_vkCmdSetFragmentShadingRateEnumNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetFragmentShadingRateEnumNV, in_commandBuffer, shadingRate, in_combinerOps);
     }
 }
 
@@ -8859,7 +8859,7 @@ void VulkanReplayConsumer::Process_vkCmdSetVertexInputEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetVertexInputEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetVertexInputEXT, in_commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions);
+        resource_dumper_->Process_vkCmdSetVertexInputEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetVertexInputEXT, in_commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions);
     }
 }
 
@@ -8938,7 +8938,7 @@ void VulkanReplayConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindInvocationMaskHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdBindInvocationMaskHUAWEI, in_commandBuffer, in_imageView, imageLayout);
+        resource_dumper_->Process_vkCmdBindInvocationMaskHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdBindInvocationMaskHUAWEI, in_commandBuffer, in_imageView, imageLayout);
     }
 }
 
@@ -8971,7 +8971,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPatchControlPointsEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetPatchControlPointsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPatchControlPointsEXT, in_commandBuffer, patchControlPoints);
+        resource_dumper_->Process_vkCmdSetPatchControlPointsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPatchControlPointsEXT, in_commandBuffer, patchControlPoints);
     }
 }
 
@@ -8986,7 +8986,7 @@ void VulkanReplayConsumer::Process_vkCmdSetRasterizerDiscardEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetRasterizerDiscardEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizerDiscardEnableEXT, in_commandBuffer, rasterizerDiscardEnable);
+        resource_dumper_->Process_vkCmdSetRasterizerDiscardEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizerDiscardEnableEXT, in_commandBuffer, rasterizerDiscardEnable);
     }
 }
 
@@ -9001,7 +9001,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBiasEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthBiasEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBiasEnableEXT, in_commandBuffer, depthBiasEnable);
+        resource_dumper_->Process_vkCmdSetDepthBiasEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthBiasEnableEXT, in_commandBuffer, depthBiasEnable);
     }
 }
 
@@ -9016,7 +9016,7 @@ void VulkanReplayConsumer::Process_vkCmdSetLogicOpEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetLogicOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLogicOpEXT, in_commandBuffer, logicOp);
+        resource_dumper_->Process_vkCmdSetLogicOpEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLogicOpEXT, in_commandBuffer, logicOp);
     }
 }
 
@@ -9031,7 +9031,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveRestartEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetPrimitiveRestartEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveRestartEnableEXT, in_commandBuffer, primitiveRestartEnable);
+        resource_dumper_->Process_vkCmdSetPrimitiveRestartEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPrimitiveRestartEnableEXT, in_commandBuffer, primitiveRestartEnable);
     }
 }
 
@@ -9081,7 +9081,7 @@ void VulkanReplayConsumer::Process_vkCmdSetColorWriteEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetColorWriteEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorWriteEnableEXT, in_commandBuffer, attachmentCount, in_pColorWriteEnables);
+        resource_dumper_->Process_vkCmdSetColorWriteEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorWriteEnableEXT, in_commandBuffer, attachmentCount, in_pColorWriteEnables);
     }
 }
 
@@ -9101,7 +9101,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMultiEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawMultiEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMultiEXT, in_commandBuffer, drawCount, in_pVertexInfo, instanceCount, firstInstance, stride);
+        resource_dumper_->Process_vkCmdDrawMultiEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMultiEXT, in_commandBuffer, drawCount, in_pVertexInfo, instanceCount, firstInstance, stride);
     }
 }
 
@@ -9123,7 +9123,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMultiIndexedEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawMultiIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMultiIndexedEXT, in_commandBuffer, drawCount, in_pIndexInfo, instanceCount, firstInstance, stride, in_pVertexOffset);
+        resource_dumper_->Process_vkCmdDrawMultiIndexedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMultiIndexedEXT, in_commandBuffer, drawCount, in_pIndexInfo, instanceCount, firstInstance, stride, in_pVertexOffset);
     }
 }
 
@@ -9176,7 +9176,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildMicromapsEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBuildMicromapsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildMicromapsEXT, in_commandBuffer, infoCount, in_pInfos);
+        resource_dumper_->Process_vkCmdBuildMicromapsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildMicromapsEXT, in_commandBuffer, infoCount, in_pInfos);
     }
 }
 
@@ -9277,7 +9277,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMicromapEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyMicromapEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMicromapEXT, in_commandBuffer, in_pInfo);
+        resource_dumper_->Process_vkCmdCopyMicromapEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMicromapEXT, in_commandBuffer, in_pInfo);
     }
 }
 
@@ -9294,7 +9294,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMicromapToMemoryEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyMicromapToMemoryEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMicromapToMemoryEXT, in_commandBuffer, in_pInfo);
+        resource_dumper_->Process_vkCmdCopyMicromapToMemoryEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMicromapToMemoryEXT, in_commandBuffer, in_pInfo);
     }
 }
 
@@ -9311,7 +9311,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMemoryToMicromapEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyMemoryToMicromapEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMemoryToMicromapEXT, in_commandBuffer, in_pInfo);
+        resource_dumper_->Process_vkCmdCopyMemoryToMicromapEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMemoryToMicromapEXT, in_commandBuffer, in_pInfo);
     }
 }
 
@@ -9332,7 +9332,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteMicromapsPropertiesEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWriteMicromapsPropertiesEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteMicromapsPropertiesEXT, in_commandBuffer, micromapCount, in_pMicromaps, queryType, in_queryPool, firstQuery);
+        resource_dumper_->Process_vkCmdWriteMicromapsPropertiesEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdWriteMicromapsPropertiesEXT, in_commandBuffer, micromapCount, in_pMicromaps, queryType, in_queryPool, firstQuery);
     }
 }
 
@@ -9378,7 +9378,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawClusterHUAWEI(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawClusterHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawClusterHUAWEI, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
+        resource_dumper_->Process_vkCmdDrawClusterHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawClusterHUAWEI, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
     }
 }
 
@@ -9395,7 +9395,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawClusterIndirectHUAWEI(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawClusterIndirectHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawClusterIndirectHUAWEI, in_commandBuffer, in_buffer, offset);
+        resource_dumper_->Process_vkCmdDrawClusterIndirectHUAWEI(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawClusterIndirectHUAWEI, in_commandBuffer, in_buffer, offset);
     }
 }
 
@@ -9469,7 +9469,7 @@ void VulkanReplayConsumer::Process_vkCmdUpdatePipelineIndirectBufferNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdUpdatePipelineIndirectBufferNV(call_info, GetDeviceTable(in_commandBuffer)->CmdUpdatePipelineIndirectBufferNV, in_commandBuffer, pipelineBindPoint, in_pipeline);
+        resource_dumper_->Process_vkCmdUpdatePipelineIndirectBufferNV(call_info, GetDeviceTable(in_commandBuffer)->CmdUpdatePipelineIndirectBufferNV, in_commandBuffer, pipelineBindPoint, in_pipeline);
     }
 }
 
@@ -9497,7 +9497,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthClampEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthClampEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClampEnableEXT, in_commandBuffer, depthClampEnable);
+        resource_dumper_->Process_vkCmdSetDepthClampEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClampEnableEXT, in_commandBuffer, depthClampEnable);
     }
 }
 
@@ -9512,7 +9512,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPolygonModeEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetPolygonModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPolygonModeEXT, in_commandBuffer, polygonMode);
+        resource_dumper_->Process_vkCmdSetPolygonModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetPolygonModeEXT, in_commandBuffer, polygonMode);
     }
 }
 
@@ -9527,7 +9527,7 @@ void VulkanReplayConsumer::Process_vkCmdSetRasterizationSamplesEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetRasterizationSamplesEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizationSamplesEXT, in_commandBuffer, rasterizationSamples);
+        resource_dumper_->Process_vkCmdSetRasterizationSamplesEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizationSamplesEXT, in_commandBuffer, rasterizationSamples);
     }
 }
 
@@ -9544,7 +9544,7 @@ void VulkanReplayConsumer::Process_vkCmdSetSampleMaskEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetSampleMaskEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleMaskEXT, in_commandBuffer, samples, in_pSampleMask);
+        resource_dumper_->Process_vkCmdSetSampleMaskEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleMaskEXT, in_commandBuffer, samples, in_pSampleMask);
     }
 }
 
@@ -9559,7 +9559,7 @@ void VulkanReplayConsumer::Process_vkCmdSetAlphaToCoverageEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetAlphaToCoverageEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAlphaToCoverageEnableEXT, in_commandBuffer, alphaToCoverageEnable);
+        resource_dumper_->Process_vkCmdSetAlphaToCoverageEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAlphaToCoverageEnableEXT, in_commandBuffer, alphaToCoverageEnable);
     }
 }
 
@@ -9574,7 +9574,7 @@ void VulkanReplayConsumer::Process_vkCmdSetAlphaToOneEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetAlphaToOneEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAlphaToOneEnableEXT, in_commandBuffer, alphaToOneEnable);
+        resource_dumper_->Process_vkCmdSetAlphaToOneEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAlphaToOneEnableEXT, in_commandBuffer, alphaToOneEnable);
     }
 }
 
@@ -9589,7 +9589,7 @@ void VulkanReplayConsumer::Process_vkCmdSetLogicOpEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetLogicOpEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLogicOpEnableEXT, in_commandBuffer, logicOpEnable);
+        resource_dumper_->Process_vkCmdSetLogicOpEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLogicOpEnableEXT, in_commandBuffer, logicOpEnable);
     }
 }
 
@@ -9607,7 +9607,7 @@ void VulkanReplayConsumer::Process_vkCmdSetColorBlendEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetColorBlendEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendEnableEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendEnables);
+        resource_dumper_->Process_vkCmdSetColorBlendEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendEnableEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendEnables);
     }
 }
 
@@ -9625,7 +9625,7 @@ void VulkanReplayConsumer::Process_vkCmdSetColorBlendEquationEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetColorBlendEquationEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendEquationEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendEquations);
+        resource_dumper_->Process_vkCmdSetColorBlendEquationEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendEquationEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendEquations);
     }
 }
 
@@ -9643,7 +9643,7 @@ void VulkanReplayConsumer::Process_vkCmdSetColorWriteMaskEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetColorWriteMaskEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorWriteMaskEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorWriteMasks);
+        resource_dumper_->Process_vkCmdSetColorWriteMaskEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorWriteMaskEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorWriteMasks);
     }
 }
 
@@ -9658,7 +9658,7 @@ void VulkanReplayConsumer::Process_vkCmdSetTessellationDomainOriginEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetTessellationDomainOriginEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetTessellationDomainOriginEXT, in_commandBuffer, domainOrigin);
+        resource_dumper_->Process_vkCmdSetTessellationDomainOriginEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetTessellationDomainOriginEXT, in_commandBuffer, domainOrigin);
     }
 }
 
@@ -9673,7 +9673,7 @@ void VulkanReplayConsumer::Process_vkCmdSetRasterizationStreamEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetRasterizationStreamEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizationStreamEXT, in_commandBuffer, rasterizationStream);
+        resource_dumper_->Process_vkCmdSetRasterizationStreamEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRasterizationStreamEXT, in_commandBuffer, rasterizationStream);
     }
 }
 
@@ -9688,7 +9688,7 @@ void VulkanReplayConsumer::Process_vkCmdSetConservativeRasterizationModeEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetConservativeRasterizationModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetConservativeRasterizationModeEXT, in_commandBuffer, conservativeRasterizationMode);
+        resource_dumper_->Process_vkCmdSetConservativeRasterizationModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetConservativeRasterizationModeEXT, in_commandBuffer, conservativeRasterizationMode);
     }
 }
 
@@ -9703,7 +9703,7 @@ void VulkanReplayConsumer::Process_vkCmdSetExtraPrimitiveOverestimationSizeEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetExtraPrimitiveOverestimationSizeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExtraPrimitiveOverestimationSizeEXT, in_commandBuffer, extraPrimitiveOverestimationSize);
+        resource_dumper_->Process_vkCmdSetExtraPrimitiveOverestimationSizeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetExtraPrimitiveOverestimationSizeEXT, in_commandBuffer, extraPrimitiveOverestimationSize);
     }
 }
 
@@ -9718,7 +9718,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthClipEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthClipEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClipEnableEXT, in_commandBuffer, depthClipEnable);
+        resource_dumper_->Process_vkCmdSetDepthClipEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClipEnableEXT, in_commandBuffer, depthClipEnable);
     }
 }
 
@@ -9733,7 +9733,7 @@ void VulkanReplayConsumer::Process_vkCmdSetSampleLocationsEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetSampleLocationsEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleLocationsEnableEXT, in_commandBuffer, sampleLocationsEnable);
+        resource_dumper_->Process_vkCmdSetSampleLocationsEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetSampleLocationsEnableEXT, in_commandBuffer, sampleLocationsEnable);
     }
 }
 
@@ -9751,7 +9751,7 @@ void VulkanReplayConsumer::Process_vkCmdSetColorBlendAdvancedEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetColorBlendAdvancedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendAdvancedEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendAdvanced);
+        resource_dumper_->Process_vkCmdSetColorBlendAdvancedEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetColorBlendAdvancedEXT, in_commandBuffer, firstAttachment, attachmentCount, in_pColorBlendAdvanced);
     }
 }
 
@@ -9766,7 +9766,7 @@ void VulkanReplayConsumer::Process_vkCmdSetProvokingVertexModeEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetProvokingVertexModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetProvokingVertexModeEXT, in_commandBuffer, provokingVertexMode);
+        resource_dumper_->Process_vkCmdSetProvokingVertexModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetProvokingVertexModeEXT, in_commandBuffer, provokingVertexMode);
     }
 }
 
@@ -9781,7 +9781,7 @@ void VulkanReplayConsumer::Process_vkCmdSetLineRasterizationModeEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetLineRasterizationModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineRasterizationModeEXT, in_commandBuffer, lineRasterizationMode);
+        resource_dumper_->Process_vkCmdSetLineRasterizationModeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineRasterizationModeEXT, in_commandBuffer, lineRasterizationMode);
     }
 }
 
@@ -9796,7 +9796,7 @@ void VulkanReplayConsumer::Process_vkCmdSetLineStippleEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetLineStippleEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleEnableEXT, in_commandBuffer, stippledLineEnable);
+        resource_dumper_->Process_vkCmdSetLineStippleEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetLineStippleEnableEXT, in_commandBuffer, stippledLineEnable);
     }
 }
 
@@ -9811,7 +9811,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthClipNegativeOneToOneEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthClipNegativeOneToOneEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClipNegativeOneToOneEXT, in_commandBuffer, negativeOneToOne);
+        resource_dumper_->Process_vkCmdSetDepthClipNegativeOneToOneEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClipNegativeOneToOneEXT, in_commandBuffer, negativeOneToOne);
     }
 }
 
@@ -9826,7 +9826,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWScalingEnableNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetViewportWScalingEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWScalingEnableNV, in_commandBuffer, viewportWScalingEnable);
+        resource_dumper_->Process_vkCmdSetViewportWScalingEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportWScalingEnableNV, in_commandBuffer, viewportWScalingEnable);
     }
 }
 
@@ -9844,7 +9844,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportSwizzleNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetViewportSwizzleNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportSwizzleNV, in_commandBuffer, firstViewport, viewportCount, in_pViewportSwizzles);
+        resource_dumper_->Process_vkCmdSetViewportSwizzleNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetViewportSwizzleNV, in_commandBuffer, firstViewport, viewportCount, in_pViewportSwizzles);
     }
 }
 
@@ -9859,7 +9859,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageToColorEnableNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetCoverageToColorEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageToColorEnableNV, in_commandBuffer, coverageToColorEnable);
+        resource_dumper_->Process_vkCmdSetCoverageToColorEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageToColorEnableNV, in_commandBuffer, coverageToColorEnable);
     }
 }
 
@@ -9874,7 +9874,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageToColorLocationNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetCoverageToColorLocationNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageToColorLocationNV, in_commandBuffer, coverageToColorLocation);
+        resource_dumper_->Process_vkCmdSetCoverageToColorLocationNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageToColorLocationNV, in_commandBuffer, coverageToColorLocation);
     }
 }
 
@@ -9889,7 +9889,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageModulationModeNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetCoverageModulationModeNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationModeNV, in_commandBuffer, coverageModulationMode);
+        resource_dumper_->Process_vkCmdSetCoverageModulationModeNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationModeNV, in_commandBuffer, coverageModulationMode);
     }
 }
 
@@ -9904,7 +9904,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageModulationTableEnableNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetCoverageModulationTableEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationTableEnableNV, in_commandBuffer, coverageModulationTableEnable);
+        resource_dumper_->Process_vkCmdSetCoverageModulationTableEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationTableEnableNV, in_commandBuffer, coverageModulationTableEnable);
     }
 }
 
@@ -9921,7 +9921,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageModulationTableNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetCoverageModulationTableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationTableNV, in_commandBuffer, coverageModulationTableCount, in_pCoverageModulationTable);
+        resource_dumper_->Process_vkCmdSetCoverageModulationTableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageModulationTableNV, in_commandBuffer, coverageModulationTableCount, in_pCoverageModulationTable);
     }
 }
 
@@ -9936,7 +9936,7 @@ void VulkanReplayConsumer::Process_vkCmdSetShadingRateImageEnableNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetShadingRateImageEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetShadingRateImageEnableNV, in_commandBuffer, shadingRateImageEnable);
+        resource_dumper_->Process_vkCmdSetShadingRateImageEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetShadingRateImageEnableNV, in_commandBuffer, shadingRateImageEnable);
     }
 }
 
@@ -9951,7 +9951,7 @@ void VulkanReplayConsumer::Process_vkCmdSetRepresentativeFragmentTestEnableNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetRepresentativeFragmentTestEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRepresentativeFragmentTestEnableNV, in_commandBuffer, representativeFragmentTestEnable);
+        resource_dumper_->Process_vkCmdSetRepresentativeFragmentTestEnableNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRepresentativeFragmentTestEnableNV, in_commandBuffer, representativeFragmentTestEnable);
     }
 }
 
@@ -9966,7 +9966,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCoverageReductionModeNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetCoverageReductionModeNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageReductionModeNV, in_commandBuffer, coverageReductionMode);
+        resource_dumper_->Process_vkCmdSetCoverageReductionModeNV(call_info, GetDeviceTable(in_commandBuffer)->CmdSetCoverageReductionModeNV, in_commandBuffer, coverageReductionMode);
     }
 }
 
@@ -10083,7 +10083,7 @@ void VulkanReplayConsumer::Process_vkCmdOpticalFlowExecuteNV(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdOpticalFlowExecuteNV(call_info, GetDeviceTable(in_commandBuffer)->CmdOpticalFlowExecuteNV, in_commandBuffer, in_session, in_pExecuteInfo);
+        resource_dumper_->Process_vkCmdOpticalFlowExecuteNV(call_info, GetDeviceTable(in_commandBuffer)->CmdOpticalFlowExecuteNV, in_commandBuffer, in_session, in_pExecuteInfo);
     }
 }
 
@@ -10177,7 +10177,7 @@ void VulkanReplayConsumer::Process_vkCmdBindShadersEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBindShadersEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindShadersEXT, in_commandBuffer, stageCount, in_pStages, in_pShaders);
+        resource_dumper_->Process_vkCmdBindShadersEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdBindShadersEXT, in_commandBuffer, stageCount, in_pStages, in_pShaders);
     }
 }
 
@@ -10194,7 +10194,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthClampRangeEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetDepthClampRangeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClampRangeEXT, in_commandBuffer, depthClampMode, in_pDepthClampRange);
+        resource_dumper_->Process_vkCmdSetDepthClampRangeEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetDepthClampRangeEXT, in_commandBuffer, depthClampMode, in_pDepthClampRange);
     }
 }
 
@@ -10338,7 +10338,7 @@ void VulkanReplayConsumer::Process_vkCmdSetAttachmentFeedbackLoopEnableEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetAttachmentFeedbackLoopEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAttachmentFeedbackLoopEnableEXT, in_commandBuffer, aspectMask);
+        resource_dumper_->Process_vkCmdSetAttachmentFeedbackLoopEnableEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdSetAttachmentFeedbackLoopEnableEXT, in_commandBuffer, aspectMask);
     }
 }
 
@@ -10372,7 +10372,7 @@ void VulkanReplayConsumer::Process_vkCmdPreprocessGeneratedCommandsEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdPreprocessGeneratedCommandsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdPreprocessGeneratedCommandsEXT, in_commandBuffer, in_pGeneratedCommandsInfo, in_stateCommandBuffer);
+        resource_dumper_->Process_vkCmdPreprocessGeneratedCommandsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdPreprocessGeneratedCommandsEXT, in_commandBuffer, in_pGeneratedCommandsInfo, in_stateCommandBuffer);
     }
 }
 
@@ -10390,7 +10390,7 @@ void VulkanReplayConsumer::Process_vkCmdExecuteGeneratedCommandsEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdExecuteGeneratedCommandsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteGeneratedCommandsEXT, in_commandBuffer, isPreprocessed, in_pGeneratedCommandsInfo);
+        resource_dumper_->Process_vkCmdExecuteGeneratedCommandsEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdExecuteGeneratedCommandsEXT, in_commandBuffer, isPreprocessed, in_pGeneratedCommandsInfo);
     }
 }
 
@@ -10542,7 +10542,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBuildAccelerationStructuresKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBuildAccelerationStructuresKHR, in_commandBuffer->handle, infoCount, pInfos->GetPointer(), ppBuildRangeInfos->GetPointer());
+        resource_dumper_->Process_vkCmdBuildAccelerationStructuresKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBuildAccelerationStructuresKHR, in_commandBuffer->handle, infoCount, pInfos->GetPointer(), ppBuildRangeInfos->GetPointer());
     }
 }
 
@@ -10566,7 +10566,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdBuildAccelerationStructuresIndirectKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildAccelerationStructuresIndirectKHR, in_commandBuffer, infoCount, in_pInfos, in_pIndirectDeviceAddresses, in_pIndirectStrides, in_ppMaxPrimitiveCounts);
+        resource_dumper_->Process_vkCmdBuildAccelerationStructuresIndirectKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBuildAccelerationStructuresIndirectKHR, in_commandBuffer, infoCount, in_pInfos, in_pIndirectDeviceAddresses, in_pIndirectStrides, in_ppMaxPrimitiveCounts);
     }
 }
 
@@ -10634,7 +10634,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyAccelerationStructureKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdCopyAccelerationStructureKHR, in_commandBuffer->handle, pInfo->GetPointer());
+        resource_dumper_->Process_vkCmdCopyAccelerationStructureKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdCopyAccelerationStructureKHR, in_commandBuffer->handle, pInfo->GetPointer());
     }
 }
 
@@ -10651,7 +10651,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyAccelerationStructureToMemoryKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyAccelerationStructureToMemoryKHR, in_commandBuffer, in_pInfo);
+        resource_dumper_->Process_vkCmdCopyAccelerationStructureToMemoryKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyAccelerationStructureToMemoryKHR, in_commandBuffer, in_pInfo);
     }
 }
 
@@ -10668,7 +10668,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdCopyMemoryToAccelerationStructureKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMemoryToAccelerationStructureKHR, in_commandBuffer, in_pInfo);
+        resource_dumper_->Process_vkCmdCopyMemoryToAccelerationStructureKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdCopyMemoryToAccelerationStructureKHR, in_commandBuffer, in_pInfo);
     }
 }
 
@@ -10702,7 +10702,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdWriteAccelerationStructuresPropertiesKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdWriteAccelerationStructuresPropertiesKHR, in_commandBuffer->handle, accelerationStructureCount, pAccelerationStructures->GetHandlePointer(), queryType, in_queryPool->handle, firstQuery);
+        resource_dumper_->Process_vkCmdWriteAccelerationStructuresPropertiesKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdWriteAccelerationStructuresPropertiesKHR, in_commandBuffer->handle, accelerationStructureCount, pAccelerationStructures->GetHandlePointer(), queryType, in_queryPool->handle, firstQuery);
     }
 }
 
@@ -10754,7 +10754,7 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdTraceRaysKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdTraceRaysKHR, in_commandBuffer->handle, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
+        resource_dumper_->Process_vkCmdTraceRaysKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdTraceRaysKHR, in_commandBuffer->handle, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
     }
 }
 
@@ -10795,7 +10795,7 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysIndirectKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdTraceRaysIndirectKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysIndirectKHR, in_commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress);
+        resource_dumper_->Process_vkCmdTraceRaysIndirectKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdTraceRaysIndirectKHR, in_commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress);
     }
 }
 
@@ -10824,7 +10824,7 @@ void VulkanReplayConsumer::Process_vkCmdSetRayTracingPipelineStackSizeKHR(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdSetRayTracingPipelineStackSizeKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRayTracingPipelineStackSizeKHR, in_commandBuffer, pipelineStackSize);
+        resource_dumper_->Process_vkCmdSetRayTracingPipelineStackSizeKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdSetRayTracingPipelineStackSizeKHR, in_commandBuffer, pipelineStackSize);
     }
 }
 
@@ -10841,7 +10841,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawMeshTasksEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksEXT, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
+        resource_dumper_->Process_vkCmdDrawMeshTasksEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksEXT, in_commandBuffer, groupCountX, groupCountY, groupCountZ);
     }
 }
 
@@ -10860,7 +10860,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawMeshTasksIndirectEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectEXT, in_commandBuffer, in_buffer, offset, drawCount, stride);
+        resource_dumper_->Process_vkCmdDrawMeshTasksIndirectEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectEXT, in_commandBuffer, in_buffer, offset, drawCount, stride);
     }
 }
 
@@ -10882,7 +10882,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectCountEXT(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_.Process_vkCmdDrawMeshTasksIndirectCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectCountEXT, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
+        resource_dumper_->Process_vkCmdDrawMeshTasksIndirectCountEXT(call_info, GetDeviceTable(in_commandBuffer)->CmdDrawMeshTasksIndirectCountEXT, in_commandBuffer, in_buffer, offset, in_countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 }
 

--- a/framework/generated/generated_vulkan_replay_dump_resources.cpp
+++ b/framework/generated/generated_vulkan_replay_dump_resources.cpp
@@ -51,7 +51,7 @@ void VulkanReplayDumpResources::Process_vkCmdBindPipeline(
     PFN_vkCmdBindPipeline                       func,
     VkCommandBuffer                             commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
-    const PipelineInfo*                         pipeline)
+    const VulkanPipelineInfo*                   pipeline)
 {
     if (IsRecording(commandBuffer))
     {
@@ -308,7 +308,7 @@ void VulkanReplayDumpResources::Process_vkCmdBindDescriptorSets(
     PFN_vkCmdBindDescriptorSets                 func,
     VkCommandBuffer                             commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
-    const PipelineLayoutInfo*                   layout,
+    const VulkanPipelineLayoutInfo*             layout,
     uint32_t                                    firstSet,
     uint32_t                                    descriptorSetCount,
     HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets,
@@ -325,7 +325,7 @@ void VulkanReplayDumpResources::Process_vkCmdBindIndexBuffer(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdBindIndexBuffer                    func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
     VkIndexType                                 indexType)
 {
@@ -385,7 +385,7 @@ void VulkanReplayDumpResources::Process_vkCmdDrawIndirect(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndirect                       func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
     uint32_t                                    drawCount,
     uint32_t                                    stride)
@@ -400,7 +400,7 @@ void VulkanReplayDumpResources::Process_vkCmdDrawIndexedIndirect(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndexedIndirect                func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
     uint32_t                                    drawCount,
     uint32_t                                    stride)
@@ -429,7 +429,7 @@ void VulkanReplayDumpResources::Process_vkCmdDispatchIndirect(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDispatchIndirect                   func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset)
 {
     if (IsRecording(commandBuffer))
@@ -1188,9 +1188,9 @@ void VulkanReplayDumpResources::Process_vkCmdDrawIndirectCount(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndirectCount                  func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
-    const BufferInfo*                           countBuffer,
+    const VulkanBufferInfo*                     countBuffer,
     VkDeviceSize                                countBufferOffset,
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
@@ -1205,9 +1205,9 @@ void VulkanReplayDumpResources::Process_vkCmdDrawIndexedIndirectCount(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndexedIndirectCount           func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
-    const BufferInfo*                           countBuffer,
+    const VulkanBufferInfo*                     countBuffer,
     VkDeviceSize                                countBufferOffset,
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
@@ -2273,9 +2273,9 @@ void VulkanReplayDumpResources::Process_vkCmdDrawIndirectCountKHR(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndirectCountKHR               func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
-    const BufferInfo*                           countBuffer,
+    const VulkanBufferInfo*                     countBuffer,
     VkDeviceSize                                countBufferOffset,
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
@@ -2290,9 +2290,9 @@ void VulkanReplayDumpResources::Process_vkCmdDrawIndexedIndirectCountKHR(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndexedIndirectCountKHR        func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
-    const BufferInfo*                           countBuffer,
+    const VulkanBufferInfo*                     countBuffer,
     VkDeviceSize                                countBufferOffset,
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride)
@@ -2752,7 +2752,7 @@ void VulkanReplayDumpResources::Process_vkCmdBindIndexBuffer2KHR(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdBindIndexBuffer2KHR                func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
     VkDeviceSize                                size,
     VkIndexType                                 indexType)

--- a/framework/generated/generated_vulkan_replay_dump_resources.h
+++ b/framework/generated/generated_vulkan_replay_dump_resources.h
@@ -64,7 +64,7 @@ void Process_vkCmdBindPipeline(
     PFN_vkCmdBindPipeline                       func,
     VkCommandBuffer                             commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
-    const PipelineInfo*                         pipeline);
+    const VulkanPipelineInfo*                   pipeline);
 
 void Process_vkCmdSetViewport(
     const ApiCallInfo&                          call_info,
@@ -135,7 +135,7 @@ void Process_vkCmdBindDescriptorSets(
     PFN_vkCmdBindDescriptorSets                 func,
     VkCommandBuffer                             commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
-    const PipelineLayoutInfo*                   layout,
+    const VulkanPipelineLayoutInfo*             layout,
     uint32_t                                    firstSet,
     uint32_t                                    descriptorSetCount,
     HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets,
@@ -146,7 +146,7 @@ void Process_vkCmdBindIndexBuffer(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdBindIndexBuffer                    func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
     VkIndexType                                 indexType);
 
@@ -182,7 +182,7 @@ void Process_vkCmdDrawIndirect(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndirect                       func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
     uint32_t                                    drawCount,
     uint32_t                                    stride);
@@ -191,7 +191,7 @@ void Process_vkCmdDrawIndexedIndirect(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndexedIndirect                func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
     uint32_t                                    drawCount,
     uint32_t                                    stride);
@@ -208,7 +208,7 @@ void Process_vkCmdDispatchIndirect(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDispatchIndirect                   func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset);
 
 void Process_vkCmdCopyBuffer(
@@ -465,9 +465,9 @@ void Process_vkCmdDrawIndirectCount(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndirectCount                  func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
-    const BufferInfo*                           countBuffer,
+    const VulkanBufferInfo*                     countBuffer,
     VkDeviceSize                                countBufferOffset,
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride);
@@ -476,9 +476,9 @@ void Process_vkCmdDrawIndexedIndirectCount(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndexedIndirectCount           func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
-    const BufferInfo*                           countBuffer,
+    const VulkanBufferInfo*                     countBuffer,
     VkDeviceSize                                countBufferOffset,
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride);
@@ -820,9 +820,9 @@ void Process_vkCmdDrawIndirectCountKHR(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndirectCountKHR               func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
-    const BufferInfo*                           countBuffer,
+    const VulkanBufferInfo*                     countBuffer,
     VkDeviceSize                                countBufferOffset,
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride);
@@ -831,9 +831,9 @@ void Process_vkCmdDrawIndexedIndirectCountKHR(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdDrawIndexedIndirectCountKHR        func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
-    const BufferInfo*                           countBuffer,
+    const VulkanBufferInfo*                     countBuffer,
     VkDeviceSize                                countBufferOffset,
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride);
@@ -968,7 +968,7 @@ void Process_vkCmdBindIndexBuffer2KHR(
     const ApiCallInfo&                          call_info,
     PFN_vkCmdBindIndexBuffer2KHR                func,
     VkCommandBuffer                             commandBuffer,
-    const BufferInfo*                           buffer,
+    const VulkanBufferInfo*                     buffer,
     VkDeviceSize                                offset,
     VkDeviceSize                                size,
     VkIndexType                                 indexType);

--- a/framework/generated/generated_vulkan_replay_dump_resources.h
+++ b/framework/generated/generated_vulkan_replay_dump_resources.h
@@ -49,7 +49,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class VulkanReplayDumpResources : public VulkanReplayDumpResourcesBase
 {
   public:
-    VulkanReplayDumpResources(const VulkanReplayOptions& options, VulkanObjectInfoTable& object_info_table) : VulkanReplayDumpResourcesBase(options, object_info_table) { }
+    VulkanReplayDumpResources(const VulkanReplayOptions& options, CommonObjectInfoTable& object_info_table) : VulkanReplayDumpResourcesBase(options, object_info_table) { }
 
     ~VulkanReplayDumpResources() { }
 

--- a/framework/generated/generated_vulkan_replay_dump_resources.h
+++ b/framework/generated/generated_vulkan_replay_dump_resources.h
@@ -49,7 +49,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class VulkanReplayDumpResources : public VulkanReplayDumpResourcesBase
 {
   public:
-    VulkanReplayDumpResources(const VulkanReplayOptions& options, CommonObjectInfoTable& object_info_table) : VulkanReplayDumpResourcesBase(options, object_info_table) { }
+    VulkanReplayDumpResources(const VulkanReplayOptions& options, CommonObjectInfoTable* object_info_table) : VulkanReplayDumpResourcesBase(options, object_info_table) { }
 
     ~VulkanReplayDumpResources() { }
 

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -40,27 +40,27 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-void MapStructHandles(Decoded_VkBufferMemoryBarrier* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBufferMemoryBarrier* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkBufferMemoryBarrier* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImageMemoryBarrier* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImageMemoryBarrier* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImageMemoryBarrier* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDeviceCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDeviceCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -71,7 +71,7 @@ void MapStructHandles(Decoded_VkDeviceCreateInfo* wrapper, const VulkanObjectInf
     }
 }
 
-void MapStructHandles(Decoded_VkSubmitInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSubmitInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -82,25 +82,25 @@ void MapStructHandles(Decoded_VkSubmitInfo* wrapper, const VulkanObjectInfoTable
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->pWaitSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->pWaitSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
 
-        value->pCommandBuffers = handle_mapping::MapHandleArray<VulkanCommandBufferInfo>(&wrapper->pCommandBuffers, object_info_table, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+        value->pCommandBuffers = handle_mapping::MapHandleArray<VulkanCommandBufferInfo>(&wrapper->pCommandBuffers, object_info_table, &CommonObjectInfoTable::GetVkCommandBufferInfo);
 
-        value->pSignalSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pSignalSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->pSignalSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pSignalSemaphores, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMappedMemoryRange* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMappedMemoryRange* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMappedMemoryRange* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMemoryAllocateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMemoryAllocateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -111,63 +111,63 @@ void MapStructHandles(Decoded_VkMemoryAllocateInfo* wrapper, const VulkanObjectI
     }
 }
 
-void MapStructHandles(Decoded_VkSparseMemoryBind* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSparseMemoryBind* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSparseMemoryBind* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSparseBufferMemoryBindInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSparseBufferMemoryBindInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSparseBufferMemoryBindInfo* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
 
         MapStructArrayHandles<Decoded_VkSparseMemoryBind>(wrapper->pBinds->GetMetaStructPointer(), wrapper->pBinds->GetLength(), object_info_table);
     }
 }
 
-void MapStructHandles(Decoded_VkSparseImageOpaqueMemoryBindInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSparseImageOpaqueMemoryBindInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSparseImageOpaqueMemoryBindInfo* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
         MapStructArrayHandles<Decoded_VkSparseMemoryBind>(wrapper->pBinds->GetMetaStructPointer(), wrapper->pBinds->GetLength(), object_info_table);
     }
 }
 
-void MapStructHandles(Decoded_VkSparseImageMemoryBind* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSparseImageMemoryBind* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSparseImageMemoryBind* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSparseImageMemoryBindInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSparseImageMemoryBindInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSparseImageMemoryBindInfo* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
         MapStructArrayHandles<Decoded_VkSparseImageMemoryBind>(wrapper->pBinds->GetMetaStructPointer(), wrapper->pBinds->GetLength(), object_info_table);
     }
 }
 
-void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -178,7 +178,7 @@ void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const VulkanObjectInfoT
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->pWaitSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->pWaitSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
 
         MapStructArrayHandles<Decoded_VkSparseBufferMemoryBindInfo>(wrapper->pBufferBinds->GetMetaStructPointer(), wrapper->pBufferBinds->GetLength(), object_info_table);
 
@@ -186,21 +186,21 @@ void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const VulkanObjectInfoT
 
         MapStructArrayHandles<Decoded_VkSparseImageMemoryBindInfo>(wrapper->pImageBinds->GetMetaStructPointer(), wrapper->pImageBinds->GetLength(), object_info_table);
 
-        value->pSignalSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pSignalSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->pSignalSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pSignalSemaphores, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkBufferViewCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBufferViewCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkBufferViewCreateInfo* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImageCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImageCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -211,7 +211,7 @@ void MapStructHandles(Decoded_VkImageCreateInfo* wrapper, const VulkanObjectInfo
     }
 }
 
-void MapStructHandles(Decoded_VkImageViewCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImageViewCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -222,11 +222,11 @@ void MapStructHandles(Decoded_VkImageViewCreateInfo* wrapper, const VulkanObject
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkShaderModuleCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkShaderModuleCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -237,7 +237,7 @@ void MapStructHandles(Decoded_VkShaderModuleCreateInfo* wrapper, const VulkanObj
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineShaderStageCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPipelineShaderStageCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -248,11 +248,11 @@ void MapStructHandles(Decoded_VkPipelineShaderStageCreateInfo* wrapper, const Vu
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->module = handle_mapping::MapHandle<VulkanShaderModuleInfo>(wrapper->module, object_info_table, &VulkanObjectInfoTable::GetVkShaderModuleInfo);
+        value->module = handle_mapping::MapHandle<VulkanShaderModuleInfo>(wrapper->module, object_info_table, &CommonObjectInfoTable::GetVkShaderModuleInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkComputePipelineCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkComputePipelineCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -265,13 +265,13 @@ void MapStructHandles(Decoded_VkComputePipelineCreateInfo* wrapper, const Vulkan
 
         MapStructHandles(wrapper->stage, object_info_table);
 
-        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
 
-        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkGraphicsPipelineCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGraphicsPipelineCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -284,25 +284,25 @@ void MapStructHandles(Decoded_VkGraphicsPipelineCreateInfo* wrapper, const Vulka
 
         MapStructArrayHandles<Decoded_VkPipelineShaderStageCreateInfo>(wrapper->pStages->GetMetaStructPointer(), wrapper->pStages->GetLength(), object_info_table);
 
-        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
 
-        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo);
+        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &CommonObjectInfoTable::GetVkRenderPassInfo);
 
-        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineLayoutCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPipelineLayoutCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkPipelineLayoutCreateInfo* value = wrapper->decoded_value;
 
-        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
+        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSamplerCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSamplerCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -313,51 +313,51 @@ void MapStructHandles(Decoded_VkSamplerCreateInfo* wrapper, const VulkanObjectIn
     }
 }
 
-void MapStructHandles(Decoded_VkCopyDescriptorSet* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyDescriptorSet* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyDescriptorSet* value = wrapper->decoded_value;
 
-        value->srcSet = handle_mapping::MapHandle<VulkanDescriptorSetInfo>(wrapper->srcSet, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
+        value->srcSet = handle_mapping::MapHandle<VulkanDescriptorSetInfo>(wrapper->srcSet, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetInfo);
 
-        value->dstSet = handle_mapping::MapHandle<VulkanDescriptorSetInfo>(wrapper->dstSet, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
+        value->dstSet = handle_mapping::MapHandle<VulkanDescriptorSetInfo>(wrapper->dstSet, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDescriptorBufferInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDescriptorBufferInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDescriptorBufferInfo* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDescriptorSetAllocateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDescriptorSetAllocateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDescriptorSetAllocateInfo* value = wrapper->decoded_value;
 
-        value->descriptorPool = handle_mapping::MapHandle<VulkanDescriptorPoolInfo>(wrapper->descriptorPool, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorPoolInfo);
+        value->descriptorPool = handle_mapping::MapHandle<VulkanDescriptorPoolInfo>(wrapper->descriptorPool, object_info_table, &CommonObjectInfoTable::GetVkDescriptorPoolInfo);
 
-        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
+        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDescriptorSetLayoutBinding* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDescriptorSetLayoutBinding* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDescriptorSetLayoutBinding* value = wrapper->decoded_value;
 
-        value->pImmutableSamplers = handle_mapping::MapHandleArray<VulkanSamplerInfo>(&wrapper->pImmutableSamplers, object_info_table, &VulkanObjectInfoTable::GetVkSamplerInfo);
+        value->pImmutableSamplers = handle_mapping::MapHandleArray<VulkanSamplerInfo>(&wrapper->pImmutableSamplers, object_info_table, &CommonObjectInfoTable::GetVkSamplerInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDescriptorSetLayoutCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDescriptorSetLayoutCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -365,41 +365,41 @@ void MapStructHandles(Decoded_VkDescriptorSetLayoutCreateInfo* wrapper, const Vu
     }
 }
 
-void MapStructHandles(Decoded_VkFramebufferCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkFramebufferCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkFramebufferCreateInfo* value = wrapper->decoded_value;
 
-        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo);
+        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &CommonObjectInfoTable::GetVkRenderPassInfo);
 
-        value->pAttachments = handle_mapping::MapHandleArray<VulkanImageViewInfo>(&wrapper->pAttachments, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
+        value->pAttachments = handle_mapping::MapHandleArray<VulkanImageViewInfo>(&wrapper->pAttachments, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCommandBufferAllocateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCommandBufferAllocateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCommandBufferAllocateInfo* value = wrapper->decoded_value;
 
-        value->commandPool = handle_mapping::MapHandle<VulkanCommandPoolInfo>(wrapper->commandPool, object_info_table, &VulkanObjectInfoTable::GetVkCommandPoolInfo);
+        value->commandPool = handle_mapping::MapHandle<VulkanCommandPoolInfo>(wrapper->commandPool, object_info_table, &CommonObjectInfoTable::GetVkCommandPoolInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCommandBufferInheritanceInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCommandBufferInheritanceInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCommandBufferInheritanceInfo* value = wrapper->decoded_value;
 
-        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo);
+        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &CommonObjectInfoTable::GetVkRenderPassInfo);
 
-        value->framebuffer = handle_mapping::MapHandle<VulkanFramebufferInfo>(wrapper->framebuffer, object_info_table, &VulkanObjectInfoTable::GetVkFramebufferInfo);
+        value->framebuffer = handle_mapping::MapHandle<VulkanFramebufferInfo>(wrapper->framebuffer, object_info_table, &CommonObjectInfoTable::GetVkFramebufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCommandBufferBeginInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCommandBufferBeginInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -407,7 +407,7 @@ void MapStructHandles(Decoded_VkCommandBufferBeginInfo* wrapper, const VulkanObj
     }
 }
 
-void MapStructHandles(Decoded_VkRenderPassBeginInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkRenderPassBeginInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -418,25 +418,25 @@ void MapStructHandles(Decoded_VkRenderPassBeginInfo* wrapper, const VulkanObject
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo);
+        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &CommonObjectInfoTable::GetVkRenderPassInfo);
 
-        value->framebuffer = handle_mapping::MapHandle<VulkanFramebufferInfo>(wrapper->framebuffer, object_info_table, &VulkanObjectInfoTable::GetVkFramebufferInfo);
+        value->framebuffer = handle_mapping::MapHandle<VulkanFramebufferInfo>(wrapper->framebuffer, object_info_table, &CommonObjectInfoTable::GetVkFramebufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkBindBufferMemoryInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBindBufferMemoryInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkBindBufferMemoryInfo* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkBindImageMemoryInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBindImageMemoryInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -447,165 +447,165 @@ void MapStructHandles(Decoded_VkBindImageMemoryInfo* wrapper, const VulkanObject
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMemoryDedicatedAllocateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMemoryDedicatedAllocateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMemoryDedicatedAllocateInfo* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPhysicalDeviceGroupProperties* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPhysicalDeviceGroupProperties* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
-        handle_mapping::MapHandleArray<VulkanPhysicalDeviceInfo>(&wrapper->physicalDevices, object_info_table, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+        handle_mapping::MapHandleArray<VulkanPhysicalDeviceInfo>(&wrapper->physicalDevices, object_info_table, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDeviceGroupDeviceCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDeviceGroupDeviceCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDeviceGroupDeviceCreateInfo* value = wrapper->decoded_value;
 
-        value->pPhysicalDevices = handle_mapping::MapHandleArray<VulkanPhysicalDeviceInfo>(&wrapper->pPhysicalDevices, object_info_table, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
+        value->pPhysicalDevices = handle_mapping::MapHandleArray<VulkanPhysicalDeviceInfo>(&wrapper->pPhysicalDevices, object_info_table, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkBufferMemoryRequirementsInfo2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBufferMemoryRequirementsInfo2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkBufferMemoryRequirementsInfo2* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImageMemoryRequirementsInfo2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImageMemoryRequirementsInfo2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImageMemoryRequirementsInfo2* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImageSparseMemoryRequirementsInfo2* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSamplerYcbcrConversionInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSamplerYcbcrConversionInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSamplerYcbcrConversionInfo* value = wrapper->decoded_value;
 
-        value->conversion = handle_mapping::MapHandle<VulkanSamplerYcbcrConversionInfo>(wrapper->conversion, object_info_table, &VulkanObjectInfoTable::GetVkSamplerYcbcrConversionInfo);
+        value->conversion = handle_mapping::MapHandle<VulkanSamplerYcbcrConversionInfo>(wrapper->conversion, object_info_table, &CommonObjectInfoTable::GetVkSamplerYcbcrConversionInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDescriptorUpdateTemplateCreateInfo* value = wrapper->decoded_value;
 
-        value->descriptorSetLayout = handle_mapping::MapHandle<VulkanDescriptorSetLayoutInfo>(wrapper->descriptorSetLayout, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
+        value->descriptorSetLayout = handle_mapping::MapHandle<VulkanDescriptorSetLayoutInfo>(wrapper->descriptorSetLayout, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetLayoutInfo);
 
-        value->pipelineLayout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->pipelineLayout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->pipelineLayout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->pipelineLayout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkRenderPassAttachmentBeginInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkRenderPassAttachmentBeginInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkRenderPassAttachmentBeginInfo* value = wrapper->decoded_value;
 
-        value->pAttachments = handle_mapping::MapHandleArray<VulkanImageViewInfo>(&wrapper->pAttachments, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
+        value->pAttachments = handle_mapping::MapHandleArray<VulkanImageViewInfo>(&wrapper->pAttachments, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSemaphoreWaitInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSemaphoreWaitInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSemaphoreWaitInfo* value = wrapper->decoded_value;
 
-        value->pSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->pSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pSemaphores, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSemaphoreSignalInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSemaphoreSignalInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSemaphoreSignalInfo* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkBufferDeviceAddressInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBufferDeviceAddressInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkBufferDeviceAddressInfo* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDeviceMemoryOpaqueCaptureAddressInfo* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkBufferMemoryBarrier2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBufferMemoryBarrier2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkBufferMemoryBarrier2* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImageMemoryBarrier2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImageMemoryBarrier2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImageMemoryBarrier2* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDependencyInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDependencyInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -615,27 +615,27 @@ void MapStructHandles(Decoded_VkDependencyInfo* wrapper, const VulkanObjectInfoT
     }
 }
 
-void MapStructHandles(Decoded_VkSemaphoreSubmitInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSemaphoreSubmitInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSemaphoreSubmitInfo* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCommandBufferSubmitInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCommandBufferSubmitInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCommandBufferSubmitInfo* value = wrapper->decoded_value;
 
-        value->commandBuffer = handle_mapping::MapHandle<VulkanCommandBufferInfo>(wrapper->commandBuffer, object_info_table, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
+        value->commandBuffer = handle_mapping::MapHandle<VulkanCommandBufferInfo>(wrapper->commandBuffer, object_info_table, &CommonObjectInfoTable::GetVkCommandBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSubmitInfo2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSubmitInfo2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -652,91 +652,91 @@ void MapStructHandles(Decoded_VkSubmitInfo2* wrapper, const VulkanObjectInfoTabl
     }
 }
 
-void MapStructHandles(Decoded_VkCopyBufferInfo2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyBufferInfo2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyBufferInfo2* value = wrapper->decoded_value;
 
-        value->srcBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->srcBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->srcBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->srcBuffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
 
-        value->dstBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->dstBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->dstBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->dstBuffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyImageInfo2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyImageInfo2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyImageInfo2* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
-        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyBufferToImageInfo2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyBufferToImageInfo2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyBufferToImageInfo2* value = wrapper->decoded_value;
 
-        value->srcBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->srcBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->srcBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->srcBuffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
 
-        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyImageToBufferInfo2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyImageToBufferInfo2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyImageToBufferInfo2* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
-        value->dstBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->dstBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->dstBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->dstBuffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkBlitImageInfo2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBlitImageInfo2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkBlitImageInfo2* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
-        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkResolveImageInfo2* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkResolveImageInfo2* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkResolveImageInfo2* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
-        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkRenderingAttachmentInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkRenderingAttachmentInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkRenderingAttachmentInfo* value = wrapper->decoded_value;
 
-        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
+        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo);
 
-        value->resolveImageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->resolveImageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
+        value->resolveImageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->resolveImageView, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkRenderingInfo* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkRenderingInfo* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -753,7 +753,7 @@ void MapStructHandles(Decoded_VkRenderingInfo* wrapper, const VulkanObjectInfoTa
     }
 }
 
-void MapStructHandles(Decoded_VkDeviceImageMemoryRequirements* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDeviceImageMemoryRequirements* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -761,19 +761,19 @@ void MapStructHandles(Decoded_VkDeviceImageMemoryRequirements* wrapper, const Vu
     }
 }
 
-void MapStructHandles(Decoded_VkSwapchainCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSwapchainCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSwapchainCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->surface = handle_mapping::MapHandle<VulkanSurfaceKHRInfo>(wrapper->surface, object_info_table, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo);
+        value->surface = handle_mapping::MapHandle<VulkanSurfaceKHRInfo>(wrapper->surface, object_info_table, &CommonObjectInfoTable::GetVkSurfaceKHRInfo);
 
-        value->oldSwapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->oldSwapchain, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+        value->oldSwapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->oldSwapchain, object_info_table, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPresentInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPresentInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -784,97 +784,97 @@ void MapStructHandles(Decoded_VkPresentInfoKHR* wrapper, const VulkanObjectInfoT
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->pWaitSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->pWaitSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
 
-        value->pSwapchains = handle_mapping::MapHandleArray<VulkanSwapchainKHRInfo>(&wrapper->pSwapchains, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+        value->pSwapchains = handle_mapping::MapHandleArray<VulkanSwapchainKHRInfo>(&wrapper->pSwapchains, object_info_table, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImageSwapchainCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImageSwapchainCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImageSwapchainCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkBindImageMemorySwapchainInfoKHR* value = wrapper->decoded_value;
 
-        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkAcquireNextImageInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkAcquireNextImageInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkAcquireNextImageInfoKHR* value = wrapper->decoded_value;
 
-        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
 
-        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
 
-        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
+        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &CommonObjectInfoTable::GetVkFenceInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDisplayModePropertiesKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDisplayModePropertiesKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDisplayModePropertiesKHR* value = wrapper->decoded_value;
 
-        value->displayMode = handle_mapping::MapHandle<VulkanDisplayModeKHRInfo>(wrapper->displayMode, object_info_table, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo);
+        value->displayMode = handle_mapping::MapHandle<VulkanDisplayModeKHRInfo>(wrapper->displayMode, object_info_table, &CommonObjectInfoTable::GetVkDisplayModeKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDisplayPlanePropertiesKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDisplayPlanePropertiesKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDisplayPlanePropertiesKHR* value = wrapper->decoded_value;
 
-        value->currentDisplay = handle_mapping::MapHandle<VulkanDisplayKHRInfo>(wrapper->currentDisplay, object_info_table, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
+        value->currentDisplay = handle_mapping::MapHandle<VulkanDisplayKHRInfo>(wrapper->currentDisplay, object_info_table, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDisplayPropertiesKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDisplayPropertiesKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDisplayPropertiesKHR* value = wrapper->decoded_value;
 
-        value->display = handle_mapping::MapHandle<VulkanDisplayKHRInfo>(wrapper->display, object_info_table, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
+        value->display = handle_mapping::MapHandle<VulkanDisplayKHRInfo>(wrapper->display, object_info_table, &CommonObjectInfoTable::GetVkDisplayKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDisplaySurfaceCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->displayMode = handle_mapping::MapHandle<VulkanDisplayModeKHRInfo>(wrapper->displayMode, object_info_table, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo);
+        value->displayMode = handle_mapping::MapHandle<VulkanDisplayModeKHRInfo>(wrapper->displayMode, object_info_table, &CommonObjectInfoTable::GetVkDisplayModeKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkVideoPictureResourceInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkVideoPictureResourceInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkVideoPictureResourceInfoKHR* value = wrapper->decoded_value;
 
-        value->imageViewBinding = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageViewBinding, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
+        value->imageViewBinding = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageViewBinding, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkVideoReferenceSlotInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkVideoReferenceSlotInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -882,43 +882,43 @@ void MapStructHandles(Decoded_VkVideoReferenceSlotInfoKHR* wrapper, const Vulkan
     }
 }
 
-void MapStructHandles(Decoded_VkBindVideoSessionMemoryInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBindVideoSessionMemoryInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkBindVideoSessionMemoryInfoKHR* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkVideoSessionParametersCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkVideoSessionParametersCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkVideoSessionParametersCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->videoSessionParametersTemplate = handle_mapping::MapHandle<VulkanVideoSessionParametersKHRInfo>(wrapper->videoSessionParametersTemplate, object_info_table, &VulkanObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
+        value->videoSessionParametersTemplate = handle_mapping::MapHandle<VulkanVideoSessionParametersKHRInfo>(wrapper->videoSessionParametersTemplate, object_info_table, &CommonObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
 
-        value->videoSession = handle_mapping::MapHandle<VulkanVideoSessionKHRInfo>(wrapper->videoSession, object_info_table, &VulkanObjectInfoTable::GetVkVideoSessionKHRInfo);
+        value->videoSession = handle_mapping::MapHandle<VulkanVideoSessionKHRInfo>(wrapper->videoSession, object_info_table, &CommonObjectInfoTable::GetVkVideoSessionKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkVideoBeginCodingInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkVideoBeginCodingInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkVideoBeginCodingInfoKHR* value = wrapper->decoded_value;
 
-        value->videoSession = handle_mapping::MapHandle<VulkanVideoSessionKHRInfo>(wrapper->videoSession, object_info_table, &VulkanObjectInfoTable::GetVkVideoSessionKHRInfo);
+        value->videoSession = handle_mapping::MapHandle<VulkanVideoSessionKHRInfo>(wrapper->videoSession, object_info_table, &CommonObjectInfoTable::GetVkVideoSessionKHRInfo);
 
-        value->videoSessionParameters = handle_mapping::MapHandle<VulkanVideoSessionParametersKHRInfo>(wrapper->videoSessionParameters, object_info_table, &VulkanObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
+        value->videoSessionParameters = handle_mapping::MapHandle<VulkanVideoSessionParametersKHRInfo>(wrapper->videoSessionParameters, object_info_table, &CommonObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
 
         MapStructArrayHandles<Decoded_VkVideoReferenceSlotInfoKHR>(wrapper->pReferenceSlots->GetMetaStructPointer(), wrapper->pReferenceSlots->GetLength(), object_info_table);
     }
 }
 
-void MapStructHandles(Decoded_VkVideoDecodeInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkVideoDecodeInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -929,7 +929,7 @@ void MapStructHandles(Decoded_VkVideoDecodeInfoKHR* wrapper, const VulkanObjectI
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->srcBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->srcBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->srcBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->srcBuffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
 
         MapStructHandles(wrapper->dstPictureResource, object_info_table);
 
@@ -939,149 +939,149 @@ void MapStructHandles(Decoded_VkVideoDecodeInfoKHR* wrapper, const VulkanObjectI
     }
 }
 
-void MapStructHandles(Decoded_VkRenderingFragmentShadingRateAttachmentInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkRenderingFragmentShadingRateAttachmentInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkRenderingFragmentShadingRateAttachmentInfoKHR* value = wrapper->decoded_value;
 
-        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
+        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkRenderingFragmentDensityMapAttachmentInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkRenderingFragmentDensityMapAttachmentInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkRenderingFragmentDensityMapAttachmentInfoEXT* value = wrapper->decoded_value;
 
-        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
+        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMemoryGetWin32HandleInfoKHR* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMemoryGetFdInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMemoryGetFdInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMemoryGetFdInfoKHR* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkWin32KeyedMutexAcquireReleaseInfoKHR* value = wrapper->decoded_value;
 
-        value->pAcquireSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pAcquireSyncs, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->pAcquireSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pAcquireSyncs, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
 
-        value->pReleaseSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pReleaseSyncs, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->pReleaseSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pReleaseSyncs, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImportSemaphoreWin32HandleInfoKHR* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSemaphoreGetWin32HandleInfoKHR* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImportSemaphoreFdInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImportSemaphoreFdInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImportSemaphoreFdInfoKHR* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSemaphoreGetFdInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSemaphoreGetFdInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSemaphoreGetFdInfoKHR* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImportFenceWin32HandleInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImportFenceWin32HandleInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImportFenceWin32HandleInfoKHR* value = wrapper->decoded_value;
 
-        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
+        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &CommonObjectInfoTable::GetVkFenceInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkFenceGetWin32HandleInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkFenceGetWin32HandleInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkFenceGetWin32HandleInfoKHR* value = wrapper->decoded_value;
 
-        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
+        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &CommonObjectInfoTable::GetVkFenceInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImportFenceFdInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImportFenceFdInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImportFenceFdInfoKHR* value = wrapper->decoded_value;
 
-        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
+        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &CommonObjectInfoTable::GetVkFenceInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkFenceGetFdInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkFenceGetFdInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkFenceGetFdInfoKHR* value = wrapper->decoded_value;
 
-        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
+        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &CommonObjectInfoTable::GetVkFenceInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkPhysicalDeviceSurfaceInfo2KHR* value = wrapper->decoded_value;
 
-        value->surface = handle_mapping::MapHandle<VulkanSurfaceKHRInfo>(wrapper->surface, object_info_table, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo);
+        value->surface = handle_mapping::MapHandle<VulkanSurfaceKHRInfo>(wrapper->surface, object_info_table, &CommonObjectInfoTable::GetVkSurfaceKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDisplayProperties2KHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDisplayProperties2KHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1089,7 +1089,7 @@ void MapStructHandles(Decoded_VkDisplayProperties2KHR* wrapper, const VulkanObje
     }
 }
 
-void MapStructHandles(Decoded_VkDisplayPlaneProperties2KHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDisplayPlaneProperties2KHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1097,7 +1097,7 @@ void MapStructHandles(Decoded_VkDisplayPlaneProperties2KHR* wrapper, const Vulka
     }
 }
 
-void MapStructHandles(Decoded_VkDisplayModeProperties2KHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDisplayModeProperties2KHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1105,67 +1105,67 @@ void MapStructHandles(Decoded_VkDisplayModeProperties2KHR* wrapper, const Vulkan
     }
 }
 
-void MapStructHandles(Decoded_VkDisplayPlaneInfo2KHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDisplayPlaneInfo2KHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDisplayPlaneInfo2KHR* value = wrapper->decoded_value;
 
-        value->mode = handle_mapping::MapHandle<VulkanDisplayModeKHRInfo>(wrapper->mode, object_info_table, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo);
+        value->mode = handle_mapping::MapHandle<VulkanDisplayModeKHRInfo>(wrapper->mode, object_info_table, &CommonObjectInfoTable::GetVkDisplayModeKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPipelineInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkPipelineInfoKHR* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineExecutableInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPipelineExecutableInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkPipelineExecutableInfoKHR* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMemoryMapInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMemoryMapInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMemoryMapInfoKHR* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMemoryUnmapInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMemoryUnmapInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMemoryUnmapInfoKHR* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineLibraryCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPipelineLibraryCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkPipelineLibraryCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->pLibraries = handle_mapping::MapHandleArray<VulkanPipelineInfo>(&wrapper->pLibraries, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pLibraries = handle_mapping::MapHandleArray<VulkanPipelineInfo>(&wrapper->pLibraries, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkVideoEncodeInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkVideoEncodeInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1176,7 +1176,7 @@ void MapStructHandles(Decoded_VkVideoEncodeInfoKHR* wrapper, const VulkanObjectI
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->dstBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->dstBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->dstBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->dstBuffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
 
         MapStructHandles(wrapper->srcPictureResource, object_info_table);
 
@@ -1186,17 +1186,17 @@ void MapStructHandles(Decoded_VkVideoEncodeInfoKHR* wrapper, const VulkanObjectI
     }
 }
 
-void MapStructHandles(Decoded_VkVideoEncodeSessionParametersGetInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkVideoEncodeSessionParametersGetInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkVideoEncodeSessionParametersGetInfoKHR* value = wrapper->decoded_value;
 
-        value->videoSessionParameters = handle_mapping::MapHandle<VulkanVideoSessionParametersKHRInfo>(wrapper->videoSessionParameters, object_info_table, &VulkanObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
+        value->videoSessionParameters = handle_mapping::MapHandle<VulkanVideoSessionParametersKHRInfo>(wrapper->videoSessionParameters, object_info_table, &CommonObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDeviceImageSubresourceInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDeviceImageSubresourceInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1204,67 +1204,67 @@ void MapStructHandles(Decoded_VkDeviceImageSubresourceInfoKHR* wrapper, const Vu
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineBinaryCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPipelineBinaryCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkPipelineBinaryCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineBinaryInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPipelineBinaryInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkPipelineBinaryInfoKHR* value = wrapper->decoded_value;
 
-        value->pPipelineBinaries = handle_mapping::MapHandleArray<VulkanPipelineBinaryKHRInfo>(&wrapper->pPipelineBinaries, object_info_table, &VulkanObjectInfoTable::GetVkPipelineBinaryKHRInfo);
+        value->pPipelineBinaries = handle_mapping::MapHandleArray<VulkanPipelineBinaryKHRInfo>(&wrapper->pPipelineBinaries, object_info_table, &CommonObjectInfoTable::GetVkPipelineBinaryKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkReleaseCapturedPipelineDataInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkReleaseCapturedPipelineDataInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkReleaseCapturedPipelineDataInfoKHR* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineBinaryDataInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPipelineBinaryDataInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkPipelineBinaryDataInfoKHR* value = wrapper->decoded_value;
 
-        value->pipelineBinary = handle_mapping::MapHandle<VulkanPipelineBinaryKHRInfo>(wrapper->pipelineBinary, object_info_table, &VulkanObjectInfoTable::GetVkPipelineBinaryKHRInfo);
+        value->pipelineBinary = handle_mapping::MapHandle<VulkanPipelineBinaryKHRInfo>(wrapper->pipelineBinary, object_info_table, &CommonObjectInfoTable::GetVkPipelineBinaryKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineBinaryHandlesInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPipelineBinaryHandlesInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkPipelineBinaryHandlesInfoKHR* value = wrapper->decoded_value;
 
-        value->pPipelineBinaries = handle_mapping::MapHandleArray<VulkanPipelineBinaryKHRInfo>(&wrapper->pPipelineBinaries, object_info_table, &VulkanObjectInfoTable::GetVkPipelineBinaryKHRInfo);
+        value->pPipelineBinaries = handle_mapping::MapHandleArray<VulkanPipelineBinaryKHRInfo>(&wrapper->pPipelineBinaries, object_info_table, &CommonObjectInfoTable::GetVkPipelineBinaryKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkVideoInlineQueryInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkVideoInlineQueryInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkVideoInlineQueryInfoKHR* value = wrapper->decoded_value;
 
-        value->queryPool = handle_mapping::MapHandle<VulkanQueryPoolInfo>(wrapper->queryPool, object_info_table, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
+        value->queryPool = handle_mapping::MapHandle<VulkanQueryPoolInfo>(wrapper->queryPool, object_info_table, &CommonObjectInfoTable::GetVkQueryPoolInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkBindDescriptorSetsInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBindDescriptorSetsInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1275,13 +1275,13 @@ void MapStructHandles(Decoded_VkBindDescriptorSetsInfoKHR* wrapper, const Vulkan
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
 
-        value->pDescriptorSets = handle_mapping::MapHandleArray<VulkanDescriptorSetInfo>(&wrapper->pDescriptorSets, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
+        value->pDescriptorSets = handle_mapping::MapHandleArray<VulkanDescriptorSetInfo>(&wrapper->pDescriptorSets, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPushConstantsInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPushConstantsInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1292,11 +1292,11 @@ void MapStructHandles(Decoded_VkPushConstantsInfoKHR* wrapper, const VulkanObjec
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkPushDescriptorSetInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPushDescriptorSetInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1307,13 +1307,13 @@ void MapStructHandles(Decoded_VkPushDescriptorSetInfoKHR* wrapper, const VulkanO
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
 
         MapStructArrayHandles<Decoded_VkWriteDescriptorSet>(wrapper->pDescriptorWrites->GetMetaStructPointer(), wrapper->pDescriptorWrites->GetLength(), object_info_table);
     }
 }
 
-void MapStructHandles(Decoded_VkSetDescriptorBufferOffsetsInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSetDescriptorBufferOffsetsInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1324,11 +1324,11 @@ void MapStructHandles(Decoded_VkSetDescriptorBufferOffsetsInfoEXT* wrapper, cons
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1339,11 +1339,11 @@ void MapStructHandles(Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT* wra
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1353,7 +1353,7 @@ void MapStructHandles(Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper, const Vul
     }
 }
 
-void MapStructHandles(Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1363,53 +1363,53 @@ void MapStructHandles(Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper, const Vulk
     }
 }
 
-void MapStructHandles(Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDedicatedAllocationMemoryAllocateInfoNV* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImageViewHandleInfoNVX* value = wrapper->decoded_value;
 
-        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
+        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &CommonObjectInfoTable::GetVkImageViewInfo);
 
-        value->sampler = handle_mapping::MapHandle<VulkanSamplerInfo>(wrapper->sampler, object_info_table, &VulkanObjectInfoTable::GetVkSamplerInfo);
+        value->sampler = handle_mapping::MapHandle<VulkanSamplerInfo>(wrapper->sampler, object_info_table, &CommonObjectInfoTable::GetVkSamplerInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkWin32KeyedMutexAcquireReleaseInfoNV* value = wrapper->decoded_value;
 
-        value->pAcquireSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pAcquireSyncs, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->pAcquireSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pAcquireSyncs, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
 
-        value->pReleaseSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pReleaseSyncs, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->pReleaseSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pReleaseSyncs, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkConditionalRenderingBeginInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkConditionalRenderingBeginInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkConditionalRenderingBeginInfoEXT* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1419,7 +1419,7 @@ void MapStructHandles(Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper, const Vulk
     }
 }
 
-void MapStructHandles(Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1429,27 +1429,27 @@ void MapStructHandles(Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper, const Vulka
     }
 }
 
-void MapStructHandles(Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMemoryGetAndroidHardwareBufferInfoANDROID* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkShaderModuleValidationCacheCreateInfoEXT* value = wrapper->decoded_value;
 
-        value->validationCache = handle_mapping::MapHandle<VulkanValidationCacheEXTInfo>(wrapper->validationCache, object_info_table, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo);
+        value->validationCache = handle_mapping::MapHandle<VulkanValidationCacheEXTInfo>(wrapper->validationCache, object_info_table, &CommonObjectInfoTable::GetVkValidationCacheEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1457,37 +1457,37 @@ void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoNV* wrapper, const V
 
         MapStructArrayHandles<Decoded_VkPipelineShaderStageCreateInfo>(wrapper->pStages->GetMetaStructPointer(), wrapper->pStages->GetLength(), object_info_table);
 
-        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
 
-        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkGeometryTrianglesNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGeometryTrianglesNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkGeometryTrianglesNV* value = wrapper->decoded_value;
 
-        value->vertexData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->vertexData, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->vertexData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->vertexData, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
 
-        value->indexData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->indexData, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->indexData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->indexData, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
 
-        value->transformData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->transformData, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->transformData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->transformData, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkGeometryAABBNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGeometryAABBNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkGeometryAABBNV* value = wrapper->decoded_value;
 
-        value->aabbData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->aabbData, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->aabbData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->aabbData, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkGeometryDataNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGeometryDataNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1497,7 +1497,7 @@ void MapStructHandles(Decoded_VkGeometryDataNV* wrapper, const VulkanObjectInfoT
     }
 }
 
-void MapStructHandles(Decoded_VkGeometryNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGeometryNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1505,7 +1505,7 @@ void MapStructHandles(Decoded_VkGeometryNV* wrapper, const VulkanObjectInfoTable
     }
 }
 
-void MapStructHandles(Decoded_VkAccelerationStructureInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkAccelerationStructureInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1513,7 +1513,7 @@ void MapStructHandles(Decoded_VkAccelerationStructureInfoNV* wrapper, const Vulk
     }
 }
 
-void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1521,101 +1521,101 @@ void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoNV* wrapper, cons
     }
 }
 
-void MapStructHandles(Decoded_VkBindAccelerationStructureMemoryInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkBindAccelerationStructureMemoryInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkBindAccelerationStructureMemoryInfoNV* value = wrapper->decoded_value;
 
-        value->accelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureNVInfo>(wrapper->accelerationStructure, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
+        value->accelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureNVInfo>(wrapper->accelerationStructure, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo);
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkWriteDescriptorSetAccelerationStructureNV* value = wrapper->decoded_value;
 
-        value->pAccelerationStructures = handle_mapping::MapHandleArray<VulkanAccelerationStructureNVInfo>(&wrapper->pAccelerationStructures, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
+        value->pAccelerationStructures = handle_mapping::MapHandleArray<VulkanAccelerationStructureNVInfo>(&wrapper->pAccelerationStructures, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkAccelerationStructureMemoryRequirementsInfoNV* value = wrapper->decoded_value;
 
-        value->accelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureNVInfo>(wrapper->accelerationStructure, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
+        value->accelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureNVInfo>(wrapper->accelerationStructure, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureNVInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyMemoryToImageInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyMemoryToImageInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyMemoryToImageInfoEXT* value = wrapper->decoded_value;
 
-        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyImageToMemoryInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyImageToMemoryInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyImageToMemoryInfoEXT* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyImageToImageInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyImageToImageInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyImageToImageInfoEXT* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
-        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkHostImageLayoutTransitionInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkHostImageLayoutTransitionInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkHostImageLayoutTransitionInfoEXT* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSwapchainPresentFenceInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSwapchainPresentFenceInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSwapchainPresentFenceInfoEXT* value = wrapper->decoded_value;
 
-        value->pFences = handle_mapping::MapHandleArray<VulkanFenceInfo>(&wrapper->pFences, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
+        value->pFences = handle_mapping::MapHandleArray<VulkanFenceInfo>(&wrapper->pFences, object_info_table, &CommonObjectInfoTable::GetVkFenceInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkReleaseSwapchainImagesInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkReleaseSwapchainImagesInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkReleaseSwapchainImagesInfoEXT* value = wrapper->decoded_value;
 
-        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
+        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &CommonObjectInfoTable::GetVkSwapchainKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkGraphicsShaderGroupCreateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGraphicsShaderGroupCreateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1623,7 +1623,7 @@ void MapStructHandles(Decoded_VkGraphicsShaderGroupCreateInfoNV* wrapper, const 
     }
 }
 
-void MapStructHandles(Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1631,31 +1631,31 @@ void MapStructHandles(Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV* wrappe
 
         MapStructArrayHandles<Decoded_VkGraphicsShaderGroupCreateInfoNV>(wrapper->pGroups->GetMetaStructPointer(), wrapper->pGroups->GetLength(), object_info_table);
 
-        value->pPipelines = handle_mapping::MapHandleArray<VulkanPipelineInfo>(&wrapper->pPipelines, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pPipelines = handle_mapping::MapHandleArray<VulkanPipelineInfo>(&wrapper->pPipelines, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkIndirectCommandsStreamNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkIndirectCommandsStreamNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkIndirectCommandsStreamNV* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkIndirectCommandsLayoutTokenNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkIndirectCommandsLayoutTokenNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkIndirectCommandsLayoutTokenNV* value = wrapper->decoded_value;
 
-        value->pushconstantPipelineLayout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->pushconstantPipelineLayout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->pushconstantPipelineLayout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->pushconstantPipelineLayout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1663,173 +1663,173 @@ void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoNV* wrapper, con
     }
 }
 
-void MapStructHandles(Decoded_VkGeneratedCommandsInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGeneratedCommandsInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkGeneratedCommandsInfoNV* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
 
-        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutNVInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo);
+        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutNVInfo>(wrapper->indirectCommandsLayout, object_info_table, &CommonObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo);
 
         MapStructArrayHandles<Decoded_VkIndirectCommandsStreamNV>(wrapper->pStreams->GetMetaStructPointer(), wrapper->pStreams->GetLength(), object_info_table);
 
-        value->preprocessBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->preprocessBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->preprocessBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->preprocessBuffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
 
-        value->sequencesCountBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->sequencesCountBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->sequencesCountBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->sequencesCountBuffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
 
-        value->sequencesIndexBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->sequencesIndexBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->sequencesIndexBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->sequencesIndexBuffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkGeneratedCommandsMemoryRequirementsInfoNV* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
 
-        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutNVInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo);
+        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutNVInfo>(wrapper->indirectCommandsLayout, object_info_table, &CommonObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMemoryGetZirconHandleInfoFUCHSIA* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMemoryGetZirconHandleInfoFUCHSIA* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMemoryGetZirconHandleInfoFUCHSIA* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkImportSemaphoreZirconHandleInfoFUCHSIA* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkSemaphoreGetZirconHandleInfoFUCHSIA* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMemoryGetRemoteAddressInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMemoryGetRemoteAddressInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMemoryGetRemoteAddressInfoNV* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &CommonObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkFrameBoundaryEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkFrameBoundaryEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkFrameBoundaryEXT* value = wrapper->decoded_value;
 
-        value->pImages = handle_mapping::MapHandleArray<VulkanImageInfo>(&wrapper->pImages, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
+        value->pImages = handle_mapping::MapHandleArray<VulkanImageInfo>(&wrapper->pImages, object_info_table, &CommonObjectInfoTable::GetVkImageInfo);
 
-        value->pBuffers = handle_mapping::MapHandleArray<VulkanBufferInfo>(&wrapper->pBuffers, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->pBuffers = handle_mapping::MapHandleArray<VulkanBufferInfo>(&wrapper->pBuffers, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMicromapBuildInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMicromapBuildInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMicromapBuildInfoEXT* value = wrapper->decoded_value;
 
-        value->dstMicromap = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->dstMicromap, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
+        value->dstMicromap = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->dstMicromap, object_info_table, &CommonObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkMicromapCreateInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkMicromapCreateInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkMicromapCreateInfoEXT* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyMicromapToMemoryInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyMicromapToMemoryInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyMicromapToMemoryInfoEXT* value = wrapper->decoded_value;
 
-        value->src = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
+        value->src = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->src, object_info_table, &CommonObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyMemoryToMicromapInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyMemoryToMicromapInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyMemoryToMicromapInfoEXT* value = wrapper->decoded_value;
 
-        value->dst = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
+        value->dst = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->dst, object_info_table, &CommonObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyMicromapInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyMicromapInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyMicromapInfoEXT* value = wrapper->decoded_value;
 
-        value->src = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
+        value->src = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->src, object_info_table, &CommonObjectInfoTable::GetVkMicromapEXTInfo);
 
-        value->dst = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
+        value->dst = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->dst, object_info_table, &CommonObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkAccelerationStructureTrianglesOpacityMicromapEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkAccelerationStructureTrianglesOpacityMicromapEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkAccelerationStructureTrianglesOpacityMicromapEXT* value = wrapper->decoded_value;
 
-        value->micromap = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->micromap, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
+        value->micromap = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->micromap, object_info_table, &CommonObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkAccelerationStructureTrianglesDisplacementMicromapNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkAccelerationStructureTrianglesDisplacementMicromapNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkAccelerationStructureTrianglesDisplacementMicromapNV* value = wrapper->decoded_value;
 
-        value->micromap = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->micromap, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
+        value->micromap = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->micromap, object_info_table, &CommonObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkDescriptorSetBindingReferenceVALVE* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkDescriptorSetBindingReferenceVALVE* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkDescriptorSetBindingReferenceVALVE* value = wrapper->decoded_value;
 
-        value->descriptorSetLayout = handle_mapping::MapHandle<VulkanDescriptorSetLayoutInfo>(wrapper->descriptorSetLayout, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
+        value->descriptorSetLayout = handle_mapping::MapHandle<VulkanDescriptorSetLayoutInfo>(wrapper->descriptorSetLayout, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkRenderPassStripeSubmitInfoARM* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkRenderPassStripeSubmitInfoARM* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1837,37 +1837,37 @@ void MapStructHandles(Decoded_VkRenderPassStripeSubmitInfoARM* wrapper, const Vu
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineIndirectDeviceAddressInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkPipelineIndirectDeviceAddressInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkPipelineIndirectDeviceAddressInfoNV* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkShaderCreateInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkShaderCreateInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkShaderCreateInfoEXT* value = wrapper->decoded_value;
 
-        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
+        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkLatencySleepInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkLatencySleepInfoNV* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkLatencySleepInfoNV* value = wrapper->decoded_value;
 
-        value->signalSemaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->signalSemaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
+        value->signalSemaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->signalSemaphore, object_info_table, &CommonObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1878,45 +1878,45 @@ void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoEXT* wrap
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->indirectExecutionSet = handle_mapping::MapHandle<VulkanIndirectExecutionSetEXTInfo>(wrapper->indirectExecutionSet, object_info_table, &VulkanObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
+        value->indirectExecutionSet = handle_mapping::MapHandle<VulkanIndirectExecutionSetEXTInfo>(wrapper->indirectExecutionSet, object_info_table, &CommonObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
 
-        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutEXTInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutEXTInfo);
+        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutEXTInfo>(wrapper->indirectCommandsLayout, object_info_table, &CommonObjectInfoTable::GetVkIndirectCommandsLayoutEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkIndirectExecutionSetPipelineInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkIndirectExecutionSetPipelineInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkIndirectExecutionSetPipelineInfoEXT* value = wrapper->decoded_value;
 
-        value->initialPipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->initialPipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->initialPipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->initialPipeline, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkIndirectExecutionSetShaderLayoutInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkIndirectExecutionSetShaderLayoutInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkIndirectExecutionSetShaderLayoutInfoEXT* value = wrapper->decoded_value;
 
-        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
+        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &CommonObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkIndirectExecutionSetShaderInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkIndirectExecutionSetShaderInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkIndirectExecutionSetShaderInfoEXT* value = wrapper->decoded_value;
 
-        value->pInitialShaders = handle_mapping::MapHandleArray<VulkanShaderEXTInfo>(&wrapper->pInitialShaders, object_info_table, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
+        value->pInitialShaders = handle_mapping::MapHandleArray<VulkanShaderEXTInfo>(&wrapper->pInitialShaders, object_info_table, &CommonObjectInfoTable::GetVkShaderEXTInfo);
 
         MapStructArrayHandles<Decoded_VkIndirectExecutionSetShaderLayoutInfoEXT>(wrapper->pSetLayoutInfos->GetMetaStructPointer(), wrapper->pSetLayoutInfos->GetLength(), object_info_table);
     }
 }
 
-void MapStructHandles(Decoded_VkGeneratedCommandsInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGeneratedCommandsInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1927,23 +1927,23 @@ void MapStructHandles(Decoded_VkGeneratedCommandsInfoEXT* wrapper, const VulkanO
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->indirectExecutionSet = handle_mapping::MapHandle<VulkanIndirectExecutionSetEXTInfo>(wrapper->indirectExecutionSet, object_info_table, &VulkanObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
+        value->indirectExecutionSet = handle_mapping::MapHandle<VulkanIndirectExecutionSetEXTInfo>(wrapper->indirectExecutionSet, object_info_table, &CommonObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
 
-        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutEXTInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutEXTInfo);
+        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutEXTInfo>(wrapper->indirectCommandsLayout, object_info_table, &CommonObjectInfoTable::GetVkIndirectCommandsLayoutEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkWriteIndirectExecutionSetPipelineEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkWriteIndirectExecutionSetPipelineEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkWriteIndirectExecutionSetPipelineEXT* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -1954,41 +1954,41 @@ void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoEXT* wrapper, co
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->pipelineLayout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->pipelineLayout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->pipelineLayout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->pipelineLayout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkGeneratedCommandsPipelineInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGeneratedCommandsPipelineInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkGeneratedCommandsPipelineInfoEXT* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkGeneratedCommandsShaderInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkGeneratedCommandsShaderInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkGeneratedCommandsShaderInfoEXT* value = wrapper->decoded_value;
 
-        value->pShaders = handle_mapping::MapHandleArray<VulkanShaderEXTInfo>(&wrapper->pShaders, object_info_table, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
+        value->pShaders = handle_mapping::MapHandleArray<VulkanShaderEXTInfo>(&wrapper->pShaders, object_info_table, &CommonObjectInfoTable::GetVkShaderEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkWriteIndirectExecutionSetShaderEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkWriteIndirectExecutionSetShaderEXT* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkWriteIndirectExecutionSetShaderEXT* value = wrapper->decoded_value;
 
-        value->shader = handle_mapping::MapHandle<VulkanShaderEXTInfo>(wrapper->shader, object_info_table, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
+        value->shader = handle_mapping::MapHandle<VulkanShaderEXTInfo>(wrapper->shader, object_info_table, &CommonObjectInfoTable::GetVkShaderEXTInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkAccelerationStructureGeometryTrianglesDataKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkAccelerationStructureGeometryTrianglesDataKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if (wrapper != nullptr)
     {
@@ -1999,69 +1999,69 @@ void MapStructHandles(Decoded_VkAccelerationStructureGeometryTrianglesDataKHR* w
     }
 }
 
-void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkAccelerationStructureCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &CommonObjectInfoTable::GetVkBufferInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkWriteDescriptorSetAccelerationStructureKHR* value = wrapper->decoded_value;
 
-        value->pAccelerationStructures = handle_mapping::MapHandleArray<VulkanAccelerationStructureKHRInfo>(&wrapper->pAccelerationStructures, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
+        value->pAccelerationStructures = handle_mapping::MapHandleArray<VulkanAccelerationStructureKHRInfo>(&wrapper->pAccelerationStructures, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkAccelerationStructureDeviceAddressInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkAccelerationStructureDeviceAddressInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkAccelerationStructureDeviceAddressInfoKHR* value = wrapper->decoded_value;
 
-        value->accelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->accelerationStructure, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
+        value->accelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->accelerationStructure, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyAccelerationStructureToMemoryInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyAccelerationStructureToMemoryInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyAccelerationStructureToMemoryInfoKHR* value = wrapper->decoded_value;
 
-        value->src = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
+        value->src = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->src, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyMemoryToAccelerationStructureInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyMemoryToAccelerationStructureInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyMemoryToAccelerationStructureInfoKHR* value = wrapper->decoded_value;
 
-        value->dst = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
+        value->dst = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->dst, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkCopyAccelerationStructureInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkCopyAccelerationStructureInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
         VkCopyAccelerationStructureInfoKHR* value = wrapper->decoded_value;
 
-        value->src = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
+        value->src = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->src, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo);
 
-        value->dst = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
+        value->dst = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->dst, object_info_table, &CommonObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     }
 }
 
-void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
     {
@@ -2076,13 +2076,13 @@ void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoKHR* wrapper, const 
 
         MapStructArrayHandles<Decoded_VkPipelineLibraryCreateInfoKHR>(wrapper->pLibraryInfo->GetMetaStructPointer(), 1, object_info_table);
 
-        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
 
-        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
+        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &CommonObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
-void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectInfoTable& object_info_table)
+void MapPNextStructHandles(const void* value, void* wrapper, const CommonObjectInfoTable& object_info_table)
 {
     if ((value != nullptr) && (wrapper != nullptr))
     {
@@ -2178,39 +2178,39 @@ void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectI
     }
 }
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, const VkPhysicalDeviceGroupProperties* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, const VkPhysicalDeviceGroupProperties* handle_struct, CommonObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandleArray<VulkanPhysicalDeviceInfo>(parent_id, id_wrapper->physicalDevices.GetPointer(), id_wrapper->physicalDevices.GetLength(), handle_struct->physicalDevices, handle_struct->physicalDeviceCount, object_info_table, &VulkanObjectInfoTable::AddVkPhysicalDeviceInfo);
+        handle_mapping::AddHandleArray<VulkanPhysicalDeviceInfo>(parent_id, id_wrapper->physicalDevices.GetPointer(), id_wrapper->physicalDevices.GetLength(), handle_struct->physicalDevices, handle_struct->physicalDeviceCount, object_info_table, &CommonObjectInfoTable::AddVkPhysicalDeviceInfo);
     }
 }
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPropertiesKHR* id_wrapper, const VkDisplayPropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPropertiesKHR* id_wrapper, const VkDisplayPropertiesKHR* handle_struct, CommonObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandle<VulkanDisplayKHRInfo>(parent_id, id_wrapper->display, handle_struct->display, object_info_table, &VulkanObjectInfoTable::AddVkDisplayKHRInfo);
+        handle_mapping::AddHandle<VulkanDisplayKHRInfo>(parent_id, id_wrapper->display, handle_struct->display, object_info_table, &CommonObjectInfoTable::AddVkDisplayKHRInfo);
     }
 }
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, const VkDisplayPlanePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, const VkDisplayPlanePropertiesKHR* handle_struct, CommonObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandle<VulkanDisplayKHRInfo>(parent_id, id_wrapper->currentDisplay, handle_struct->currentDisplay, object_info_table, &VulkanObjectInfoTable::AddVkDisplayKHRInfo);
+        handle_mapping::AddHandle<VulkanDisplayKHRInfo>(parent_id, id_wrapper->currentDisplay, handle_struct->currentDisplay, object_info_table, &CommonObjectInfoTable::AddVkDisplayKHRInfo);
     }
 }
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModePropertiesKHR* id_wrapper, const VkDisplayModePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModePropertiesKHR* id_wrapper, const VkDisplayModePropertiesKHR* handle_struct, CommonObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandle<VulkanDisplayModeKHRInfo>(parent_id, id_wrapper->displayMode, handle_struct->displayMode, object_info_table, &VulkanObjectInfoTable::AddVkDisplayModeKHRInfo);
+        handle_mapping::AddHandle<VulkanDisplayModeKHRInfo>(parent_id, id_wrapper->displayMode, handle_struct->displayMode, object_info_table, &CommonObjectInfoTable::AddVkDisplayModeKHRInfo);
     }
 }
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayProperties2KHR* id_wrapper, const VkDisplayProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayProperties2KHR* id_wrapper, const VkDisplayProperties2KHR* handle_struct, CommonObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
@@ -2218,7 +2218,7 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPropert
     }
 }
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, const VkDisplayPlaneProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, const VkDisplayPlaneProperties2KHR* handle_struct, CommonObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
@@ -2226,7 +2226,7 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlanePr
     }
 }
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, CommonObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
@@ -2234,11 +2234,11 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModePro
     }
 }
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkPipelineBinaryHandlesInfoKHR* id_wrapper, const VkPipelineBinaryHandlesInfoKHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkPipelineBinaryHandlesInfoKHR* id_wrapper, const VkPipelineBinaryHandlesInfoKHR* handle_struct, CommonObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandleArray<VulkanPipelineBinaryKHRInfo>(parent_id, id_wrapper->pPipelineBinaries.GetPointer(), id_wrapper->pPipelineBinaries.GetLength(), handle_struct->pPipelineBinaries, handle_struct->pipelineBinaryCount, object_info_table, &VulkanObjectInfoTable::AddVkPipelineBinaryKHRInfo);
+        handle_mapping::AddHandleArray<VulkanPipelineBinaryKHRInfo>(parent_id, id_wrapper->pPipelineBinaries.GetPointer(), id_wrapper->pPipelineBinaries.GetLength(), handle_struct->pPipelineBinaries, handle_struct->pipelineBinaryCount, object_info_table, &CommonObjectInfoTable::AddVkPipelineBinaryKHRInfo);
     }
 }
 

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -46,7 +46,7 @@ void MapStructHandles(Decoded_VkBufferMemoryBarrier* wrapper, const VulkanObject
     {
         VkBufferMemoryBarrier* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -56,7 +56,7 @@ void MapStructHandles(Decoded_VkImageMemoryBarrier* wrapper, const VulkanObjectI
     {
         VkImageMemoryBarrier* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -82,11 +82,11 @@ void MapStructHandles(Decoded_VkSubmitInfo* wrapper, const VulkanObjectInfoTable
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->pWaitSemaphores = handle_mapping::MapHandleArray<SemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->pWaitSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
 
-        value->pCommandBuffers = handle_mapping::MapHandleArray<CommandBufferInfo>(&wrapper->pCommandBuffers, object_info_table, &VulkanObjectInfoTable::GetCommandBufferInfo);
+        value->pCommandBuffers = handle_mapping::MapHandleArray<VulkanCommandBufferInfo>(&wrapper->pCommandBuffers, object_info_table, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
 
-        value->pSignalSemaphores = handle_mapping::MapHandleArray<SemaphoreInfo>(&wrapper->pSignalSemaphores, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->pSignalSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pSignalSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -96,7 +96,7 @@ void MapStructHandles(Decoded_VkMappedMemoryRange* wrapper, const VulkanObjectIn
     {
         VkMappedMemoryRange* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -117,7 +117,7 @@ void MapStructHandles(Decoded_VkSparseMemoryBind* wrapper, const VulkanObjectInf
     {
         VkSparseMemoryBind* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -127,7 +127,7 @@ void MapStructHandles(Decoded_VkSparseBufferMemoryBindInfo* wrapper, const Vulka
     {
         VkSparseBufferMemoryBindInfo* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
 
         MapStructArrayHandles<Decoded_VkSparseMemoryBind>(wrapper->pBinds->GetMetaStructPointer(), wrapper->pBinds->GetLength(), object_info_table);
     }
@@ -139,7 +139,7 @@ void MapStructHandles(Decoded_VkSparseImageOpaqueMemoryBindInfo* wrapper, const 
     {
         VkSparseImageOpaqueMemoryBindInfo* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
         MapStructArrayHandles<Decoded_VkSparseMemoryBind>(wrapper->pBinds->GetMetaStructPointer(), wrapper->pBinds->GetLength(), object_info_table);
     }
@@ -151,7 +151,7 @@ void MapStructHandles(Decoded_VkSparseImageMemoryBind* wrapper, const VulkanObje
     {
         VkSparseImageMemoryBind* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -161,7 +161,7 @@ void MapStructHandles(Decoded_VkSparseImageMemoryBindInfo* wrapper, const Vulkan
     {
         VkSparseImageMemoryBindInfo* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
         MapStructArrayHandles<Decoded_VkSparseImageMemoryBind>(wrapper->pBinds->GetMetaStructPointer(), wrapper->pBinds->GetLength(), object_info_table);
     }
@@ -178,7 +178,7 @@ void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const VulkanObjectInfoT
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->pWaitSemaphores = handle_mapping::MapHandleArray<SemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->pWaitSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
 
         MapStructArrayHandles<Decoded_VkSparseBufferMemoryBindInfo>(wrapper->pBufferBinds->GetMetaStructPointer(), wrapper->pBufferBinds->GetLength(), object_info_table);
 
@@ -186,7 +186,7 @@ void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const VulkanObjectInfoT
 
         MapStructArrayHandles<Decoded_VkSparseImageMemoryBindInfo>(wrapper->pImageBinds->GetMetaStructPointer(), wrapper->pImageBinds->GetLength(), object_info_table);
 
-        value->pSignalSemaphores = handle_mapping::MapHandleArray<SemaphoreInfo>(&wrapper->pSignalSemaphores, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->pSignalSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pSignalSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -196,7 +196,7 @@ void MapStructHandles(Decoded_VkBufferViewCreateInfo* wrapper, const VulkanObjec
     {
         VkBufferViewCreateInfo* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -222,7 +222,7 @@ void MapStructHandles(Decoded_VkImageViewCreateInfo* wrapper, const VulkanObject
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -248,7 +248,7 @@ void MapStructHandles(Decoded_VkPipelineShaderStageCreateInfo* wrapper, const Vu
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->module = handle_mapping::MapHandle<ShaderModuleInfo>(wrapper->module, object_info_table, &VulkanObjectInfoTable::GetShaderModuleInfo);
+        value->module = handle_mapping::MapHandle<VulkanShaderModuleInfo>(wrapper->module, object_info_table, &VulkanObjectInfoTable::GetVkShaderModuleInfo);
     }
 }
 
@@ -265,9 +265,9 @@ void MapStructHandles(Decoded_VkComputePipelineCreateInfo* wrapper, const Vulkan
 
         MapStructHandles(wrapper->stage, object_info_table);
 
-        value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
 
-        value->basePipelineHandle = handle_mapping::MapHandle<PipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -284,11 +284,11 @@ void MapStructHandles(Decoded_VkGraphicsPipelineCreateInfo* wrapper, const Vulka
 
         MapStructArrayHandles<Decoded_VkPipelineShaderStageCreateInfo>(wrapper->pStages->GetMetaStructPointer(), wrapper->pStages->GetLength(), object_info_table);
 
-        value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
 
-        value->renderPass = handle_mapping::MapHandle<RenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetRenderPassInfo);
+        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo);
 
-        value->basePipelineHandle = handle_mapping::MapHandle<PipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -298,7 +298,7 @@ void MapStructHandles(Decoded_VkPipelineLayoutCreateInfo* wrapper, const VulkanO
     {
         VkPipelineLayoutCreateInfo* value = wrapper->decoded_value;
 
-        value->pSetLayouts = handle_mapping::MapHandleArray<DescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetLayoutInfo);
+        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     }
 }
 
@@ -319,9 +319,9 @@ void MapStructHandles(Decoded_VkCopyDescriptorSet* wrapper, const VulkanObjectIn
     {
         VkCopyDescriptorSet* value = wrapper->decoded_value;
 
-        value->srcSet = handle_mapping::MapHandle<DescriptorSetInfo>(wrapper->srcSet, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetInfo);
+        value->srcSet = handle_mapping::MapHandle<VulkanDescriptorSetInfo>(wrapper->srcSet, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
 
-        value->dstSet = handle_mapping::MapHandle<DescriptorSetInfo>(wrapper->dstSet, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetInfo);
+        value->dstSet = handle_mapping::MapHandle<VulkanDescriptorSetInfo>(wrapper->dstSet, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
     }
 }
 
@@ -331,7 +331,7 @@ void MapStructHandles(Decoded_VkDescriptorBufferInfo* wrapper, const VulkanObjec
     {
         VkDescriptorBufferInfo* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -341,9 +341,9 @@ void MapStructHandles(Decoded_VkDescriptorSetAllocateInfo* wrapper, const Vulkan
     {
         VkDescriptorSetAllocateInfo* value = wrapper->decoded_value;
 
-        value->descriptorPool = handle_mapping::MapHandle<DescriptorPoolInfo>(wrapper->descriptorPool, object_info_table, &VulkanObjectInfoTable::GetDescriptorPoolInfo);
+        value->descriptorPool = handle_mapping::MapHandle<VulkanDescriptorPoolInfo>(wrapper->descriptorPool, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorPoolInfo);
 
-        value->pSetLayouts = handle_mapping::MapHandleArray<DescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetLayoutInfo);
+        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     }
 }
 
@@ -353,7 +353,7 @@ void MapStructHandles(Decoded_VkDescriptorSetLayoutBinding* wrapper, const Vulka
     {
         VkDescriptorSetLayoutBinding* value = wrapper->decoded_value;
 
-        value->pImmutableSamplers = handle_mapping::MapHandleArray<SamplerInfo>(&wrapper->pImmutableSamplers, object_info_table, &VulkanObjectInfoTable::GetSamplerInfo);
+        value->pImmutableSamplers = handle_mapping::MapHandleArray<VulkanSamplerInfo>(&wrapper->pImmutableSamplers, object_info_table, &VulkanObjectInfoTable::GetVkSamplerInfo);
     }
 }
 
@@ -371,9 +371,9 @@ void MapStructHandles(Decoded_VkFramebufferCreateInfo* wrapper, const VulkanObje
     {
         VkFramebufferCreateInfo* value = wrapper->decoded_value;
 
-        value->renderPass = handle_mapping::MapHandle<RenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetRenderPassInfo);
+        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo);
 
-        value->pAttachments = handle_mapping::MapHandleArray<ImageViewInfo>(&wrapper->pAttachments, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo);
+        value->pAttachments = handle_mapping::MapHandleArray<VulkanImageViewInfo>(&wrapper->pAttachments, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
@@ -383,7 +383,7 @@ void MapStructHandles(Decoded_VkCommandBufferAllocateInfo* wrapper, const Vulkan
     {
         VkCommandBufferAllocateInfo* value = wrapper->decoded_value;
 
-        value->commandPool = handle_mapping::MapHandle<CommandPoolInfo>(wrapper->commandPool, object_info_table, &VulkanObjectInfoTable::GetCommandPoolInfo);
+        value->commandPool = handle_mapping::MapHandle<VulkanCommandPoolInfo>(wrapper->commandPool, object_info_table, &VulkanObjectInfoTable::GetVkCommandPoolInfo);
     }
 }
 
@@ -393,9 +393,9 @@ void MapStructHandles(Decoded_VkCommandBufferInheritanceInfo* wrapper, const Vul
     {
         VkCommandBufferInheritanceInfo* value = wrapper->decoded_value;
 
-        value->renderPass = handle_mapping::MapHandle<RenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetRenderPassInfo);
+        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo);
 
-        value->framebuffer = handle_mapping::MapHandle<FramebufferInfo>(wrapper->framebuffer, object_info_table, &VulkanObjectInfoTable::GetFramebufferInfo);
+        value->framebuffer = handle_mapping::MapHandle<VulkanFramebufferInfo>(wrapper->framebuffer, object_info_table, &VulkanObjectInfoTable::GetVkFramebufferInfo);
     }
 }
 
@@ -418,9 +418,9 @@ void MapStructHandles(Decoded_VkRenderPassBeginInfo* wrapper, const VulkanObject
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->renderPass = handle_mapping::MapHandle<RenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetRenderPassInfo);
+        value->renderPass = handle_mapping::MapHandle<VulkanRenderPassInfo>(wrapper->renderPass, object_info_table, &VulkanObjectInfoTable::GetVkRenderPassInfo);
 
-        value->framebuffer = handle_mapping::MapHandle<FramebufferInfo>(wrapper->framebuffer, object_info_table, &VulkanObjectInfoTable::GetFramebufferInfo);
+        value->framebuffer = handle_mapping::MapHandle<VulkanFramebufferInfo>(wrapper->framebuffer, object_info_table, &VulkanObjectInfoTable::GetVkFramebufferInfo);
     }
 }
 
@@ -430,9 +430,9 @@ void MapStructHandles(Decoded_VkBindBufferMemoryInfo* wrapper, const VulkanObjec
     {
         VkBindBufferMemoryInfo* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -447,9 +447,9 @@ void MapStructHandles(Decoded_VkBindImageMemoryInfo* wrapper, const VulkanObject
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -459,9 +459,9 @@ void MapStructHandles(Decoded_VkMemoryDedicatedAllocateInfo* wrapper, const Vulk
     {
         VkMemoryDedicatedAllocateInfo* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -469,7 +469,7 @@ void MapStructHandles(Decoded_VkPhysicalDeviceGroupProperties* wrapper, const Vu
 {
     if (wrapper != nullptr)
     {
-        handle_mapping::MapHandleArray<PhysicalDeviceInfo>(&wrapper->physicalDevices, object_info_table, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
+        handle_mapping::MapHandleArray<VulkanPhysicalDeviceInfo>(&wrapper->physicalDevices, object_info_table, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
     }
 }
 
@@ -479,7 +479,7 @@ void MapStructHandles(Decoded_VkDeviceGroupDeviceCreateInfo* wrapper, const Vulk
     {
         VkDeviceGroupDeviceCreateInfo* value = wrapper->decoded_value;
 
-        value->pPhysicalDevices = handle_mapping::MapHandleArray<PhysicalDeviceInfo>(&wrapper->pPhysicalDevices, object_info_table, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
+        value->pPhysicalDevices = handle_mapping::MapHandleArray<VulkanPhysicalDeviceInfo>(&wrapper->pPhysicalDevices, object_info_table, &VulkanObjectInfoTable::GetVkPhysicalDeviceInfo);
     }
 }
 
@@ -489,7 +489,7 @@ void MapStructHandles(Decoded_VkBufferMemoryRequirementsInfo2* wrapper, const Vu
     {
         VkBufferMemoryRequirementsInfo2* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -499,7 +499,7 @@ void MapStructHandles(Decoded_VkImageMemoryRequirementsInfo2* wrapper, const Vul
     {
         VkImageMemoryRequirementsInfo2* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -509,7 +509,7 @@ void MapStructHandles(Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper, con
     {
         VkImageSparseMemoryRequirementsInfo2* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -519,7 +519,7 @@ void MapStructHandles(Decoded_VkSamplerYcbcrConversionInfo* wrapper, const Vulka
     {
         VkSamplerYcbcrConversionInfo* value = wrapper->decoded_value;
 
-        value->conversion = handle_mapping::MapHandle<SamplerYcbcrConversionInfo>(wrapper->conversion, object_info_table, &VulkanObjectInfoTable::GetSamplerYcbcrConversionInfo);
+        value->conversion = handle_mapping::MapHandle<VulkanSamplerYcbcrConversionInfo>(wrapper->conversion, object_info_table, &VulkanObjectInfoTable::GetVkSamplerYcbcrConversionInfo);
     }
 }
 
@@ -529,9 +529,9 @@ void MapStructHandles(Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper, con
     {
         VkDescriptorUpdateTemplateCreateInfo* value = wrapper->decoded_value;
 
-        value->descriptorSetLayout = handle_mapping::MapHandle<DescriptorSetLayoutInfo>(wrapper->descriptorSetLayout, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetLayoutInfo);
+        value->descriptorSetLayout = handle_mapping::MapHandle<VulkanDescriptorSetLayoutInfo>(wrapper->descriptorSetLayout, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
 
-        value->pipelineLayout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->pipelineLayout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->pipelineLayout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->pipelineLayout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
@@ -541,7 +541,7 @@ void MapStructHandles(Decoded_VkRenderPassAttachmentBeginInfo* wrapper, const Vu
     {
         VkRenderPassAttachmentBeginInfo* value = wrapper->decoded_value;
 
-        value->pAttachments = handle_mapping::MapHandleArray<ImageViewInfo>(&wrapper->pAttachments, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo);
+        value->pAttachments = handle_mapping::MapHandleArray<VulkanImageViewInfo>(&wrapper->pAttachments, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
@@ -551,7 +551,7 @@ void MapStructHandles(Decoded_VkSemaphoreWaitInfo* wrapper, const VulkanObjectIn
     {
         VkSemaphoreWaitInfo* value = wrapper->decoded_value;
 
-        value->pSemaphores = handle_mapping::MapHandleArray<SemaphoreInfo>(&wrapper->pSemaphores, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->pSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -561,7 +561,7 @@ void MapStructHandles(Decoded_VkSemaphoreSignalInfo* wrapper, const VulkanObject
     {
         VkSemaphoreSignalInfo* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<SemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -571,7 +571,7 @@ void MapStructHandles(Decoded_VkBufferDeviceAddressInfo* wrapper, const VulkanOb
     {
         VkBufferDeviceAddressInfo* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -581,7 +581,7 @@ void MapStructHandles(Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo* wrapper, c
     {
         VkDeviceMemoryOpaqueCaptureAddressInfo* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -591,7 +591,7 @@ void MapStructHandles(Decoded_VkBufferMemoryBarrier2* wrapper, const VulkanObjec
     {
         VkBufferMemoryBarrier2* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -601,7 +601,7 @@ void MapStructHandles(Decoded_VkImageMemoryBarrier2* wrapper, const VulkanObject
     {
         VkImageMemoryBarrier2* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -621,7 +621,7 @@ void MapStructHandles(Decoded_VkSemaphoreSubmitInfo* wrapper, const VulkanObject
     {
         VkSemaphoreSubmitInfo* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<SemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -631,7 +631,7 @@ void MapStructHandles(Decoded_VkCommandBufferSubmitInfo* wrapper, const VulkanOb
     {
         VkCommandBufferSubmitInfo* value = wrapper->decoded_value;
 
-        value->commandBuffer = handle_mapping::MapHandle<CommandBufferInfo>(wrapper->commandBuffer, object_info_table, &VulkanObjectInfoTable::GetCommandBufferInfo);
+        value->commandBuffer = handle_mapping::MapHandle<VulkanCommandBufferInfo>(wrapper->commandBuffer, object_info_table, &VulkanObjectInfoTable::GetVkCommandBufferInfo);
     }
 }
 
@@ -658,9 +658,9 @@ void MapStructHandles(Decoded_VkCopyBufferInfo2* wrapper, const VulkanObjectInfo
     {
         VkCopyBufferInfo2* value = wrapper->decoded_value;
 
-        value->srcBuffer = handle_mapping::MapHandle<BufferInfo>(wrapper->srcBuffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->srcBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->srcBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
 
-        value->dstBuffer = handle_mapping::MapHandle<BufferInfo>(wrapper->dstBuffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->dstBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->dstBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -670,9 +670,9 @@ void MapStructHandles(Decoded_VkCopyImageInfo2* wrapper, const VulkanObjectInfoT
     {
         VkCopyImageInfo2* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<ImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
-        value->dstImage = handle_mapping::MapHandle<ImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -682,9 +682,9 @@ void MapStructHandles(Decoded_VkCopyBufferToImageInfo2* wrapper, const VulkanObj
     {
         VkCopyBufferToImageInfo2* value = wrapper->decoded_value;
 
-        value->srcBuffer = handle_mapping::MapHandle<BufferInfo>(wrapper->srcBuffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->srcBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->srcBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
 
-        value->dstImage = handle_mapping::MapHandle<ImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -694,9 +694,9 @@ void MapStructHandles(Decoded_VkCopyImageToBufferInfo2* wrapper, const VulkanObj
     {
         VkCopyImageToBufferInfo2* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<ImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
-        value->dstBuffer = handle_mapping::MapHandle<BufferInfo>(wrapper->dstBuffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->dstBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->dstBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -706,9 +706,9 @@ void MapStructHandles(Decoded_VkBlitImageInfo2* wrapper, const VulkanObjectInfoT
     {
         VkBlitImageInfo2* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<ImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
-        value->dstImage = handle_mapping::MapHandle<ImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -718,9 +718,9 @@ void MapStructHandles(Decoded_VkResolveImageInfo2* wrapper, const VulkanObjectIn
     {
         VkResolveImageInfo2* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<ImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
-        value->dstImage = handle_mapping::MapHandle<ImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -730,9 +730,9 @@ void MapStructHandles(Decoded_VkRenderingAttachmentInfo* wrapper, const VulkanOb
     {
         VkRenderingAttachmentInfo* value = wrapper->decoded_value;
 
-        value->imageView = handle_mapping::MapHandle<ImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo);
+        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
 
-        value->resolveImageView = handle_mapping::MapHandle<ImageViewInfo>(wrapper->resolveImageView, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo);
+        value->resolveImageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->resolveImageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
@@ -767,9 +767,9 @@ void MapStructHandles(Decoded_VkSwapchainCreateInfoKHR* wrapper, const VulkanObj
     {
         VkSwapchainCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->surface = handle_mapping::MapHandle<SurfaceKHRInfo>(wrapper->surface, object_info_table, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
+        value->surface = handle_mapping::MapHandle<VulkanSurfaceKHRInfo>(wrapper->surface, object_info_table, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo);
 
-        value->oldSwapchain = handle_mapping::MapHandle<SwapchainKHRInfo>(wrapper->oldSwapchain, object_info_table, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
+        value->oldSwapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->oldSwapchain, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
     }
 }
 
@@ -784,9 +784,9 @@ void MapStructHandles(Decoded_VkPresentInfoKHR* wrapper, const VulkanObjectInfoT
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->pWaitSemaphores = handle_mapping::MapHandleArray<SemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->pWaitSemaphores = handle_mapping::MapHandleArray<VulkanSemaphoreInfo>(&wrapper->pWaitSemaphores, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
 
-        value->pSwapchains = handle_mapping::MapHandleArray<SwapchainKHRInfo>(&wrapper->pSwapchains, object_info_table, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
+        value->pSwapchains = handle_mapping::MapHandleArray<VulkanSwapchainKHRInfo>(&wrapper->pSwapchains, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
     }
 }
 
@@ -796,7 +796,7 @@ void MapStructHandles(Decoded_VkImageSwapchainCreateInfoKHR* wrapper, const Vulk
     {
         VkImageSwapchainCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->swapchain = handle_mapping::MapHandle<SwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
+        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
     }
 }
 
@@ -806,7 +806,7 @@ void MapStructHandles(Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper, const 
     {
         VkBindImageMemorySwapchainInfoKHR* value = wrapper->decoded_value;
 
-        value->swapchain = handle_mapping::MapHandle<SwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
+        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
     }
 }
 
@@ -816,11 +816,11 @@ void MapStructHandles(Decoded_VkAcquireNextImageInfoKHR* wrapper, const VulkanOb
     {
         VkAcquireNextImageInfoKHR* value = wrapper->decoded_value;
 
-        value->swapchain = handle_mapping::MapHandle<SwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
+        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
 
-        value->semaphore = handle_mapping::MapHandle<SemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
 
-        value->fence = handle_mapping::MapHandle<FenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetFenceInfo);
+        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
     }
 }
 
@@ -830,7 +830,7 @@ void MapStructHandles(Decoded_VkDisplayModePropertiesKHR* wrapper, const VulkanO
     {
         VkDisplayModePropertiesKHR* value = wrapper->decoded_value;
 
-        value->displayMode = handle_mapping::MapHandle<DisplayModeKHRInfo>(wrapper->displayMode, object_info_table, &VulkanObjectInfoTable::GetDisplayModeKHRInfo);
+        value->displayMode = handle_mapping::MapHandle<VulkanDisplayModeKHRInfo>(wrapper->displayMode, object_info_table, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo);
     }
 }
 
@@ -840,7 +840,7 @@ void MapStructHandles(Decoded_VkDisplayPlanePropertiesKHR* wrapper, const Vulkan
     {
         VkDisplayPlanePropertiesKHR* value = wrapper->decoded_value;
 
-        value->currentDisplay = handle_mapping::MapHandle<DisplayKHRInfo>(wrapper->currentDisplay, object_info_table, &VulkanObjectInfoTable::GetDisplayKHRInfo);
+        value->currentDisplay = handle_mapping::MapHandle<VulkanDisplayKHRInfo>(wrapper->currentDisplay, object_info_table, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
     }
 }
 
@@ -850,7 +850,7 @@ void MapStructHandles(Decoded_VkDisplayPropertiesKHR* wrapper, const VulkanObjec
     {
         VkDisplayPropertiesKHR* value = wrapper->decoded_value;
 
-        value->display = handle_mapping::MapHandle<DisplayKHRInfo>(wrapper->display, object_info_table, &VulkanObjectInfoTable::GetDisplayKHRInfo);
+        value->display = handle_mapping::MapHandle<VulkanDisplayKHRInfo>(wrapper->display, object_info_table, &VulkanObjectInfoTable::GetVkDisplayKHRInfo);
     }
 }
 
@@ -860,7 +860,7 @@ void MapStructHandles(Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper, const Vulk
     {
         VkDisplaySurfaceCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->displayMode = handle_mapping::MapHandle<DisplayModeKHRInfo>(wrapper->displayMode, object_info_table, &VulkanObjectInfoTable::GetDisplayModeKHRInfo);
+        value->displayMode = handle_mapping::MapHandle<VulkanDisplayModeKHRInfo>(wrapper->displayMode, object_info_table, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo);
     }
 }
 
@@ -870,7 +870,7 @@ void MapStructHandles(Decoded_VkVideoPictureResourceInfoKHR* wrapper, const Vulk
     {
         VkVideoPictureResourceInfoKHR* value = wrapper->decoded_value;
 
-        value->imageViewBinding = handle_mapping::MapHandle<ImageViewInfo>(wrapper->imageViewBinding, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo);
+        value->imageViewBinding = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageViewBinding, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
@@ -888,7 +888,7 @@ void MapStructHandles(Decoded_VkBindVideoSessionMemoryInfoKHR* wrapper, const Vu
     {
         VkBindVideoSessionMemoryInfoKHR* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -898,9 +898,9 @@ void MapStructHandles(Decoded_VkVideoSessionParametersCreateInfoKHR* wrapper, co
     {
         VkVideoSessionParametersCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->videoSessionParametersTemplate = handle_mapping::MapHandle<VideoSessionParametersKHRInfo>(wrapper->videoSessionParametersTemplate, object_info_table, &VulkanObjectInfoTable::GetVideoSessionParametersKHRInfo);
+        value->videoSessionParametersTemplate = handle_mapping::MapHandle<VulkanVideoSessionParametersKHRInfo>(wrapper->videoSessionParametersTemplate, object_info_table, &VulkanObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
 
-        value->videoSession = handle_mapping::MapHandle<VideoSessionKHRInfo>(wrapper->videoSession, object_info_table, &VulkanObjectInfoTable::GetVideoSessionKHRInfo);
+        value->videoSession = handle_mapping::MapHandle<VulkanVideoSessionKHRInfo>(wrapper->videoSession, object_info_table, &VulkanObjectInfoTable::GetVkVideoSessionKHRInfo);
     }
 }
 
@@ -910,9 +910,9 @@ void MapStructHandles(Decoded_VkVideoBeginCodingInfoKHR* wrapper, const VulkanOb
     {
         VkVideoBeginCodingInfoKHR* value = wrapper->decoded_value;
 
-        value->videoSession = handle_mapping::MapHandle<VideoSessionKHRInfo>(wrapper->videoSession, object_info_table, &VulkanObjectInfoTable::GetVideoSessionKHRInfo);
+        value->videoSession = handle_mapping::MapHandle<VulkanVideoSessionKHRInfo>(wrapper->videoSession, object_info_table, &VulkanObjectInfoTable::GetVkVideoSessionKHRInfo);
 
-        value->videoSessionParameters = handle_mapping::MapHandle<VideoSessionParametersKHRInfo>(wrapper->videoSessionParameters, object_info_table, &VulkanObjectInfoTable::GetVideoSessionParametersKHRInfo);
+        value->videoSessionParameters = handle_mapping::MapHandle<VulkanVideoSessionParametersKHRInfo>(wrapper->videoSessionParameters, object_info_table, &VulkanObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
 
         MapStructArrayHandles<Decoded_VkVideoReferenceSlotInfoKHR>(wrapper->pReferenceSlots->GetMetaStructPointer(), wrapper->pReferenceSlots->GetLength(), object_info_table);
     }
@@ -929,7 +929,7 @@ void MapStructHandles(Decoded_VkVideoDecodeInfoKHR* wrapper, const VulkanObjectI
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->srcBuffer = handle_mapping::MapHandle<BufferInfo>(wrapper->srcBuffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->srcBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->srcBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
 
         MapStructHandles(wrapper->dstPictureResource, object_info_table);
 
@@ -945,7 +945,7 @@ void MapStructHandles(Decoded_VkRenderingFragmentShadingRateAttachmentInfoKHR* w
     {
         VkRenderingFragmentShadingRateAttachmentInfoKHR* value = wrapper->decoded_value;
 
-        value->imageView = handle_mapping::MapHandle<ImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo);
+        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
@@ -955,7 +955,7 @@ void MapStructHandles(Decoded_VkRenderingFragmentDensityMapAttachmentInfoEXT* wr
     {
         VkRenderingFragmentDensityMapAttachmentInfoEXT* value = wrapper->decoded_value;
 
-        value->imageView = handle_mapping::MapHandle<ImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo);
+        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
     }
 }
 
@@ -965,7 +965,7 @@ void MapStructHandles(Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper, const Vulk
     {
         VkMemoryGetWin32HandleInfoKHR* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -975,7 +975,7 @@ void MapStructHandles(Decoded_VkMemoryGetFdInfoKHR* wrapper, const VulkanObjectI
     {
         VkMemoryGetFdInfoKHR* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -985,9 +985,9 @@ void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper, c
     {
         VkWin32KeyedMutexAcquireReleaseInfoKHR* value = wrapper->decoded_value;
 
-        value->pAcquireSyncs = handle_mapping::MapHandleArray<DeviceMemoryInfo>(&wrapper->pAcquireSyncs, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->pAcquireSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pAcquireSyncs, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
 
-        value->pReleaseSyncs = handle_mapping::MapHandleArray<DeviceMemoryInfo>(&wrapper->pReleaseSyncs, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->pReleaseSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pReleaseSyncs, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -997,7 +997,7 @@ void MapStructHandles(Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper, cons
     {
         VkImportSemaphoreWin32HandleInfoKHR* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<SemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -1007,7 +1007,7 @@ void MapStructHandles(Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper, const V
     {
         VkSemaphoreGetWin32HandleInfoKHR* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<SemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -1017,7 +1017,7 @@ void MapStructHandles(Decoded_VkImportSemaphoreFdInfoKHR* wrapper, const VulkanO
     {
         VkImportSemaphoreFdInfoKHR* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<SemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -1027,7 +1027,7 @@ void MapStructHandles(Decoded_VkSemaphoreGetFdInfoKHR* wrapper, const VulkanObje
     {
         VkSemaphoreGetFdInfoKHR* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<SemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -1037,7 +1037,7 @@ void MapStructHandles(Decoded_VkImportFenceWin32HandleInfoKHR* wrapper, const Vu
     {
         VkImportFenceWin32HandleInfoKHR* value = wrapper->decoded_value;
 
-        value->fence = handle_mapping::MapHandle<FenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetFenceInfo);
+        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
     }
 }
 
@@ -1047,7 +1047,7 @@ void MapStructHandles(Decoded_VkFenceGetWin32HandleInfoKHR* wrapper, const Vulka
     {
         VkFenceGetWin32HandleInfoKHR* value = wrapper->decoded_value;
 
-        value->fence = handle_mapping::MapHandle<FenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetFenceInfo);
+        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
     }
 }
 
@@ -1057,7 +1057,7 @@ void MapStructHandles(Decoded_VkImportFenceFdInfoKHR* wrapper, const VulkanObjec
     {
         VkImportFenceFdInfoKHR* value = wrapper->decoded_value;
 
-        value->fence = handle_mapping::MapHandle<FenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetFenceInfo);
+        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
     }
 }
 
@@ -1067,7 +1067,7 @@ void MapStructHandles(Decoded_VkFenceGetFdInfoKHR* wrapper, const VulkanObjectIn
     {
         VkFenceGetFdInfoKHR* value = wrapper->decoded_value;
 
-        value->fence = handle_mapping::MapHandle<FenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetFenceInfo);
+        value->fence = handle_mapping::MapHandle<VulkanFenceInfo>(wrapper->fence, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
     }
 }
 
@@ -1077,7 +1077,7 @@ void MapStructHandles(Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper, const Vu
     {
         VkPhysicalDeviceSurfaceInfo2KHR* value = wrapper->decoded_value;
 
-        value->surface = handle_mapping::MapHandle<SurfaceKHRInfo>(wrapper->surface, object_info_table, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
+        value->surface = handle_mapping::MapHandle<VulkanSurfaceKHRInfo>(wrapper->surface, object_info_table, &VulkanObjectInfoTable::GetVkSurfaceKHRInfo);
     }
 }
 
@@ -1111,7 +1111,7 @@ void MapStructHandles(Decoded_VkDisplayPlaneInfo2KHR* wrapper, const VulkanObjec
     {
         VkDisplayPlaneInfo2KHR* value = wrapper->decoded_value;
 
-        value->mode = handle_mapping::MapHandle<DisplayModeKHRInfo>(wrapper->mode, object_info_table, &VulkanObjectInfoTable::GetDisplayModeKHRInfo);
+        value->mode = handle_mapping::MapHandle<VulkanDisplayModeKHRInfo>(wrapper->mode, object_info_table, &VulkanObjectInfoTable::GetVkDisplayModeKHRInfo);
     }
 }
 
@@ -1121,7 +1121,7 @@ void MapStructHandles(Decoded_VkPipelineInfoKHR* wrapper, const VulkanObjectInfo
     {
         VkPipelineInfoKHR* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<PipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1131,7 +1131,7 @@ void MapStructHandles(Decoded_VkPipelineExecutableInfoKHR* wrapper, const Vulkan
     {
         VkPipelineExecutableInfoKHR* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<PipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1141,7 +1141,7 @@ void MapStructHandles(Decoded_VkMemoryMapInfoKHR* wrapper, const VulkanObjectInf
     {
         VkMemoryMapInfoKHR* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -1151,7 +1151,7 @@ void MapStructHandles(Decoded_VkMemoryUnmapInfoKHR* wrapper, const VulkanObjectI
     {
         VkMemoryUnmapInfoKHR* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -1161,7 +1161,7 @@ void MapStructHandles(Decoded_VkPipelineLibraryCreateInfoKHR* wrapper, const Vul
     {
         VkPipelineLibraryCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->pLibraries = handle_mapping::MapHandleArray<PipelineInfo>(&wrapper->pLibraries, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pLibraries = handle_mapping::MapHandleArray<VulkanPipelineInfo>(&wrapper->pLibraries, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1176,7 +1176,7 @@ void MapStructHandles(Decoded_VkVideoEncodeInfoKHR* wrapper, const VulkanObjectI
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->dstBuffer = handle_mapping::MapHandle<BufferInfo>(wrapper->dstBuffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->dstBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->dstBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
 
         MapStructHandles(wrapper->srcPictureResource, object_info_table);
 
@@ -1192,7 +1192,7 @@ void MapStructHandles(Decoded_VkVideoEncodeSessionParametersGetInfoKHR* wrapper,
     {
         VkVideoEncodeSessionParametersGetInfoKHR* value = wrapper->decoded_value;
 
-        value->videoSessionParameters = handle_mapping::MapHandle<VideoSessionParametersKHRInfo>(wrapper->videoSessionParameters, object_info_table, &VulkanObjectInfoTable::GetVideoSessionParametersKHRInfo);
+        value->videoSessionParameters = handle_mapping::MapHandle<VulkanVideoSessionParametersKHRInfo>(wrapper->videoSessionParameters, object_info_table, &VulkanObjectInfoTable::GetVkVideoSessionParametersKHRInfo);
     }
 }
 
@@ -1210,7 +1210,7 @@ void MapStructHandles(Decoded_VkPipelineBinaryCreateInfoKHR* wrapper, const Vulk
     {
         VkPipelineBinaryCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<PipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1220,7 +1220,7 @@ void MapStructHandles(Decoded_VkPipelineBinaryInfoKHR* wrapper, const VulkanObje
     {
         VkPipelineBinaryInfoKHR* value = wrapper->decoded_value;
 
-        value->pPipelineBinaries = handle_mapping::MapHandleArray<PipelineBinaryKHRInfo>(&wrapper->pPipelineBinaries, object_info_table, &VulkanObjectInfoTable::GetPipelineBinaryKHRInfo);
+        value->pPipelineBinaries = handle_mapping::MapHandleArray<VulkanPipelineBinaryKHRInfo>(&wrapper->pPipelineBinaries, object_info_table, &VulkanObjectInfoTable::GetVkPipelineBinaryKHRInfo);
     }
 }
 
@@ -1230,7 +1230,7 @@ void MapStructHandles(Decoded_VkReleaseCapturedPipelineDataInfoKHR* wrapper, con
     {
         VkReleaseCapturedPipelineDataInfoKHR* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<PipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1240,7 +1240,7 @@ void MapStructHandles(Decoded_VkPipelineBinaryDataInfoKHR* wrapper, const Vulkan
     {
         VkPipelineBinaryDataInfoKHR* value = wrapper->decoded_value;
 
-        value->pipelineBinary = handle_mapping::MapHandle<PipelineBinaryKHRInfo>(wrapper->pipelineBinary, object_info_table, &VulkanObjectInfoTable::GetPipelineBinaryKHRInfo);
+        value->pipelineBinary = handle_mapping::MapHandle<VulkanPipelineBinaryKHRInfo>(wrapper->pipelineBinary, object_info_table, &VulkanObjectInfoTable::GetVkPipelineBinaryKHRInfo);
     }
 }
 
@@ -1250,7 +1250,7 @@ void MapStructHandles(Decoded_VkPipelineBinaryHandlesInfoKHR* wrapper, const Vul
     {
         VkPipelineBinaryHandlesInfoKHR* value = wrapper->decoded_value;
 
-        value->pPipelineBinaries = handle_mapping::MapHandleArray<PipelineBinaryKHRInfo>(&wrapper->pPipelineBinaries, object_info_table, &VulkanObjectInfoTable::GetPipelineBinaryKHRInfo);
+        value->pPipelineBinaries = handle_mapping::MapHandleArray<VulkanPipelineBinaryKHRInfo>(&wrapper->pPipelineBinaries, object_info_table, &VulkanObjectInfoTable::GetVkPipelineBinaryKHRInfo);
     }
 }
 
@@ -1260,7 +1260,7 @@ void MapStructHandles(Decoded_VkVideoInlineQueryInfoKHR* wrapper, const VulkanOb
     {
         VkVideoInlineQueryInfoKHR* value = wrapper->decoded_value;
 
-        value->queryPool = handle_mapping::MapHandle<QueryPoolInfo>(wrapper->queryPool, object_info_table, &VulkanObjectInfoTable::GetQueryPoolInfo);
+        value->queryPool = handle_mapping::MapHandle<VulkanQueryPoolInfo>(wrapper->queryPool, object_info_table, &VulkanObjectInfoTable::GetVkQueryPoolInfo);
     }
 }
 
@@ -1275,9 +1275,9 @@ void MapStructHandles(Decoded_VkBindDescriptorSetsInfoKHR* wrapper, const Vulkan
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
 
-        value->pDescriptorSets = handle_mapping::MapHandleArray<DescriptorSetInfo>(&wrapper->pDescriptorSets, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetInfo);
+        value->pDescriptorSets = handle_mapping::MapHandleArray<VulkanDescriptorSetInfo>(&wrapper->pDescriptorSets, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetInfo);
     }
 }
 
@@ -1292,7 +1292,7 @@ void MapStructHandles(Decoded_VkPushConstantsInfoKHR* wrapper, const VulkanObjec
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
@@ -1307,7 +1307,7 @@ void MapStructHandles(Decoded_VkPushDescriptorSetInfoKHR* wrapper, const VulkanO
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
 
         MapStructArrayHandles<Decoded_VkWriteDescriptorSet>(wrapper->pDescriptorWrites->GetMetaStructPointer(), wrapper->pDescriptorWrites->GetLength(), object_info_table);
     }
@@ -1324,7 +1324,7 @@ void MapStructHandles(Decoded_VkSetDescriptorBufferOffsetsInfoEXT* wrapper, cons
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
@@ -1339,7 +1339,7 @@ void MapStructHandles(Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT* wra
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
@@ -1369,9 +1369,9 @@ void MapStructHandles(Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper
     {
         VkDedicatedAllocationMemoryAllocateInfoNV* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -1381,9 +1381,9 @@ void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const VulkanObj
     {
         VkImageViewHandleInfoNVX* value = wrapper->decoded_value;
 
-        value->imageView = handle_mapping::MapHandle<ImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo);
+        value->imageView = handle_mapping::MapHandle<VulkanImageViewInfo>(wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetVkImageViewInfo);
 
-        value->sampler = handle_mapping::MapHandle<SamplerInfo>(wrapper->sampler, object_info_table, &VulkanObjectInfoTable::GetSamplerInfo);
+        value->sampler = handle_mapping::MapHandle<VulkanSamplerInfo>(wrapper->sampler, object_info_table, &VulkanObjectInfoTable::GetVkSamplerInfo);
     }
 }
 
@@ -1393,9 +1393,9 @@ void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper, co
     {
         VkWin32KeyedMutexAcquireReleaseInfoNV* value = wrapper->decoded_value;
 
-        value->pAcquireSyncs = handle_mapping::MapHandleArray<DeviceMemoryInfo>(&wrapper->pAcquireSyncs, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->pAcquireSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pAcquireSyncs, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
 
-        value->pReleaseSyncs = handle_mapping::MapHandleArray<DeviceMemoryInfo>(&wrapper->pReleaseSyncs, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->pReleaseSyncs = handle_mapping::MapHandleArray<VulkanDeviceMemoryInfo>(&wrapper->pReleaseSyncs, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -1405,7 +1405,7 @@ void MapStructHandles(Decoded_VkConditionalRenderingBeginInfoEXT* wrapper, const
     {
         VkConditionalRenderingBeginInfoEXT* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -1435,7 +1435,7 @@ void MapStructHandles(Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapp
     {
         VkMemoryGetAndroidHardwareBufferInfoANDROID* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -1445,7 +1445,7 @@ void MapStructHandles(Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrappe
     {
         VkShaderModuleValidationCacheCreateInfoEXT* value = wrapper->decoded_value;
 
-        value->validationCache = handle_mapping::MapHandle<ValidationCacheEXTInfo>(wrapper->validationCache, object_info_table, &VulkanObjectInfoTable::GetValidationCacheEXTInfo);
+        value->validationCache = handle_mapping::MapHandle<VulkanValidationCacheEXTInfo>(wrapper->validationCache, object_info_table, &VulkanObjectInfoTable::GetVkValidationCacheEXTInfo);
     }
 }
 
@@ -1457,9 +1457,9 @@ void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoNV* wrapper, const V
 
         MapStructArrayHandles<Decoded_VkPipelineShaderStageCreateInfo>(wrapper->pStages->GetMetaStructPointer(), wrapper->pStages->GetLength(), object_info_table);
 
-        value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
 
-        value->basePipelineHandle = handle_mapping::MapHandle<PipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1469,11 +1469,11 @@ void MapStructHandles(Decoded_VkGeometryTrianglesNV* wrapper, const VulkanObject
     {
         VkGeometryTrianglesNV* value = wrapper->decoded_value;
 
-        value->vertexData = handle_mapping::MapHandle<BufferInfo>(wrapper->vertexData, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->vertexData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->vertexData, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
 
-        value->indexData = handle_mapping::MapHandle<BufferInfo>(wrapper->indexData, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->indexData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->indexData, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
 
-        value->transformData = handle_mapping::MapHandle<BufferInfo>(wrapper->transformData, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->transformData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->transformData, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -1483,7 +1483,7 @@ void MapStructHandles(Decoded_VkGeometryAABBNV* wrapper, const VulkanObjectInfoT
     {
         VkGeometryAABBNV* value = wrapper->decoded_value;
 
-        value->aabbData = handle_mapping::MapHandle<BufferInfo>(wrapper->aabbData, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->aabbData = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->aabbData, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -1527,9 +1527,9 @@ void MapStructHandles(Decoded_VkBindAccelerationStructureMemoryInfoNV* wrapper, 
     {
         VkBindAccelerationStructureMemoryInfoNV* value = wrapper->decoded_value;
 
-        value->accelerationStructure = handle_mapping::MapHandle<AccelerationStructureNVInfo>(wrapper->accelerationStructure, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureNVInfo);
+        value->accelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureNVInfo>(wrapper->accelerationStructure, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -1539,7 +1539,7 @@ void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapp
     {
         VkWriteDescriptorSetAccelerationStructureNV* value = wrapper->decoded_value;
 
-        value->pAccelerationStructures = handle_mapping::MapHandleArray<AccelerationStructureNVInfo>(&wrapper->pAccelerationStructures, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureNVInfo);
+        value->pAccelerationStructures = handle_mapping::MapHandleArray<VulkanAccelerationStructureNVInfo>(&wrapper->pAccelerationStructures, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
     }
 }
 
@@ -1549,7 +1549,7 @@ void MapStructHandles(Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* w
     {
         VkAccelerationStructureMemoryRequirementsInfoNV* value = wrapper->decoded_value;
 
-        value->accelerationStructure = handle_mapping::MapHandle<AccelerationStructureNVInfo>(wrapper->accelerationStructure, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureNVInfo);
+        value->accelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureNVInfo>(wrapper->accelerationStructure, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureNVInfo);
     }
 }
 
@@ -1559,7 +1559,7 @@ void MapStructHandles(Decoded_VkCopyMemoryToImageInfoEXT* wrapper, const VulkanO
     {
         VkCopyMemoryToImageInfoEXT* value = wrapper->decoded_value;
 
-        value->dstImage = handle_mapping::MapHandle<ImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -1569,7 +1569,7 @@ void MapStructHandles(Decoded_VkCopyImageToMemoryInfoEXT* wrapper, const VulkanO
     {
         VkCopyImageToMemoryInfoEXT* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<ImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -1579,9 +1579,9 @@ void MapStructHandles(Decoded_VkCopyImageToImageInfoEXT* wrapper, const VulkanOb
     {
         VkCopyImageToImageInfoEXT* value = wrapper->decoded_value;
 
-        value->srcImage = handle_mapping::MapHandle<ImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->srcImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->srcImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
-        value->dstImage = handle_mapping::MapHandle<ImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->dstImage = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->dstImage, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -1591,7 +1591,7 @@ void MapStructHandles(Decoded_VkHostImageLayoutTransitionInfoEXT* wrapper, const
     {
         VkHostImageLayoutTransitionInfoEXT* value = wrapper->decoded_value;
 
-        value->image = handle_mapping::MapHandle<ImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->image = handle_mapping::MapHandle<VulkanImageInfo>(wrapper->image, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
     }
 }
 
@@ -1601,7 +1601,7 @@ void MapStructHandles(Decoded_VkSwapchainPresentFenceInfoEXT* wrapper, const Vul
     {
         VkSwapchainPresentFenceInfoEXT* value = wrapper->decoded_value;
 
-        value->pFences = handle_mapping::MapHandleArray<FenceInfo>(&wrapper->pFences, object_info_table, &VulkanObjectInfoTable::GetFenceInfo);
+        value->pFences = handle_mapping::MapHandleArray<VulkanFenceInfo>(&wrapper->pFences, object_info_table, &VulkanObjectInfoTable::GetVkFenceInfo);
     }
 }
 
@@ -1611,7 +1611,7 @@ void MapStructHandles(Decoded_VkReleaseSwapchainImagesInfoEXT* wrapper, const Vu
     {
         VkReleaseSwapchainImagesInfoEXT* value = wrapper->decoded_value;
 
-        value->swapchain = handle_mapping::MapHandle<SwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
+        value->swapchain = handle_mapping::MapHandle<VulkanSwapchainKHRInfo>(wrapper->swapchain, object_info_table, &VulkanObjectInfoTable::GetVkSwapchainKHRInfo);
     }
 }
 
@@ -1631,7 +1631,7 @@ void MapStructHandles(Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV* wrappe
 
         MapStructArrayHandles<Decoded_VkGraphicsShaderGroupCreateInfoNV>(wrapper->pGroups->GetMetaStructPointer(), wrapper->pGroups->GetLength(), object_info_table);
 
-        value->pPipelines = handle_mapping::MapHandleArray<PipelineInfo>(&wrapper->pPipelines, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pPipelines = handle_mapping::MapHandleArray<VulkanPipelineInfo>(&wrapper->pPipelines, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1641,7 +1641,7 @@ void MapStructHandles(Decoded_VkIndirectCommandsStreamNV* wrapper, const VulkanO
     {
         VkIndirectCommandsStreamNV* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -1651,7 +1651,7 @@ void MapStructHandles(Decoded_VkIndirectCommandsLayoutTokenNV* wrapper, const Vu
     {
         VkIndirectCommandsLayoutTokenNV* value = wrapper->decoded_value;
 
-        value->pushconstantPipelineLayout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->pushconstantPipelineLayout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->pushconstantPipelineLayout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->pushconstantPipelineLayout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
@@ -1669,17 +1669,17 @@ void MapStructHandles(Decoded_VkGeneratedCommandsInfoNV* wrapper, const VulkanOb
     {
         VkGeneratedCommandsInfoNV* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<PipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
 
-        value->indirectCommandsLayout = handle_mapping::MapHandle<IndirectCommandsLayoutNVInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetIndirectCommandsLayoutNVInfo);
+        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutNVInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo);
 
         MapStructArrayHandles<Decoded_VkIndirectCommandsStreamNV>(wrapper->pStreams->GetMetaStructPointer(), wrapper->pStreams->GetLength(), object_info_table);
 
-        value->preprocessBuffer = handle_mapping::MapHandle<BufferInfo>(wrapper->preprocessBuffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->preprocessBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->preprocessBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
 
-        value->sequencesCountBuffer = handle_mapping::MapHandle<BufferInfo>(wrapper->sequencesCountBuffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->sequencesCountBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->sequencesCountBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
 
-        value->sequencesIndexBuffer = handle_mapping::MapHandle<BufferInfo>(wrapper->sequencesIndexBuffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->sequencesIndexBuffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->sequencesIndexBuffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -1689,9 +1689,9 @@ void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV* wrapp
     {
         VkGeneratedCommandsMemoryRequirementsInfoNV* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<PipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
 
-        value->indirectCommandsLayout = handle_mapping::MapHandle<IndirectCommandsLayoutNVInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetIndirectCommandsLayoutNVInfo);
+        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutNVInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutNVInfo);
     }
 }
 
@@ -1701,7 +1701,7 @@ void MapStructHandles(Decoded_VkMemoryGetZirconHandleInfoFUCHSIA* wrapper, const
     {
         VkMemoryGetZirconHandleInfoFUCHSIA* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -1711,7 +1711,7 @@ void MapStructHandles(Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA* wrapper,
     {
         VkImportSemaphoreZirconHandleInfoFUCHSIA* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<SemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -1721,7 +1721,7 @@ void MapStructHandles(Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA* wrapper, co
     {
         VkSemaphoreGetZirconHandleInfoFUCHSIA* value = wrapper->decoded_value;
 
-        value->semaphore = handle_mapping::MapHandle<SemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->semaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->semaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -1731,7 +1731,7 @@ void MapStructHandles(Decoded_VkMemoryGetRemoteAddressInfoNV* wrapper, const Vul
     {
         VkMemoryGetRemoteAddressInfoNV* value = wrapper->decoded_value;
 
-        value->memory = handle_mapping::MapHandle<DeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
+        value->memory = handle_mapping::MapHandle<VulkanDeviceMemoryInfo>(wrapper->memory, object_info_table, &VulkanObjectInfoTable::GetVkDeviceMemoryInfo);
     }
 }
 
@@ -1741,9 +1741,9 @@ void MapStructHandles(Decoded_VkFrameBoundaryEXT* wrapper, const VulkanObjectInf
     {
         VkFrameBoundaryEXT* value = wrapper->decoded_value;
 
-        value->pImages = handle_mapping::MapHandleArray<ImageInfo>(&wrapper->pImages, object_info_table, &VulkanObjectInfoTable::GetImageInfo);
+        value->pImages = handle_mapping::MapHandleArray<VulkanImageInfo>(&wrapper->pImages, object_info_table, &VulkanObjectInfoTable::GetVkImageInfo);
 
-        value->pBuffers = handle_mapping::MapHandleArray<BufferInfo>(&wrapper->pBuffers, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->pBuffers = handle_mapping::MapHandleArray<VulkanBufferInfo>(&wrapper->pBuffers, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -1753,7 +1753,7 @@ void MapStructHandles(Decoded_VkMicromapBuildInfoEXT* wrapper, const VulkanObjec
     {
         VkMicromapBuildInfoEXT* value = wrapper->decoded_value;
 
-        value->dstMicromap = handle_mapping::MapHandle<MicromapEXTInfo>(wrapper->dstMicromap, object_info_table, &VulkanObjectInfoTable::GetMicromapEXTInfo);
+        value->dstMicromap = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->dstMicromap, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
@@ -1763,7 +1763,7 @@ void MapStructHandles(Decoded_VkMicromapCreateInfoEXT* wrapper, const VulkanObje
     {
         VkMicromapCreateInfoEXT* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -1773,7 +1773,7 @@ void MapStructHandles(Decoded_VkCopyMicromapToMemoryInfoEXT* wrapper, const Vulk
     {
         VkCopyMicromapToMemoryInfoEXT* value = wrapper->decoded_value;
 
-        value->src = handle_mapping::MapHandle<MicromapEXTInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetMicromapEXTInfo);
+        value->src = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
@@ -1783,7 +1783,7 @@ void MapStructHandles(Decoded_VkCopyMemoryToMicromapInfoEXT* wrapper, const Vulk
     {
         VkCopyMemoryToMicromapInfoEXT* value = wrapper->decoded_value;
 
-        value->dst = handle_mapping::MapHandle<MicromapEXTInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetMicromapEXTInfo);
+        value->dst = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
@@ -1793,9 +1793,9 @@ void MapStructHandles(Decoded_VkCopyMicromapInfoEXT* wrapper, const VulkanObject
     {
         VkCopyMicromapInfoEXT* value = wrapper->decoded_value;
 
-        value->src = handle_mapping::MapHandle<MicromapEXTInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetMicromapEXTInfo);
+        value->src = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
 
-        value->dst = handle_mapping::MapHandle<MicromapEXTInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetMicromapEXTInfo);
+        value->dst = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
@@ -1805,7 +1805,7 @@ void MapStructHandles(Decoded_VkAccelerationStructureTrianglesOpacityMicromapEXT
     {
         VkAccelerationStructureTrianglesOpacityMicromapEXT* value = wrapper->decoded_value;
 
-        value->micromap = handle_mapping::MapHandle<MicromapEXTInfo>(wrapper->micromap, object_info_table, &VulkanObjectInfoTable::GetMicromapEXTInfo);
+        value->micromap = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->micromap, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
@@ -1815,7 +1815,7 @@ void MapStructHandles(Decoded_VkAccelerationStructureTrianglesDisplacementMicrom
     {
         VkAccelerationStructureTrianglesDisplacementMicromapNV* value = wrapper->decoded_value;
 
-        value->micromap = handle_mapping::MapHandle<MicromapEXTInfo>(wrapper->micromap, object_info_table, &VulkanObjectInfoTable::GetMicromapEXTInfo);
+        value->micromap = handle_mapping::MapHandle<VulkanMicromapEXTInfo>(wrapper->micromap, object_info_table, &VulkanObjectInfoTable::GetVkMicromapEXTInfo);
     }
 }
 
@@ -1825,7 +1825,7 @@ void MapStructHandles(Decoded_VkDescriptorSetBindingReferenceVALVE* wrapper, con
     {
         VkDescriptorSetBindingReferenceVALVE* value = wrapper->decoded_value;
 
-        value->descriptorSetLayout = handle_mapping::MapHandle<DescriptorSetLayoutInfo>(wrapper->descriptorSetLayout, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetLayoutInfo);
+        value->descriptorSetLayout = handle_mapping::MapHandle<VulkanDescriptorSetLayoutInfo>(wrapper->descriptorSetLayout, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     }
 }
 
@@ -1843,7 +1843,7 @@ void MapStructHandles(Decoded_VkPipelineIndirectDeviceAddressInfoNV* wrapper, co
     {
         VkPipelineIndirectDeviceAddressInfoNV* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<PipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1853,7 +1853,7 @@ void MapStructHandles(Decoded_VkShaderCreateInfoEXT* wrapper, const VulkanObject
     {
         VkShaderCreateInfoEXT* value = wrapper->decoded_value;
 
-        value->pSetLayouts = handle_mapping::MapHandleArray<DescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetLayoutInfo);
+        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     }
 }
 
@@ -1863,7 +1863,7 @@ void MapStructHandles(Decoded_VkLatencySleepInfoNV* wrapper, const VulkanObjectI
     {
         VkLatencySleepInfoNV* value = wrapper->decoded_value;
 
-        value->signalSemaphore = handle_mapping::MapHandle<SemaphoreInfo>(wrapper->signalSemaphore, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo);
+        value->signalSemaphore = handle_mapping::MapHandle<VulkanSemaphoreInfo>(wrapper->signalSemaphore, object_info_table, &VulkanObjectInfoTable::GetVkSemaphoreInfo);
     }
 }
 
@@ -1878,9 +1878,9 @@ void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoEXT* wrap
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->indirectExecutionSet = handle_mapping::MapHandle<IndirectExecutionSetEXTInfo>(wrapper->indirectExecutionSet, object_info_table, &VulkanObjectInfoTable::GetIndirectExecutionSetEXTInfo);
+        value->indirectExecutionSet = handle_mapping::MapHandle<VulkanIndirectExecutionSetEXTInfo>(wrapper->indirectExecutionSet, object_info_table, &VulkanObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
 
-        value->indirectCommandsLayout = handle_mapping::MapHandle<IndirectCommandsLayoutEXTInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetIndirectCommandsLayoutEXTInfo);
+        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutEXTInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutEXTInfo);
     }
 }
 
@@ -1890,7 +1890,7 @@ void MapStructHandles(Decoded_VkIndirectExecutionSetPipelineInfoEXT* wrapper, co
     {
         VkIndirectExecutionSetPipelineInfoEXT* value = wrapper->decoded_value;
 
-        value->initialPipeline = handle_mapping::MapHandle<PipelineInfo>(wrapper->initialPipeline, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->initialPipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->initialPipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1900,7 +1900,7 @@ void MapStructHandles(Decoded_VkIndirectExecutionSetShaderLayoutInfoEXT* wrapper
     {
         VkIndirectExecutionSetShaderLayoutInfoEXT* value = wrapper->decoded_value;
 
-        value->pSetLayouts = handle_mapping::MapHandleArray<DescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetLayoutInfo);
+        value->pSetLayouts = handle_mapping::MapHandleArray<VulkanDescriptorSetLayoutInfo>(&wrapper->pSetLayouts, object_info_table, &VulkanObjectInfoTable::GetVkDescriptorSetLayoutInfo);
     }
 }
 
@@ -1910,7 +1910,7 @@ void MapStructHandles(Decoded_VkIndirectExecutionSetShaderInfoEXT* wrapper, cons
     {
         VkIndirectExecutionSetShaderInfoEXT* value = wrapper->decoded_value;
 
-        value->pInitialShaders = handle_mapping::MapHandleArray<ShaderEXTInfo>(&wrapper->pInitialShaders, object_info_table, &VulkanObjectInfoTable::GetShaderEXTInfo);
+        value->pInitialShaders = handle_mapping::MapHandleArray<VulkanShaderEXTInfo>(&wrapper->pInitialShaders, object_info_table, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
 
         MapStructArrayHandles<Decoded_VkIndirectExecutionSetShaderLayoutInfoEXT>(wrapper->pSetLayoutInfos->GetMetaStructPointer(), wrapper->pSetLayoutInfos->GetLength(), object_info_table);
     }
@@ -1927,9 +1927,9 @@ void MapStructHandles(Decoded_VkGeneratedCommandsInfoEXT* wrapper, const VulkanO
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->indirectExecutionSet = handle_mapping::MapHandle<IndirectExecutionSetEXTInfo>(wrapper->indirectExecutionSet, object_info_table, &VulkanObjectInfoTable::GetIndirectExecutionSetEXTInfo);
+        value->indirectExecutionSet = handle_mapping::MapHandle<VulkanIndirectExecutionSetEXTInfo>(wrapper->indirectExecutionSet, object_info_table, &VulkanObjectInfoTable::GetVkIndirectExecutionSetEXTInfo);
 
-        value->indirectCommandsLayout = handle_mapping::MapHandle<IndirectCommandsLayoutEXTInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetIndirectCommandsLayoutEXTInfo);
+        value->indirectCommandsLayout = handle_mapping::MapHandle<VulkanIndirectCommandsLayoutEXTInfo>(wrapper->indirectCommandsLayout, object_info_table, &VulkanObjectInfoTable::GetVkIndirectCommandsLayoutEXTInfo);
     }
 }
 
@@ -1939,7 +1939,7 @@ void MapStructHandles(Decoded_VkWriteIndirectExecutionSetPipelineEXT* wrapper, c
     {
         VkWriteIndirectExecutionSetPipelineEXT* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<PipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1954,7 +1954,7 @@ void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoEXT* wrapper, co
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
         }
 
-        value->pipelineLayout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->pipelineLayout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->pipelineLayout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->pipelineLayout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
     }
 }
 
@@ -1964,7 +1964,7 @@ void MapStructHandles(Decoded_VkGeneratedCommandsPipelineInfoEXT* wrapper, const
     {
         VkGeneratedCommandsPipelineInfoEXT* value = wrapper->decoded_value;
 
-        value->pipeline = handle_mapping::MapHandle<PipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->pipeline = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->pipeline, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -1974,7 +1974,7 @@ void MapStructHandles(Decoded_VkGeneratedCommandsShaderInfoEXT* wrapper, const V
     {
         VkGeneratedCommandsShaderInfoEXT* value = wrapper->decoded_value;
 
-        value->pShaders = handle_mapping::MapHandleArray<ShaderEXTInfo>(&wrapper->pShaders, object_info_table, &VulkanObjectInfoTable::GetShaderEXTInfo);
+        value->pShaders = handle_mapping::MapHandleArray<VulkanShaderEXTInfo>(&wrapper->pShaders, object_info_table, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
     }
 }
 
@@ -1984,7 +1984,7 @@ void MapStructHandles(Decoded_VkWriteIndirectExecutionSetShaderEXT* wrapper, con
     {
         VkWriteIndirectExecutionSetShaderEXT* value = wrapper->decoded_value;
 
-        value->shader = handle_mapping::MapHandle<ShaderEXTInfo>(wrapper->shader, object_info_table, &VulkanObjectInfoTable::GetShaderEXTInfo);
+        value->shader = handle_mapping::MapHandle<VulkanShaderEXTInfo>(wrapper->shader, object_info_table, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
     }
 }
 
@@ -2005,7 +2005,7 @@ void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoKHR* wrapper, con
     {
         VkAccelerationStructureCreateInfoKHR* value = wrapper->decoded_value;
 
-        value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+        value->buffer = handle_mapping::MapHandle<VulkanBufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetVkBufferInfo);
     }
 }
 
@@ -2015,7 +2015,7 @@ void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureKHR* wrap
     {
         VkWriteDescriptorSetAccelerationStructureKHR* value = wrapper->decoded_value;
 
-        value->pAccelerationStructures = handle_mapping::MapHandleArray<AccelerationStructureKHRInfo>(&wrapper->pAccelerationStructures, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+        value->pAccelerationStructures = handle_mapping::MapHandleArray<VulkanAccelerationStructureKHRInfo>(&wrapper->pAccelerationStructures, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     }
 }
 
@@ -2025,7 +2025,7 @@ void MapStructHandles(Decoded_VkAccelerationStructureDeviceAddressInfoKHR* wrapp
     {
         VkAccelerationStructureDeviceAddressInfoKHR* value = wrapper->decoded_value;
 
-        value->accelerationStructure = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(wrapper->accelerationStructure, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+        value->accelerationStructure = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->accelerationStructure, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     }
 }
 
@@ -2035,7 +2035,7 @@ void MapStructHandles(Decoded_VkCopyAccelerationStructureToMemoryInfoKHR* wrappe
     {
         VkCopyAccelerationStructureToMemoryInfoKHR* value = wrapper->decoded_value;
 
-        value->src = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+        value->src = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     }
 }
 
@@ -2045,7 +2045,7 @@ void MapStructHandles(Decoded_VkCopyMemoryToAccelerationStructureInfoKHR* wrappe
     {
         VkCopyMemoryToAccelerationStructureInfoKHR* value = wrapper->decoded_value;
 
-        value->dst = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+        value->dst = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     }
 }
 
@@ -2055,9 +2055,9 @@ void MapStructHandles(Decoded_VkCopyAccelerationStructureInfoKHR* wrapper, const
     {
         VkCopyAccelerationStructureInfoKHR* value = wrapper->decoded_value;
 
-        value->src = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+        value->src = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->src, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
 
-        value->dst = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+        value->dst = handle_mapping::MapHandle<VulkanAccelerationStructureKHRInfo>(wrapper->dst, object_info_table, &VulkanObjectInfoTable::GetVkAccelerationStructureKHRInfo);
     }
 }
 
@@ -2076,9 +2076,9 @@ void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoKHR* wrapper, const 
 
         MapStructArrayHandles<Decoded_VkPipelineLibraryCreateInfoKHR>(wrapper->pLibraryInfo->GetMetaStructPointer(), 1, object_info_table);
 
-        value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
+        value->layout = handle_mapping::MapHandle<VulkanPipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetVkPipelineLayoutInfo);
 
-        value->basePipelineHandle = handle_mapping::MapHandle<PipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo);
+        value->basePipelineHandle = handle_mapping::MapHandle<VulkanPipelineInfo>(wrapper->basePipelineHandle, object_info_table, &VulkanObjectInfoTable::GetVkPipelineInfo);
     }
 }
 
@@ -2182,7 +2182,7 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkPhysicalDevice
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandleArray<PhysicalDeviceInfo>(parent_id, id_wrapper->physicalDevices.GetPointer(), id_wrapper->physicalDevices.GetLength(), handle_struct->physicalDevices, handle_struct->physicalDeviceCount, object_info_table, &VulkanObjectInfoTable::AddPhysicalDeviceInfo);
+        handle_mapping::AddHandleArray<VulkanPhysicalDeviceInfo>(parent_id, id_wrapper->physicalDevices.GetPointer(), id_wrapper->physicalDevices.GetLength(), handle_struct->physicalDevices, handle_struct->physicalDeviceCount, object_info_table, &VulkanObjectInfoTable::AddVkPhysicalDeviceInfo);
     }
 }
 
@@ -2190,7 +2190,7 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPropert
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandle<DisplayKHRInfo>(parent_id, id_wrapper->display, handle_struct->display, object_info_table, &VulkanObjectInfoTable::AddDisplayKHRInfo);
+        handle_mapping::AddHandle<VulkanDisplayKHRInfo>(parent_id, id_wrapper->display, handle_struct->display, object_info_table, &VulkanObjectInfoTable::AddVkDisplayKHRInfo);
     }
 }
 
@@ -2198,7 +2198,7 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlanePr
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandle<DisplayKHRInfo>(parent_id, id_wrapper->currentDisplay, handle_struct->currentDisplay, object_info_table, &VulkanObjectInfoTable::AddDisplayKHRInfo);
+        handle_mapping::AddHandle<VulkanDisplayKHRInfo>(parent_id, id_wrapper->currentDisplay, handle_struct->currentDisplay, object_info_table, &VulkanObjectInfoTable::AddVkDisplayKHRInfo);
     }
 }
 
@@ -2206,7 +2206,7 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModePro
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandle<DisplayModeKHRInfo>(parent_id, id_wrapper->displayMode, handle_struct->displayMode, object_info_table, &VulkanObjectInfoTable::AddDisplayModeKHRInfo);
+        handle_mapping::AddHandle<VulkanDisplayModeKHRInfo>(parent_id, id_wrapper->displayMode, handle_struct->displayMode, object_info_table, &VulkanObjectInfoTable::AddVkDisplayModeKHRInfo);
     }
 }
 
@@ -2238,7 +2238,7 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkPipelineBinary
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandleArray<PipelineBinaryKHRInfo>(parent_id, id_wrapper->pPipelineBinaries.GetPointer(), id_wrapper->pPipelineBinaries.GetLength(), handle_struct->pPipelineBinaries, handle_struct->pipelineBinaryCount, object_info_table, &VulkanObjectInfoTable::AddPipelineBinaryKHRInfo);
+        handle_mapping::AddHandleArray<VulkanPipelineBinaryKHRInfo>(parent_id, id_wrapper->pPipelineBinaries.GetPointer(), id_wrapper->pPipelineBinaries.GetLength(), handle_struct->pPipelineBinaries, handle_struct->pipelineBinaryCount, object_info_table, &VulkanObjectInfoTable::AddVkPipelineBinaryKHRInfo);
     }
 }
 

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -30,7 +30,7 @@
 #ifndef  GFXRECON_GENERATED_VULKAN_STRUCT_HANDLE_MAPPERS_H
 #define  GFXRECON_GENERATED_VULKAN_STRUCT_HANDLE_MAPPERS_H
 
-#include "decode/vulkan_object_info_table.h"
+#include "decode/common_object_info_table.h"
 #include "decode/vulkan_pnext_node.h"
 #include "format/platform_types.h"
 #include "decode/custom_vulkan_struct_handle_mappers.h"
@@ -49,428 +49,391 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-void MapStructHandles(Decoded_VkBufferMemoryBarrier* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBufferMemoryBarrier* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImageMemoryBarrier* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImageMemoryBarrier* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDeviceCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDeviceCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSubmitInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSubmitInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMappedMemoryRange* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMappedMemoryRange* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMemoryAllocateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMemoryAllocateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSparseMemoryBind* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSparseMemoryBind* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSparseBufferMemoryBindInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSparseBufferMemoryBindInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSparseImageOpaqueMemoryBindInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSparseImageOpaqueMemoryBindInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSparseImageMemoryBind* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSparseImageMemoryBind* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSparseImageMemoryBindInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSparseImageMemoryBindInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBufferViewCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBufferViewCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImageCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImageCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImageViewCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImageViewCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkShaderModuleCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkShaderModuleCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPipelineShaderStageCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPipelineShaderStageCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkComputePipelineCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkComputePipelineCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGraphicsPipelineCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGraphicsPipelineCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPipelineLayoutCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPipelineLayoutCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSamplerCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSamplerCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyDescriptorSet* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyDescriptorSet* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDescriptorBufferInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDescriptorBufferInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDescriptorSetAllocateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDescriptorSetAllocateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDescriptorSetLayoutBinding* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDescriptorSetLayoutBinding* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDescriptorSetLayoutCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDescriptorSetLayoutCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkFramebufferCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkFramebufferCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCommandBufferAllocateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCommandBufferAllocateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCommandBufferInheritanceInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCommandBufferInheritanceInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCommandBufferBeginInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCommandBufferBeginInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkRenderPassBeginInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkRenderPassBeginInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBindBufferMemoryInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBindBufferMemoryInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBindImageMemoryInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBindImageMemoryInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMemoryDedicatedAllocateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMemoryDedicatedAllocateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPhysicalDeviceGroupProperties* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPhysicalDeviceGroupProperties* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDeviceGroupDeviceCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDeviceGroupDeviceCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBufferMemoryRequirementsInfo2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBufferMemoryRequirementsInfo2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImageMemoryRequirementsInfo2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImageMemoryRequirementsInfo2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSamplerYcbcrConversionInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSamplerYcbcrConversionInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkRenderPassAttachmentBeginInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkRenderPassAttachmentBeginInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSemaphoreWaitInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSemaphoreWaitInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSemaphoreSignalInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSemaphoreSignalInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBufferDeviceAddressInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBufferDeviceAddressInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBufferMemoryBarrier2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBufferMemoryBarrier2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImageMemoryBarrier2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImageMemoryBarrier2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDependencyInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDependencyInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSemaphoreSubmitInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSemaphoreSubmitInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCommandBufferSubmitInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCommandBufferSubmitInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSubmitInfo2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSubmitInfo2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyBufferInfo2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyBufferInfo2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyImageInfo2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyImageInfo2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyBufferToImageInfo2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyBufferToImageInfo2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyImageToBufferInfo2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyImageToBufferInfo2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBlitImageInfo2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBlitImageInfo2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkResolveImageInfo2* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkResolveImageInfo2* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkRenderingAttachmentInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkRenderingAttachmentInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkRenderingInfo* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkRenderingInfo* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDeviceImageMemoryRequirements* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDeviceImageMemoryRequirements* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSwapchainCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSwapchainCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPresentInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPresentInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImageSwapchainCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImageSwapchainCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkAcquireNextImageInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkAcquireNextImageInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDisplayModePropertiesKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDisplayModePropertiesKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDisplayPlanePropertiesKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDisplayPlanePropertiesKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDisplayPropertiesKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDisplayPropertiesKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkVideoPictureResourceInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkVideoPictureResourceInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkVideoReferenceSlotInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkVideoReferenceSlotInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBindVideoSessionMemoryInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBindVideoSessionMemoryInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkVideoSessionParametersCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkVideoSessionParametersCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkVideoBeginCodingInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkVideoBeginCodingInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkVideoDecodeInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkVideoDecodeInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkRenderingFragmentShadingRateAttachmentInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkRenderingFragmentShadingRateAttachmentInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkRenderingFragmentDensityMapAttachmentInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkRenderingFragmentDensityMapAttachmentInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMemoryGetFdInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMemoryGetFdInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImportSemaphoreFdInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImportSemaphoreFdInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSemaphoreGetFdInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSemaphoreGetFdInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImportFenceWin32HandleInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImportFenceWin32HandleInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkFenceGetWin32HandleInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkFenceGetWin32HandleInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImportFenceFdInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImportFenceFdInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkFenceGetFdInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkFenceGetFdInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDisplayProperties2KHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDisplayProperties2KHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDisplayPlaneProperties2KHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDisplayPlaneProperties2KHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDisplayModeProperties2KHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDisplayModeProperties2KHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDisplayPlaneInfo2KHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDisplayPlaneInfo2KHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPipelineInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPipelineInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPipelineExecutableInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPipelineExecutableInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMemoryMapInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMemoryMapInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMemoryUnmapInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMemoryUnmapInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPipelineLibraryCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPipelineLibraryCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkVideoEncodeInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkVideoEncodeInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkVideoEncodeSessionParametersGetInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkVideoEncodeSessionParametersGetInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDeviceImageSubresourceInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDeviceImageSubresourceInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPipelineBinaryCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPipelineBinaryCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPipelineBinaryInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPipelineBinaryInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkReleaseCapturedPipelineDataInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkReleaseCapturedPipelineDataInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPipelineBinaryDataInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPipelineBinaryDataInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPipelineBinaryHandlesInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPipelineBinaryHandlesInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkVideoInlineQueryInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkVideoInlineQueryInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBindDescriptorSetsInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBindDescriptorSetsInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPushConstantsInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPushConstantsInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPushDescriptorSetInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPushDescriptorSetInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSetDescriptorBufferOffsetsInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSetDescriptorBufferOffsetsInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkConditionalRenderingBeginInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkConditionalRenderingBeginInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGeometryTrianglesNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGeometryTrianglesNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGeometryAABBNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGeometryAABBNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGeometryDataNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGeometryDataNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGeometryNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGeometryNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkAccelerationStructureInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkAccelerationStructureInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkBindAccelerationStructureMemoryInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkBindAccelerationStructureMemoryInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyMemoryToImageInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyMemoryToImageInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyImageToMemoryInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyImageToMemoryInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyImageToImageInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyImageToImageInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkHostImageLayoutTransitionInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkHostImageLayoutTransitionInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSwapchainPresentFenceInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSwapchainPresentFenceInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkReleaseSwapchainImagesInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkReleaseSwapchainImagesInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGraphicsShaderGroupCreateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGraphicsShaderGroupCreateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkIndirectCommandsStreamNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkIndirectCommandsStreamNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkIndirectCommandsLayoutTokenNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkIndirectCommandsLayoutTokenNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGeneratedCommandsInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGeneratedCommandsInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMemoryGetZirconHandleInfoFUCHSIA* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMemoryGetZirconHandleInfoFUCHSIA* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMemoryGetRemoteAddressInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMemoryGetRemoteAddressInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkFrameBoundaryEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkFrameBoundaryEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMicromapBuildInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMicromapBuildInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkMicromapCreateInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkMicromapCreateInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyMicromapToMemoryInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyMicromapToMemoryInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyMemoryToMicromapInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyMemoryToMicromapInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyMicromapInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyMicromapInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkAccelerationStructureTrianglesOpacityMicromapEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkAccelerationStructureTrianglesOpacityMicromapEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkAccelerationStructureTrianglesDisplacementMicromapNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkAccelerationStructureTrianglesDisplacementMicromapNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkDescriptorSetBindingReferenceVALVE* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkDescriptorSetBindingReferenceVALVE* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkRenderPassStripeSubmitInfoARM* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkRenderPassStripeSubmitInfoARM* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPipelineIndirectDeviceAddressInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkPipelineIndirectDeviceAddressInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkShaderCreateInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkShaderCreateInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkLatencySleepInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkLatencySleepInfoNV* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGeneratedCommandsMemoryRequirementsInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkIndirectExecutionSetPipelineInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkIndirectExecutionSetPipelineInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkIndirectExecutionSetShaderLayoutInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkIndirectExecutionSetShaderLayoutInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkIndirectExecutionSetShaderInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkIndirectExecutionSetShaderInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGeneratedCommandsInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGeneratedCommandsInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkWriteIndirectExecutionSetPipelineEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkWriteIndirectExecutionSetPipelineEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGeneratedCommandsPipelineInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGeneratedCommandsPipelineInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkGeneratedCommandsShaderInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkGeneratedCommandsShaderInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkWriteIndirectExecutionSetShaderEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkWriteIndirectExecutionSetShaderEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkAccelerationStructureGeometryTrianglesDataKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkAccelerationStructureGeometryTrianglesDataKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkAccelerationStructureDeviceAddressInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkAccelerationStructureDeviceAddressInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyAccelerationStructureToMemoryInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyAccelerationStructureToMemoryInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyMemoryToAccelerationStructureInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyMemoryToAccelerationStructureInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkCopyAccelerationStructureInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkCopyAccelerationStructureInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
 
-void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectInfoTable& object_info_table);
+void MapPNextStructHandles(const void* value, void* wrapper, const CommonObjectInfoTable& object_info_table);
 
-template <typename T>
-void MapStructArrayHandles(T* structs, size_t len, const VulkanObjectInfoTable& object_info_table)
-{
-    if (structs != nullptr)
-    {
-        for (size_t i = 0; i < len; ++i)
-        {
-            MapStructHandles(&structs[i], object_info_table);
-        }
-    }
-}
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, const VkPhysicalDeviceGroupProperties* handle_struct, CommonObjectInfoTable* object_info_table);
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, const VkPhysicalDeviceGroupProperties* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPropertiesKHR* id_wrapper, const VkDisplayPropertiesKHR* handle_struct, CommonObjectInfoTable* object_info_table);
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPropertiesKHR* id_wrapper, const VkDisplayPropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, const VkDisplayPlanePropertiesKHR* handle_struct, CommonObjectInfoTable* object_info_table);
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, const VkDisplayPlanePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModePropertiesKHR* id_wrapper, const VkDisplayModePropertiesKHR* handle_struct, CommonObjectInfoTable* object_info_table);
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModePropertiesKHR* id_wrapper, const VkDisplayModePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayProperties2KHR* id_wrapper, const VkDisplayProperties2KHR* handle_struct, CommonObjectInfoTable* object_info_table);
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayProperties2KHR* id_wrapper, const VkDisplayProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, const VkDisplayPlaneProperties2KHR* handle_struct, CommonObjectInfoTable* object_info_table);
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, const VkDisplayPlaneProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, CommonObjectInfoTable* object_info_table);
 
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
-
-void AddStructHandles(format::HandleId parent_id, const Decoded_VkPipelineBinaryHandlesInfoKHR* id_wrapper, const VkPipelineBinaryHandlesInfoKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
-
-template <typename T>
-void AddStructArrayHandles(format::HandleId parent_id, const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable* object_info_table)
-{
-    if (id_wrappers != nullptr && handle_structs != nullptr)
-    {
-        // TODO: Improved handling of array size mismatch.
-        size_t len = std::min(id_len, handle_len);
-        for (size_t i = 0; i < len; ++i)
-        {
-            AddStructHandles(parent_id, &id_wrappers[i], &handle_structs[i], object_info_table);
-        }
-    }
-}
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkPipelineBinaryHandlesInfoKHR* id_wrapper, const VkPipelineBinaryHandlesInfoKHR* handle_struct, CommonObjectInfoTable* object_info_table);
 
 void SetStructHandleLengths(Decoded_VkPhysicalDeviceGroupProperties* wrapper);
 
 void SetStructHandleLengths(Decoded_VkPipelineBinaryHandlesInfoKHR* wrapper);
 
-template <typename T>
-void SetStructArrayHandleLengths(T* wrappers, size_t len)
-{
-    if (wrappers != nullptr)
-    {
-        for (size_t i = 0; i < len; ++i)
-        {
-            SetStructHandleLengths(&wrappers[i]);
-        }
-    }
-}
-
+#include "decode/common_struct_handle_mappers.h"
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -1392,6 +1392,8 @@ class BaseGenerator(OutputGenerator):
             type_name = value.base_type
 
             if is_override:
+                prefix_from_type = self.get_prefix_from_type(value.base_type)
+                info_type = prefix_from_type + value.base_type[2:] + 'Info'
                 if value.is_pointer or value.is_array:
                     count = value.pointer_count
                     if self.is_struct(type_name):
@@ -1400,7 +1402,7 @@ class BaseGenerator(OutputGenerator):
                         )
                     elif self.is_class(value):
                         if count == 1:
-                            param_type = type_name[2:] + 'Info*'
+                            param_type = info_type + '*'
                         else:
                             param_type = 'HandlePointerDecoder<{}*>'.format(type_name)
                     elif self.is_handle(type_name) and type_name != 'VkCommandBuffer':
@@ -1409,7 +1411,7 @@ class BaseGenerator(OutputGenerator):
                         param_type = 'const ' + type_name + '*'
                 else:
                     if self.is_handle(type_name) and type_name != 'VkCommandBuffer':
-                        param_type = "const " + type_name[2:] + "Info*"
+                        param_type = 'const ' + info_type + '*'
                     else:
                         param_type = type_name
             else:
@@ -1501,7 +1503,7 @@ class BaseGenerator(OutputGenerator):
     def get_api_prefix(self):
         return 'Vulkan'
 
-    def get_prefix_from_type(self):
+    def get_prefix_from_type(self, type):
         return 'Vulkan'
 
     def get_wrapper_prefix_from_type(self):

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -385,7 +385,7 @@ class BaseGenerator(OutputGenerator):
         self.generate_video = False
 
         # Typenames
-        self.base_types = dict()
+        self.base_types = dict()  # Set of OpenXR basetypes
         self.struct_names = set()  # Set of Vulkan struct typenames
         self.handle_names = set()  # Set of Vulkan handle typenames
         self.flags_types = dict(
@@ -420,6 +420,9 @@ class BaseGenerator(OutputGenerator):
             self.extension_structs_with_handle_ptrs = OrderedDict()  # Map of extension struct names to a Boolean value indicating that a struct member with a handle type is a pointer
         if self.process_cmds:
             self.feature_cmd_params = OrderedDict()                # Map of cmd names to lists of per-parameter ValueInfo
+
+        # Not used for Vulkan
+        self.base_header_structs = dict()  # Map of base header struct names to lists of child struct names
 
     #
     # Indicates that the current feature has C++ code to generate.
@@ -780,6 +783,12 @@ class BaseGenerator(OutputGenerator):
             return True
         return False
 
+    def is_atom(self, base_type):
+        return False
+
+    def get_default_handle_atom_value(self, base_type):
+        return 'VK_NULL_HANDLE'
+
     def has_basetype(self, base_type):
         if base_type in self.base_types and self.base_types[base_type] is not None:
             return True
@@ -958,6 +967,12 @@ class BaseGenerator(OutputGenerator):
             key for key in self.feature_cmd_params
             if not self.is_cmd_black_listed(key)
         ]
+
+    def is_manually_generated_cmd_name(self, command):
+        """Determines if a command is in the list of manually generated command names."""
+        if self.MANUALLY_GENERATED_COMMANDS is not None and command in self.MANUALLY_GENERATED_COMMANDS:
+           return True
+        return False
 
     def clean_type_define(self, full_type):
         """Default to identity function, base classes may override."""
@@ -1396,6 +1411,7 @@ class BaseGenerator(OutputGenerator):
                 info_type = prefix_from_type + value.base_type[2:] + 'Info'
                 if value.is_pointer or value.is_array:
                     count = value.pointer_count
+
                     if self.is_struct(type_name):
                         param_type = 'StructPointerDecoder<Decoded_{}>*'.format(
                             type_name
@@ -1504,7 +1520,7 @@ class BaseGenerator(OutputGenerator):
         return 'Vulkan'
 
     def get_prefix_from_type(self, type):
-        return 'Vulkan'
+        return self.get_api_prefix()
 
     def get_wrapper_prefix_from_type(self):
         return 'vulkan_wrappers'
@@ -1601,6 +1617,9 @@ class BaseGenerator(OutputGenerator):
 
     def is_dx12_class(self):
         return True if ('Dx12' in self.__class__.__name__) else False
+
+    def is_openxr_class(self):
+        return True if ('OpenXr' in self.__class__.__name__) else False
 
     def is_resource_dump_class(self):
         return True if ('ReplayDumpResources' in self.__class__.__name__) else False

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -237,20 +237,6 @@ def make_gen_opts(args):
 
     #
     # API call decoder generators
-    gen_opts['generated_vulkan_decoder.cpp'] = [
-        VulkanDecoderBodyGenerator,
-        VulkanDecoderBodyGeneratorOptions(
-            filename='generated_vulkan_decoder.cpp',
-            directory=directory,
-            blacklists=blacklists,
-            platform_types=platform_types,
-            prefix_text=prefix_strings + vk_prefix_strings,
-            protect_file=False,
-            protect_feature=False,
-            extraVulkanHeaders=extraVulkanHeaders
-        )
-    ]
-
     gen_opts['generated_vulkan_decoder.h'] = [
         VulkanDecoderHeaderGenerator,
         VulkanDecoderHeaderGeneratorOptions(
@@ -260,6 +246,20 @@ def make_gen_opts(args):
             platform_types=platform_types,
             prefix_text=prefix_strings + vk_prefix_strings,
             protect_file=True,
+            protect_feature=False,
+            extraVulkanHeaders=extraVulkanHeaders
+        )
+    ]
+
+    gen_opts['generated_vulkan_decoder.cpp'] = [
+        VulkanDecoderBodyGenerator,
+        VulkanDecoderBodyGeneratorOptions(
+            filename='generated_vulkan_decoder.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            platform_types=platform_types,
+            prefix_text=prefix_strings + vk_prefix_strings,
+            protect_file=False,
             protect_feature=False,
             extraVulkanHeaders=extraVulkanHeaders
         )
@@ -503,7 +503,7 @@ def make_gen_opts(args):
             base_class_header='vulkan_replay_dump_resources.h',
             is_override=True,
             constructor_args=
-            'const VulkanReplayOptions& options, CommonObjectInfoTable& object_info_table',
+            'const VulkanReplayOptions& options, CommonObjectInfoTable* object_info_table',
             filename='generated_vulkan_replay_dump_resources.h',
             directory=directory,
             blacklists=None,

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -503,7 +503,7 @@ def make_gen_opts(args):
             base_class_header='vulkan_replay_dump_resources.h',
             is_override=True,
             constructor_args=
-            'const VulkanReplayOptions& options, VulkanObjectInfoTable& object_info_table',
+            'const VulkanReplayOptions& options, CommonObjectInfoTable& object_info_table',
             filename='generated_vulkan_replay_dump_resources.h',
             directory=directory,
             blacklists=None,

--- a/framework/generated/vulkan_generators/vulkan_decoder_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_decoder_body_generator.py
@@ -63,18 +63,17 @@ class VulkanDecoderBodyGenerator(BaseDecoderBodyGenerator, BaseGenerator):
     def __init__(
         self, err_file=sys.stderr, warn_file=sys.stderr, diag_file=sys.stdout
     ):
+        BaseDecoderBodyGenerator.__init__(self)
+
         BaseGenerator.__init__(
             self,
             process_cmds=True,
             process_structs=False,
-            feature_break=True,
+            feature_break=False,
             err_file=err_file,
             warn_file=warn_file,
             diag_file=diag_file
         )
-
-        # Names of all Vulkan commands processed by the generator.
-        self.cmd_names = []
 
     def beginFile(self, gen_opts):
         """Method override."""
@@ -106,6 +105,9 @@ class VulkanDecoderBodyGenerator(BaseDecoderBodyGenerator, BaseGenerator):
 
     def endFile(self):
         """Method override."""
+        self.newline()
+        self.generate_commands()
+
         self.newline()
         # Generate the VulkanDecoder::DecodeFunctionCall method for all of the commands processed by the generator.
         self.generate_decode_cases()

--- a/framework/generated/vulkan_generators/vulkan_object_info_table_base2_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_object_info_table_base2_header_generator.py
@@ -99,15 +99,16 @@ class VulkanObjectInfoTableBase2HeaderGenerator(BaseGenerator):
         for handle_name in sorted(self.handle_names):
             if handle_name in self.DUPLICATE_HANDLE_TYPES:
                 continue
-            handle_name = handle_name[2:]
-            handle_info = handle_name + 'Info'
-            handle_map = handle_name[0].lower() + handle_name[1:] + '_map_'
-            add_code += '    void Add{0}({0}&& info) {{ AddObjectInfo(std::move(info), &{1}); }}\n'.format(handle_info, handle_map)
-            remove_code += '    void Remove{0}(format::HandleId id) {{ {1}.erase(id); }}\n'.format(handle_info, handle_map)
-            const_get_code += '    const {0}* Get{0}(format::HandleId id) const {{ return GetObjectInfo<{0}>(id, &{1}); }}\n'.format(handle_info, handle_map)
-            get_code += '    {0}* Get{0}(format::HandleId id) {{ return GetObjectInfo<{0}>(id, &{1}); }}\n'.format(handle_info, handle_map)
-            visit_code += '    void Visit{0}(std::function<void(const {0}*)> visitor) const {{  for (const auto& entry : {1}) {{ visitor(&entry.second); }}  }}\n'.format(handle_info, handle_map)
-            map_code += '     std::unordered_map<format::HandleId, {0}> {1};\n'.format(handle_info, handle_map)
+            short_handle_name = handle_name[2:]
+            handle_info = short_handle_name + 'Info'
+            function_info = handle_name + 'Info'
+            handle_map = short_handle_name[0].lower() + short_handle_name[1:] + '_map_'
+            add_code += '    void Add{0}(Vulkan{1}&& info) {{ AddObjectInfo(std::move(info), &{2}); }}\n'.format(function_info, handle_info, handle_map)
+            remove_code += '    void Remove{0}(format::HandleId id) {{ {1}.erase(id); }}\n'.format(function_info, handle_map)
+            const_get_code += '    const Vulkan{0}* Get{1}(format::HandleId id) const {{ return GetObjectInfo<Vulkan{0}>(id, &{2}); }}\n'.format(handle_info, function_info, handle_map)
+            get_code += '    Vulkan{0}* Get{1}(format::HandleId id) {{ return GetObjectInfo<Vulkan{0}>(id, &{2}); }}\n'.format(handle_info, function_info, handle_map)
+            visit_code += '    void Visit{0}(std::function<void(const Vulkan{1}*)> visitor) const {{  for (const auto& entry : {2}) {{ visitor(&entry.second); }}  }}\n'.format(function_info, handle_info, handle_map)
+            map_code += '     std::unordered_map<format::HandleId, Vulkan{0}> {1};\n'.format(handle_info, handle_map)
 
         self.newline()
         code = 'class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase\n'

--- a/framework/generated/vulkan_generators/vulkan_object_info_table_base2_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_object_info_table_base2_header_generator.py
@@ -103,10 +103,10 @@ class VulkanObjectInfoTableBase2HeaderGenerator(BaseGenerator):
             handle_info = short_handle_name + 'Info'
             function_info = handle_name + 'Info'
             handle_map = short_handle_name[0].lower() + short_handle_name[1:] + '_map_'
-            add_code += '    void Add{0}(Vulkan{1}&& info) {{ AddObjectInfo(std::move(info), &{2}); }}\n'.format(function_info, handle_info, handle_map)
+            add_code += '    void Add{0}(Vulkan{1}&& info) {{ AddVkObjectInfo(std::move(info), &{2}); }}\n'.format(function_info, handle_info, handle_map)
             remove_code += '    void Remove{0}(format::HandleId id) {{ {1}.erase(id); }}\n'.format(function_info, handle_map)
-            const_get_code += '    const Vulkan{0}* Get{1}(format::HandleId id) const {{ return GetObjectInfo<Vulkan{0}>(id, &{2}); }}\n'.format(handle_info, function_info, handle_map)
-            get_code += '    Vulkan{0}* Get{1}(format::HandleId id) {{ return GetObjectInfo<Vulkan{0}>(id, &{2}); }}\n'.format(handle_info, function_info, handle_map)
+            const_get_code += '    const Vulkan{0}* Get{1}(format::HandleId id) const {{ return GetVkObjectInfo<Vulkan{0}>(id, &{2}); }}\n'.format(handle_info, function_info, handle_map)
+            get_code += '    Vulkan{0}* Get{1}(format::HandleId id) {{ return GetVkObjectInfo<Vulkan{0}>(id, &{2}); }}\n'.format(handle_info, function_info, handle_map)
             visit_code += '    void Visit{0}(std::function<void(const Vulkan{1}*)> visitor) const {{  for (const auto& entry : {2}) {{ visitor(&entry.second); }}  }}\n'.format(function_info, handle_info, handle_map)
             map_code += '     std::unordered_map<format::HandleId, Vulkan{0}> {1};\n'.format(handle_info, handle_map)
 

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -401,9 +401,9 @@ class VulkanReplayConsumerBodyGenerator(
             body += '    if (options_.dumping_resources)\n'
             body += '    {\n'
             if return_type == 'VkResult':
-                body += '        resource_dumper_.Process_{}(call_info, {}, returnValue, {});\n'.format(name, dispatchfunc, dump_resource_arglist)
+                body += '        resource_dumper_->Process_{}(call_info, {}, returnValue, {});\n'.format(name, dispatchfunc, dump_resource_arglist)
             else:
-                body += '        resource_dumper_.Process_{}(call_info, {}, {});\n'.format(name, dispatchfunc, dump_resource_arglist)
+                body += '        resource_dumper_->Process_{}(call_info, {}, {});\n'.format(name, dispatchfunc, dump_resource_arglist)
 
             body += '    }\n'
 

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -298,8 +298,8 @@ class VulkanReplayConsumerBodyGenerator(
                 dispatchfunc = 'GetInstanceTable'
                 if values[0].base_type == 'VkDevice':
                     object_name = 'physical_device'
-                    preexpr.append("DeviceInfo* device_info = GetObjectInfoTable().GetDeviceInfo(device);")
-                    preexpr.append("VkPhysicalDevice             physical_device = device_info->parent;")
+                    preexpr.append("VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(device);")
+                    preexpr.append("VkPhysicalDevice  physical_device = device_info->parent;")
             else:
                 dispatchfunc = 'GetDeviceTable'
 
@@ -385,11 +385,11 @@ class VulkanReplayConsumerBodyGenerator(
                             else:
                                 dump_resource_arglist += 'in_' + val.name
                         elif val.base_type == 'VkPipeline':
-                            dump_resource_arglist += 'GetObjectInfoTable().GetPipelineInfo(pipeline)'
+                            dump_resource_arglist += 'GetObjectInfoTable().GetVkPipelineInfo(pipeline)'
                         elif self.is_handle(val.base_type) and not val.is_pointer and val.base_type == 'VkCommandBuffer':
                             dump_resource_arglist += 'in_' + val.name
                         elif self.is_handle(val.base_type) and not val.is_pointer and val.base_type != 'VkCommandBuffer':
-                            dump_resource_arglist += 'GetObjectInfoTable().Get' + val.base_type[2:] + "Info(" + val.name + ")"
+                            dump_resource_arglist += 'GetObjectInfoTable().Get' + val.base_type + "Info(" + val.name + ")"
                         else:
                             dump_resource_arglist += val.name
                         dump_resource_arglist += ', '
@@ -429,9 +429,9 @@ class VulkanReplayConsumerBodyGenerator(
             handle_value = values[1]
 
         index_id = 'k{}Array{}'.format(handle_value.base_type[2:], name[2:])
-        handle_type = '{}Info'.format(handle_value.base_type[2:])
+        handle_type = 'Vulkan{}Info'.format(handle_value.base_type[2:])
         info_func = '&VulkanObjectInfoTable::Get{}Info'.format(
-            handle_value.base_type[2:]
+            handle_value.base_type
         )
 
         return 'if ({}->IsNull()) {{ SetOutputArrayCount<{}>({}, {}, {}, {}); }}'.format(
@@ -463,9 +463,9 @@ class VulkanReplayConsumerBodyGenerator(
             )
 
         index_id = 'k{}Array{}'.format(handle_value.base_type[2:], name[2:])
-        handle_type = '{}Info'.format(handle_value.base_type[2:])
+        handle_type = 'Vulkan{}Info'.format(handle_value.base_type[2:])
         info_func = '&VulkanObjectInfoTable::Get{}Info'.format(
-            handle_value.base_type[2:]
+            handle_value.base_type
         )
 
         return 'GetOutputArrayCount<{}, {}>("{}", {}, {}, {}, {}, {}, {})'.format(
@@ -576,8 +576,8 @@ class VulkanReplayConsumerBodyGenerator(
                             )
                     elif self.is_handle(value.base_type):
                         # We received an array of 64-bit integer IDs from the decoder.
-                        expr += 'MapHandles<{type}Info>({}, {}, &VulkanObjectInfoTable::Get{type}Info);'.format(
-                            value.name, length_name, type=value.base_type[2:]
+                        expr += 'MapHandles<Vulkan{type}Info>({}, {}, &VulkanObjectInfoTable::Get{base_type}Info);'.format(
+                            value.name, length_name, type=value.base_type[2:], base_type=value.base_type
                         )
                     else:
                         if need_temp_value:
@@ -613,7 +613,7 @@ class VulkanReplayConsumerBodyGenerator(
                                         var_name, value.name
                                     )
                                     preexpr.append(expr)
-                                    expr = 'if (GetObjectInfoTable().GetSurfaceKHRInfo({}->surface) == nullptr || GetObjectInfoTable().GetSurfaceKHRInfo({}->surface)->surface_creation_skipped) {{ return; }}'.format(
+                                    expr = 'if (GetObjectInfoTable().GetVkSurfaceKHRInfo({}->surface) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo({}->surface)->surface_creation_skipped) {{ return; }}'.format(
                                         var_name,
                                         var_name
                                     )
@@ -654,33 +654,34 @@ class VulkanReplayConsumerBodyGenerator(
                                 )
                                 if self.is_pool_allocation(name):
                                     postexpr.append(
-                                        'AddPoolHandles<{pooltype}Info, {basetype}Info>({}, handle_mapping::GetPoolId({}->GetMetaStructPointer()), {paramname}->GetPointer(), {paramname}->GetLength(), {}, {}, &VulkanObjectInfoTable::Get{pooltype}Info, &VulkanObjectInfoTable::Add{basetype}Info);'
+                                        'AddPoolHandles<Vulkan{pooltype}Info, Vulkan{type}Info>({}, handle_mapping::GetPoolId({}->GetMetaStructPointer()), {paramname}->GetPointer(), {paramname}->GetLength(), {}, {}, &VulkanObjectInfoTable::Get{pooltype}Info, &VulkanObjectInfoTable::Add{basetype}Info);'
                                         .format(
                                             self.get_parent_id(value, values),
                                             values[1].name,
                                             arg_name,
                                             length_name,
                                             paramname=value.name,
-                                            basetype=value.base_type[2:],
-                                            pooltype=self.
-                                            POOL_OBJECT_ASSOCIATIONS[
-                                                value.base_type][2:]
+                                            type=value.base_type[2:],
+                                            basetype=value.base_type,
+                                            pooltype=self.POOL_OBJECT_ASSOCIATIONS[value.base_type][2:],
+                                            poolbasetype=self.POOL_OBJECT_ASSOCIATIONS[value.base_type]
                                         )
                                     )
                                 else:
                                     postexpr.append(
-                                        'AddHandles<{basetype}Info>({}, {paramname}->GetPointer(), {paramname}->GetLength(), {}, {}, &VulkanObjectInfoTable::Add{basetype}Info);'
+                                        'AddHandles<Vulkan{type}Info>({}, {paramname}->GetPointer(), {paramname}->GetLength(), {}, {}, &VulkanObjectInfoTable::Add{basetype}Info);'
                                         .format(
                                             self.get_parent_id(value, values),
                                             arg_name,
                                             length_name,
                                             paramname=value.name,
-                                            basetype=value.base_type[2:]
+                                            type=value.base_type[2:],
+                                            basetype=value.base_type
                                         )
                                     )
                             else:
                                 preexpr.append(
-                                    'std::vector<{}Info> handle_info({});'.
+                                    'std::vector<Vulkan{}Info> handle_info({});'.
                                     format(value.base_type[2:], length_name)
                                 )
                                 expr = 'for (size_t i = 0; i < {}; ++i) {{ {}->SetConsumerData(i, &handle_info[i]); }}'.format(
@@ -688,38 +689,40 @@ class VulkanReplayConsumerBodyGenerator(
                                 )
                                 if self.is_pool_allocation(name):
                                     postexpr.append(
-                                        'AddPoolHandles<{pooltype}Info, {basetype}Info>({}, handle_mapping::GetPoolId({}->GetMetaStructPointer()), {paramname}->GetPointer(), {paramname}->GetLength(), {paramname}->GetHandlePointer(), {}, std::move(handle_info), &VulkanObjectInfoTable::Get{pooltype}Info, &VulkanObjectInfoTable::Add{basetype}Info);'
+                                        'AddPoolHandles<Vulkan{pooltype}Info, Vulkan{type}Info>({}, handle_mapping::GetPoolId({}->GetMetaStructPointer()), {paramname}->GetPointer(), {paramname}->GetLength(), {paramname}->GetHandlePointer(), {}, std::move(handle_info), &VulkanObjectInfoTable::Get{poolbasetype}Info, &VulkanObjectInfoTable::Add{basetype}Info);'
                                         .format(
                                             self.get_parent_id(value, values),
                                             values[1].name,
                                             length_name,
                                             paramname=value.name,
-                                            basetype=value.base_type[2:],
-                                            pooltype=self.
-                                            POOL_OBJECT_ASSOCIATIONS[
-                                                value.base_type][2:]
+                                            type=value.base_type[2:],
+                                            basetype=value.base_type,
+                                            pooltype=self.POOL_OBJECT_ASSOCIATIONS[value.base_type][2:],
+                                            poolbasetype=self.POOL_OBJECT_ASSOCIATIONS[value.base_type]   
                                         )
                                     )
                                 else:
                                     # additionally add an asynchronous flavour to postexpr, so both are available later
                                     if name in self.REPLAY_ASYNC_OVERRIDES:
                                         postexpr.append(
-                                            'AddHandlesAsync<{basetype}Info>({}, {paramname}->GetPointer(), {paramname}->GetLength(), std::move(handle_info), &VulkanObjectInfoTable::Add{basetype}Info, std::move(task));'
+                                            'AddHandlesAsync<Vulkan{type}Info>({}, {paramname}->GetPointer(), {paramname}->GetLength(), std::move(handle_info), &VulkanObjectInfoTable::Add{basetype}Info, std::move(task));'
                                             .format(
                                                 self.get_parent_id(value, values),
                                                 arg_name,
                                                 length_name,
                                                 paramname=value.name,
-                                                basetype=value.base_type[2:]
+                                                type=value.base_type[2:],
+                                                basetype=value.base_type
                                             )
                                         )
                                     postexpr.append(
-                                        'AddHandles<{basetype}Info>({}, {paramname}->GetPointer(), {paramname}->GetLength(), {paramname}->GetHandlePointer(), {}, std::move(handle_info), &VulkanObjectInfoTable::Add{basetype}Info);'
+                                        'AddHandles<Vulkan{type}Info>({}, {paramname}->GetPointer(), {paramname}->GetLength(), {paramname}->GetHandlePointer(), {}, std::move(handle_info), &VulkanObjectInfoTable::Add{basetype}Info);'
                                         .format(
                                             self.get_parent_id(value, values),
                                             length_name,
                                             paramname=value.name,
-                                            basetype=value.base_type[2:]
+                                            type=value.base_type[2:],
+                                            basetype=value.base_type
                                         )
                                     )
 
@@ -836,17 +839,18 @@ class VulkanReplayConsumerBodyGenerator(
                                     value.name
                                 )
                                 postexpr.append(
-                                    'AddHandle<{basetype}Info>({}, {}->GetPointer(), {}, &VulkanObjectInfoTable::Add{basetype}Info);'
+                                    'AddHandle<Vulkan{type}Info>({}, {}->GetPointer(), {}, &VulkanObjectInfoTable::Add{basetype}Info);'
                                     .format(
                                         self.get_parent_id(value, values),
                                         value.name,
                                         arg_name,
-                                        basetype=value.base_type[2:]
+                                        type=value.base_type[2:],
+                                        basetype=value.base_type
                                     )
                                 )
                             else:
                                 preexpr.append(
-                                    '{}Info handle_info;'.format(
+                                    'Vulkan{}Info handle_info;'.format(
                                         value.base_type[2:]
                                     )
                                 )
@@ -854,11 +858,12 @@ class VulkanReplayConsumerBodyGenerator(
                                     value.name
                                 )
                                 postexpr.append(
-                                    'AddHandle<{basetype}Info>({}, {paramname}->GetPointer(), {paramname}->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::Add{basetype}Info);'
+                                    'AddHandle<Vulkan{type}Info>({}, {paramname}->GetPointer(), {paramname}->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::Add{basetype}Info);'
                                     .format(
                                         self.get_parent_id(value, values),
                                         paramname=value.name,
-                                        basetype=value.base_type[2:]
+                                        type=value.base_type[2:],
+                                        basetype=value.base_type
                                     )
                                 )
                         else:
@@ -947,7 +952,7 @@ class VulkanReplayConsumerBodyGenerator(
                 if is_override:
                     # We use auto in case the compiler can determine if the value should be const or non-const based on the override function signature.
                     expr = 'auto {} = GetObjectInfoTable().Get{}Info({});'.format(
-                        arg_name, value.base_type[2:], value.name
+                        arg_name, value.base_type, value.name
                     )
                     preexpr.append(expr)
 
@@ -961,23 +966,23 @@ class VulkanReplayConsumerBodyGenerator(
                         preexpr.append(expr)
                 else:
                     expr = '{} {} = '.format(value.full_type, arg_name)
-                    expr += 'MapHandle<{type}Info>({}, &VulkanObjectInfoTable::Get{type}Info);'.format(
-                        value.name, type=value.base_type[2:]
+                    expr += 'MapHandle<Vulkan{type}Info>({}, &VulkanObjectInfoTable::Get{basetype}Info);'.format(
+                        value.name, type=value.base_type[2:], basetype=value.base_type
                     )
                     preexpr.append(expr)
 
                     # If surface was not created, need to automatically ignore for non-overrides queries
                     # Swapchain also need to check if a dummy swapchain was created instead
                     if value.name == "surface":
-                        expr = 'if (GetObjectInfoTable().GetSurfaceKHRInfo({}) == nullptr || GetObjectInfoTable().GetSurfaceKHRInfo({})->surface_creation_skipped) {{ return; }}'.format(
+                        expr = 'if (GetObjectInfoTable().GetVkSurfaceKHRInfo({}) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo({})->surface_creation_skipped) {{ return; }}'.format(
                             value.name,
                             value.name
                         )
                         preexpr.append(expr)
                     elif value.name == "swapchain":
-                        expr = 'if (GetObjectInfoTable().GetSurfaceKHRInfo(GetObjectInfoTable().Get{}Info({})->surface_id) == nullptr || GetObjectInfoTable().GetSurfaceKHRInfo(GetObjectInfoTable().Get{}Info({})->surface_id)->surface_creation_skipped) {{ return; }}'.format(
-                            value.base_type[2:], value.name,
-                            value.base_type[2:], value.name
+                        expr = 'if (GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().Get{}Info({})->surface_id) == nullptr || GetObjectInfoTable().GetVkSurfaceKHRInfo(GetObjectInfoTable().Get{}Info({})->surface_id)->surface_creation_skipped) {{ return; }}'.format(
+                            value.base_type, value.name,
+                            value.base_type, value.name
                         )
                         preexpr.append(expr)
             elif self.is_generic_cmd_handle_value(name, value.name):
@@ -1014,25 +1019,28 @@ class VulkanReplayConsumerBodyGenerator(
                 'vkDestroyInstance', 'vkDestroyDevice'
             ] else values[1]
             if value.base_type not in self.POOL_OBJECT_ASSOCIATIONS:
-                expr = 'RemoveHandle({}, &VulkanObjectInfoTable::Remove{basetype}Info);'.format(
-                    value.name, basetype=value.base_type[2:]
+                expr = 'RemoveHandle({}, &VulkanObjectInfoTable::Remove{}Info);'.format(
+                    value.name, value.base_type
                 )
             else:
                 # Pools require special case processing to cleanup objects allocated from them.
-                expr = 'RemovePoolHandle<{basetype}Info>({}, &VulkanObjectInfoTable::Get{basetype}Info, &VulkanObjectInfoTable::Remove{basetype}Info, &VulkanObjectInfoTable::Remove{}Info);'.format(
+                expr = 'RemovePoolHandle<Vulkan{type}Info>({}, &VulkanObjectInfoTable::Get{basetype}Info, &VulkanObjectInfoTable::Remove{basetype}Info, &VulkanObjectInfoTable::Remove{}Info);'.format(
                     value.name,
-                    self.POOL_OBJECT_ASSOCIATIONS[value.base_type][2:],
-                    basetype=value.base_type[2:]
+                    self.POOL_OBJECT_ASSOCIATIONS[value.base_type],
+                    type=value.base_type[2:],
+                    basetype=value.base_type
                 )
         elif name.startswith('vkFree'):
             # For pool based vkFreeCommandBuffers and vkFreeDescriptorSets, the pool handle is the second parameter, the array count is the third parameter and the array of handles to free is the fourth parameter.
             value = values[3]
-            expr = 'RemovePoolHandles<{pooltype}Info, {basetype}Info>({}, {}, {}, &VulkanObjectInfoTable::Get{pooltype}Info, &VulkanObjectInfoTable::Remove{basetype}Info);'.format(
+            expr = 'RemovePoolHandles<Vulkan{pooltype}Info, Vulkan{type}Info>({}, {}, {}, &VulkanObjectInfoTable::Get{poolbasetype}Info, &VulkanObjectInfoTable::Remove{basetype}Info);'.format(
                 values[1].name,
                 value.name,
                 values[2].name,
-                basetype=value.base_type[2:],
-                pooltype=self.POOL_OBJECT_ASSOCIATIONS[value.base_type][2:]
+                type=value.base_type[2:],
+                basetype=value.base_type,
+                pooltype=self.POOL_OBJECT_ASSOCIATIONS[value.base_type][2:],
+                poolbasetype=self.POOL_OBJECT_ASSOCIATIONS[value.base_type]
             )
 
         return expr

--- a/framework/generated/vulkan_generators/vulkan_state_table_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_state_table_header_generator.py
@@ -107,7 +107,7 @@ class VulkanStateTableHeaderGenerator(BaseGenerator):
                 continue
             handle_name = vkhandle_name[2:]
             wrapper_prefix = self.get_wrapper_prefix_from_type()
-            handle_prefix = self.get_prefix_from_type(vkhandle_name)
+            handle_prefix = self.get_api_prefix()
             handle_wrapper_func = handle_name + 'Wrapper'
             handle_wrapper_type = wrapper_prefix + '::' + handle_name + 'Wrapper'
             handle_map = handle_name[0].lower() + handle_name[1:] + '_map_'

--- a/framework/generated/vulkan_generators/vulkan_state_table_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_state_table_header_generator.py
@@ -107,7 +107,7 @@ class VulkanStateTableHeaderGenerator(BaseGenerator):
                 continue
             handle_name = vkhandle_name[2:]
             wrapper_prefix = self.get_wrapper_prefix_from_type()
-            handle_prefix = self.get_prefix_from_type()
+            handle_prefix = self.get_prefix_from_type(vkhandle_name)
             handle_wrapper_func = handle_name + 'Wrapper'
             handle_wrapper_type = wrapper_prefix + '::' + handle_name + 'Wrapper'
             handle_map = handle_name[0].lower() + handle_name[1:] + '_map_'

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
@@ -89,7 +89,7 @@ class VulkanStructHandleMappersHeaderGenerator(
         BaseGenerator.beginFile(self, gen_opts)
 
         write(
-            '#include "decode/vulkan_object_info_table.h"', file=self.outFile
+            '#include "decode/common_object_info_table.h"', file=self.outFile
         )
         write('#include "decode/vulkan_pnext_node.h"', file=self.outFile)
         write('#include "format/platform_types.h"', file=self.outFile)

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -243,7 +243,7 @@ void VulkanDeviceUtil::RestoreModifiedPhysicalDeviceFeatures()
 void VulkanDeviceUtil::GetReplayDeviceProperties(uint32_t                           instance_api_version,
                                                  const encode::VulkanInstanceTable* instance_table,
                                                  VkPhysicalDevice                   physical_device,
-                                                 decode::ReplayDeviceInfo*          replay_device_info)
+                                                 decode::VulkanReplayDeviceInfo*    replay_device_info)
 {
     GFXRECON_ASSERT(instance_table != nullptr);
     GFXRECON_ASSERT(replay_device_info != nullptr);

--- a/framework/graphics/vulkan_device_util.h
+++ b/framework/graphics/vulkan_device_util.h
@@ -31,7 +31,7 @@
 namespace gfxrecon::decode
 {
 //! forward declaration to avoid cyclic include
-struct ReplayDeviceInfo;
+struct VulkanReplayDeviceInfo;
 } // namespace gfxrecon::decode
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -66,7 +66,7 @@ class VulkanDeviceUtil
     static void GetReplayDeviceProperties(uint32_t                           instance_api_version,
                                           const encode::VulkanInstanceTable* instance_table,
                                           VkPhysicalDevice                   physical_device,
-                                          decode::ReplayDeviceInfo*          replay_device_info);
+                                          decode::VulkanReplayDeviceInfo*    replay_device_info);
 
   private:
     template <typename T>


### PR DESCRIPTION

* Rename Vulkan Info objects and accessors
Other API's may have device, instance, swapchain objects, so qualify Vulkan state with Vulkan or Vk

