### PR TITLE
Fix a recent regression related to --pipeline-creation-jobs option.

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -8408,8 +8408,11 @@ void VulkanReplayConsumerBase::OverrideCmdBindPipeline(PFN_vkCmdBindPipeline    
 
     if (command_buffer_info != nullptr && pipeline_info != nullptr)
     {
-        command_buffer = command_buffer_info->handle;
-        pipeline       = pipeline_info->handle;
+        command_buffer = MapHandle<VulkanCommandBufferInfo>(command_buffer_info->capture_id,
+                                                            &CommonObjectInfoTable::GetVkCommandBufferInfo);
+
+        // MapHandle will force synchronization with potentially running asynchronous tasks.
+        pipeline = MapHandle<VulkanPipelineInfo>(pipeline_info->capture_id, &CommonObjectInfoTable::GetVkPipelineInfo);
 
         // keep track of currently bound pipeline
         command_buffer_info->bound_pipeline_id = pipeline_info->capture_id;


### PR DESCRIPTION
`OverrideCmdBindPipeline` was added recently, but a mandatory synchronization w. asynchronous operations was dropped. that causes race-conditions and bugs when using the `--pipeline-creation-jobs` feature.
this is fixed here. 

note:
this regression also marks the point where we should enforce CI-coverage for that feature.