### PR TITLE
openxr: Clean Vulkan virtual swapchain on destroy

### DIFF
--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -244,6 +244,11 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
                                              PointerDecoder<uint32_t>*                                  index,
                                              XrResult                                                   replay_result);
 
+    void UpdateState_xrDestroySwapchain(const ApiCallInfo& call_info,
+                                        XrResult           returnValue,
+                                        format::HandleId   swapchain,
+                                        XrResult           replay_result);
+
     void SetFatalErrorHandler(std::function<void(const char*)> handler)
     {
         fatal_error_handler_ = handler;
@@ -622,6 +627,16 @@ struct CustomProcess<format::ApiCallId::ApiCall_xrAcquireSwapchainImage>
     static void UpdateState(OpenXrReplayConsumerBase* consumer, Args... args)
     {
         consumer->UpdateState_xrAcquireSwapchainImage(args...);
+    }
+};
+
+template <>
+struct CustomProcess<format::ApiCallId::ApiCall_xrDestroySwapchain>
+{
+    template <typename... Args>
+    static void UpdateState(OpenXrReplayConsumerBase* consumer, Args... args)
+    {
+        consumer->UpdateState_xrDestroySwapchain(args...);
     }
 };
 

--- a/framework/decode/openxr_replay_session_state.cpp
+++ b/framework/decode/openxr_replay_session_state.cpp
@@ -23,6 +23,8 @@
 #if ENABLE_OPENXR_SUPPORT
 
 #include "decode/openxr_replay_session_state.h"
+#include "decode/openxr_replay_swapchain_state.h"
+#include "decode/openxr_object_info.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -111,6 +113,17 @@ void SessionData::ClearViewRelativeProxySpaces(const encode::OpenXrInstanceTable
         }
     }
     proxy_spaces_.clear();
+}
+
+void SessionData::ClearSwapchains(CommonObjectInfoTable& table)
+{
+    for (format::HandleId swapchain : swapchains_)
+    {
+        OpenXrSwapchainInfo* swapchain_data = table.GetXrSwapchainInfo(swapchain);
+        assert((swapchain_data != nullptr) && swapchain_data->replay_data);
+        swapchain_data->replay_data->Clear();
+    }
+    swapchains_.clear();
 }
 
 void SessionData::RemapFrameEndSpaces(XrFrameEndInfo& frame_end_info)

--- a/framework/decode/openxr_replay_session_state.h
+++ b/framework/decode/openxr_replay_session_state.h
@@ -56,7 +56,6 @@ struct VulkanSwapchainInfo
 
     std::vector<ProxyImage>                proxy_images;
     std::vector<XrSwapchainImageVulkanKHR> replay_images;
-    std::vector<VkCommandBuffer>           transfer_commandbuffer; // Indexed by replay image index
     VkCommandPool                          command_pool = VK_NULL_HANDLE;
 };
 
@@ -119,8 +118,11 @@ class SessionData : public BaseReplayData<XrSession>
                                    const format::ViewRelativeLocation& location,
                                    XrSpace                             replay_space);
     void ClearViewRelativeProxySpaces(const encode::OpenXrInstanceTable* instance_table);
+    void ClearSwapchains(CommonObjectInfoTable& table);
 
     void RemapFrameEndSpaces(XrFrameEndInfo& frame_end_info);
+    void AddSwapchain(format::HandleId swapchain) { swapchains_.insert(swapchain); }
+    void RemoveSwapchain(format::HandleId swapchain) { swapchains_.erase(swapchain); }
 
   protected:
     ReferenceSpaceSet         reference_spaces_;
@@ -130,6 +132,7 @@ class SessionData : public BaseReplayData<XrSession>
 
     // These are the replay handles
     GraphicsBinding graphics_binding_;
+    std::unordered_set<format::HandleId> swapchains_;
 };
 
 GFXRECON_END_NAMESPACE(openxr)

--- a/framework/decode/openxr_replay_swapchain_state.h
+++ b/framework/decode/openxr_replay_swapchain_state.h
@@ -55,12 +55,16 @@ class SwapchainData : public BaseReplayData<XrSwapchain>
     XrResult ReleaseSwapchainImage(StructPointerDecoder<Decoded_XrSwapchainImageReleaseInfo>* releaseInfo);
     void     WaitedWithoutTimeout();
 
+    void Clear();
+
   protected:
     static void MapVulkanSwapchainImageFlags(XrSwapchainUsageFlags xr_flags, VkImageCreateInfo& info);
     XrResult    InitSwapchainData(const XrSwapchainCreateInfo& xr_info, VulkanSwapchainInfo& vk_info);
     XrResult    AcquireSwapchainImage(uint32_t capture_index, uint32_t replay_index, VulkanSwapchainInfo& swap_info);
     XrResult    ReleaseSwapchainImage(StructPointerDecoder<Decoded_XrSwapchainImageReleaseInfo>* releaseInfo,
                                       VulkanSwapchainInfo&                                       swap_info);
+
+    void Clear(VulkanSwapchainInfo& swap_info);
 
     XrSwapchain                            swapchain_;
     XrSwapchainCreateInfo                  create_info_;


### PR DESCRIPTION
Whether the OpenXR swapchain is explicitly or implicitly destroyed.

Resolves #1718 