### PR TITLE
External memory FD

### DIFF
--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -8,6 +8,8 @@ target_sources(gfxrecon_encode
                    ${GFXRECON_SOURCE_DIR}/framework/encode/capture_manager.cpp               
                    ${GFXRECON_SOURCE_DIR}/framework/encode/capture_settings.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/capture_settings.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/command_writer.h
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/command_writer.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/custom_vulkan_encoder_commands.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/custom_vulkan_api_call_encoders.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/custom_vulkan_api_call_encoders.cpp

--- a/android/framework/util/CMakeLists.txt
+++ b/android/framework/util/CMakeLists.txt
@@ -46,6 +46,8 @@ target_sources(gfxrecon_util
                    ${GFXRECON_SOURCE_DIR}/framework/util/spirv_parsing_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/strings.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/strings.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/util/thread_data.h
+                   ${GFXRECON_SOURCE_DIR}/framework/util/thread_data.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/to_string.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/to_string.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/options.h

--- a/framework/decode/vulkan_default_allocator.cpp
+++ b/framework/decode/vulkan_default_allocator.cpp
@@ -661,7 +661,7 @@ void VulkanDefaultAllocator::ReportBindIncompatibility(const VkMemoryRequirement
             auto     memory_alloc_info = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
             uint32_t memory_type_index = memory_alloc_info->memory_type_index;
 
-            if ((requirements[i].memoryTypeBits & (1 << memory_type_index)) != 0)
+            if ((requirements[i].memoryTypeBits & (1 << memory_type_index)) == 0)
             {
                 GFXRECON_LOG_FATAL(
                     "Resource memory bind failed: resource is not compatible with the specified memory type.");

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4360,9 +4360,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
         VulkanResourceAllocator::MemoryData allocator_data;
 
-        auto *modified_allocate_info = const_cast<VkMemoryAllocateInfo*>(pAllocateInfo->GetPointer());
-        auto                                replay_memory        = pMemory->GetHandlePointer();
-        auto                                capture_id           = (*pMemory->GetPointer());
+        auto* modified_allocate_info = const_cast<VkMemoryAllocateInfo*>(pAllocateInfo->GetPointer());
+        auto  replay_memory          = pMemory->GetHandlePointer();
+        auto  capture_id             = (*pMemory->GetPointer());
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
         ProcessImportAndroidHardwareBufferInfo(pAllocateInfo);
@@ -4450,18 +4450,15 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
                 opaque_address = 0;
             }
 
-            VkMemoryOpaqueCaptureAddressAllocateInfo address_info           = {
-                          VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
-                          modified_allocate_info->pNext,
-                          opaque_address
+            VkMemoryOpaqueCaptureAddressAllocateInfo address_info = {
+                VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
+                modified_allocate_info->pNext,
+                opaque_address
             };
             modified_allocate_info->pNext = &address_info;
 
-            result = allocator->AllocateMemory(modified_allocate_info,
-                                               GetAllocationCallbacks(pAllocator),
-                                               capture_id,
-                                               replay_memory,
-                                               &allocator_data);
+            result = allocator->AllocateMemory(
+                modified_allocate_info, GetAllocationCallbacks(pAllocator), capture_id, replay_memory, &allocator_data);
         }
         else
         {

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -77,9 +77,20 @@ VulkanResourceInitializer::~VulkanResourceInitializer()
         resource_allocator_->FreeMemoryDirect(staging_memory_, nullptr, staging_memory_data_);
     }
 
-    device_table_->DestroySampler(device_, draw_sampler_, nullptr);
-    device_table_->DestroyDescriptorPool(device_, draw_pool_, nullptr);
-    device_table_->DestroyDescriptorSetLayout(device_, draw_set_layout_, nullptr);
+    if (draw_sampler_ != VK_NULL_HANDLE)
+    {
+        device_table_->DestroySampler(device_, draw_sampler_, nullptr);
+    }
+
+    if (draw_pool_ != VK_NULL_HANDLE)
+    {
+        device_table_->DestroyDescriptorPool(device_, draw_pool_, nullptr);
+    }
+
+    if (draw_set_layout_ != VK_NULL_HANDLE)
+    {
+        device_table_->DestroyDescriptorSetLayout(device_, draw_set_layout_, nullptr);
+    }
 }
 
 VkResult VulkanResourceInitializer::LoadData(VkDeviceSize                          size,

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018-2022 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 # Copyright (c) 2019-2023 Advanced Micro Devices, Inc.
 # All rights reserved
 #
@@ -36,6 +36,8 @@ target_sources(gfxrecon_encode
                     ${CMAKE_CURRENT_LIST_DIR}/capture_manager.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/capture_settings.h
                     ${CMAKE_CURRENT_LIST_DIR}/capture_settings.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/command_writer.h
+                    ${CMAKE_CURRENT_LIST_DIR}/command_writer.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_encoder_commands.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_api_call_encoders.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_api_call_encoders.cpp

--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -201,6 +201,23 @@ class ApiCaptureManager
     {
         common_manager_->WriteFillMemoryCmd(api_family_, memory_id, offset, size, data);
     }
+
+    void WriteBeginResourceInitCmd(format::HandleId device_id, uint64_t max_resource_size)
+    {
+        common_manager_->WriteBeginResourceInitCmd(api_family_, device_id, max_resource_size);
+    }
+
+    void WriteEndResourceInitCmd(format::HandleId device_id)
+    {
+        common_manager_->WriteEndResourceInitCmd(api_family_, device_id);
+    }
+
+    void WriteInitBufferCmd(
+        format::HandleId device_id, format::HandleId buffer_id, uint64_t offset, uint64_t size, const void* data)
+    {
+        common_manager_->WriteInitBufferCmd(api_family_, device_id, buffer_id, offset, size, data);
+    }
+
     void WriteCreateHeapAllocationCmd(uint64_t allocation_id, uint64_t allocation_size)
     {
         common_manager_->WriteCreateHeapAllocationCmd(api_family_, allocation_id, allocation_size);

--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2022 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -43,16 +43,16 @@ class ApiCaptureManager
     static auto AcquireExclusiveApiCallLock() { return std::move(CommonCaptureManager::AcquireExclusiveApiCallLock()); }
 
     // Virtual interface
-    virtual void CreateStateTracker()                                                               = 0;
-    virtual void DestroyStateTracker()                                                              = 0;
-    virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) = 0;
+    virtual void CreateStateTracker()                                                                  = 0;
+    virtual void DestroyStateTracker()                                                                 = 0;
+    virtual void WriteTrackedState(util::FileOutputStream* file_stream, util::ThreadData* thread_data) = 0;
     virtual void WriteTrackedStateWithAssetFile(util::FileOutputStream* file_stream,
-                                                format::ThreadId        thread_id,
+                                                util::ThreadData*       thread_data,
                                                 util::FileOutputStream* asset_file_stream,
-                                                const std::string*      asset_file_name)                 = 0;
+                                                const std::string*      asset_file_name)                    = 0;
     virtual void WriteAssets(util::FileOutputStream* asset_file_stream,
                              const std::string*      asset_file_name,
-                             format::ThreadId        thread_id)                                            = 0;
+                             util::ThreadData*       thread_data)                                            = 0;
 
     virtual CaptureSettings::TraceSettings GetDefaultTraceSettings();
 
@@ -212,12 +212,6 @@ class ApiCaptureManager
         common_manager_->WriteEndResourceInitCmd(api_family_, device_id);
     }
 
-    void WriteInitBufferCmd(
-        format::HandleId device_id, format::HandleId buffer_id, uint64_t offset, uint64_t size, const void* data)
-    {
-        common_manager_->WriteInitBufferCmd(api_family_, device_id, buffer_id, offset, size, data);
-    }
-
     void WriteCreateHeapAllocationCmd(uint64_t allocation_id, uint64_t allocation_size)
     {
         common_manager_->WriteCreateHeapAllocationCmd(api_family_, allocation_id, allocation_size);
@@ -230,15 +224,16 @@ class ApiCaptureManager
         common_manager_->CombineAndWriteToFile<N>(buffers);
     }
 
-    CommonCaptureManager::ThreadData* GetThreadData() { return common_manager_->GetThreadData(); }
-    util::Compressor*                 GetCompressor() { return common_manager_->GetCompressor(); }
-    std::mutex&                       GetMappedMemoryLock() { return common_manager_->GetMappedMemoryLock(); }
-    util::Keyboard&                   GetKeyboard() { return common_manager_->GetKeyboard(); }
-    const std::string&                GetScreenshotPrefix() const { return common_manager_->GetScreenshotPrefix(); }
-    util::ScreenshotFormat            GetScreenshotFormat() { return common_manager_->GetScreenshotFormat(); }
-    auto                              GetTrimBoundary() const { return common_manager_->GetTrimBoundary(); }
-    auto                              GetTrimDrawCalls() const { return common_manager_->GetTrimDrawCalls(); }
-    bool                              GetUseAssetFile() const { return common_manager_->GetUseAssetFile(); }
+    util::ThreadData*      GetThreadData() { return common_manager_->GetThreadData(); }
+    util::Compressor*      GetCompressor() { return common_manager_->GetCompressor(); }
+    std::mutex&            GetMappedMemoryLock() { return common_manager_->GetMappedMemoryLock(); }
+    util::Keyboard&        GetKeyboard() { return common_manager_->GetKeyboard(); }
+    const std::string&     GetScreenshotPrefix() const { return common_manager_->GetScreenshotPrefix(); }
+    util::ScreenshotFormat GetScreenshotFormat() { return common_manager_->GetScreenshotFormat(); }
+    auto                   GetTrimBoundary() const { return common_manager_->GetTrimBoundary(); }
+    auto                   GetTrimDrawCalls() const { return common_manager_->GetTrimDrawCalls(); }
+    bool                   GetUseAssetFile() const { return common_manager_->GetUseAssetFile(); }
+    CommandWriter*         GetCommandWriter() { return common_manager_->GetCommandWriter(); }
 
   protected:
     const format::ApiFamilyId api_family_;

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2022 Valve Corporation
-** Copyright (c) 2018-2022 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -55,45 +55,12 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 const uint32_t kFirstFrame           = 1;
 const size_t   kFileStreamBufferSize = 256 * 1024;
 
-std::mutex                                     CommonCaptureManager::ThreadData::count_lock_;
-format::ThreadId                               CommonCaptureManager::ThreadData::thread_count_ = 0;
-std::unordered_map<uint64_t, format::ThreadId> CommonCaptureManager::ThreadData::id_map_;
-
-CommonCaptureManager*                                          CommonCaptureManager::singleton_;
-std::mutex                                                     CommonCaptureManager::instance_lock_;
-thread_local std::unique_ptr<CommonCaptureManager::ThreadData> CommonCaptureManager::thread_data_;
-CommonCaptureManager::ApiCallMutexT                            CommonCaptureManager::api_call_mutex_;
+CommonCaptureManager*                          CommonCaptureManager::singleton_;
+std::mutex                                     CommonCaptureManager::instance_lock_;
+thread_local std::unique_ptr<util::ThreadData> CommonCaptureManager::thread_data_;
+CommonCaptureManager::ApiCallMutexT            CommonCaptureManager::api_call_mutex_;
 
 std::atomic<format::HandleId> CommonCaptureManager::unique_id_counter_{ format::kNullHandleId };
-
-CommonCaptureManager::ThreadData::ThreadData() :
-    thread_id_(GetThreadId()), object_id_(format::kNullHandleId), call_id_(format::ApiCallId::ApiCall_Unknown),
-    block_index_(0)
-{
-    parameter_buffer_  = std::make_unique<encode::ParameterBuffer>();
-    parameter_encoder_ = std::make_unique<ParameterEncoder>(parameter_buffer_.get());
-}
-
-format::ThreadId CommonCaptureManager::ThreadData::GetThreadId()
-{
-    format::ThreadId id  = 0;
-    uint64_t         tid = util::platform::GetCurrentThreadId();
-
-    // Using a uint64_t sequence number associated with the thread ID.
-    std::lock_guard<std::mutex> lock(count_lock_);
-    auto                        entry = id_map_.find(tid);
-    if (entry != id_map_.end())
-    {
-        id = entry->second;
-    }
-    else
-    {
-        id = ++thread_count_;
-        id_map_.insert(std::make_pair(tid, id));
-    }
-
-    return id;
-}
 
 CommonCaptureManager::CommonCaptureManager() :
     force_file_flush_(false), timestamp_filename_(true),
@@ -491,14 +458,19 @@ bool CommonCaptureManager::Initialize(format::ApiFamilyId                   api_
         capture_mode_ = kModeDisabled;
     }
 
+    if (success)
+    {
+        command_writer_ = std::make_unique<CommandWriter>(GetThreadData(), file_stream_.get(), compressor_.get());
+    }
+
     return success;
 }
 
-CommonCaptureManager::ThreadData* CommonCaptureManager::GetThreadData()
+util::ThreadData* CommonCaptureManager::GetThreadData()
 {
     if (!thread_data_)
     {
-        thread_data_ = std::make_unique<ThreadData>();
+        thread_data_ = std::make_unique<util::ThreadData>();
     }
     return thread_data_.get();
 }
@@ -834,15 +806,15 @@ void CommonCaptureManager::CheckStartCaptureForTrackMode(format::ApiFamilyId    
     {
         capture_mode_ |= kModeWrite;
 
-        auto thread_data = GetThreadData();
-        assert(thread_data != nullptr);
+        auto* thread_data = GetThreadData();
+        GFXRECON_ASSERT(thread_data != nullptr);
 
         std::unique_ptr<util::FileOutputStream> asset_file_stream = CreateAssetFile();
         if (asset_file_stream)
         {
             for (auto& manager : api_capture_managers_)
             {
-                manager.first->WriteAssets(asset_file_stream.get(), &asset_file_name_, thread_data->thread_id_);
+                manager.first->WriteAssets(asset_file_stream.get(), &asset_file_name_, thread_data);
             }
         }
 
@@ -1053,7 +1025,7 @@ std::unique_ptr<util::FileOutputStream> CommonCaptureManager::CreateAssetFile()
     }
 
     std::unique_ptr<util::FileOutputStream> asset_file_stream =
-        std::make_unique<util::FileOutputStream>(asset_file_name_, kFileStreamBufferSize, true);
+        std::make_unique<CaptureFileOutputStream>(this, asset_file_name_, kFileStreamBufferSize, true);
     if (!asset_file_stream->IsValid())
     {
         GFXRECON_LOG_ERROR("Failed opening asset file %s", asset_file_name_.c_str())
@@ -1084,7 +1056,7 @@ bool CommonCaptureManager::CreateCaptureFile(format::ApiFamilyId api_family, con
         capture_filename_ = util::filepath::GenerateTimestampedFilename(capture_filename_);
     }
 
-    file_stream_ = std::make_unique<util::FileOutputStream>(capture_filename_, kFileStreamBufferSize);
+    file_stream_ = std::make_unique<CaptureFileOutputStream>(this, capture_filename_, kFileStreamBufferSize);
 
     if (file_stream_->IsValid())
     {
@@ -1226,22 +1198,22 @@ void CommonCaptureManager::ActivateTrimming(std::shared_lock<ApiCallMutexT>& cur
 
         capture_mode_ |= kModeWrite;
 
-        auto thread_data = GetThreadData();
-        assert(thread_data != nullptr);
+        auto* thread_data = GetThreadData();
+        GFXRECON_ASSERT(thread_data != nullptr);
         if (use_asset_file_)
         {
             std::unique_ptr<util::FileOutputStream> asset_file_stream = CreateAssetFile();
             for (auto& manager : api_capture_managers_)
             {
                 manager.first->WriteTrackedStateWithAssetFile(
-                    file_stream_.get(), thread_data->thread_id_, asset_file_stream.get(), &asset_file_name_);
+                    file_stream_.get(), thread_data, asset_file_stream.get(), &asset_file_name_);
             }
         }
         else
         {
             for (auto& manager : api_capture_managers_)
             {
-                manager.first->WriteTrackedState(file_stream_.get(), thread_data->thread_id_);
+                manager.first->WriteTrackedState(file_stream_.get(), thread_data);
             }
         }
     }
@@ -1507,69 +1479,6 @@ void CommonCaptureManager::WriteEndResourceInitCmd(format::ApiFamilyId api_famil
     WriteToFile(&init_cmd, sizeof(init_cmd));
 }
 
-void CommonCaptureManager::WriteInitBufferCmd(format::ApiFamilyId api_family,
-                                              format::HandleId    device_id,
-                                              format::HandleId    buffer_id,
-                                              uint64_t            offset,
-                                              uint64_t            size,
-                                              const void*         data)
-{
-    if ((capture_mode_ & kModeWrite) != kModeWrite)
-    {
-        return;
-    }
-
-    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, size);
-
-    format::InitBufferCommandHeader init_cmd;
-    size_t                          header_size       = sizeof(format::InitBufferCommandHeader);
-    const uint8_t*                  uncompressed_data = (static_cast<const uint8_t*>(data) + offset);
-    size_t                          uncompressed_size = static_cast<size_t>(size);
-
-    auto thread_data = GetThreadData();
-    assert(thread_data != nullptr);
-
-    init_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    init_cmd.meta_header.meta_data_id = format::MakeMetaDataId(api_family, format::MetaDataType::kInitBufferCommand);
-    init_cmd.thread_id                = thread_data->thread_id_;
-    init_cmd.device_id                = device_id;
-    init_cmd.buffer_id                = buffer_id;
-    init_cmd.data_size                = size;
-
-    bool not_compressed = true;
-
-    if (compressor_ != nullptr)
-    {
-        size_t compressed_size =
-            compressor_->Compress(uncompressed_size, uncompressed_data, &thread_data->compressed_buffer_, header_size);
-
-        if ((compressed_size > 0) && (compressed_size < uncompressed_size))
-        {
-            not_compressed = false;
-
-            // We don't have a special header for compressed fill commands because the header always includes
-            // the uncompressed size, so we just change the type to indicate the data is compressed.
-            init_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
-
-            // Calculate size of packet with uncompressed data size.
-            init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + compressed_size;
-
-            // Copy header to beginning of compressed_buffer_
-            util::platform::MemoryCopy(thread_data->compressed_buffer_.data(), header_size, &init_cmd, header_size);
-
-            WriteToFile(thread_data->compressed_buffer_.data(), header_size + compressed_size);
-        }
-    }
-
-    if (not_compressed)
-    {
-        // Calculate size of packet with compressed data size.
-        init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + uncompressed_size;
-
-        CombineAndWriteToFile({ { &init_cmd, header_size }, { uncompressed_data, uncompressed_size } });
-    }
-}
-
 void CommonCaptureManager::WriteCreateHeapAllocationCmd(format::ApiFamilyId api_family,
                                                         uint64_t            allocation_id,
                                                         uint64_t            allocation_size)
@@ -1595,44 +1504,7 @@ void CommonCaptureManager::WriteCreateHeapAllocationCmd(format::ApiFamilyId api_
 
 void CommonCaptureManager::WriteToFile(const void* data, size_t size, util::FileOutputStream* file_stream)
 {
-    if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUserfaultfd)
-    {
-        util::PageGuardManager* manager = util::PageGuardManager::Get();
-        if (manager)
-        {
-            // fwrite hides a lock inside to synchronize writes to files. If a thread is in the middle
-            // of a write to the capture file and the uffd mechanism interupts it, it will cause
-            // a deadlock as uffd will also try to write to the capture file as well. For this
-            // reason RT signal needs to be disabled while writing.
-            // This can be removed once writing to the capture file(s) is delegated to a separate thread.
-            manager->UffdBlockRtSignal();
-        }
-    }
-
-    util::FileOutputStream* output_stream = (file_stream != nullptr) ? file_stream : file_stream_.get();
-
-    output_stream->Write(data, size);
-    if (force_file_flush_)
-    {
-        output_stream->Flush();
-    }
-
-    if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUserfaultfd)
-    {
-        util::PageGuardManager* manager = util::PageGuardManager::Get();
-        if (manager)
-        {
-            // Enable again signal
-            manager->UffdUnblockRtSignal();
-        }
-    }
-
-    // Increment block index
-    auto thread_data = GetThreadData();
-    assert(thread_data != nullptr);
-
-    ++block_index_;
-    thread_data->block_index_ = block_index_.load();
+    file_stream ? file_stream->Write(data, size) : file_stream_->Write(data, size);
 }
 
 void CommonCaptureManager::AtExit()
@@ -1751,6 +1623,53 @@ void CommonCaptureManager::WriteCaptureOptions(std::string& operation_annotation
     operation_annotation += "\": \n    {";
     operation_annotation += buffer;
     operation_annotation += "\n    }";
+}
+
+CaptureFileOutputStream::CaptureFileOutputStream(CommonCaptureManager* capture_manager,
+                                                 const std::string&    filename,
+                                                 size_t                buffer_size,
+                                                 bool                  append) :
+    FileOutputStream(filename, buffer_size, append), capture_manager_(capture_manager)
+{}
+
+bool CaptureFileOutputStream::Write(const void* data, size_t len)
+{
+    GFXRECON_ASSERT(capture_manager_);
+
+    if (capture_manager_->GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUserfaultfd)
+    {
+        util::PageGuardManager* manager = util::PageGuardManager::Get();
+        if (manager)
+        {
+            // fwrite hides a lock inside to synchronize writes to files. If a thread is in the middle
+            // of a write to the capture file and the uffd mechanism interupts it, it will cause
+            // a deadlock as uffd will also try to write to the capture file as well. For this
+            // reason RT signal needs to be disabled while writing.
+            // This can be removed once writing to the capture file(s) is delegated to a separate thread.
+            manager->UffdBlockRtSignal();
+        }
+    }
+
+    bool ret = FileOutputStream::Write(data, len);
+
+    if (capture_manager_->GetForceFileFlush())
+    {
+        Flush();
+    }
+
+    if (capture_manager_->GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUserfaultfd)
+    {
+        util::PageGuardManager* manager = util::PageGuardManager::Get();
+        if (manager)
+        {
+            // Enable again signal
+            manager->UffdUnblockRtSignal();
+        }
+    }
+
+    capture_manager_->IncrementBlockIndex(1);
+
+    return ret;
 }
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2022 Valve Corporation
-** Copyright (c) 2018-2022 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -26,6 +26,7 @@
 #define GFXRECON_ENCODE_CAPTURE_MANAGER_H
 
 #include "encode/capture_settings.h"
+#include "encode/command_writer.h"
 #include "encode/handle_unwrap_memory.h"
 #include "encode/parameter_buffer.h"
 #include "encode/parameter_encoder.h"
@@ -36,6 +37,7 @@
 #include "util/defines.h"
 #include "util/file_output_stream.h"
 #include "util/keyboard.h"
+#include "util/thread_data.h"
 
 #include <atomic>
 #include <cassert>
@@ -203,41 +205,9 @@ class CommonCaptureManager
 
     typedef uint32_t CaptureMode;
 
-    class ThreadData
-    {
-      public:
-        ThreadData();
-
-        ~ThreadData() {}
-
-        std::vector<uint8_t>& GetScratchBuffer() { return scratch_buffer_; }
-
-      public:
-        const format::ThreadId                   thread_id_;
-        format::ApiCallId                        call_id_;
-        format::HandleId                         object_id_;
-        std::unique_ptr<encode::ParameterBuffer> parameter_buffer_;
-        std::unique_ptr<ParameterEncoder>        parameter_encoder_;
-        std::vector<uint8_t>                     compressed_buffer_;
-        HandleUnwrapMemory                       handle_unwrap_memory_;
-        uint64_t                                 block_index_;
-
-      private:
-        static format::ThreadId GetThreadId();
-
-      private:
-        static std::mutex                                     count_lock_;
-        static format::ThreadId                               thread_count_;
-        static std::unordered_map<uint64_t, format::ThreadId> id_map_;
-
-      private:
-        // Used for combining multiple buffers for a single file write.
-        std::vector<uint8_t> scratch_buffer_;
-    };
-
-    ThreadData* GetThreadData();
-    bool        IsCaptureModeTrack() const;
-    bool        IsCaptureModeWrite() const;
+    util::ThreadData* GetThreadData();
+    bool              IsCaptureModeTrack() const;
+    bool              IsCaptureModeWrite() const;
 
     void DestroyInstance(ApiCaptureManager* singleton);
 
@@ -276,6 +246,7 @@ class CommonCaptureManager
     util::Keyboard&        GetKeyboard() { return keyboard_; }
     const std::string&     GetScreenshotPrefix() const { return screenshot_prefix_; }
     util::ScreenshotFormat GetScreenShotFormat() const { return screenshot_format_; }
+    CommandWriter*         GetCommandWriter() { return command_writer_.get(); }
 
     std::string CreateTrimFilename(const std::string& base_filename, const util::UintRange& trim_range);
     std::string CreateTrimDrawCallsFilename(const std::string&                    base_filename,
@@ -307,14 +278,13 @@ class CommonCaptureManager
 
     void WriteEndResourceInitCmd(format::ApiFamilyId api_family, format::HandleId device_id);
 
-    void WriteInitBufferCmd(format::ApiFamilyId api_family,
-                            format::HandleId    device_id,
-                            format::HandleId    buffer_id,
-                            uint64_t            offset,
-                            uint64_t            size,
-                            const void*         data);
-
     void WriteCreateHeapAllocationCmd(format::ApiFamilyId api_family, uint64_t allocation_id, uint64_t allocation_size);
+
+    bool OutputStreamWrite(const void* data, size_t len)
+    {
+        WriteToFile(data, len);
+        return true;
+    }
 
     void WriteToFile(const void* data, size_t size, util::FileOutputStream* file_stream = nullptr);
 
@@ -322,19 +292,8 @@ class CommonCaptureManager
     void CombineAndWriteToFile(const std::pair<const void*, size_t> (&buffers)[N],
                                util::FileOutputStream* file_stream = nullptr)
     {
-        static_assert(N != 1, "Use WriteToFile(void*, size) when writing a single buffer.");
-
-        // Combine buffers for a single write.
-        std::vector<uint8_t>& scratch_buffer = GetThreadData()->GetScratchBuffer();
-        scratch_buffer.clear();
-        for (size_t i = 0; i < N; ++i)
-        {
-            const uint8_t* const data = reinterpret_cast<const uint8_t*>(buffers[i].first);
-            const size_t         size = buffers[i].second;
-            scratch_buffer.insert(scratch_buffer.end(), data, data + size);
-        }
-
-        WriteToFile(scratch_buffer.data(), scratch_buffer.size(), file_stream);
+        file_stream ? file_stream->CombineAndWrite<N>(buffers, GetThreadData()->GetScratchBuffer())
+                    : file_stream_->CombineAndWrite<N>(buffers, GetThreadData()->GetScratchBuffer());
     }
 
     void IncrementBlockIndex(uint64_t blocks)
@@ -366,11 +325,11 @@ class CommonCaptureManager
     static void AtExit();
 
   private:
-    static std::mutex                               instance_lock_;
-    static CommonCaptureManager*                    singleton_;
-    static thread_local std::unique_ptr<ThreadData> thread_data_;
-    static std::atomic<format::HandleId>            unique_id_counter_;
-    static ApiCallMutexT                            api_call_mutex_;
+    static std::mutex                                     instance_lock_;
+    static CommonCaptureManager*                          singleton_;
+    static thread_local std::unique_ptr<util::ThreadData> thread_data_;
+    static std::atomic<format::HandleId>                  unique_id_counter_;
+    static ApiCallMutexT                                  api_call_mutex_;
 
     uint32_t instance_count_ = 0;
     struct ApiInstanceRecord
@@ -439,6 +398,28 @@ class CommonCaptureManager
         uint16_t descriptor_mask{ RvAnnotationUtil::kDescriptorMask };
         uint64_t shaderid_mask{ RvAnnotationUtil::kShaderIDMask };
     } rv_annotation_info_;
+
+    std::unique_ptr<CommandWriter> command_writer_;
+};
+
+/**
+ * @brief `CaptureFileOutputStream` is a `FileOutputStream` decorator for `CommonCaptureManager`.
+ *
+ * It wraps calls to `FileOutputStream::Write` to perform some operations required by the capture manager before
+ * and after writing. At the same time it can be passed as input to the `CommandWriter` as an `OutputStream`.
+ */
+class CaptureFileOutputStream : public util::FileOutputStream
+{
+  public:
+    CaptureFileOutputStream(CommonCaptureManager* capture_manager,
+                            const std::string&    filename,
+                            size_t                buffer_size,
+                            bool                  append = false);
+
+    bool Write(const void* data, size_t len) override;
+
+  private:
+    CommonCaptureManager* capture_manager_;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -302,6 +302,18 @@ class CommonCaptureManager
     void WriteFillMemoryCmd(
         format::ApiFamilyId api_family, format::HandleId memory_id, uint64_t offset, uint64_t size, const void* data);
 
+    void
+    WriteBeginResourceInitCmd(format::ApiFamilyId api_family, format::HandleId device_id, uint64_t max_resource_size);
+
+    void WriteEndResourceInitCmd(format::ApiFamilyId api_family, format::HandleId device_id);
+
+    void WriteInitBufferCmd(format::ApiFamilyId api_family,
+                            format::HandleId    device_id,
+                            format::HandleId    buffer_id,
+                            uint64_t            offset,
+                            uint64_t            size,
+                            const void*         data);
+
     void WriteCreateHeapAllocationCmd(format::ApiFamilyId api_family, uint64_t allocation_id, uint64_t allocation_size);
 
     void WriteToFile(const void* data, size_t size, util::FileOutputStream* file_stream = nullptr);

--- a/framework/encode/command_writer.cpp
+++ b/framework/encode/command_writer.cpp
@@ -1,0 +1,165 @@
+/*
+ ** Copyright (c) 2025 LunarG, Inc.
+ **
+ ** Permission is hereby granted, free of charge, to any person obtaining a
+ ** copy of this software and associated documentation files (the "Software"),
+ ** to deal in the Software without restriction, including without limitation
+ ** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ ** and/or sell copies of the Software, and to permit persons to whom the
+ ** Software is furnished to do so, subject to the following conditions:
+ **
+ ** The above copyright notice and this permission notice shall be included in
+ ** all copies or substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ ** DEALINGS IN THE SOFTWARE.
+ */
+
+#include "encode/command_writer.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+CommandWriter::CommandWriter(util::ThreadData*   thread_data,
+                             util::OutputStream* output_stream,
+                             util::Compressor*   compressor) :
+    thread_data_(thread_data), output_stream_(output_stream), compressor_(compressor)
+{
+    GFXRECON_ASSERT(thread_data_ != nullptr);
+}
+
+void CommandWriter::WriteInitBufferCmd(format::ApiFamilyId api_family,
+                                       format::HandleId    device_id,
+                                       format::HandleId    buffer_id,
+                                       uint64_t            offset,
+                                       uint64_t            size,
+                                       const void*         data)
+{
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, size);
+
+    format::InitBufferCommandHeader init_cmd = {};
+
+    size_t         header_size       = sizeof(format::InitBufferCommandHeader);
+    const uint8_t* uncompressed_data = static_cast<const uint8_t*>(data) + offset;
+    size_t         uncompressed_size = static_cast<size_t>(size);
+
+    init_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
+    init_cmd.meta_header.meta_data_id = format::MakeMetaDataId(api_family, format::MetaDataType::kInitBufferCommand);
+    init_cmd.thread_id                = thread_data_->thread_id_;
+    init_cmd.device_id                = device_id;
+    init_cmd.buffer_id                = buffer_id;
+    init_cmd.data_size                = size;
+
+    bool compressed = false;
+
+    if (compressor_ != nullptr)
+    {
+        std::vector<uint8_t>& compressed_buffer = thread_data_->compressed_buffer_;
+
+        size_t compressed_size =
+            compressor_->Compress(uncompressed_size, uncompressed_data, &compressed_buffer, header_size);
+
+        if ((compressed_size > 0) && (compressed_size < uncompressed_size))
+        {
+            compressed = true;
+
+            // We don't have a special header for compressed fill commands because the header always includes
+            // the uncompressed size, so we just change the type to indicate the data is compressed.
+            init_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
+
+            // Calculate size of packet with uncompressed data size.
+            init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + compressed_size;
+
+            // Copy header to beginning of compressed_buffer.
+            util::platform::MemoryCopy(compressed_buffer.data(), header_size, &init_cmd, header_size);
+
+            output_stream_->Write(compressed_buffer.data(), header_size + compressed_size);
+        }
+    }
+
+    if (!compressed)
+    {
+        // Calculate size of packet with uncompressed data size.
+        init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + uncompressed_size;
+
+        output_stream_->CombineAndWrite({ { &init_cmd, header_size }, { uncompressed_data, uncompressed_size } },
+                                        thread_data_->GetScratchBuffer());
+    }
+}
+
+void CommandWriter::WriteInitImageCmd(format::ApiFamilyId          api_family,
+                                      format::HandleId             device_id,
+                                      format::HandleId             image_id,
+                                      uint32_t                     aspect,
+                                      uint32_t                     layout,
+                                      uint32_t                     mip_levels,
+                                      const std::vector<uint64_t>& level_sizes,
+                                      uint64_t                     size,
+                                      const void*                  data)
+{
+
+    format::InitImageCommandHeader upload_cmd;
+
+    // Packet size without the resource data.
+    upload_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(upload_cmd);
+    upload_cmd.meta_header.block_header.type = format::kMetaDataBlock;
+    upload_cmd.meta_header.meta_data_id = format::MakeMetaDataId(api_family, format::MetaDataType::kInitImageCommand);
+    upload_cmd.thread_id                = thread_data_->thread_id_;
+    upload_cmd.device_id                = device_id;
+    upload_cmd.image_id                 = image_id;
+    upload_cmd.aspect                   = aspect;
+    upload_cmd.layout                   = layout;
+
+    auto* bytes = reinterpret_cast<const uint8_t*>(data);
+
+    if (bytes != nullptr)
+    {
+        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, size);
+        size_t data_size = static_cast<size_t>(size);
+        // Store uncompressed data size in packet.
+        upload_cmd.data_size = data_size;
+
+        GFXRECON_ASSERT(mip_levels > 0);
+        upload_cmd.level_count = mip_levels;
+
+        if (compressor_ != nullptr)
+        {
+            std::vector<uint8_t>& compressed_buffer = thread_data_->compressed_buffer_;
+            size_t                compressed_size   = compressor_->Compress(data_size, bytes, &compressed_buffer, 0);
+
+            if ((compressed_size > 0) && (compressed_size < data_size))
+            {
+                upload_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
+
+                bytes     = compressed_buffer.data();
+                data_size = compressed_size;
+            }
+        }
+
+        // Calculate size of packet with compressed or uncompressed data size.
+        size_t levels_size = level_sizes.size() * sizeof(level_sizes[0]);
+
+        upload_cmd.meta_header.block_header.size += levels_size + data_size;
+
+        output_stream_->Write(&upload_cmd, sizeof(upload_cmd));
+        output_stream_->Write(level_sizes.data(), levels_size);
+        output_stream_->Write(bytes, data_size);
+    }
+    else
+    {
+        // Write a packet without resource data; replay must still perform a layout transition at image
+        // initialization.
+        upload_cmd.data_size   = 0;
+        upload_cmd.level_count = 0;
+
+        output_stream_->Write(&upload_cmd, sizeof(upload_cmd));
+    }
+}
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/command_writer.h
+++ b/framework/encode/command_writer.h
@@ -1,0 +1,69 @@
+/*
+ ** Copyright (c) 2025 LunarG, Inc.
+ **
+ ** Permission is hereby granted, free of charge, to any person obtaining a
+ ** copy of this software and associated documentation files (the "Software"),
+ ** to deal in the Software without restriction, including without limitation
+ ** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ ** and/or sell copies of the Software, and to permit persons to whom the
+ ** Software is furnished to do so, subject to the following conditions:
+ **
+ ** The above copyright notice and this permission notice shall be included in
+ ** all copies or substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ ** DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef GFXRECON_ENCODE_COMMAND_WRITER_H
+#define GFXRECON_ENCODE_COMMAND_WRITER_H
+
+#include "format/format.h"
+#include "util/compressor.h"
+#include "util/defines.h"
+#include "util/thread_data.h"
+#include "util/output_stream.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+/**
+ * @brief `CommandWriter` is a utility for writing commands to an `OutputStream`.
+ */
+class CommandWriter
+{
+  public:
+    CommandWriter(util::ThreadData* thread_data, util::OutputStream* output_stream, util::Compressor* compressor);
+
+    void WriteInitBufferCmd(format::ApiFamilyId p_api_family,
+                            format::HandleId    p_device_id,
+                            format::HandleId    p_buffer_id,
+                            uint64_t            p_offset,
+                            uint64_t            p_size,
+                            const void*         p_data);
+
+    void WriteInitImageCmd(format::ApiFamilyId          p_api_family,
+                           format::HandleId             p_device_id,
+                           format::HandleId             p_image_id,
+                           uint32_t                     p_aspect,
+                           uint32_t                     p_layout,
+                           uint32_t                     p_mip_levels,
+                           const std::vector<uint64_t>& p_level_sizes,
+                           uint64_t                     p_size,
+                           const void*                  p_data);
+
+  private:
+    util::ThreadData*   thread_data_;
+    util::OutputStream* output_stream_;
+    util::Compressor*   compressor_;
+};
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_ENCODE_COMMAND_WRITER_H

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -172,10 +172,9 @@ void D3D12CaptureManager::EndCommandListMethodCallCapture(ID3D12CommandList_Wrap
     EndMethodCallCapture();
 }
 
-void D3D12CaptureManager::WriteTrackedState(util::FileOutputStream* file_stream,
-                                            format::ThreadId        thread_id)
+void D3D12CaptureManager::WriteTrackedState(util::FileOutputStream* file_stream, util::ThreadData* thread_data)
 {
-    Dx12StateWriter state_writer(file_stream, GetCompressor(), thread_id);
+    Dx12StateWriter state_writer(file_stream, GetCompressor(), thread_data->thread_id_);
     state_tracker_->WriteState(&state_writer, GetCurrentFrame());
 }
 

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -848,22 +848,22 @@ class D3D12CaptureManager : public ApiCaptureManager
 
     virtual void DestroyStateTracker() override { state_tracker_ = nullptr; }
 
-    virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) override;
+    virtual void WriteTrackedState(util::FileOutputStream* file_stream, util::ThreadData* thread_data) override;
 
     virtual void WriteTrackedStateWithAssetFile(util::FileOutputStream* file_stream,
-                                                format::ThreadId        thread_id,
+                                                util::ThreadData*       thread_data,
                                                 util::FileOutputStream* asset_file_stream,
                                                 const std::string*      asset_file_name) override
     {
         GFXRECON_UNREFERENCED_PARAMETER(file_stream);
-        GFXRECON_UNREFERENCED_PARAMETER(thread_id);
+        GFXRECON_UNREFERENCED_PARAMETER(thread_data);
         GFXRECON_UNREFERENCED_PARAMETER(asset_file_stream);
         GFXRECON_UNREFERENCED_PARAMETER(asset_file_name);
     }
 
     virtual void WriteAssets(util::FileOutputStream* assert_file_stream,
                              const std::string*      asset_file_name,
-                             format::ThreadId        thread_id) override
+                             util::ThreadData*       thread_data) override
     {}
 
     void PreAcquireSwapChainImages(IDXGISwapChain_Wrapper* wrapper,

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -785,62 +785,23 @@ class VulkanCaptureManager : public ApiCaptureManager
         }
     }
 
+    void ProcessImportFd(VkDevice device, VkBuffer buffer, VkDeviceSize memoryOffset);
+
     void PostProcess_vkBindBufferMemory(
-        VkResult result, VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset)
-    {
-        if (IsCaptureModeTrack() && (result == VK_SUCCESS))
-        {
-            assert(state_tracker_ != nullptr);
-            state_tracker_->TrackBufferMemoryBinding(device, buffer, memory, memoryOffset);
-        }
-    }
+        VkResult result, VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset);
 
     void PostProcess_vkBindBufferMemory2(VkResult                      result,
                                          VkDevice                      device,
                                          uint32_t                      bindInfoCount,
-                                         const VkBindBufferMemoryInfo* pBindInfos)
-    {
-        if (IsCaptureModeTrack() && (result == VK_SUCCESS) && (pBindInfos != nullptr))
-        {
-            assert(state_tracker_ != nullptr);
-
-            for (uint32_t i = 0; i < bindInfoCount; ++i)
-            {
-                state_tracker_->TrackBufferMemoryBinding(device,
-                                                         pBindInfos[i].buffer,
-                                                         pBindInfos[i].memory,
-                                                         pBindInfos[i].memoryOffset,
-                                                         pBindInfos[i].pNext);
-            }
-        }
-    }
+                                         const VkBindBufferMemoryInfo* pBindInfos);
 
     void PostProcess_vkBindImageMemory(
-        VkResult result, VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset)
-    {
-        if (IsCaptureModeTrack() && (result == VK_SUCCESS))
-        {
-            assert(state_tracker_ != nullptr);
-            state_tracker_->TrackImageMemoryBinding(device, image, memory, memoryOffset);
-        }
-    }
+        VkResult result, VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset);
 
     void PostProcess_vkBindImageMemory2(VkResult                     result,
                                         VkDevice                     device,
                                         uint32_t                     bindInfoCount,
-                                        const VkBindImageMemoryInfo* pBindInfos)
-    {
-        if (IsCaptureModeTrack() && (result == VK_SUCCESS) && (pBindInfos != nullptr))
-        {
-            assert(state_tracker_ != nullptr);
-
-            for (uint32_t i = 0; i < bindInfoCount; ++i)
-            {
-                state_tracker_->TrackImageMemoryBinding(
-                    device, pBindInfos[i].image, pBindInfos[i].memory, pBindInfos[i].memoryOffset, pBindInfos[i].pNext);
-            }
-        }
-    }
+                                        const VkBindImageMemoryInfo* pBindInfos);
 
     void PostProcess_vkCmdBeginRenderPass(VkCommandBuffer              commandBuffer,
                                           const VkRenderPassBeginInfo* pRenderPassBegin,

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1,6 +1,6 @@
 /*
  ** Copyright (c) 2018-2021 Valve Corporation
- ** Copyright (c) 2018-2023 LunarG, Inc.
+ ** Copyright (c) 2018-2025 LunarG, Inc.
  ** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  **
  ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -785,7 +785,8 @@ class VulkanCaptureManager : public ApiCaptureManager
         }
     }
 
-    void ProcessImportFd(VkDevice device, VkBuffer buffer, VkDeviceSize memoryOffset);
+    void ProcessImportFdForBuffer(VkDevice device, VkBuffer buffer, VkDeviceSize memoryOffset);
+    void ProcessImportFdForImage(VkDevice device, VkImage image, VkDeviceSize memoryOffset);
 
     void PostProcess_vkBindBufferMemory(
         VkResult result, VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset);
@@ -1553,16 +1554,16 @@ class VulkanCaptureManager : public ApiCaptureManager
         state_tracker_ = nullptr;
     }
 
-    virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) override;
+    virtual void WriteTrackedState(util::FileOutputStream* file_stream, util::ThreadData* thread_data) override;
 
     virtual void WriteTrackedStateWithAssetFile(util::FileOutputStream* file_stream,
-                                                format::ThreadId        thread_id,
+                                                util::ThreadData*       thread_data,
                                                 util::FileOutputStream* asset_file_stream,
                                                 const std::string*      asset_file_name) override;
 
     virtual void WriteAssets(util::FileOutputStream* asset_file_stream,
                              const std::string*      asset_file_name,
-                             format::ThreadId        thread_id) override;
+                             util::ThreadData*       thread_data) override;
 
   private:
     struct HardwareBufferInfo

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -251,6 +251,7 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
     uintptr_t        shadow_allocation{ util::PageGuardManager::kNullShadowHandle };
     AHardwareBuffer* hardware_buffer{ nullptr };
     format::HandleId hardware_buffer_memory_id{ format::kNullHandleId };
+    int              imported_fd{ -1 };
 
     // State tracking info for memory with device addresses.
     format::HandleId device_id{ format::kNullHandleId };

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2021 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -56,7 +56,7 @@ class VulkanStateTracker
     ~VulkanStateTracker();
 
     uint64_t WriteState(util::FileOutputStream*           file_stream,
-                        format::ThreadId                  thread_id,
+                        util::ThreadData*                 thread_data,
                         std::function<format::HandleId()> get_unique_id_fn,
                         util::Compressor*                 compressor,
                         uint64_t                          frame_number,
@@ -65,7 +65,7 @@ class VulkanStateTracker
     {
         VulkanStateWriter state_writer(file_stream,
                                        compressor,
-                                       thread_id,
+                                       thread_data,
                                        get_unique_id_fn,
                                        asset_file_stream,
                                        asset_file_name,
@@ -77,15 +77,20 @@ class VulkanStateTracker
 
     uint64_t WriteAssets(util::FileOutputStream*           asset_file_stream,
                          const std::string*                asset_file_name,
-                         format::ThreadId                  thread_id,
+                         util::ThreadData*                 thread_data,
                          std::function<format::HandleId()> get_unique_id_fn,
                          util::Compressor*                 compressor)
     {
         assert(asset_file_stream != nullptr);
         assert(asset_file_name != nullptr);
 
-        VulkanStateWriter state_writer(
-            nullptr, compressor, thread_id, get_unique_id_fn, asset_file_stream, asset_file_name, &asset_file_offsets_);
+        VulkanStateWriter state_writer(nullptr,
+                                       compressor,
+                                       thread_data,
+                                       get_unique_id_fn,
+                                       asset_file_stream,
+                                       asset_file_name,
+                                       &asset_file_offsets_);
 
         std::unique_lock<std::mutex> lock(state_table_mutex_);
         return state_writer.WriteAssets(state_table_);

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -1,5 +1,5 @@
 /*
- ** Copyright (c) 2019-2021 LunarG, Inc.
+ ** Copyright (c) 2019-2025 LunarG, Inc.
  ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
  **
  ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -24,6 +24,7 @@
 #ifndef GFXRECON_ENCODE_VULKAN_STATE_WRITER_H
 #define GFXRECON_ENCODE_VULKAN_STATE_WRITER_H
 
+#include "encode/command_writer.h"
 #include "encode/parameter_encoder.h"
 #include "encode/vulkan_handle_wrappers.h"
 #include "generated/generated_vulkan_state_table.h"
@@ -35,6 +36,7 @@
 #include "util/defines.h"
 #include "util/file_output_stream.h"
 #include "util/memory_output_stream.h"
+#include "util/thread_data.h"
 
 #include "vulkan/vulkan.h"
 
@@ -53,18 +55,20 @@ class VulkanStateWriter
 
     VulkanStateWriter(util::FileOutputStream*                  output_stream,
                       util::Compressor*                        compressor,
-                      format::ThreadId                         thread_id,
+                      util::ThreadData*                        thread_data,
                       std::function<format::HandleId()>        get_unique_id_fn,
                       util::FileOutputStream*                  asset_file_stream  = nullptr,
                       const std::string*                       asset_file_name    = nullptr,
                       VulkanStateWriter::AssetFileOffsetsInfo* asset_file_offsets = nullptr);
 
+    util::ThreadData* GetThreadData() { return thread_data_; }
+
+    bool OutputStreamWrite(const void* data, size_t len);
+
     // Returns number of blocks written to the output_stream.
     uint64_t WriteState(const VulkanStateTable& state_table, uint64_t frame_number);
 
     uint64_t WriteAssets(const VulkanStateTable& state_table);
-
-    bool OutputStreamWrite(const void* data, size_t len);
 
     void WriteFillMemoryCmd(format::HandleId memory_id, VkDeviceSize offset, VkDeviceSize size, const void* data);
 
@@ -427,7 +431,7 @@ class VulkanStateWriter
     util::FileOutputStream*  output_stream_;
     util::Compressor*        compressor_;
     std::vector<uint8_t>     compressed_parameter_buffer_;
-    format::ThreadId         thread_id_;
+    util::ThreadData*        thread_data_;
     util::MemoryOutputStream parameter_stream_;
     ParameterEncoder         encoder_;
     uint64_t                 blocks_written_{ 0 };
@@ -438,6 +442,8 @@ class VulkanStateWriter
     util::FileOutputStream* asset_file_stream_;
     std::string             asset_file_name_;
     AssetFileOffsetsInfo*   asset_file_offsets_;
+
+    CommandWriter command_writer_;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/graphics/vulkan_struct_get_pnext.h
+++ b/framework/graphics/vulkan_struct_get_pnext.h
@@ -107,6 +107,42 @@ static T* vulkan_struct_get_pnext(Parent_T* parent)
     return nullptr;
 }
 
+/**
+ * @brief   vulkan_struct_remove_pnext can be used to remove elements in-place from a
+ *          provided structure's pNext-chain by their type.
+ *
+ * Searches through the parent's pNext-chain for the first struct with the requested struct_type.
+ * @p T and @p Parent_T must be Vulkan structure-types. Returns nullptr if no matching struct could be found.
+ *
+ * @tparam  T           the structure-type to remove from pNext-chain
+ * @tparam  Parent_T    implicit type of provided structure
+ * @param   parent      pointer to a non-const vulkan-structure containing a pNext-chain.
+ * @return  a typed pointer to a structure removed from the pNext-chain or nullptr.
+ */
+template <typename T, typename Parent_T>
+static T* vulkan_struct_remove_pnext(Parent_T* parent)
+{
+    static_assert(is_vulkan_struct_v<T> && is_vulkan_struct_v<Parent_T>);
+
+    if (parent != nullptr)
+    {
+        auto prev_struct    = reinterpret_cast<VkBaseOutStructure*>(parent);
+        auto current_struct = reinterpret_cast<VkBaseOutStructure*>(parent)->pNext;
+
+        while (current_struct != nullptr)
+        {
+            if (current_struct->sType == gfxrecon::util::GetSType<T>())
+            {
+                prev_struct->pNext = current_struct->pNext;
+                return reinterpret_cast<T*>(current_struct);
+            }
+            prev_struct    = current_struct;
+            current_struct = current_struct->pNext;
+        }
+    }
+    return nullptr;
+}
+
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018-2020,2023 LunarG, Inc.
+# Copyright (c) 2018-2020,2023-2025 LunarG, Inc.
 # Copyright (c) 2018-2023 Advanced Micro Devices, Inc. All rights reserved
 # All rights reserved
 #
@@ -101,8 +101,8 @@ target_sources(gfxrecon_util
                     ${CMAKE_CURRENT_LIST_DIR}/strings.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/to_string.h
                     ${CMAKE_CURRENT_LIST_DIR}/to_string.cpp
-                    ${CMAKE_CURRENT_LIST_DIR}/options.h
-                    ${CMAKE_CURRENT_LIST_DIR}/options.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/thread_data.h
+                    ${CMAKE_CURRENT_LIST_DIR}/thread_data.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/custom_common_to_string.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_common_to_string.cpp
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_enum_to_string.h

--- a/framework/util/file_output_stream.h
+++ b/framework/util/file_output_stream.h
@@ -28,6 +28,7 @@
 #include "util/defines.h"
 #include "util/output_stream.h"
 #include "util/platform.h"
+#include "util/thread_data.h"
 
 #include <cstdint>
 #include <cstdio>

--- a/framework/util/thread_data.cpp
+++ b/framework/util/thread_data.cpp
@@ -1,0 +1,62 @@
+/*
+ ** Copyright (c) 2025 LunarG, Inc.
+ **
+ ** Permission is hereby granted, free of charge, to any person obtaining a
+ ** copy of this software and associated documentation files (the "Software"),
+ ** to deal in the Software without restriction, including without limitation
+ ** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ ** and/or sell copies of the Software, and to permit persons to whom the
+ ** Software is furnished to do so, subject to the following conditions:
+ **
+ ** The above copyright notice and this permission notice shall be included in
+ ** all copies or substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ ** DEALINGS IN THE SOFTWARE.
+ */
+
+#include "util/thread_data.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+std::mutex                                     ThreadData::count_lock_;
+format::ThreadId                               ThreadData::thread_count_ = 0;
+std::unordered_map<uint64_t, format::ThreadId> ThreadData::id_map_;
+
+ThreadData::ThreadData() :
+    thread_id_(GetThreadId()), object_id_(format::kNullHandleId), call_id_(format::ApiCallId::ApiCall_Unknown),
+    block_index_(0)
+{
+    parameter_buffer_  = std::make_unique<encode::ParameterBuffer>();
+    parameter_encoder_ = std::make_unique<encode::ParameterEncoder>(parameter_buffer_.get());
+}
+
+format::ThreadId ThreadData::GetThreadId()
+{
+    format::ThreadId id  = 0;
+    uint64_t         tid = util::platform::GetCurrentThreadId();
+
+    // Using a uint64_t sequence number associated with the thread ID.
+    std::lock_guard<std::mutex> lock(count_lock_);
+    auto                        entry = id_map_.find(tid);
+    if (entry != id_map_.end())
+    {
+        id = entry->second;
+    }
+    else
+    {
+        id = ++thread_count_;
+        id_map_.insert(std::make_pair(tid, id));
+    }
+
+    return id;
+}
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/thread_data.h
+++ b/framework/util/thread_data.h
@@ -1,0 +1,65 @@
+/*
+** Copyright (c) 2025 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_UTIL_THREAD_DATA_H
+#define GFXRECON_UTIL_THREAD_DATA_H
+
+#include "encode/handle_unwrap_memory.h"
+#include "encode/parameter_buffer.h"
+#include "encode/parameter_encoder.h"
+#include "format/format.h"
+#include "util/defines.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+class ThreadData
+{
+  public:
+    ThreadData();
+
+    std::vector<uint8_t>& GetScratchBuffer() { return scratch_buffer_; }
+
+    const format::ThreadId                    thread_id_;
+    format::ApiCallId                         call_id_;
+    format::HandleId                          object_id_;
+    std::unique_ptr<encode::ParameterBuffer>  parameter_buffer_;
+    std::unique_ptr<encode::ParameterEncoder> parameter_encoder_;
+    std::vector<uint8_t>                      compressed_buffer_;
+    encode::HandleUnwrapMemory                handle_unwrap_memory_;
+    uint64_t                                  block_index_;
+
+  private:
+    static format::ThreadId GetThreadId();
+
+    static std::mutex                                     count_lock_;
+    static format::ThreadId                               thread_count_;
+    static std::unordered_map<uint64_t, format::ThreadId> id_map_;
+
+    // Used for combining multiple buffers for a single file write.
+    std::vector<uint8_t> scratch_buffer_;
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_THREAD_DATA_H


### PR DESCRIPTION
Initial support for VK_KHR_external_memory_fd.

Capture: once a device memory imported from external FD is bound to a buffer, an InitBuffer command is generated with the current content of the memory.

Replay: the import memory FD structure is removed from the pNext chain of `VkMemoryAllocateInfo`, and the initial content of the buffer is initialized through the InitBuffer command.

It supports images as well!