### PR TITLE
Clear CachedPSO data for CreatePipelineState replay

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -741,6 +741,12 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                Decoded_GUID                                                     riid,
                                                HandlePointerDecoder<void*>* pipelineState);
 
+    HRESULT OverrideCreatePipelineState(DxObjectInfo* device_object_info,
+                                        HRESULT       original_result,
+                                        StructPointerDecoder<Decoded_D3D12_PIPELINE_STATE_STREAM_DESC>* pDesc,
+                                        Decoded_GUID                                                    riid,
+                                        HandlePointerDecoder<void*>* ppPipelineState);
+
     HRESULT OverrideSetFullscreenState(DxObjectInfo* swapchain_info,
                                        HRESULT       original_result,
                                        BOOL          Fullscreen,

--- a/framework/generated/dx12_generators/replay_overrides.json
+++ b/framework/generated/dx12_generators/replay_overrides.json
@@ -39,6 +39,9 @@
     "ID3D12Device1": {
       "CreatePipelineLibrary": "OverrideCreatePipelineLibrary"
     },
+    "ID3D12Device2": {
+      "CreatePipelineState": "OverrideCreatePipelineState"
+    },
     "ID3D12Device3": {
       "EnqueueMakeResident": "OverrideEnqueueMakeResident",
       "OpenExistingHeapFromAddress": "OverrideOpenExistingHeapFromAddress"

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -10214,14 +10214,16 @@ void Dx12ReplayConsumer::Process_ID3D12Device2_CreatePipelineState(
             ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
-        auto out_p_ppPipelineState    = ppPipelineState->GetPointer();
-        auto out_hp_ppPipelineState   = ppPipelineState->GetHandlePointer();
-        auto replay_result = reinterpret_cast<ID3D12Device2*>(replay_object->object)->CreatePipelineState(pDesc->GetPointer(),
-                                                                                                          *riid.decoded_value,
-                                                                                                          out_hp_ppPipelineState);
+        DxObjectInfo object_info_ppPipelineState{};
+        ppPipelineState->SetConsumerData(0, &object_info_ppPipelineState);
+        auto replay_result = OverrideCreatePipelineState(replay_object,
+                                                         return_value,
+                                                         pDesc,
+                                                         riid,
+                                                         ppPipelineState);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppPipelineState, out_hp_ppPipelineState, format::ApiCall_ID3D12Device2_CreatePipelineState);
+            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info_ppPipelineState), format::ApiCall_ID3D12Device2_CreatePipelineState);
         }
         CheckReplayResult("ID3D12Device2_CreatePipelineState", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device2_CreatePipelineState>::Dispatch(


### PR DESCRIPTION
When the replay --use-cached-psos option is not specified, clear the cached PSO data from the ID3D12Device2::CreatePipelineState parameters, similar to what is currently done for the ID3D12Device CreateComputePipelineState and CreateGraphicsPipelineState methods.