### PR TITLE
remove unused FileProcessor functions and simplify file_header usage

### DIFF
--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -40,7 +40,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 const uint32_t kFirstFrame = 0;
 
 FileProcessor::FileProcessor() :
-    file_header_{}, file_descriptor_(nullptr), current_frame_number_(kFirstFrame), bytes_read_(0),
+    file_descriptor_(nullptr), current_frame_number_(kFirstFrame), bytes_read_(0),
     error_state_(kErrorInvalidFileDescriptor), annotation_handler_(nullptr), compressor_(nullptr), block_index_(0),
     api_call_index_(0), block_limit_(0), capture_uses_frame_markers_(false), first_frame_(kFirstFrame + 1)
 {}
@@ -180,17 +180,18 @@ bool FileProcessor::ContinueDecoding()
 
 bool FileProcessor::ProcessFileHeader()
 {
-    bool success = false;
+    bool                                success = false;
+    format::FileHeader                  file_header{};
 
-    if (ReadBytes(&file_header_, sizeof(file_header_)))
+    if (ReadBytes(&file_header, sizeof(file_header)))
     {
-        success = format::ValidateFileHeader(file_header_);
+        success = format::ValidateFileHeader(file_header);
 
         if (success)
         {
-            file_options_.resize(file_header_.num_options);
+            file_options_.resize(file_header.num_options);
 
-            size_t option_data_size = file_header_.num_options * sizeof(format::FileOptionPair);
+            size_t option_data_size = file_header.num_options * sizeof(format::FileOptionPair);
 
             success = ReadBytes(file_options_.data(), option_data_size);
 

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -180,8 +180,8 @@ bool FileProcessor::ContinueDecoding()
 
 bool FileProcessor::ProcessFileHeader()
 {
-    bool                                success = false;
-    format::FileHeader                  file_header{};
+    bool               success = false;
+    format::FileHeader file_header{};
 
     if (ReadBytes(&file_header, sizeof(file_header)))
     {

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -92,8 +92,6 @@ class FileProcessor
     // Returns false if processing failed.  Use GetErrorState() to determine error condition for failure case.
     bool ProcessAllFrames();
 
-    const format::FileHeader& GetFileHeader() const { return file_header_; }
-
     const std::vector<format::FileOptionPair>& GetFileOptions() const { return file_options_; }
 
     uint32_t GetCurrentFrameNumber() const { return current_frame_number_; }
@@ -165,13 +163,10 @@ class FileProcessor
                                        size_t  expected_uncompressed_size,
                                        size_t* uncompressed_buffer_size);
 
-    bool IsFileHeaderValid() const { return (file_header_.fourcc == GFXRECON_FOURCC); }
-
     bool IsFileValid() const { return (file_descriptor_ && !feof(file_descriptor_) && !ferror(file_descriptor_)); }
 
   private:
     std::string                         filename_;
-    format::FileHeader                  file_header_;
     std::vector<format::FileOptionPair> file_options_;
     format::EnabledOptions              enabled_options_;
     std::vector<uint8_t>                parameter_buffer_;

--- a/framework/decode/file_transformer.cpp
+++ b/framework/decode/file_transformer.cpp
@@ -32,7 +32,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 FileTransformer::FileTransformer() :
-    file_header_{}, input_file_(nullptr), output_file_(nullptr), bytes_read_(0), bytes_written_(0),
+    input_file_(nullptr), output_file_(nullptr), bytes_read_(0), bytes_written_(0),
     error_state_(kErrorInvalidFileDescriptor), loading_state_(false)
 {}
 
@@ -161,17 +161,18 @@ bool FileTransformer::Process()
 
 bool FileTransformer::ProcessFileHeader()
 {
-    bool success = false;
+    bool               success = false;
+    format::FileHeader file_header{};
 
-    if (ReadBytes(&file_header_, sizeof(file_header_)))
+    if (ReadBytes(&file_header, sizeof(file_header)))
     {
-        success = format::ValidateFileHeader(file_header_);
+        success = format::ValidateFileHeader(file_header);
 
         if (success)
         {
-            file_options_.resize(file_header_.num_options);
+            file_options_.resize(file_header.num_options);
 
-            size_t option_data_size = file_header_.num_options * sizeof(format::FileOptionPair);
+            size_t option_data_size = file_header.num_options * sizeof(format::FileOptionPair);
 
             success = ReadBytes(file_options_.data(), option_data_size);
 
@@ -196,7 +197,7 @@ bool FileTransformer::ProcessFileHeader()
             if (success)
             {
                 // Write header to output file.
-                success = WriteFileHeader(file_header_, file_options_);
+                success = WriteFileHeader(file_header, file_options_);
             }
         }
         else

--- a/framework/decode/file_transformer.h
+++ b/framework/decode/file_transformer.h
@@ -72,8 +72,6 @@ class FileTransformer
     // Returns false if processing failed.  Use GetErrorState() to determine error condition for failure case.
     bool Process();
 
-    const format::FileHeader& GetFileHeader() const { return file_header_; }
-
     const std::vector<format::FileOptionPair>& GetFileOptions() const { return file_options_; }
 
     uint64_t GetNumBytesRead() const { return bytes_read_; }
@@ -83,8 +81,6 @@ class FileTransformer
     Error GetErrorState() const { return error_state_; }
 
   protected:
-    bool IsFileHeaderValid() const { return (file_header_.fourcc == GFXRECON_FOURCC); }
-
     bool IsFileValid(FILE* fd) const { return ((fd != nullptr) && !feof(fd) && !ferror(fd)); }
 
     bool IsLoadingState() const { return loading_state_; }
@@ -151,7 +147,6 @@ class FileTransformer
     std::string                         tool_;
     FILE*                               input_file_;
     FILE*                               output_file_;
-    format::FileHeader                  file_header_;
     std::vector<format::FileOptionPair> file_options_;
     format::EnabledOptions              enabled_options_;
     uint64_t                            bytes_read_;


### PR DESCRIPTION
Remove two FileProcessor functions that aren't used and bring the member variable they referenced into the one function that used that member.

(Help to simplify #1644)