### PR TITLE
Add VulkanDirectAllocator

### DIFF
--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -235,9 +235,13 @@ class VulkanResourceAllocator
                                                        const ResourceData*                    allocator_resource_datas,
                                                        const MemoryData* allocator_memory_datas) = 0;
 
-    // Direct allocation methods that perform memory allocation and resource creation without performing memory
-    // translation.  These methods allow the replay tool to allocate staging resources through the resource allocator so
-    // that the allocator is aware of all allocations performed at replay.
+    // Direct allocation methods allocate memory and create resources without performing memory translation, while using
+    // the replay memory type of the current allocator implementation.
+    //
+    // Replay allocates staging resources, which were not created during capture, for operations such as screenshot
+    // creation and resource initialization during the initial state setup for trimmed files. Allocating staging
+    // resources through the resource allocator allows the resource allocator to be aware of all memory allocations
+    // performed for replay.
     virtual VkResult CreateBufferDirect(const VkBufferCreateInfo*    create_info,
                                         const VkAllocationCallbacks* allocation_callbacks,
                                         VkBuffer*                    buffer,


### PR DESCRIPTION
Here's my attempt at simplifying the `VulkanResourceAllocator` interface by extracting `*Direct` functions into a separate class `VulkanDirectAllocator`.

This is one option: `VulkanResourceAllocator` subclasses, just need to implement `GetDirectAllocator()`.

Currently, `VulkanDirectAllocator` is just a copy of `VulkanDefaultAllocator`. If we want to keep it decoupled by the other allocators, it can evolve separately.

Another option might be having `VulkanDirectAllocator` accept a pointer to the concrete allocator, and make all direct functions forward their arguments to the concrete allocator. E.g.:

```c++
class VulkanDirectAllocator {
    VulkanResourceAllocator& alloc_;

    VkResult CreateBuffer(const VkBufferCreateInfo*    create_info,
                          const VkAllocationCallbacks* allocation_callbacks,
                          VkBuffer*                    buffer,
                          ResourceData*                allocator_data)
    {
        return alloc_.CrateBuffer(create_info, allocation_callbacks, format::kNullHandleId, buffer, allocator_data);
    }
}
```

Closes #1824