### PR TITLE
Save swapchain HDR state for trimmed captures

### DIFF
--- a/framework/encode/custom_dx12_wrapper_commands.h
+++ b/framework/encode/custom_dx12_wrapper_commands.h
@@ -774,6 +774,27 @@ struct CustomWrapperPostCall<format::ApiCallId::ApiCall_CreateDXGIFactory2>
     }
 };
 
+template <>
+struct CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain3_SetColorSpace1>
+{
+    template <typename... Args>
+    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_IDXGISwapChain3_SetColorSpace1(args...);
+    }
+};
+
+template <>
+struct CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain4_SetHDRMetaData>
+{
+    template <typename... Args>
+    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_IDXGISwapChain4_SetHDRMetaData(args...);
+    }
+};
+
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -3693,5 +3693,24 @@ D3D12CaptureManager::GetCommandListsForTrimDrawCalls(ID3D12CommandList_Wrapper* 
     return cmd_sets;
 }
 
+void D3D12CaptureManager::PostProcess_IDXGISwapChain3_SetColorSpace1(IDXGISwapChain_Wrapper* wrapper,
+                                                                     HRESULT                 result,
+                                                                     DXGI_COLOR_SPACE_TYPE   ColorSpace)
+{
+    if (IsCaptureModeTrack())
+    {
+        state_tracker_->TrackSetColorSpace1(wrapper, result, ColorSpace);
+    }
+}
+
+void D3D12CaptureManager::PostProcess_IDXGISwapChain4_SetHDRMetaData(
+    IDXGISwapChain_Wrapper* wrapper, HRESULT result, DXGI_HDR_METADATA_TYPE Type, UINT Size, void* pMetaData)
+{
+    if (IsCaptureModeTrack())
+    {
+        state_tracker_->TrackSetHDRMetaData(wrapper, result, Type, Size, pMetaData);
+    }
+}
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -820,6 +820,13 @@ class D3D12CaptureManager : public ApiCaptureManager
     std::vector<graphics::dx12::CommandSet> GetCommandListsForTrimDrawCalls(ID3D12CommandList_Wrapper* wrapper,
                                                                             format::ApiCallId          api_call_id);
 
+    void PostProcess_IDXGISwapChain3_SetColorSpace1(IDXGISwapChain_Wrapper* wrapper,
+                                                    HRESULT                 result,
+                                                    DXGI_COLOR_SPACE_TYPE   ColorSpace);
+
+    void PostProcess_IDXGISwapChain4_SetHDRMetaData(
+        IDXGISwapChain_Wrapper* wrapper, HRESULT result, DXGI_HDR_METADATA_TYPE Type, UINT Size, void* pMetaData);
+
   protected:
     D3D12CaptureManager();
 

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -32,6 +32,7 @@
 
 #include <d3d12.h>
 #include <dxgi.h>
+#include <dxgi1_5.h>
 
 #include <array>
 #include <unordered_set>
@@ -243,6 +244,14 @@ struct IDXGISwapChainInfo : public DxgiWrapperInfo
     uint32_t                         last_presented_image{ std::numeric_limits<uint32_t>::max() };
     std::vector<DxImageAcquiredInfo> image_acquired_info;
     DxResizeBuffersInfo              resize_info;
+
+    // HDR state
+    bool                   set_color_space{ false };
+    bool                   set_hdr_metadata{ false };
+    DXGI_COLOR_SPACE_TYPE  color_space_type{};
+    DXGI_HDR_METADATA_TYPE hdr_metadata_type{};
+    UINT                   hdr_metadata_size{ 0 };
+    void*                  hdr_metadata{ nullptr };
 };
 
 struct IDXGIDeviceInfo : public DxgiWrapperInfo

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -1194,6 +1194,34 @@ Dx12StateTracker::CommitAccelerationStructureCopyInfo(DxAccelerationStructureCop
     return CommitAccelerationStructureBuildInfo(dest_build_info);
 }
 
+void Dx12StateTracker::TrackSetColorSpace1(IDXGISwapChain_Wrapper* wrapper,
+                                           HRESULT                 result,
+                                           DXGI_COLOR_SPACE_TYPE   ColorSpace)
+{
+    GFXRECON_ASSERT(wrapper != nullptr);
+    auto wrapper_info = wrapper->GetObjectInfo();
+
+    wrapper_info->set_color_space  = true;
+    wrapper_info->color_space_type = ColorSpace;
+}
+
+void Dx12StateTracker::TrackSetHDRMetaData(
+    IDXGISwapChain_Wrapper* wrapper, HRESULT result, DXGI_HDR_METADATA_TYPE Type, UINT Size, void* pMetaData)
+{
+    GFXRECON_ASSERT(wrapper != nullptr);
+    auto wrapper_info = wrapper->GetObjectInfo();
+
+    wrapper_info->set_hdr_metadata  = true;
+    wrapper_info->hdr_metadata_type = Type;
+    wrapper_info->hdr_metadata_size = Size;
+
+    if (pMetaData != nullptr)
+    {
+        wrapper_info->hdr_metadata = new char[Size]();
+        memcpy(wrapper_info->hdr_metadata, pMetaData, Size);
+    }
+}
+
 #ifdef GFXRECON_AGS_SUPPORT
 void Dx12StateTracker::TrackAgsCalls(void*                           object_ptr,
                                      format::ApiCallId               call_id,

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -222,6 +222,11 @@ class Dx12StateTracker
 
     bool IsAccelerationStructureResource(format::HandleId id);
 
+    void TrackSetColorSpace1(IDXGISwapChain_Wrapper* wrapper, HRESULT result, DXGI_COLOR_SPACE_TYPE ColorSpace);
+
+    void TrackSetHDRMetaData(
+        IDXGISwapChain_Wrapper* wrapper, HRESULT result, DXGI_HDR_METADATA_TYPE Type, UINT Size, void* pMetaData);
+
 #ifdef GFXRECON_AGS_SUPPORT
     void
     TrackAgsCalls(void* object_ptr, format::ApiCallId call_id, const util::MemoryOutputStream* create_parameter_buffer);

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1307,7 +1307,6 @@ void Dx12StateWriter::WriteSwapChainState(const Dx12StateTable& state_table)
         auto swapchain_info = swapchain_wrapper->GetObjectInfo();
 
         // Write swapchain creation call.
-        // Write swapchain creation call.
         StandardCreateWrite(swapchain_wrapper);
 
         // Write swapchain set color space for HDR

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1307,7 +1307,32 @@ void Dx12StateWriter::WriteSwapChainState(const Dx12StateTable& state_table)
         auto swapchain_info = swapchain_wrapper->GetObjectInfo();
 
         // Write swapchain creation call.
+        // Write swapchain creation call.
         StandardCreateWrite(swapchain_wrapper);
+
+        // Write swapchain set color space for HDR
+        if (swapchain_info->set_color_space)
+        {
+            encoder_.EncodeEnumValue(swapchain_info->color_space_type);
+            encoder_.EncodeInt32Value(S_OK);
+            WriteMethodCall(format::ApiCallId::ApiCall_IDXGISwapChain3_SetColorSpace1,
+                            swapchain_wrapper->GetCaptureId(),
+                            &parameter_stream_);
+            parameter_stream_.Clear();
+        }
+
+        // Write swapchain set hdr metadata for HDR
+        if (swapchain_info->set_hdr_metadata)
+        {
+            encoder_.EncodeEnumValue(swapchain_info->hdr_metadata_type);
+            encoder_.EncodeUInt32Value(swapchain_info->hdr_metadata_size);
+            encoder_.EncodeVoidArray(swapchain_info->hdr_metadata, swapchain_info->hdr_metadata_size);
+            encoder_.EncodeInt32Value(S_OK);
+            WriteMethodCall(format::ApiCallId::ApiCall_IDXGISwapChain4_SetHDRMetaData,
+                            swapchain_wrapper->GetCaptureId(),
+                            &parameter_stream_);
+            parameter_stream_.Clear();
+        }
 
         // Write call to resize the swapchain buffers.
         if (swapchain_info->resize_info.call_id != format::ApiCall_Unknown)


### PR DESCRIPTION
**Problem**
Trimmed traces did not replay in HDR mode, but full ones do.

**Solution**
Track `SetColorSpace1` and `SetHDRMetaData` during capture if trimming is enabled. Then write it out to file so that replay can properly setup HDR as it was during live app.

**Testing**
Trimmed trace replays in HDR mode.