### PR TITLE
A handful of interface changes to support OpenXR future rebasing

### DIFF
--- a/framework/decode/dx_replay_options.h
+++ b/framework/decode/dx_replay_options.h
@@ -56,13 +56,7 @@ struct DxReplayOptions : public ReplayOptions
     bool                 override_object_names{ false };
     bool                 enable_dump_resources{ false };
     DumpResourcesTarget  dump_resources_target{};
-
-    util::ScreenshotFormat       screenshot_format{ util::ScreenshotFormat::kBmp };
-    std::vector<ScreenshotRange> screenshot_ranges;
-    std::string                  screenshot_dir;
-    std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
-    std::string                  replace_dir;
-    int32_t                      memory_usage{ kDefaultBatchingMemoryUsage };
+    int32_t              memory_usage{ kDefaultBatchingMemoryUsage };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -41,27 +41,34 @@ struct ScreenshotRange
 
 struct ReplayOptions
 {
-    bool        enable_validation_layer{ false };
-    bool        sync_queue_submissions{ false };
-    bool        enable_debug_device_lost{ false };
-    bool        create_dummy_allocations{ false };
-    bool        omit_null_hardware_buffers{ false };
-    bool        quit_after_measurement_frame_range{ false };
-    bool        flush_measurement_frame_range{ false };
-    bool        flush_inside_measurement_range{ false };
-    bool        force_windowed{ false };
-    uint32_t    windowed_width{ 0 };
-    uint32_t    windowed_height{ 0 };
-    bool        force_windowed_origin{ false };
-    int32_t     window_topleft_x{ 0 };
-    int32_t     window_topleft_y{ 0 };
-    int32_t     override_gpu_index{ -1 };
-    std::string capture_filename;
-    bool        enable_print_block_info{ false };
-    int64_t     block_index_from{ -1 };
-    int64_t     block_index_to{ -1 };
-    int32_t     num_pipeline_creation_jobs{ 0 };
-    std::string asset_file_path;
+    bool                         enable_validation_layer{ false };
+    bool                         sync_queue_submissions{ false };
+    bool                         enable_debug_device_lost{ false };
+    bool                         create_dummy_allocations{ false };
+    bool                         omit_null_hardware_buffers{ false };
+    bool                         quit_after_measurement_frame_range{ false };
+    bool                         flush_measurement_frame_range{ false };
+    bool                         flush_inside_measurement_range{ false };
+    bool                         force_windowed{ false };
+    uint32_t                     windowed_width{ 0 };
+    uint32_t                     windowed_height{ 0 };
+    bool                         force_windowed_origin{ false };
+    int32_t                      window_topleft_x{ 0 };
+    int32_t                      window_topleft_y{ 0 };
+    int32_t                      override_gpu_index{ -1 };
+    std::string                  capture_filename;
+    bool                         enable_print_block_info{ false };
+    int64_t                      block_index_from{ -1 };
+    int64_t                      block_index_to{ -1 };
+    bool                         skip_failed_allocations{ false };
+    bool                         remove_unsupported_features{ false };
+    util::ScreenshotFormat       screenshot_format{ util::ScreenshotFormat::kBmp };
+    std::vector<ScreenshotRange> screenshot_ranges;
+    std::string                  screenshot_dir;
+    std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
+    uint32_t                     screenshot_width, screenshot_height;
+    int32_t                      num_pipeline_creation_jobs{ 0 };
+    std::string                  asset_file_path;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/struct_pointer_decoder.h
+++ b/framework/decode/struct_pointer_decoder.h
@@ -248,7 +248,10 @@ class StructPointerDecoder<T*> : public PointerDecoderBase
 
                     typename T::struct_type* inner_struct_memory =
                         DecodeAllocator::Allocate<typename T::struct_type>(inner_lens_[i]);
-                    T* inner_decoded_structs = DecodeAllocator::Allocate<T>(inner_lens_[i]);
+                    // TODO: We initialize == true because the nexe field isn't always cleared on kIsNull in the lower
+                    //       level decoders.  If this is a performance bottleneck, can clean up the lower decoders to
+                    //       initialize all fields.
+                    T* inner_decoded_structs = DecodeAllocator::Allocate<T>(inner_lens_[i], true);
 
                     for (size_t j = 0; j < inner_lens_[i]; ++j)
                     {

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -288,6 +288,16 @@ struct VulkanPhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 
     // Closest matching replay device.
     VulkanReplayDeviceInfo* replay_device_info{ nullptr };
+
+    // Because Vulkan captures unwrapped handles, and layered APIs (like OpenXR)
+    // capture wrapped handles, during replay two HandleId values will reference
+    // the same VkPhysical device.  The vulkan_alias is the handleId as known by
+    // the vulkan_consumers, which will be created/updated, etc, by all Vulkan replay
+    // calls, s.t. the information known by the vulkan_consumer need not be duplicated.
+    // Operations on this, will use the vulkan_alias as the effective HandleId when set.
+
+    // When Non-null, the GetVkObject will recur on the alias Id
+    format::HandleId vulkan_alias{ format::kNullHandleId };
 };
 
 struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>

--- a/framework/decode/vulkan_object_info_table_base.h
+++ b/framework/decode/vulkan_object_info_table_base.h
@@ -32,6 +32,7 @@
 
 #include <cassert>
 #include <functional>
+#include <type_traits>
 #include <unordered_map>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -48,6 +49,72 @@ struct has_handle_future<T, decltype((void)T::future, 0)>
 
 template <typename T>
 inline constexpr bool has_handle_future_v = has_handle_future<T>::value;
+
+// NOTE: There's nothing VulkanSpecific in these utilities
+// TODO: Find a better home for these
+
+// Utility functors to implement const and non-const versions of getters in a common impl
+template <typename Container>
+using ConstCorrectMappedTypePtr = decltype(&(std::declval<Container>().begin()->second));
+
+struct ObjectInfoGetterBase
+{
+    template <typename Map, typename MappedTypePtr>
+    MappedTypePtr GetObjectInfoImpl(format::HandleId id, Map* map)
+    {
+        assert(map != nullptr);
+
+        MappedTypePtr object_info = nullptr;
+
+        if (id != 0)
+        {
+            const auto entry = map->find(id);
+
+            if (entry != map->end())
+            {
+                object_info = &entry->second;
+            }
+        }
+
+        return object_info;
+    }
+    template <typename Map, typename MappedTypePtr>
+    MappedTypePtr GetAliasingObjectInfoImpl(format::HandleId id, Map* map)
+    {
+        MappedTypePtr object_info = GetObjectInfoImpl<Map, MappedTypePtr>(id, map);
+        if (object_info && (object_info->vulkan_alias != format::kNullHandleId))
+        {
+            object_info = GetObjectInfoImpl<Map, MappedTypePtr>(object_info->vulkan_alias, map);
+            // Note: if id has an alias and the alias is valid, the alias must not alias. Aliasing is single level.
+            assert(!object_info || (object_info->vulkan_alias == format::kNullHandleId));
+        }
+        return object_info;
+    }
+};
+
+// Because of " explicit specialization in non-namespace scope" these must be implemented outside the class below
+template <typename T>
+struct ObjectInfoGetter : public ObjectInfoGetterBase
+{
+    template <typename Map, typename MappedTypePtr = ConstCorrectMappedTypePtr<Map>>
+    MappedTypePtr operator()(format::HandleId id, Map* map)
+    {
+        return GetObjectInfoImpl<Map, MappedTypePtr>(id, map);
+    }
+};
+
+// Specialize to handle physical device aliasing. See comments for VulkanPhysicalDeviceInfo::vulkan_alias
+// Note: could do SFINAE a "has member" check on vulkan_alias, but as only physical device needs aliasing support at
+//       this time, it's simpler just to specialize for VulkanPhysicalDeviceInfo
+template <>
+struct ObjectInfoGetter<VulkanPhysicalDeviceInfo> : public ObjectInfoGetterBase
+{
+    template <typename Map, typename MappedTypePtr = ConstCorrectMappedTypePtr<Map>>
+    MappedTypePtr operator()(format::HandleId id, Map* map)
+    {
+        return GetAliasingObjectInfoImpl<Map, MappedTypePtr>(id, map);
+    }
+};
 
 class VulkanObjectInfoTableBase
 {
@@ -132,41 +199,13 @@ class VulkanObjectInfoTableBase
     template <typename T>
     const T* GetVkObjectInfo(format::HandleId id, const std::unordered_map<format::HandleId, T>* map) const
     {
-        assert(map != nullptr);
-
-        const T* object_info = nullptr;
-
-        if (id != 0)
-        {
-            const auto entry = map->find(id);
-
-            if (entry != map->end())
-            {
-                object_info = &entry->second;
-            }
-        }
-
-        return object_info;
+        return ObjectInfoGetter<T>()(id, map);
     }
 
     template <typename T>
     T* GetVkObjectInfo(format::HandleId id, std::unordered_map<format::HandleId, T>* map)
     {
-        assert(map != nullptr);
-
-        T* object_info = nullptr;
-
-        if (id != 0)
-        {
-            auto entry = map->find(id);
-
-            if (entry != map->end())
-            {
-                object_info = &entry->second;
-            }
-        }
-
-        return object_info;
+        return ObjectInfoGetter<T>()(id, map);
     }
 };
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5794,7 +5794,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
            (pShaderModule != nullptr) && !pShaderModule->IsNull());
 
     auto original_info = pCreateInfo->GetPointer();
-    if (original_result < 0 || options_.replace_dir.empty())
+    if (original_result < 0 || options_.replace_shader_dir.empty())
     {
         VkResult vk_res = func(
             device_info->handle, original_info, GetAllocationCallbacks(pAllocator), pShaderModule->GetHandlePointer());
@@ -5833,7 +5833,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
     const size_t            orig_size = original_info->codeSize;
     uint64_t                handle_id = *pShaderModule->GetPointer();
     std::string             file_name = "sh" + std::to_string(handle_id);
-    std::string             file_path = util::filepath::Join(options_.replace_dir, file_name);
+    std::string             file_path = util::filepath::Join(options_.replace_shader_dir, file_name);
 
     FILE*   fp     = nullptr;
     int32_t result = util::platform::FileOpen(&fp, file_path.c_str(), "rb");
@@ -9746,7 +9746,7 @@ void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
                     uint64_t    handle_id   = pipelines[i];
                     std::string file_name =
                         "sh" + std::to_string(handle_id) + "_" + std::to_string(stage_create_info.stage);
-                    std::string file_path = util::filepath::Join(options_.replace_dir, file_name);
+                    std::string file_path = util::filepath::Join(options_.replace_shader_dir, file_name);
 
                     FILE*   fp     = nullptr;
                     int32_t result = util::platform::FileOpen(&fp, file_path.c_str(), "rb");
@@ -9794,7 +9794,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateGraphicsPipelines(
     std::vector<std::unique_ptr<char[]>> replaced_file_code;
     auto*                                maybe_replaced_create_infos = in_p_create_infos;
 
-    if (original_result >= 0 && !options_.replace_dir.empty())
+    if (original_result >= 0 && !options_.replace_shader_dir.empty())
     {
         uint32_t num_bytes = graphics::vulkan_struct_deep_copy(in_p_create_infos, create_info_count, nullptr);
         create_info_data.resize(num_bytes);
@@ -9885,7 +9885,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateComputePipelines(
         size_t      orig_size   = create_info->codeSize;
         uint64_t    handle_id   = shaders[i];
         std::string file_name   = "sh" + std::to_string(handle_id);
-        std::string file_path   = util::filepath::Join(options_.replace_dir, file_name);
+        std::string file_path   = util::filepath::Join(options_.replace_shader_dir, file_name);
 
         FILE*   fp     = nullptr;
         int32_t result = util::platform::FileOpen(&fp, file_path.c_str(), "rb");
@@ -9927,7 +9927,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShadersEXT(
     std::vector<std::unique_ptr<char[]>> replaced_file_code;
     auto*                                maybe_replaced_create_infos = in_p_create_infos;
 
-    if (original_result >= 0 && !options_.replace_dir.empty())
+    if (original_result >= 0 && !options_.replace_shader_dir.empty())
     {
         uint32_t num_bytes = graphics::vulkan_struct_deep_copy(in_p_create_infos, create_info_count, nullptr);
         create_info_data.resize(num_bytes);
@@ -10098,7 +10098,7 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
         auto                    create_infos = reinterpret_cast<VkGraphicsPipelineCreateInfo*>(create_info_data.data());
 
         std::vector<std::unique_ptr<char[]>> replaced_file_code;
-        if (returnValue >= 0 && !options_.replace_dir.empty())
+        if (returnValue >= 0 && !options_.replace_shader_dir.empty())
         {
             replaced_file_code = ReplaceShaders(createInfoCount, create_infos, pipelines.data());
         }
@@ -10233,7 +10233,7 @@ VulkanReplayConsumerBase::AsyncCreateShadersEXT(const ApiCallInfo&              
         auto                     create_infos = reinterpret_cast<VkShaderCreateInfoEXT*>(create_info_data.data());
 
         std::vector<std::unique_ptr<char[]>> replaced_file_code;
-        if (returnValue >= 0 && !options_.replace_dir.empty())
+        if (returnValue >= 0 && !options_.replace_shader_dir.empty())
         {
             replaced_file_code = ReplaceShaders(createInfoCount, create_infos, shaders.data());
         }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1270,6 +1270,41 @@ void VulkanReplayConsumerBase::CheckReplayDeviceInfo(VulkanPhysicalDeviceInfo* p
     }
 }
 
+// Needed to support physical device aliasing. See comments for VulkanPhysicalDeviceInfo::vulkan_alias
+void VulkanReplayConsumerBase::SetPhysicalDeviceAlias(format::HandleId          instance,
+                                                      VulkanPhysicalDeviceInfo& replay_physical_device)
+{
+    if ((replay_physical_device.capture_id == format::kNullHandleId) ||
+        (replay_physical_device.handle == VK_NULL_HANDLE))
+    {
+        return;
+    }
+
+    const format::HandleId match_id     = replay_physical_device.capture_id;
+    const VkPhysicalDevice match_handle = replay_physical_device.handle;
+
+    auto instance_info = object_info_table_->GetVkInstanceInfo(instance);
+    assert(instance_info);
+
+    for (const format::HandleId capture_device : instance_info->capture_devices)
+    {
+        const VulkanPhysicalDeviceInfo* physical_device_info =
+            GetObjectInfoTable().GetVkPhysicalDeviceInfo(capture_device);
+        if (!physical_device_info || (physical_device_info->vulkan_alias != format::kNullHandleId))
+        {
+            continue; // only single depth aliasing
+        }
+
+        const format::HandleId& capture_id = physical_device_info->capture_id;
+        const VkPhysicalDevice& handle     = physical_device_info->handle;
+        if ((handle == match_handle) && (capture_id != match_id))
+        {
+            replay_physical_device.vulkan_alias = capture_id;
+            break;
+        }
+    }
+}
+
 void VulkanReplayConsumerBase::SetPhysicalDeviceInstanceInfo(VulkanInstanceInfo*       instance_info,
                                                              VulkanPhysicalDeviceInfo* physical_device_info,
                                                              VkPhysicalDevice          replay_device)
@@ -1570,6 +1605,13 @@ bool VulkanReplayConsumerBase::GetOverrideDeviceGroup(VulkanInstanceInfo*       
     GFXRECON_LOG_INFO("  Specified device is: %s", override_device_name.c_str());
 
     return true;
+}
+
+void VulkanReplayConsumerBase::GetMatchingDevice(VulkanPhysicalDeviceInfo* physical_device_info)
+{
+    VulkanInstanceInfo* instance_info = object_info_table_->GetVkInstanceInfo(physical_device_info->parent_id);
+    assert(instance_info);
+    GetMatchingDevice(instance_info, physical_device_info);
 }
 
 void VulkanReplayConsumerBase::GetMatchingDevice(VulkanInstanceInfo*       instance_info,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -240,6 +240,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     const encode::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
 
     const encode::VulkanDeviceTable* GetDeviceTable(const void* handle) const;
+    void AddImageHandle(format::HandleId parent_id, format::HandleId id, VkImage handle, VulkanImageInfo&& initial_info)
+    {
+        AddHandle<VulkanImageInfo>(
+            parent_id, &id, &handle, std::move(initial_info), &VulkanObjectInfoTable::AddVkImageInfo);
+    }
 
   protected:
     const CommonObjectInfoTable& GetObjectInfoTable() const { return *object_info_table_; }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -297,6 +297,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         return get_instance_proc_addr_;
     }
 
+    void SetPhysicalDeviceAlias(format::HandleId instance, VulkanPhysicalDeviceInfo& replay_physical_device);
+
+    // Need the side effects from this when creating vulkan devices from OpenXr
+    void GetMatchingDevice(VulkanPhysicalDeviceInfo* physical_device_info);
+
   protected:
     const CommonObjectInfoTable& GetObjectInfoTable() const { return *object_info_table_; }
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -237,14 +237,14 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         return MapHandle<VulkanDeviceInfo>(capture_id, &CommonObjectInfoTable::GetVkDeviceInfo);
     }
 
+    const encode::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
+
+    const encode::VulkanDeviceTable* GetDeviceTable(const void* handle) const;
+
   protected:
     const CommonObjectInfoTable& GetObjectInfoTable() const { return *object_info_table_; }
 
     CommonObjectInfoTable& GetObjectInfoTable() { return *object_info_table_; }
-
-    const encode::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
-
-    const encode::VulkanDeviceTable* GetDeviceTable(const void* handle) const;
 
     void* PreProcessExternalObject(uint64_t object_id, format::ApiCallId call_id, const char* call_name);
 

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -57,9 +57,7 @@ static constexpr int kUnspecifiedColorAttachment = -1;
 struct VulkanReplayOptions : public ReplayOptions
 {
     bool                         enable_vulkan{ true };
-    bool                         skip_failed_allocations{ false };
     bool                         omit_pipeline_cache_data{ false };
-    bool                         remove_unsupported_features{ false };
     bool                         use_colorspace_fallback{ false };
     bool                         offscreen_swapchain_frame_boundary{ false };
     util::SwapchainOption        swapchain_option{ util::SwapchainOption::kVirtual };
@@ -67,13 +65,9 @@ struct VulkanReplayOptions : public ReplayOptions
     int32_t                      override_gpu_group_index{ -1 };
     int32_t                      surface_index{ -1 };
     CreateResourceAllocator      create_resource_allocator;
-    util::ScreenshotFormat       screenshot_format{ util::ScreenshotFormat::kBmp };
-    std::vector<ScreenshotRange> screenshot_ranges;
-    std::string                  screenshot_dir;
-    std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
     uint32_t                     screenshot_width, screenshot_height;
     float                        screenshot_scale;
-    std::string                  replace_dir;
+    std::string                  replace_shader_dir;
     SkipGetFenceStatus           skip_get_fence_status{ SkipGetFenceStatus::NoSkip };
     std::vector<util::UintRange> skip_get_fence_ranges;
     bool                         wait_before_present{ false };

--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -186,6 +186,7 @@ class ApiCaptureManager
     bool                              IsTrimEnabled() const { return common_manager_->IsTrimEnabled(); }
     uint32_t                          GetCurrentFrame() const { return common_manager_->GetCurrentFrame(); }
     CommonCaptureManager::CaptureMode GetCaptureMode() const { return common_manager_->GetCaptureMode(); }
+    void SetCaptureMode(CommonCaptureManager::CaptureMode mode) { common_manager_->SetCaptureMode(mode); }
     bool                              GetDebugLayerSetting() const { return common_manager_->GetDebugLayerSetting(); }
     bool GetDebugDeviceLostSetting() const { return common_manager_->GetDebugDeviceLostSetting(); }
     bool GetDisableDxrSetting() const { return common_manager_->GetDisableDxrSetting(); }

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -260,6 +260,7 @@ class CommonCaptureManager
     bool                                IsTrimEnabled() const { return trim_enabled_; }
     uint32_t                            GetCurrentFrame() const { return current_frame_; }
     CaptureMode                         GetCaptureMode() const { return capture_mode_; }
+    void                                SetCaptureMode(CaptureMode new_mode) { capture_mode_ = new_mode; }
     bool                                GetDebugLayerSetting() const { return debug_layer_; }
     bool                                GetDebugDeviceLostSetting() const { return debug_device_lost_; }
     bool                                GetDisableDxrSetting() const { return disable_dxr_; }

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -133,8 +133,8 @@ void android_main(struct android_app* app)
                     return;
                 }
 
-                gfxrecon::decode::VulkanReplayConsumer replay_consumer(application, replay_options);
-                gfxrecon::decode::VulkanDecoder        decoder;
+                gfxrecon::decode::VulkanReplayConsumer vulkan_replay_consumer(application, replay_options);
+                gfxrecon::decode::VulkanDecoder        vulkan_decoder;
                 uint32_t                               start_frame, end_frame;
                 bool        has_mfr = GetMeasurementFrameRange(arg_parser, start_frame, end_frame);
                 std::string measurement_file_name;
@@ -153,12 +153,13 @@ void android_main(struct android_app* app)
                                                      replay_options.preload_measurement_range,
                                                      measurement_file_name);
 
-                replay_consumer.SetFatalErrorHandler([](const char* message) { throw std::runtime_error(message); });
-                replay_consumer.SetFpsInfo(&fps_info);
+                vulkan_replay_consumer.SetFatalErrorHandler(
+                    [](const char* message) { throw std::runtime_error(message); });
+                vulkan_replay_consumer.SetFpsInfo(&fps_info);
 
-                decoder.AddConsumer(&replay_consumer);
+                vulkan_decoder.AddConsumer(&vulkan_replay_consumer);
 
-                file_processor->AddDecoder(&decoder);
+                file_processor->AddDecoder(&vulkan_decoder);
 
                 application->SetPauseFrame(GetPauseFrame(arg_parser));
 

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -1019,7 +1019,7 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
         replay_options.virtual_swapchain_skip_blit = true;
     }
 
-    replay_options.replace_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);
+    replay_options.replace_shader_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);
     replay_options.create_resource_allocator =
         GetCreateResourceAllocatorFunc(arg_parser, filename, replay_options, tracked_object_info_table);
 


### PR DESCRIPTION
    Add needed decoder and interface extensions
    Add interface to get/set capture mode
    Expose dispatch table getters
    Add initialize to StructPointerDecoder allocation
    Add vulkan guard to consumer and decode variables
    Split OverrideCreateInstance/Device
    Add VkPhysicalDevice aliasing support
    Reorganize common options

Not sure if these will interfere with @panos-lunarg  pending changes, will wait if needed