### PR TITLE
Have AGS device creation honor desired adapter

### DIFF
--- a/framework/decode/custom_ags_replay_consumer.cpp
+++ b/framework/decode/custom_ags_replay_consumer.cpp
@@ -179,14 +179,12 @@ void AgsReplayConsumer::Process_agsDriverExtensionsDX12_CreateDevice(
 
     if (ValidateAgsInputs(context))
     {
-        IDXGIAdapter* current_adapter = nullptr;
-
-        current_adapter = dx12_replay_consumer_->MapObject<IDXGIAdapter>(
-            reinterpret_cast<gfxrecon::format::HandleId>(creationParams->pAdapter));
+        IDXGIAdapter* current_adapter = dx12_replay_consumer_->GetAdapter();
 
         if (current_adapter == nullptr)
         {
-            current_adapter = dx12_replay_consumer_->GetAdapter();
+            current_adapter = dx12_replay_consumer_->MapObject<IDXGIAdapter>(
+                reinterpret_cast<gfxrecon::format::HandleId>(creationParams->pAdapter));
         }
 
         creationParams->pAdapter = current_adapter;


### PR DESCRIPTION
**Problem**
The `-gpu` option was always selecting GPU 0 when replaying an AGS capture

**Solution**
When creating an AGS device, make the AGS replay consumer honor the adapter coming from `GetAdapter()`

**Testing**
Replaying an AGS trace with `-gpu 1` for example ran on the correct GPU