### PR TITLE
Do not keep asset file open

### DIFF
--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -43,15 +43,16 @@ class ApiCaptureManager
     static auto AcquireExclusiveApiCallLock() { return std::move(CommonCaptureManager::AcquireExclusiveApiCallLock()); }
 
     // Virtual interface
-    virtual void CreateStateTracker()                                  = 0;
-    virtual void DestroyStateTracker()                                 = 0;
-    virtual void WriteTrackedState(util::FileOutputStream* file_stream,
-                                   format::ThreadId        thread_id,
-                                   util::FileOutputStream* asset_file_stream = nullptr,
-                                   const std::string*      asset_file_name   = nullptr) = 0;
+    virtual void CreateStateTracker()                                                               = 0;
+    virtual void DestroyStateTracker()                                                              = 0;
+    virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) = 0;
+    virtual void WriteTrackedStateWithAssetFile(util::FileOutputStream* file_stream,
+                                                format::ThreadId        thread_id,
+                                                util::FileOutputStream* asset_file_stream,
+                                                const std::string*      asset_file_name)                 = 0;
     virtual void WriteAssets(util::FileOutputStream* asset_file_stream,
                              const std::string*      asset_file_name,
-                             format::ThreadId        thread_id)                         = 0;
+                             format::ThreadId        thread_id)                                            = 0;
 
     virtual CaptureSettings::TraceSettings GetDefaultTraceSettings();
 

--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -47,11 +47,11 @@ class ApiCaptureManager
     virtual void DestroyStateTracker()                                 = 0;
     virtual void WriteTrackedState(util::FileOutputStream* file_stream,
                                    format::ThreadId        thread_id,
-                                   util::FileOutputStream* asset_file_stream,
-                                   const std::string&      asset_file_name) = 0;
+                                   util::FileOutputStream* asset_file_stream = nullptr,
+                                   const std::string*      asset_file_name   = nullptr) = 0;
     virtual void WriteAssets(util::FileOutputStream* asset_file_stream,
-                             const std::string&      asset_file_name,
-                             format::ThreadId        thread_id)               = 0;
+                             const std::string*      asset_file_name,
+                             format::ThreadId        thread_id)                         = 0;
 
     virtual CaptureSettings::TraceSettings GetDefaultTraceSettings();
 

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -1233,7 +1233,7 @@ void CommonCaptureManager::ActivateTrimming(std::shared_lock<ApiCallMutexT>& cur
             std::unique_ptr<util::FileOutputStream> asset_file_stream = CreateAssetFile();
             for (auto& manager : api_capture_managers_)
             {
-                manager.first->WriteTrackedState(
+                manager.first->WriteTrackedStateWithAssetFile(
                     file_stream_.get(), thread_data->thread_id_, asset_file_stream.get(), &asset_file_name_);
             }
         }

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -278,12 +278,12 @@ class CommonCaptureManager
     std::string CreateTrimFilename(const std::string& base_filename, const util::UintRange& trim_range);
     std::string CreateTrimDrawCallsFilename(const std::string&                    base_filename,
                                             const CaptureSettings::TrimDrawCalls& trim_draw_calls);
-    void        CreateAssetFile();
-    std::string CreateAssetFilename(const std::string& base_filename) const;
-    bool        CreateCaptureFile(format::ApiFamilyId api_family, const std::string& base_filename);
-    void        WriteCaptureOptions(std::string& operation_annotation);
-    void        ActivateTrimming(std::shared_lock<ApiCallMutexT>& current_lock);
-    void        DeactivateTrimming(std::shared_lock<ApiCallMutexT>& current_lock);
+    std::unique_ptr<util::FileOutputStream> CreateAssetFile();
+    std::string                             CreateAssetFilename(const std::string& base_filename) const;
+    bool CreateCaptureFile(format::ApiFamilyId api_family, const std::string& base_filename);
+    void WriteCaptureOptions(std::string& operation_annotation);
+    void ActivateTrimming(std::shared_lock<ApiCallMutexT>& current_lock);
+    void DeactivateTrimming(std::shared_lock<ApiCallMutexT>& current_lock);
 
     void WriteFileHeader();
 
@@ -373,7 +373,6 @@ class CommonCaptureManager
         capture_settings_; // Settings from the settings file and environment at capture manager creation time.
 
     std::unique_ptr<util::FileOutputStream> file_stream_;
-    std::unique_ptr<util::FileOutputStream> asset_file_stream_;
     format::EnabledOptions                  file_options_;
     std::string                             base_filename_;
     std::string                             capture_filename_;

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -173,13 +173,8 @@ void D3D12CaptureManager::EndCommandListMethodCallCapture(ID3D12CommandList_Wrap
 }
 
 void D3D12CaptureManager::WriteTrackedState(util::FileOutputStream* file_stream,
-                                            format::ThreadId        thread_id,
-                                            util::FileOutputStream* asset_file_stream,
-                                            const std::string*      asset_file_name)
+                                            format::ThreadId        thread_id)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(asset_file_stream);
-    GFXRECON_UNREFERENCED_PARAMETER(asset_file_name);
-
     Dx12StateWriter state_writer(file_stream, GetCompressor(), thread_id);
     state_tracker_->WriteState(&state_writer, GetCurrentFrame());
 }

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -175,7 +175,7 @@ void D3D12CaptureManager::EndCommandListMethodCallCapture(ID3D12CommandList_Wrap
 void D3D12CaptureManager::WriteTrackedState(util::FileOutputStream* file_stream,
                                             format::ThreadId        thread_id,
                                             util::FileOutputStream* asset_file_stream,
-                                            const std::string&      asset_file_name)
+                                            const std::string*      asset_file_name)
 {
     GFXRECON_UNREFERENCED_PARAMETER(asset_file_stream);
     GFXRECON_UNREFERENCED_PARAMETER(asset_file_name);

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -836,10 +836,18 @@ class D3D12CaptureManager : public ApiCaptureManager
 
     virtual void DestroyStateTracker() override { state_tracker_ = nullptr; }
 
-    virtual void WriteTrackedState(util::FileOutputStream* file_stream,
-                                   format::ThreadId        thread_id,
-                                   util::FileOutputStream* asset_file_stream = nullptr,
-                                   const std::string*      asset_file_name   = nullptr) override;
+    virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) override;
+
+    virtual void WriteTrackedStateWithAssetFile(util::FileOutputStream* file_stream,
+                                                format::ThreadId        thread_id,
+                                                util::FileOutputStream* asset_file_stream,
+                                                const std::string*      asset_file_name) override
+    {
+        GFXRECON_UNREFERENCED_PARAMETER(file_stream);
+        GFXRECON_UNREFERENCED_PARAMETER(thread_id);
+        GFXRECON_UNREFERENCED_PARAMETER(asset_file_stream);
+        GFXRECON_UNREFERENCED_PARAMETER(asset_file_name);
+    }
 
     virtual void WriteAssets(util::FileOutputStream* assert_file_stream,
                              const std::string*      asset_file_name,
@@ -888,10 +896,10 @@ class D3D12CaptureManager : public ApiCaptureManager
     void                          EnableDRED();
     bool                          RvAnnotationActive();
 
-    void                              PrePresent(IDXGISwapChain_Wrapper* wrapper);
-    void                              PostPresent(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
-                                                  IDXGISwapChain_Wrapper*                                wrapper,
-                                                  UINT                                                   flags);
+    void PrePresent(IDXGISwapChain_Wrapper* wrapper);
+    void PostPresent(std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock,
+                     IDXGISwapChain_Wrapper*                                wrapper,
+                     UINT                                                   flags);
 
     static D3D12CaptureManager*       singleton_;
     std::set<ID3D12Resource_Wrapper*> mapped_resources_; ///< Track mapped resources for unassisted tracking mode.

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -839,10 +839,10 @@ class D3D12CaptureManager : public ApiCaptureManager
     virtual void WriteTrackedState(util::FileOutputStream* file_stream,
                                    format::ThreadId        thread_id,
                                    util::FileOutputStream* asset_file_stream = nullptr,
-                                   const std::string&      asset_file_name   = "") override;
+                                   const std::string*      asset_file_name   = nullptr) override;
 
     virtual void WriteAssets(util::FileOutputStream* assert_file_stream,
-                             const std::string&      asset_file_name,
+                             const std::string*      asset_file_name,
                              format::ThreadId        thread_id) override
     {}
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -104,7 +104,7 @@ void VulkanCaptureManager::DestroyInstance()
 void VulkanCaptureManager::WriteTrackedState(util::FileOutputStream* file_stream,
                                              format::ThreadId        thread_id,
                                              util::FileOutputStream* asset_file_stream,
-                                             const std::string&      asset_file_name)
+                                             const std::string*      asset_file_name)
 {
     uint64_t n_blocks = state_tracker_->WriteState(
         file_stream,
@@ -119,7 +119,7 @@ void VulkanCaptureManager::WriteTrackedState(util::FileOutputStream* file_stream
 }
 
 void VulkanCaptureManager::WriteAssets(util::FileOutputStream* asset_file_stream,
-                                       const std::string&      asset_file_name,
+                                       const std::string*      asset_file_name,
                                        format::ThreadId        thread_id)
 {
     assert(state_tracker_ != nullptr);

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -101,10 +101,18 @@ void VulkanCaptureManager::DestroyInstance()
     singleton_->common_manager_->DestroyInstance(singleton_);
 }
 
-void VulkanCaptureManager::WriteTrackedState(util::FileOutputStream* file_stream,
-                                             format::ThreadId        thread_id,
-                                             util::FileOutputStream* asset_file_stream,
-                                             const std::string*      asset_file_name)
+void VulkanCaptureManager::WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id)
+{
+    uint64_t n_blocks = state_tracker_->WriteState(
+        file_stream, thread_id, [] { return GetUniqueId(); }, GetCompressor(), GetCurrentFrame(), nullptr, nullptr);
+
+    common_manager_->IncrementBlockIndex(n_blocks);
+}
+
+void VulkanCaptureManager::WriteTrackedStateWithAssetFile(util::FileOutputStream* file_stream,
+                                                          format::ThreadId        thread_id,
+                                                          util::FileOutputStream* asset_file_stream,
+                                                          const std::string*      asset_file_name)
 {
     uint64_t n_blocks = state_tracker_->WriteState(
         file_stream,

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1605,10 +1605,10 @@ class VulkanCaptureManager : public ApiCaptureManager
     virtual void WriteTrackedState(util::FileOutputStream* file_stream,
                                    format::ThreadId        thread_id,
                                    util::FileOutputStream* asset_file_stream = nullptr,
-                                   const std::string&      asset_file_name   = "") override;
+                                   const std::string*      asset_file_name   = nullptr) override;
 
     virtual void WriteAssets(util::FileOutputStream* asset_file_stream,
-                             const std::string&      asset_file_name,
+                             const std::string*      asset_file_name,
                              format::ThreadId        thread_id) override;
 
   private:

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1602,10 +1602,12 @@ class VulkanCaptureManager : public ApiCaptureManager
         state_tracker_ = nullptr;
     }
 
-    virtual void WriteTrackedState(util::FileOutputStream* file_stream,
-                                   format::ThreadId        thread_id,
-                                   util::FileOutputStream* asset_file_stream = nullptr,
-                                   const std::string*      asset_file_name   = nullptr) override;
+    virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) override;
+
+    virtual void WriteTrackedStateWithAssetFile(util::FileOutputStream* file_stream,
+                                                format::ThreadId        thread_id,
+                                                util::FileOutputStream* asset_file_stream,
+                                                const std::string*      asset_file_name) override;
 
     virtual void WriteAssets(util::FileOutputStream* asset_file_stream,
                              const std::string*      asset_file_name,

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -61,7 +61,7 @@ class VulkanStateTracker
                         util::Compressor*                 compressor,
                         uint64_t                          frame_number,
                         util::FileOutputStream*           asset_file_stream,
-                        const std::string&                asset_file_name)
+                        const std::string*                asset_file_name)
     {
         VulkanStateWriter state_writer(file_stream,
                                        compressor,
@@ -76,12 +76,13 @@ class VulkanStateTracker
     }
 
     uint64_t WriteAssets(util::FileOutputStream*           asset_file_stream,
-                         const std::string&                asset_file_name,
+                         const std::string*                asset_file_name,
                          format::ThreadId                  thread_id,
                          std::function<format::HandleId()> get_unique_id_fn,
                          util::Compressor*                 compressor)
     {
         assert(asset_file_stream != nullptr);
+        assert(asset_file_name != nullptr);
 
         VulkanStateWriter state_writer(
             nullptr, compressor, thread_id, get_unique_id_fn, asset_file_stream, asset_file_name, &asset_file_offsets_);

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -87,14 +87,19 @@ VulkanStateWriter::VulkanStateWriter(util::FileOutputStream*                  ou
                                      format::ThreadId                         thread_id,
                                      std::function<format::HandleId()>        get_unique_id_fn,
                                      util::FileOutputStream*                  asset_file_stream,
-                                     const std::string&                       asset_file_name,
+                                     const std::string*                       asset_file_name,
                                      VulkanStateWriter::AssetFileOffsetsInfo* asset_file_offsets) :
     output_stream_(output_stream),
     compressor_(compressor), thread_id_(thread_id), encoder_(&parameter_stream_),
     get_unique_id_(std::move(get_unique_id_fn)), asset_file_stream_(asset_file_stream),
-    asset_file_name_(asset_file_name), asset_file_offsets_(asset_file_offsets)
+    asset_file_offsets_(asset_file_offsets)
 {
     assert(output_stream != nullptr || asset_file_stream != nullptr);
+
+    if (asset_file_name != nullptr)
+    {
+        asset_file_name_ = *asset_file_name;
+    }
 }
 
 uint64_t VulkanStateWriter::WriteAssets(const VulkanStateTable& state_table)

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -56,7 +56,7 @@ class VulkanStateWriter
                       format::ThreadId                         thread_id,
                       std::function<format::HandleId()>        get_unique_id_fn,
                       util::FileOutputStream*                  asset_file_stream  = nullptr,
-                      const std::string&                       asset_file_name    = "",
+                      const std::string*                       asset_file_name    = nullptr,
                       VulkanStateWriter::AssetFileOffsetsInfo* asset_file_offsets = nullptr);
 
     // Returns number of blocks written to the output_stream.


### PR DESCRIPTION
Closing the file can allow external users to keep track of when GFXR is done updating the file and therefore is safe to access it.