### PR TITLE
Fix vkGetQueryPoolResults timeout loop

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3365,8 +3365,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetQueryPoolResults(PFN_vkGetQueryPoo
     do
     {
         result = func(device, query_pool, firstQuery, queryCount, dataSize, pData->GetOutputPointer(), stride, flags);
-    } while ((((original_result == VK_SUCCESS) && (result == VK_NOT_READY)) ||
-              ((original_result == VK_NOT_READY) && (result == VK_SUCCESS))) &&
+    } while (((original_result == VK_SUCCESS) && (result == VK_NOT_READY)) &&
              (++retries <= kMaxQueryPoolResultsRetries));
 
     return result;


### PR DESCRIPTION
Retry when capture was `SUCCESS` and replay is `NOT_READY`. Continue in all other cases, including when capture was `NOT_READY` and replay is `SUCCESS`.

Might solve #1800 as well?