### PR TITLE
Have info tool expose SubSysId during GPU enumeration

### DIFF
--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -694,7 +694,7 @@ static bool CheckOptionEnumGpuIndices(const char* exe_name, const gfxrecon::util
             gfxrecon::graphics::dx12::ActiveAdapterMap adapters{};
             gfxrecon::graphics::dx12::TrackAdapters(result, reinterpret_cast<void**>(&factory1), adapters);
 
-            GFXRECON_WRITE_CONSOLE("GPU index\tGPU name");
+            GFXRECON_WRITE_CONSOLE("GPU index\tGPU name\tSubSys ID");
             for (size_t index = 0; index < adapters.size(); ++index)
             {
                 for (auto adapter : adapters)
@@ -704,7 +704,10 @@ static bool CheckOptionEnumGpuIndices(const char* exe_name, const gfxrecon::util
                         std::string replay_adapter_str =
                             gfxrecon::util::WCharArrayToString(adapter.second.internal_desc.Description);
 
-                        GFXRECON_WRITE_CONSOLE("%-9x\t%s", adapter.second.adapter_idx, replay_adapter_str.c_str());
+                        GFXRECON_WRITE_CONSOLE("%-9x\t%s\t%u",
+                                               adapter.second.adapter_idx,
+                                               replay_adapter_str.c_str(),
+                                               adapter.second.internal_desc.SubSysId);
                         adapter.second.adapter->Release();
                         break;
                     }

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2020-2024 LunarG, Inc.
-** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
**Problem**
If there are multiple of the same GPUs on a system, using info tool to identify the right GPU isn't straight forward

**Solution**
Expose `SubSysId` beside each enumerated adapter. For some reason DXGI is showing the same adapter twice, so with this change we can identify their uniqueness.

**Testing**
Before (2-GPU system):
```
GPU index       GPU name
0               AMD Radeon RX 7900 XTX
1               AMD Radeon RX 7900 XTX
2               AMD Radeon RX 7900 XTX
3               Microsoft Basic Render Driver
```

After (2-GPU system):
```
GPU index       GPU name                        SubSysId
0               AMD Radeon RX 7900 XTX          123456
1               AMD Radeon RX 7900 XTX          ABCDEF
2               AMD Radeon RX 7900 XTX          123456
3               Microsoft Basic Render Driver   0
```
