### PR TITLE
Support Multiple AGS contexts

### DIFF
--- a/framework/decode/custom_ags_replay_consumer.h
+++ b/framework/decode/custom_ags_replay_consumer.h
@@ -116,9 +116,8 @@ class AgsReplayConsumer : public AgsConsumerBase
                            AGSDriverVersionResult capture_result,
                            AGSDriverVersionResult replay_result);
 
-    AGSContext*             captured_context_{ nullptr };
-    AGSContext*             current_context_{ nullptr };
-    Dx12ReplayConsumerBase* dx12_replay_consumer_{ nullptr };
+    std::map<AGSContext*, AGSContext*> context_map_; // Map of captured context to current context
+    Dx12ReplayConsumerBase*            dx12_replay_consumer_{ nullptr };
 };
 
 GFXRECON_END_NAMESPACE(decode)


### PR DESCRIPTION
Application could create multiple AGS contexts.
But only use one of them to create device.
GFXR have to track the contexts.