### PR TITLE
Fix crash in CreateCommandList1 when trimming

### DIFF
--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -449,13 +449,16 @@ void Dx12StateTracker::TrackCommandListCreation(ID3D12CommandList_Wrapper* list_
                                                 D3D12_COMMAND_LIST_TYPE    command_list_type,
                                                 ID3D12CommandAllocator*    pCommandAllocator)
 {
-    auto cmd_alloc_wrapper       = reinterpret_cast<ID3D12CommandAllocator_Wrapper*>(pCommandAllocator);
-
     auto list_info               = list_wrapper->GetObjectInfo();
     list_info->is_closed         = created_closed;
     list_info->command_list_type = command_list_type;
-    list_info->create_command_allocator_id   = GetDx12WrappedId(pCommandAllocator);
-    list_info->create_command_allocator_info = cmd_alloc_wrapper->GetObjectInfo();
+
+    if (pCommandAllocator != nullptr)
+    {
+        auto cmd_alloc_wrapper                   = reinterpret_cast<ID3D12CommandAllocator_Wrapper*>(pCommandAllocator);
+        list_info->create_command_allocator_id   = cmd_alloc_wrapper->GetCaptureId();
+        list_info->create_command_allocator_info = cmd_alloc_wrapper->GetObjectInfo();
+    }
 }
 
 void Dx12StateTracker::TrackDescriptorCreation(ID3D12Device_Wrapper*           create_object_wrapper,


### PR DESCRIPTION
`CreateCommandList1` creates a command list without an allocator so `pCommandAllocator` is nullptr in
`Dx12StateTracker::TrackCommandListCreation`