### PR TITLE
Dump root parameters, insted of descriptor heap

### DIFF
--- a/framework/decode/custom_dx12_replay_commands.h
+++ b/framework/decode/custom_dx12_replay_commands.h
@@ -75,6 +75,16 @@ struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateConsta
 };
 
 template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateSampler>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12Device_CreateSampler(args...);
+    }
+};
+
+template <>
 struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateShaderResourceView>
 {
     template <typename... Args>

--- a/framework/decode/dx12_dump_resources.h
+++ b/framework/decode/dx12_dump_resources.h
@@ -163,8 +163,19 @@ class Dx12DumpResourcesDelegate
     virtual void WriteSingleData(const std::vector<std::pair<std::string, int32_t>>& json_path,
                                  const std::string&                                  key,
                                  const std::string&                                  value)                                                          = 0;
-    virtual void WriteEmptyNode(const std::vector<std::pair<std::string, int32_t>>& json_path)                      = 0;
     virtual void WriteNote(const std::vector<std::pair<std::string, int32_t>>& json_path, const std::string& value) = 0;
+    virtual void WriteRootParameterInfo(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                        uint32_t                                            root_parameter_index,
+                                        const TrackRootParameter&                           root_parameter)                                 = 0;
+    virtual void WriteNotFoundView(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                   format::HandleId                                    heap_id,
+                                   uint32_t                                            heap_index)                                                             = 0;
+    virtual void WriteNULLResource(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                   format::HandleId                                    heap_id,
+                                   uint32_t                                            heap_index)                                                             = 0;
+    virtual void WriteNULLBufferLocation(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                         format::HandleId                                    heap_id,
+                                         uint32_t                                            heap_index)                                                       = 0;
 };
 
 class DefaultDx12DumpResourcesDelegate : public Dx12DumpResourcesDelegate
@@ -185,9 +196,20 @@ class DefaultDx12DumpResourcesDelegate : public Dx12DumpResourcesDelegate
     virtual void WriteSingleData(const std::vector<std::pair<std::string, int32_t>>& json_path,
                                  const std::string&                                  key,
                                  const std::string&                                  value) override;
-    virtual void WriteEmptyNode(const std::vector<std::pair<std::string, int32_t>>& json_path) override;
     virtual void WriteNote(const std::vector<std::pair<std::string, int32_t>>& json_path,
                            const std::string&                                  value) override;
+    virtual void WriteRootParameterInfo(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                        uint32_t                                            root_parameter_index,
+                                        const TrackRootParameter&                           root_parameter) override;
+    virtual void WriteNotFoundView(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                   format::HandleId                                    heap_id,
+                                   uint32_t                                            heap_index) override;
+    virtual void WriteNULLResource(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                   format::HandleId                                    heap_id,
+                                   uint32_t                                            heap_index) override;
+    virtual void WriteNULLBufferLocation(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                         format::HandleId                                    heap_id,
+                                         uint32_t                                            heap_index) override;
 
   private:
     void WriteResource(const CopyResourceDataPtr resource_data);
@@ -200,7 +222,7 @@ class DefaultDx12DumpResourcesDelegate : public Dx12DumpResourcesDelegate
     void WriteBlockStart();
     void WriteBlockEnd();
 
-    nlohmann::ordered_json* FindDrawCallJsonPath(const std::vector<std::pair<std::string, int32_t>>& json_path);
+    nlohmann::ordered_json* FindDrawCallJsonNode(const std::vector<std::pair<std::string, int32_t>>& json_path);
 
     constexpr const char* NameDrawCall() const { return "draw_call"; }
     constexpr const char* NameNotes() const { return "notes"; }
@@ -299,7 +321,7 @@ class Dx12DumpResources
                                const std::vector<format::HandleId>& front_command_list_ids,
                                graphics::dx12::Dx12DumpResourcePos  pos);
 
-    void CopyDrawCallResourceByGPUVA(DxObjectInfo*                                       queue_object_info,
+    bool CopyDrawCallResourceByGPUVA(DxObjectInfo*                                       queue_object_info,
                                      const std::vector<format::HandleId>&                front_command_list_ids,
                                      D3D12_GPU_VIRTUAL_ADDRESS                           capture_source_gpu_va,
                                      uint64_t                                            source_size,
@@ -309,7 +331,7 @@ class Dx12DumpResources
                                      format::HandleId                                    descriptor_heap_id,
                                      uint32_t                                            descriptor_heap_index);
 
-    void CopyDrawCallResourceBySubresource(DxObjectInfo*                                       queue_object_info,
+    bool CopyDrawCallResourceBySubresource(DxObjectInfo*                                       queue_object_info,
                                            const std::vector<format::HandleId>&                front_command_list_ids,
                                            format::HandleId                                    source_resource_id,
                                            uint64_t                                            source_offset,

--- a/framework/decode/dx12_dump_resources.h
+++ b/framework/decode/dx12_dump_resources.h
@@ -269,6 +269,10 @@ class Dx12DumpResources
                          StructPointerDecoder<Decoded_D3D12_RENDER_PASS_DEPTH_STENCIL_DESC>* pDepthStencil,
                          D3D12_RENDER_PASS_FLAGS                                             Flags,
                          uint64_t                                                            block_index);
+    void GetDescriptorSubresourceIndices(DHShaderResourceViewInfo& info, const DxObjectInfo* resource);
+    void GetDescriptorSubresourceIndices(DHUnorderedAccessViewInfo& info, const DxObjectInfo* resource);
+    void GetDescriptorSubresourceIndices(DHRenderTargetViewInfo& info, const DxObjectInfo* resource);
+    void GetDescriptorSubresourceIndices(DHDepthStencilViewInfo& info, const DxObjectInfo* resource);
 
   private:
     void StartDump(ID3D12Device* device, const std::string& filename);

--- a/framework/decode/dx12_dump_resources.h
+++ b/framework/decode/dx12_dump_resources.h
@@ -56,6 +56,8 @@ enum class Dx12DumpResourceType : uint32_t
     kCbv,
     kExecuteIndirectArg,
     kExecuteIndirectCount,
+    kGraphicsRootParameters,
+    kComputeRootParameters,
 };
 
 struct CopyResourceData
@@ -152,6 +154,17 @@ class Dx12DumpResourcesDelegate
     virtual void BeginDumpResources(const std::string& filename, const TrackDumpResources& track_dump_resources) = 0;
     virtual void DumpResource(CopyResourceDataPtr resource_data)                                                 = 0;
     virtual void EndDumpResources()                                                                              = 0;
+    virtual void WriteSingleData(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                 const std::string&                                  key,
+                                 uint64_t                                            value)                                                                    = 0;
+    virtual void WriteSingleData(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                 const uint32_t                                      index,
+                                 uint64_t                                            value)                                                                    = 0;
+    virtual void WriteSingleData(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                 const std::string&                                  key,
+                                 const std::string&                                  value)                                                          = 0;
+    virtual void WriteEmptyNode(const std::vector<std::pair<std::string, int32_t>>& json_path)                      = 0;
+    virtual void WriteNote(const std::vector<std::pair<std::string, int32_t>>& json_path, const std::string& value) = 0;
 };
 
 class DefaultDx12DumpResourcesDelegate : public Dx12DumpResourcesDelegate
@@ -163,6 +176,18 @@ class DefaultDx12DumpResourcesDelegate : public Dx12DumpResourcesDelegate
                                     const TrackDumpResources& track_dump_resources) override;
     virtual void DumpResource(CopyResourceDataPtr resource_data) override;
     virtual void EndDumpResources() override;
+    virtual void WriteSingleData(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                 const std::string&                                  key,
+                                 uint64_t                                            value) override;
+    virtual void WriteSingleData(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                 const uint32_t                                      index,
+                                 uint64_t                                            value) override;
+    virtual void WriteSingleData(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                 const std::string&                                  key,
+                                 const std::string&                                  value) override;
+    virtual void WriteEmptyNode(const std::vector<std::pair<std::string, int32_t>>& json_path) override;
+    virtual void WriteNote(const std::vector<std::pair<std::string, int32_t>>& json_path,
+                           const std::string&                                  value) override;
 
   private:
     void WriteResource(const CopyResourceDataPtr resource_data);
@@ -175,7 +200,10 @@ class DefaultDx12DumpResourcesDelegate : public Dx12DumpResourcesDelegate
     void WriteBlockStart();
     void WriteBlockEnd();
 
+    nlohmann::ordered_json* FindDrawCallJsonPath(const std::vector<std::pair<std::string, int32_t>>& json_path);
+
     constexpr const char* NameDrawCall() const { return "draw_call"; }
+    constexpr const char* NameNotes() const { return "notes"; }
 
     bool WriteBinaryFile(const std::string& filename, const std::vector<uint8_t>& data, uint64_t offset, uint64_t size);
 
@@ -246,6 +274,22 @@ class Dx12DumpResources
     void StartDump(ID3D12Device* device, const std::string& filename);
     void FinishDump(DxObjectInfo* queue_object_info);
     void CloseDump();
+
+    void WriteDescripotTable(DxObjectInfo*                                queue_object_info,
+                             const std::vector<format::HandleId>&         front_command_list_ids,
+                             graphics::dx12::Dx12DumpResourcePos          pos,
+                             std::vector<std::pair<std::string, int32_t>> json_path,
+                             const D3D12DescriptorHeapInfo*               heap_info,
+                             format::HandleId                             heap_id,
+                             uint32_t                                     heap_index,
+                             const D3D12_DESCRIPTOR_RANGE1*               range);
+
+    void WriteRootParameters(DxObjectInfo*                                           queue_object_info,
+                             const std::vector<format::HandleId>&                    front_command_list_ids,
+                             graphics::dx12::Dx12DumpResourcePos                     pos,
+                             Dx12DumpResourceType                                    res_type,
+                             const std::vector<format::HandleId>&                    descriptor_heap_ids,
+                             const std::unordered_map<uint32_t, TrackRootParameter>& root_parameters);
 
     void CopyDrawCallResources(DxObjectInfo*                        queue_object_info,
                                const std::vector<format::HandleId>& front_command_list_ids,

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -299,7 +299,7 @@ struct DHShaderResourceViewInfo
     bool                            is_desc_null{ false };
     format::HandleId                resource_id{ format::kNullHandleId };
     D3D12_CPU_DESCRIPTOR_HANDLE     replay_handle{ kNullCpuAddress };
-    std::vector<uint32_t>           subresource_indices;
+    std::vector<uint32_t>           subresource_indices; // Only use for dump resources
 };
 
 struct DHUnorderedAccessViewInfo
@@ -309,7 +309,7 @@ struct DHUnorderedAccessViewInfo
     format::HandleId                 resource_id{ format::kNullHandleId };
     format::HandleId                 counter_resource_id{ format::kNullHandleId };
     D3D12_CPU_DESCRIPTOR_HANDLE      replay_handle{ kNullCpuAddress };
-    std::vector<uint32_t>            subresource_indices;
+    std::vector<uint32_t>            subresource_indices; // Only use for dump resources
 };
 
 struct DHCbvSrvUavInfo
@@ -326,7 +326,7 @@ struct DHRenderTargetViewInfo
     D3D12_RENDER_TARGET_VIEW_DESC desc{};
     bool                          is_desc_null{ false };
     D3D12_CPU_DESCRIPTOR_HANDLE   replay_handle{ kNullCpuAddress };
-    std::vector<uint32_t>         subresource_indices;
+    std::vector<uint32_t>         subresource_indices; // Only use for dump resources
 };
 
 struct DHDepthStencilViewInfo
@@ -335,7 +335,7 @@ struct DHDepthStencilViewInfo
     D3D12_DEPTH_STENCIL_VIEW_DESC desc{};
     bool                          is_desc_null{ false };
     D3D12_CPU_DESCRIPTOR_HANDLE   replay_handle{ kNullCpuAddress };
-    std::vector<uint32_t>         subresource_indices;
+    std::vector<uint32_t>         subresource_indices; // Only use for dump resources
 };
 
 struct DHSamplerInfo

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -50,8 +50,6 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 constexpr size_t   kNullCpuAddress = 0;
 constexpr uint64_t kNullGpuAddress = 0;
 
-typedef std::array<UINT, D3D12_DESCRIPTOR_HEAP_TYPE_NUM_TYPES> DescriptorIncrements;
-
 enum class DxObjectInfoType : uint32_t
 {
     kUnused = 0,
@@ -286,47 +284,64 @@ struct D3D12DeviceInfo : DxObjectExtraInfo
     bool is_uma{ false };
 };
 
-struct ConstantBufferInfo
+// Constant Buffer View, Shader Resource View and Unordered Access View could overrride each other.
+// So they should be in the one container.
+struct DHConstantBufferViewInfo
 {
-    D3D12_CONSTANT_BUFFER_VIEW_DESC captured_view{};
+    D3D12_CONSTANT_BUFFER_VIEW_DESC captured_desc{};
+    bool                            is_desc_null{ false };
     D3D12_CPU_DESCRIPTOR_HANDLE     replay_handle{ kNullCpuAddress };
 };
 
-struct ShaderResourceInfo
+struct DHShaderResourceViewInfo
 {
+    D3D12_SHADER_RESOURCE_VIEW_DESC desc{};
+    bool                            is_desc_null{ false };
     format::HandleId                resource_id{ format::kNullHandleId };
-    D3D12_SHADER_RESOURCE_VIEW_DESC view{};
-    bool                            is_view_null{ false };
     D3D12_CPU_DESCRIPTOR_HANDLE     replay_handle{ kNullCpuAddress };
     std::vector<uint32_t>           subresource_indices;
 };
 
-struct UnorderedAccessInfo
+struct DHUnorderedAccessViewInfo
 {
+    D3D12_UNORDERED_ACCESS_VIEW_DESC desc{};
+    bool                             is_desc_null{ false };
     format::HandleId                 resource_id{ format::kNullHandleId };
     format::HandleId                 counter_resource_id{ format::kNullHandleId };
-    D3D12_UNORDERED_ACCESS_VIEW_DESC view{};
-    bool                             is_view_null{ false };
     D3D12_CPU_DESCRIPTOR_HANDLE      replay_handle{ kNullCpuAddress };
     std::vector<uint32_t>            subresource_indices;
 };
 
-struct RenderTargetInfo
+struct DHCbvSrvUavInfo
+{
+    D3D12_DESCRIPTOR_RANGE_TYPE type{};
+    DHConstantBufferViewInfo    cbv;
+    DHShaderResourceViewInfo    srv;
+    DHUnorderedAccessViewInfo   uav;
+};
+
+struct DHRenderTargetViewInfo
 {
     format::HandleId              resource_id{ format::kNullHandleId };
-    D3D12_RENDER_TARGET_VIEW_DESC view{};
-    bool                          is_view_null{ false };
+    D3D12_RENDER_TARGET_VIEW_DESC desc{};
+    bool                          is_desc_null{ false };
     D3D12_CPU_DESCRIPTOR_HANDLE   replay_handle{ kNullCpuAddress };
     std::vector<uint32_t>         subresource_indices;
 };
 
-struct DepthStencilInfo
+struct DHDepthStencilViewInfo
 {
     format::HandleId              resource_id{ format::kNullHandleId };
-    D3D12_DEPTH_STENCIL_VIEW_DESC view{};
-    bool                          is_view_null{ false };
+    D3D12_DEPTH_STENCIL_VIEW_DESC desc{};
+    bool                          is_desc_null{ false };
     D3D12_CPU_DESCRIPTOR_HANDLE   replay_handle{ kNullCpuAddress };
     std::vector<uint32_t>         subresource_indices;
+};
+
+struct DHSamplerInfo
+{
+    D3D12_SAMPLER_DESC          desc{};
+    D3D12_CPU_DESCRIPTOR_HANDLE replay_handle{ kNullCpuAddress };
 };
 
 struct D3D12DescriptorHeapInfo : DxObjectExtraInfo
@@ -344,11 +359,10 @@ struct D3D12DescriptorHeapInfo : DxObjectExtraInfo
     uint64_t                              replay_gpu_addr_begin{ kNullGpuAddress };
 
     // Descriptor info maps. Key is descriptor's uint32_t heap index.
-    std::map<uint32_t, ConstantBufferInfo>  constant_buffer_infos;
-    std::map<uint32_t, ShaderResourceInfo>  shader_resource_infos;
-    std::map<uint32_t, UnorderedAccessInfo> unordered_access_infos;
-    std::map<uint32_t, RenderTargetInfo>    render_target_infos;
-    std::map<uint32_t, DepthStencilInfo>    depth_stencil_infos;
+    std::map<uint32_t, DHCbvSrvUavInfo>        cbv_srv_uav_infos;
+    std::map<uint32_t, DHRenderTargetViewInfo> rtv_infos;
+    std::map<uint32_t, DHDepthStencilViewInfo> dsv_infos;
+    std::map<uint32_t, DHSamplerInfo>          sampler_infos;
 };
 
 struct D3D12FenceInfo : DxObjectExtraInfo

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -4475,7 +4475,6 @@ void Dx12ReplayConsumerBase::PreCall_ID3D12Device_CreateConstantBufferView(
 {
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
-
     GFXRECON_ASSERT(pDesc != nullptr);
     auto desc = pDesc->GetMetaStructPointer();
 
@@ -4484,10 +4483,11 @@ void Dx12ReplayConsumerBase::PreCall_ID3D12Device_CreateConstantBufferView(
         // The decoded D3D12_CONSTANT_BUFFER_VIEW_DESC pointer from pDesc is an optional parameter in the API
         // ID3D12Device::CreateConstantBufferView. In this case, the meta struct pointer returned from the
         // StructPointerDecoder could be null, so check for it.
-        ConstantBufferInfo info;
-        info.captured_view = *(desc->decoded_value);
+        DHCbvSrvUavInfo info;
+        info.type              = D3D12_DESCRIPTOR_RANGE_TYPE_CBV;
+        info.cbv.captured_desc = *(desc->decoded_value);
 
-        heap_extra_info->constant_buffer_infos[DestDescriptor.index] = std::move(info);
+        heap_extra_info->cbv_srv_uav_infos[DestDescriptor.index] = std::move(info);
     }
 }
 
@@ -4500,7 +4500,24 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateConstantBufferView(
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
 
-    heap_extra_info->constant_buffer_infos[DestDescriptor.index].replay_handle = (*DestDescriptor.decoded_value);
+    heap_extra_info->cbv_srv_uav_infos[DestDescriptor.index].cbv.replay_handle = (*DestDescriptor.decoded_value);
+}
+
+void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateSampler(
+    const ApiCallInfo&                                call_info,
+    DxObjectInfo*                                     object_info,
+    StructPointerDecoder<Decoded_D3D12_SAMPLER_DESC>* pDesc,
+    Decoded_D3D12_CPU_DESCRIPTOR_HANDLE               DestDescriptor)
+{
+    auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
+    auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+    GFXRECON_ASSERT(pDesc != nullptr);
+    auto desc = pDesc->GetMetaStructPointer();
+
+    DHSamplerInfo info;
+    info.desc                                            = *(desc->decoded_value);
+    info.replay_handle                                   = (*DestDescriptor.decoded_value);
+    heap_extra_info->sampler_infos[DestDescriptor.index] = std::move(info);
 }
 
 std::vector<uint32_t> GetDescriptorSubresourceIndices(uint32_t first_mip_slice,
@@ -4533,32 +4550,34 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
 
-    ShaderResourceInfo info;
-    info.resource_id   = pResource;
-    info.replay_handle = *DestDescriptor.decoded_value;
+    DHCbvSrvUavInfo info;
+    info.type              = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    auto& srv_info         = info.srv;
+    srv_info.resource_id   = pResource;
+    srv_info.replay_handle = *DestDescriptor.decoded_value;
     if (pDesc->IsNull())
     {
-        info.is_view_null = true;
-        info.subresource_indices.emplace_back(0);
+        srv_info.is_desc_null = true;
+        srv_info.subresource_indices.emplace_back(0);
     }
     else
     {
-        info.view         = *(pDesc->GetMetaStructPointer()->decoded_value);
-        info.is_view_null = false;
+        srv_info.desc     = *(pDesc->GetMetaStructPointer()->decoded_value);
+        srv_info.is_desc_null = false;
 
         if (pResource != format::kNullHandleId)
         {
             auto desc        = reinterpret_cast<ID3D12Resource*>(GetObjectInfo(pResource)->object)->GetDesc();
             auto mip_count   = desc.MipLevels;
             auto array_count = desc.DepthOrArraySize;
-            switch (info.view.ViewDimension)
+            switch (srv_info.desc.ViewDimension)
             {
                 case D3D12_SRV_DIMENSION_BUFFER:
-                    info.subresource_indices.emplace_back(0);
+                    srv_info.subresource_indices.emplace_back(0);
                     break;
                 case D3D12_SRV_DIMENSION_TEXTURE1D:
                 {
-                    auto view     = info.view.Texture1D;
+                    auto view     = srv_info.desc.Texture1D;
                     auto mip_size = view.MipLevels;
                     if (mip_size == -1)
                     {
@@ -4570,20 +4589,20 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                         {
                             mip_size -= view.MostDetailedMip;
                         }
-                        info.subresource_indices = GetDescriptorSubresourceIndices(
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(
                             view.MostDetailedMip, mip_size, mip_count, 0, 1, array_count, 0);
                     }
                     else
                     {
                         mip_size -= view.MostDetailedMip;
-                        info.subresource_indices = GetDescriptorSubresourceIndices(
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(
                             view.ResourceMinLODClamp, mip_size, mip_count, 0, 1, array_count, 0);
                     }
                     break;
                 }
                 case D3D12_SRV_DIMENSION_TEXTURE1DARRAY:
                 {
-                    auto view     = info.view.Texture1DArray;
+                    auto view     = srv_info.desc.Texture1DArray;
                     auto mip_size = view.MipLevels;
                     if (mip_size == -1)
                     {
@@ -4600,30 +4619,30 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                         {
                             mip_size -= view.MostDetailedMip;
                         }
-                        info.subresource_indices = GetDescriptorSubresourceIndices(view.MostDetailedMip,
-                                                                                   mip_size,
-                                                                                   mip_count,
-                                                                                   view.FirstArraySlice,
-                                                                                   array_size,
-                                                                                   array_count,
-                                                                                   0);
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(view.MostDetailedMip,
+                                                                                            mip_size,
+                                                                                            mip_count,
+                                                                                            view.FirstArraySlice,
+                                                                                            array_size,
+                                                                                            array_count,
+                                                                                            0);
                     }
                     else
                     {
                         mip_size -= view.MostDetailedMip;
-                        info.subresource_indices = GetDescriptorSubresourceIndices(view.ResourceMinLODClamp,
-                                                                                   mip_size,
-                                                                                   mip_count,
-                                                                                   view.FirstArraySlice,
-                                                                                   array_size,
-                                                                                   array_count,
-                                                                                   0);
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(view.ResourceMinLODClamp,
+                                                                                            mip_size,
+                                                                                            mip_count,
+                                                                                            view.FirstArraySlice,
+                                                                                            array_size,
+                                                                                            array_count,
+                                                                                            0);
                     }
                     break;
                 }
                 case D3D12_SRV_DIMENSION_TEXTURE2D:
                 {
-                    auto view     = info.view.Texture2D;
+                    auto view     = srv_info.desc.Texture2D;
                     auto mip_size = view.MipLevels;
                     if (mip_size == -1)
                     {
@@ -4635,20 +4654,20 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                         {
                             mip_size -= view.MostDetailedMip;
                         }
-                        info.subresource_indices = GetDescriptorSubresourceIndices(
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(
                             view.MostDetailedMip, mip_size, mip_count, 0, 1, array_count, view.PlaneSlice);
                     }
                     else
                     {
                         mip_size -= view.MostDetailedMip;
-                        info.subresource_indices = GetDescriptorSubresourceIndices(
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(
                             view.ResourceMinLODClamp, mip_size, mip_count, 0, 1, array_count, view.PlaneSlice);
                     }
                     break;
                 }
                 case D3D12_SRV_DIMENSION_TEXTURE2DARRAY:
                 {
-                    auto view     = info.view.Texture2DArray;
+                    auto view     = srv_info.desc.Texture2DArray;
                     auto mip_size = view.MipLevels;
                     if (mip_size == -1)
                     {
@@ -4665,48 +4684,49 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                         {
                             mip_size -= view.MostDetailedMip;
                         }
-                        info.subresource_indices = GetDescriptorSubresourceIndices(view.MostDetailedMip,
-                                                                                   mip_size,
-                                                                                   mip_count,
-                                                                                   view.FirstArraySlice,
-                                                                                   array_size,
-                                                                                   array_count,
-                                                                                   view.PlaneSlice);
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(view.MostDetailedMip,
+                                                                                            mip_size,
+                                                                                            mip_count,
+                                                                                            view.FirstArraySlice,
+                                                                                            array_size,
+                                                                                            array_count,
+                                                                                            view.PlaneSlice);
                     }
                     else
                     {
                         mip_size -= view.MostDetailedMip;
-                        info.subresource_indices = GetDescriptorSubresourceIndices(view.ResourceMinLODClamp,
-                                                                                   mip_size,
-                                                                                   mip_count,
-                                                                                   view.FirstArraySlice,
-                                                                                   array_size,
-                                                                                   array_count,
-                                                                                   view.PlaneSlice);
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(view.ResourceMinLODClamp,
+                                                                                            mip_size,
+                                                                                            mip_count,
+                                                                                            view.FirstArraySlice,
+                                                                                            array_size,
+                                                                                            array_count,
+                                                                                            view.PlaneSlice);
                     }
                     break;
                 }
                 case D3D12_SRV_DIMENSION_TEXTURE2DMS:
                 {
-                    info.subresource_indices = GetDescriptorSubresourceIndices(0, 1, mip_count, 0, 1, array_count, 0);
+                    srv_info.subresource_indices =
+                        GetDescriptorSubresourceIndices(0, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 }
                 case D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY:
                 {
-                    auto view       = info.view.Texture2DMSArray;
+                    auto view       = srv_info.desc.Texture2DMSArray;
                     auto array_size = view.ArraySize;
                     if (array_size == -1)
                     {
                         array_size = array_count;
                     }
-                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                    srv_info.subresource_indices = GetDescriptorSubresourceIndices(
                         0, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
                 }
                 case D3D12_SRV_DIMENSION_TEXTURE3D:
                 {
                     array_count   = 1;
-                    auto view     = info.view.Texture3D;
+                    auto view     = srv_info.desc.Texture3D;
                     auto mip_size = view.MipLevels;
                     if (mip_size == -1)
                     {
@@ -4718,19 +4738,19 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                         {
                             mip_size -= view.MostDetailedMip;
                         }
-                        info.subresource_indices = GetDescriptorSubresourceIndices(
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(
                             view.MostDetailedMip, mip_size, mip_count, 0, 1, array_count, 0);
                     }
                     else
                     {
-                        info.subresource_indices = GetDescriptorSubresourceIndices(
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(
                             view.ResourceMinLODClamp, mip_size, mip_count, 0, 1, array_count, 0);
                     }
                     break;
                 }
                 case D3D12_SRV_DIMENSION_TEXTURECUBE:
                 {
-                    auto view     = info.view.TextureCube;
+                    auto view     = srv_info.desc.TextureCube;
                     auto mip_size = view.MipLevels;
                     if (mip_size == -1)
                     {
@@ -4742,19 +4762,19 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                         {
                             mip_size -= view.MostDetailedMip;
                         }
-                        info.subresource_indices = GetDescriptorSubresourceIndices(
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(
                             view.MostDetailedMip, mip_size, mip_count, 0, 1, array_count, 0);
                     }
                     else
                     {
-                        info.subresource_indices = GetDescriptorSubresourceIndices(
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(
                             view.ResourceMinLODClamp, mip_size, mip_count, 0, 1, array_count, 0);
                     }
                     break;
                 }
                 case D3D12_SRV_DIMENSION_TEXTURECUBEARRAY:
                 {
-                    auto view     = info.view.TextureCubeArray;
+                    auto view     = srv_info.desc.TextureCubeArray;
                     auto mip_size = view.MipLevels;
                     if (mip_size == -1)
                     {
@@ -4771,23 +4791,23 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                         {
                             mip_size -= view.MostDetailedMip;
                         }
-                        info.subresource_indices = GetDescriptorSubresourceIndices(view.MostDetailedMip,
-                                                                                   mip_size,
-                                                                                   mip_count,
-                                                                                   view.First2DArrayFace,
-                                                                                   array_size,
-                                                                                   array_count,
-                                                                                   0);
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(view.MostDetailedMip,
+                                                                                            mip_size,
+                                                                                            mip_count,
+                                                                                            view.First2DArrayFace,
+                                                                                            array_size,
+                                                                                            array_count,
+                                                                                            0);
                     }
                     else
                     {
-                        info.subresource_indices = GetDescriptorSubresourceIndices(view.ResourceMinLODClamp,
-                                                                                   mip_size,
-                                                                                   mip_count,
-                                                                                   view.First2DArrayFace,
-                                                                                   array_size,
-                                                                                   array_count,
-                                                                                   0);
+                        srv_info.subresource_indices = GetDescriptorSubresourceIndices(view.ResourceMinLODClamp,
+                                                                                            mip_size,
+                                                                                            mip_count,
+                                                                                            view.First2DArrayFace,
+                                                                                            array_size,
+                                                                                            array_count,
+                                                                                            0);
                     }
                     break;
                 }
@@ -4798,7 +4818,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
             }
         }
     }
-    heap_extra_info->shader_resource_infos[DestDescriptor.index] = std::move(info);
+    heap_extra_info->cbv_srv_uav_infos[DestDescriptor.index] = std::move(info);
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateUnorderedAccessView(
@@ -4812,82 +4832,91 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateUnorderedAccessView(
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
 
-    UnorderedAccessInfo info;
-    info.resource_id         = pResource;
-    info.counter_resource_id = pCounterResource;
-    info.replay_handle       = *DestDescriptor.decoded_value;
+    DHCbvSrvUavInfo info;
+    info.type                    = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
+    auto& uav_info               = info.uav;
+    uav_info.resource_id         = pResource;
+    uav_info.counter_resource_id = pCounterResource;
+    uav_info.replay_handle       = *DestDescriptor.decoded_value;
     if (pDesc->IsNull())
     {
-        info.is_view_null = true;
-        info.subresource_indices.emplace_back(0);
+        uav_info.is_desc_null = true;
+        uav_info.subresource_indices.emplace_back(0);
     }
     else
     {
-        info.view         = *(pDesc->GetMetaStructPointer()->decoded_value);
-        info.is_view_null = false;
+        uav_info.desc         = *(pDesc->GetMetaStructPointer()->decoded_value);
+        uav_info.is_desc_null = false;
 
         if (pResource != format::kNullHandleId)
         {
             auto desc        = reinterpret_cast<ID3D12Resource*>(GetObjectInfo(pResource)->object)->GetDesc();
             auto mip_count   = desc.MipLevels;
             auto array_count = desc.DepthOrArraySize;
-            switch (info.view.ViewDimension)
+            switch (uav_info.desc.ViewDimension)
             {
                 case D3D12_UAV_DIMENSION_BUFFER:
-                    info.subresource_indices.emplace_back(0);
+                    uav_info.subresource_indices.emplace_back(0);
                     break;
                 case D3D12_UAV_DIMENSION_TEXTURE1D:
-                    info.subresource_indices = GetDescriptorSubresourceIndices(
-                        info.view.Texture1D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
+                    uav_info.subresource_indices = GetDescriptorSubresourceIndices(
+                        uav_info.desc.Texture1D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_UAV_DIMENSION_TEXTURE1DARRAY:
                 {
-                    auto view       = info.view.Texture1DArray;
+                    auto view       = uav_info.desc.Texture1DArray;
                     auto array_size = view.ArraySize;
                     if (array_size == -1)
                     {
                         array_size = array_count;
                     }
-                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                    uav_info.subresource_indices = GetDescriptorSubresourceIndices(
                         view.MipSlice, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
                 }
                 case D3D12_UAV_DIMENSION_TEXTURE2D:
-                    info.subresource_indices = GetDescriptorSubresourceIndices(
-                        info.view.Texture2D.MipSlice, 1, mip_count, 0, 1, array_count, info.view.Texture2D.PlaneSlice);
+                    uav_info.subresource_indices =
+                        GetDescriptorSubresourceIndices(uav_info.desc.Texture2D.MipSlice,
+                                                        1,
+                                                        mip_count,
+                                                        0,
+                                                        1,
+                                                        array_count,
+                                                        uav_info.desc.Texture2D.PlaneSlice);
                     break;
                 case D3D12_UAV_DIMENSION_TEXTURE2DARRAY:
                 {
-                    auto view       = info.view.Texture2DArray;
+                    auto view       = uav_info.desc.Texture2DArray;
                     auto array_size = view.ArraySize;
                     if (array_size == -1)
                     {
                         array_size = array_count;
                     }
-                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                    uav_info.subresource_indices = GetDescriptorSubresourceIndices(
                         view.MipSlice, 1, mip_count, view.FirstArraySlice, array_size, array_count, view.PlaneSlice);
                     break;
                 }
                 case D3D12_UAV_DIMENSION_TEXTURE2DMS:
-                    info.subresource_indices = GetDescriptorSubresourceIndices(0, 1, mip_count, 0, 1, array_count, 0);
+                    uav_info.subresource_indices =
+                        GetDescriptorSubresourceIndices(0, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_UAV_DIMENSION_TEXTURE2DMSARRAY:
                 {
-                    auto view       = info.view.Texture2DMSArray;
+                    auto view       = uav_info.desc.Texture2DMSArray;
                     auto array_size = view.ArraySize;
                     if (array_size == -1)
                     {
                         array_size = array_count;
                     }
-                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                    uav_info.subresource_indices = GetDescriptorSubresourceIndices(
                         0, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
                 }
                 case D3D12_UAV_DIMENSION_TEXTURE3D:
                 {
                     // DUMPTODO: handle FirstWSlice and WSize
-                    info.subresource_indices =
-                        GetDescriptorSubresourceIndices(info.view.Texture3D.MipSlice, 1, mip_count, 0, 1, 1, 0);
+                    uav_info.subresource_indices = GetDescriptorSubresourceIndices(
+                        uav_info.desc.Texture3D.MipSlice, 1, mip_count, 0, 1, 1, 0);
                     break;
                 }
                 case D3D12_UAV_DIMENSION_UNKNOWN:
@@ -4897,7 +4926,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateUnorderedAccessView(
             }
         }
     }
-    heap_extra_info->unordered_access_infos[DestDescriptor.index] = std::move(info);
+    heap_extra_info->cbv_srv_uav_infos[DestDescriptor.index] = std::move(info);
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
@@ -4910,36 +4939,36 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
 
-    RenderTargetInfo info;
+    DHRenderTargetViewInfo info;
     info.resource_id   = pResource;
     info.replay_handle = *DestDescriptor.decoded_value;
     if (pDesc->IsNull())
     {
-        info.is_view_null = true;
+        info.is_desc_null = true;
         info.subresource_indices.emplace_back(0);
     }
     else
     {
-        info.view         = *(pDesc->GetMetaStructPointer()->decoded_value);
-        info.is_view_null = false;
+        info.desc         = *(pDesc->GetMetaStructPointer()->decoded_value);
+        info.is_desc_null = false;
 
         if (pResource != format::kNullHandleId)
         {
             auto desc        = reinterpret_cast<ID3D12Resource*>(GetObjectInfo(pResource)->object)->GetDesc();
             auto mip_count   = desc.MipLevels;
             auto array_count = desc.DepthOrArraySize;
-            switch (info.view.ViewDimension)
+            switch (info.desc.ViewDimension)
             {
                 case D3D12_RTV_DIMENSION_BUFFER:
                     info.subresource_indices.emplace_back(0);
                     break;
                 case D3D12_RTV_DIMENSION_TEXTURE1D:
                     info.subresource_indices = GetDescriptorSubresourceIndices(
-                        info.view.Texture1D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
+                        info.desc.Texture1D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_RTV_DIMENSION_TEXTURE1DARRAY:
                 {
-                    auto view       = info.view.Texture1DArray;
+                    auto view       = info.desc.Texture1DArray;
                     auto array_size = view.ArraySize;
                     if (array_size == -1)
                     {
@@ -4951,11 +4980,11 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
                 }
                 case D3D12_RTV_DIMENSION_TEXTURE2D:
                     info.subresource_indices = GetDescriptorSubresourceIndices(
-                        info.view.Texture2D.MipSlice, 1, mip_count, 0, 1, array_count, info.view.Texture2D.PlaneSlice);
+                        info.desc.Texture2D.MipSlice, 1, mip_count, 0, 1, array_count, info.desc.Texture2D.PlaneSlice);
                     break;
                 case D3D12_RTV_DIMENSION_TEXTURE2DARRAY:
                 {
-                    auto view       = info.view.Texture2DArray;
+                    auto view       = info.desc.Texture2DArray;
                     auto array_size = view.ArraySize;
                     if (array_size == -1)
                     {
@@ -4970,7 +4999,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
                     break;
                 case D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY:
                 {
-                    auto view       = info.view.Texture2DMSArray;
+                    auto view       = info.desc.Texture2DMSArray;
                     auto array_size = view.ArraySize;
                     if (array_size == -1)
                     {
@@ -4984,7 +5013,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
                 {
                     // DUMPTODO: Handle FirstWSlice and WSize
                     info.subresource_indices =
-                        GetDescriptorSubresourceIndices(info.view.Texture3D.MipSlice, 1, mip_count, 0, 1, 1, 0);
+                        GetDescriptorSubresourceIndices(info.desc.Texture3D.MipSlice, 1, mip_count, 0, 1, 1, 0);
                     break;
                 }
                 case D3D12_RTV_DIMENSION_UNKNOWN:
@@ -4994,7 +5023,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
             }
         }
     }
-    heap_extra_info->render_target_infos[DestDescriptor.index] = std::move(info);
+    heap_extra_info->rtv_infos[DestDescriptor.index] = std::move(info);
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
@@ -5007,33 +5036,33 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
 
-    DepthStencilInfo info;
+    DHDepthStencilViewInfo info;
     info.resource_id   = pResource;
     info.replay_handle = *DestDescriptor.decoded_value;
     if (pDesc->IsNull())
     {
-        info.is_view_null = true;
+        info.is_desc_null = true;
         info.subresource_indices.emplace_back(0);
     }
     else
     {
-        info.view         = *(pDesc->GetMetaStructPointer()->decoded_value);
-        info.is_view_null = false;
+        info.desc         = *(pDesc->GetMetaStructPointer()->decoded_value);
+        info.is_desc_null = false;
 
         if (pResource != format::kNullHandleId)
         {
             auto desc        = reinterpret_cast<ID3D12Resource*>(GetObjectInfo(pResource)->object)->GetDesc();
             auto mip_count   = desc.MipLevels;
             auto array_count = desc.DepthOrArraySize;
-            switch (info.view.ViewDimension)
+            switch (info.desc.ViewDimension)
             {
                 case D3D12_DSV_DIMENSION_TEXTURE1D:
                     info.subresource_indices = GetDescriptorSubresourceIndices(
-                        info.view.Texture1D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
+                        info.desc.Texture1D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_DSV_DIMENSION_TEXTURE1DARRAY:
                 {
-                    auto view       = info.view.Texture1DArray;
+                    auto view       = info.desc.Texture1DArray;
                     auto array_size = view.ArraySize;
                     if (array_size == -1)
                     {
@@ -5045,11 +5074,11 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
                 }
                 case D3D12_DSV_DIMENSION_TEXTURE2D:
                     info.subresource_indices = GetDescriptorSubresourceIndices(
-                        info.view.Texture2D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
+                        info.desc.Texture2D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_DSV_DIMENSION_TEXTURE2DARRAY:
                 {
-                    auto view       = info.view.Texture2DArray;
+                    auto view       = info.desc.Texture2DArray;
                     auto array_size = view.ArraySize;
                     if (array_size == -1)
                     {
@@ -5064,7 +5093,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
                     break;
                 case D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY:
                 {
-                    auto view       = info.view.Texture2DMSArray;
+                    auto view       = info.desc.Texture2DMSArray;
                     auto array_size = view.ArraySize;
                     if (array_size == -1)
                     {
@@ -5081,7 +5110,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
             }
         }
     }
-    heap_extra_info->depth_stencil_infos[DestDescriptor.index] = std::move(info);
+    heap_extra_info->dsv_infos[DestDescriptor.index] = std::move(info);
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12GraphicsCommandList_OMSetRenderTargets(
@@ -5214,28 +5243,17 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CopyDescriptors(
             auto dest_idx = dest_descriptor_info.index + dest_i + i;
             auto src_idx  = src_descriptor_info.index + src_i + i;
 
-            if (src_heap_extra_info->constant_buffer_infos.count(src_idx) > 0)
+            if (src_heap_extra_info->cbv_srv_uav_infos.count(src_idx) > 0)
             {
-                dest_heap_extra_info->constant_buffer_infos[dest_idx] =
-                    src_heap_extra_info->constant_buffer_infos[src_idx];
+                dest_heap_extra_info->cbv_srv_uav_infos[dest_idx] = src_heap_extra_info->cbv_srv_uav_infos[src_idx];
             }
-            if (src_heap_extra_info->shader_resource_infos.count(src_idx) > 0)
+            if (src_heap_extra_info->rtv_infos.count(src_idx) > 0)
             {
-                dest_heap_extra_info->shader_resource_infos[dest_idx] =
-                    src_heap_extra_info->shader_resource_infos[src_idx];
+                dest_heap_extra_info->rtv_infos[dest_idx] = src_heap_extra_info->rtv_infos[src_idx];
             }
-            if (src_heap_extra_info->unordered_access_infos.count(src_idx) > 0)
+            if (src_heap_extra_info->dsv_infos.count(src_idx) > 0)
             {
-                dest_heap_extra_info->unordered_access_infos[dest_idx] =
-                    src_heap_extra_info->unordered_access_infos[src_idx];
-            }
-            if (src_heap_extra_info->render_target_infos.count(src_idx) > 0)
-            {
-                dest_heap_extra_info->render_target_infos[dest_idx] = src_heap_extra_info->render_target_infos[src_idx];
-            }
-            if (src_heap_extra_info->depth_stencil_infos.count(src_idx) > 0)
-            {
-                dest_heap_extra_info->depth_stencil_infos[dest_idx] = src_heap_extra_info->depth_stencil_infos[src_idx];
+                dest_heap_extra_info->dsv_infos[dest_idx] = src_heap_extra_info->dsv_infos[src_idx];
             }
         }
 
@@ -5273,26 +5291,17 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CopyDescriptorsSimple(
         auto dest_idx = DestDescriptorRangeStart.index + i;
         auto src_idx  = SrcDescriptorRangeStart.index + i;
 
-        if (src_heap_extra_info->constant_buffer_infos.count(src_idx) > 0)
+        if (src_heap_extra_info->cbv_srv_uav_infos.count(src_idx) > 0)
         {
-            dest_heap_extra_info->constant_buffer_infos[dest_idx] = src_heap_extra_info->constant_buffer_infos[src_idx];
+            dest_heap_extra_info->cbv_srv_uav_infos[dest_idx] = src_heap_extra_info->cbv_srv_uav_infos[src_idx];
         }
-        if (src_heap_extra_info->shader_resource_infos.count(src_idx) > 0)
+        if (src_heap_extra_info->rtv_infos.count(src_idx) > 0)
         {
-            dest_heap_extra_info->shader_resource_infos[dest_idx] = src_heap_extra_info->shader_resource_infos[src_idx];
+            dest_heap_extra_info->rtv_infos[dest_idx] = src_heap_extra_info->rtv_infos[src_idx];
         }
-        if (src_heap_extra_info->unordered_access_infos.count(src_idx) > 0)
+        if (src_heap_extra_info->dsv_infos.count(src_idx) > 0)
         {
-            dest_heap_extra_info->unordered_access_infos[dest_idx] =
-                src_heap_extra_info->unordered_access_infos[src_idx];
-        }
-        if (src_heap_extra_info->render_target_infos.count(src_idx) > 0)
-        {
-            dest_heap_extra_info->render_target_infos[dest_idx] = src_heap_extra_info->render_target_infos[src_idx];
-        }
-        if (src_heap_extra_info->depth_stencil_infos.count(src_idx) > 0)
-        {
-            dest_heap_extra_info->depth_stencil_infos[dest_idx] = src_heap_extra_info->depth_stencil_infos[src_idx];
+            dest_heap_extra_info->dsv_infos[dest_idx] = src_heap_extra_info->dsv_infos[src_idx];
         }
     }
 }

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -154,6 +154,11 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                    StructPointerDecoder<Decoded_D3D12_CONSTANT_BUFFER_VIEW_DESC>* pDesc,
                                                    Decoded_D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
 
+    void PostCall_ID3D12Device_CreateSampler(const ApiCallInfo&                                call_info,
+                                             DxObjectInfo*                                     object_info,
+                                             StructPointerDecoder<Decoded_D3D12_SAMPLER_DESC>* pDesc,
+                                             Decoded_D3D12_CPU_DESCRIPTOR_HANDLE               DestDescriptor);
+
     void
     PostCall_ID3D12Device_CreateShaderResourceView(const ApiCallInfo& call_info,
                                                    DxObjectInfo*      object_info,


### PR DESCRIPTION
Ex: 
new
```
    "graphics_root_parameters": [
      {
        "root_parameter_index": 2,
        "root_signature_type": "D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE",
        "cmd_bind_type": "D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE",
        "tables": [
          {
            "range_type": "D3D12_DESCRIPTOR_RANGE_TYPE_CBV",
            "num_descriptors": 14,
            "descs": [
              {
                "buffer_location": 13749356032,
                "heap_id": 65,
                "heap_index": 719156,
                "res_id": 6230,
                "dimension": "D3D12_RESOURCE_DIMENSION_BUFFER",
                "subs": [
                  {
                    "index": 0,
                    "offset": 165376,
                    "size": 256,
                    "before_file": "shadowtombraider-no-dxr_dr_cbv_res_id_6230_sub_0_before.bin",
                    "after_file": "shadowtombraider-no-dxr_dr_cbv_res_id_6230_sub_0_after.bin"
                  }
```
old
```
    "descriptor_heap": {
      "heap_id_80": {
        "constant_buffer_views": [
          {
            "res_id": 6368,
            "sub": [
              {
                "index": 0,
                "offset": 508416,
                "size": 256,
                "before_file": "shadowtombraider-no-dxr_draw_3803_0_0_0_dr_cbv_res_id_6368_sub_0_before.bin",
                "after_file": "shadowtombraider-no-dxr_draw_3803_0_0_0_dr_cbv_res_id_6368_sub_0_after.bin"
```

1. Dump `SetXXXRootDescriptorTable`, `SetXXXRootConstantBufferView`, `SetXXXRootShaderResourceView` and `SetXXXRootUnorderedAccessView` from `ID3D12GraphicsCommandList` , instead of descriptor heaps. Root parameters are more straightforward since they are used by shaders.

2. Find RootParameters info in `dx12_browse_consumer.h` and `Dx12DumpResources::CreateRootSignature`. 

3.  Dump some infos about root parameters.  Although `root_signature_type` and `cmd_bind_type` are the same thing, but they come from different places. I saw some titles that they were different, so I chose to write both.  That's a mistake and should trigger validation log.  Added a function `Dx12DumpResourcesDelegate::WriteNote` to write some help info into .json, like error log.

4. Added two flags in `dx12_dump_resources.cpp`: `TEST_WRITE_NOT_FOUND_VIEWS` and `TEST_WRITE_NULL_RESOURCE_VIEWS`.

The `NumDescriptors` in root parameters could be large, but the index might not be found in `cbv_srv_uav_infos` of `D3D12DescriptorHeapInfo`. Set `TEST_WRITE_NOT_FOUND_VIEWS`: true to write the heap info even if the index isn't found. Set false to skip it.

`BufferLocation` in `CreateConstantBufferView` or `pResource` in `CreateShaderResourceView` or `CreateUnorderedAccessView` could be 0. Set `TEST_WRITE_NULL_RESOURCE_VIEWS`: true to write the heap info even if the value is 0. Set false to skip it.

5. `CreateConstantBufferView`, `CreateShaderResourceView` and `CreateUnorderedAccessView` could set the same `DestDescriptor`. The newer view setting could override the older to get the `DestDescriptor`. In this case, changed these struct infos into one struct info.

6. If the target draw call is dispatch, dump compute root parameters. If it's not, dump graphics. But if it's `ExecuteIndirect`, dump both graphics and compute root parameters, since we don't know what it's inside.

7. `CaptureGPUAddrMatchDescriptorHeap` find the heap index for the address of root descriptor tables. Use the index to find the view in the map in the heap.

Not using `MatchDescriptorCPUGPUHandle` and "for loop" to find the view any longer. `MatchDescriptorCPUGPUHandle` has a bug to find a wrong view.

`RelayCPUAddrMatchDescriptorHeap` find the heap index for rtvs and dsv.

8. Skip dump vertices, index, rtv and dsv if the target draw call is dispatch.