### PR TITLE
Fix IDXGISwapChain::ResizeTargets capture

### DIFF
--- a/framework/encode/custom_dx12_wrapper_commands.h
+++ b/framework/encode/custom_dx12_wrapper_commands.h
@@ -177,6 +177,26 @@ struct CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain3_ResizeBu
 };
 
 template <>
+struct CustomWrapperPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_ResizeTarget>
+{
+    template <typename... Args>
+    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_IDXGISwapChain_ResizeTarget(args...);
+    }
+};
+
+template <>
+struct CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_ResizeTarget>
+{
+    template <typename... Args>
+    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_IDXGISwapChain_ResizeTarget(args...);
+    }
+};
+
+template <>
 inline void CustomWrapperDestroyCall<IDXGISwapChain_Wrapper>(IDXGISwapChain_Wrapper* wrapper)
 {
     D3D12CaptureManager::Get()->Destroy_IDXGISwapChain(wrapper);

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -743,6 +743,32 @@ void D3D12CaptureManager::PostProcess_IDXGISwapChain3_ResizeBuffers1(IDXGISwapCh
     ResizeSwapChainImages(wrapper, result, buffer_count);
 }
 
+void D3D12CaptureManager::PreProcess_IDXGISwapChain_ResizeTarget(IDXGISwapChain_Wrapper* wrapper,
+                                                                 const DXGI_MODE_DESC*   pNewTargetParameters)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(wrapper);
+    GFXRECON_UNREFERENCED_PARAMETER(pNewTargetParameters);
+
+    // ResizeTarget will resize the window associated with the swapchain. If the window has an event callback, it will
+    // be invoked for a resize event before ResizeTarget returns. Any API calls made by the callback will not be
+    // processed for capture due to the current scope count, resulting in a capture file that will not replay correctly
+    // due to missing API calls. The scope count needs to be temporarily decremented to ensure that API calls made by
+    // the callback are captured.
+    DecrementCallScope();
+}
+
+void D3D12CaptureManager::PostProcess_IDXGISwapChain_ResizeTarget(IDXGISwapChain_Wrapper* wrapper,
+                                                                  HRESULT                 result,
+                                                                  const DXGI_MODE_DESC*   pNewTargetParameters)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(wrapper);
+    GFXRECON_UNREFERENCED_PARAMETER(result);
+    GFXRECON_UNREFERENCED_PARAMETER(pNewTargetParameters);
+
+    // Restore the scope count that was decremented by the pre call.
+    IncrementCallScope();
+}
+
 void D3D12CaptureManager::Destroy_IDXGISwapChain(IDXGISwapChain_Wrapper* wrapper)
 {
     ReleaseSwapChainImages(wrapper);

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -298,6 +298,13 @@ class D3D12CaptureManager : public ApiCaptureManager
                                                     const UINT*             node_mask,
                                                     IUnknown* const*        present_queue);
 
+    void PreProcess_IDXGISwapChain_ResizeTarget(IDXGISwapChain_Wrapper* wrapper,
+                                                const DXGI_MODE_DESC*   pNewTargetParameters);
+
+    void PostProcess_IDXGISwapChain_ResizeTarget(IDXGISwapChain_Wrapper* wrapper,
+                                                 HRESULT                 result,
+                                                 const DXGI_MODE_DESC*   pNewTargetParameters);
+
     void Destroy_IDXGISwapChain(IDXGISwapChain_Wrapper* wrapper);
 
     void PostProcess_ID3D12Device_CreateDescriptorHeap(ID3D12Device_Wrapper*             wrapper,


### PR DESCRIPTION
IDXGISwapChain::ResizeTarget will resize the window associated with the swapchain. If the window has an event callback, the callback will be invoked for a resize event before ResizeTarget returns. Any API calls made by the callback will not be processed for capture due to the current scope count, resulting in a capture file that will not replay correctly due to missing API calls. The scope count needs to be decremented prior to the call and resotored after the call to ensure that API calls made by the callback are captured.