### PR TITLE
Fix a regression in dump-resources, related to vkCmdPushConstants

### DIFF
--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -2231,7 +2231,7 @@ void VulkanReplayConsumer::Process_vkCmdPushConstants(
 
     if (options_.dumping_resources)
     {
-        resource_dumper_->Process_vkCmdPushConstants(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPushConstants, in_commandBuffer->handle, in_layout->handle, stageFlags, offset, size, pValues);
+        resource_dumper_->Process_vkCmdPushConstants(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdPushConstants, in_commandBuffer->handle, in_layout->handle, stageFlags, offset, size, pValues->GetPointer());
     }
 }
 

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -375,7 +375,12 @@ class VulkanReplayConsumerBodyGenerator(
                         else:
                             dump_resource_arglist += 'in_' + val.name + '->handle'
                     else:
-                        dump_resource_arglist += val.name
+                        if val.is_pointer and val.base_type == "void":
+                            # avoids passing a PointerDecoder* here (which is wrong but compiles fine, yikes)
+                            # -> dump-resource API expects raw void*
+                            dump_resource_arglist += val.name + '->GetPointer()'
+                        else:
+                            dump_resource_arglist += val.name
                     dump_resource_arglist += ', '
                 dump_resource_arglist = dump_resource_arglist[:-2]
             else:


### PR DESCRIPTION
when adding an override to `vkCmdPushConstants` in a [recent PR](https://github.com/LunarG/gfxreconstruct/pull/1879) ,
an error manifested in our generated code, passing a wrong pointer.
this compiled fine because the parameter happened to be a `void`-pointer
this affected the dump-resource feature, when used in combination with `vkCmdPushConstant`.

this is fixed here.