### PR TITLE
Fix crash in vkBeginCommandBuffer

### DIFF
--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -348,6 +348,8 @@ class VulkanCaptureManager : public ApiCaptureManager
                                                             uint32_t*                 pQueueFamilyPropertyCount,
                                                             VkQueueFamilyProperties2* pQueueFamilyProperties);
 
+    VkResult OverrideBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo);
+
     void PostProcess_vkEnumeratePhysicalDevices(VkResult          result,
                                                 VkInstance        instance,
                                                 uint32_t*         pPhysicalDeviceCount,

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -348,6 +348,10 @@ class VulkanCaptureManager : public ApiCaptureManager
                                                             uint32_t*                 pQueueFamilyPropertyCount,
                                                             VkQueueFamilyProperties2* pQueueFamilyProperties);
 
+    VkResult OverrideAllocateCommandBuffers(VkDevice                           device,
+                                            const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                            VkCommandBuffer*                   pCommandBuffers);
+
     VkResult OverrideBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo);
 
     void PostProcess_vkEnumeratePhysicalDevices(VkResult          result,

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -837,7 +837,7 @@ inline void InitializePoolObjectState(VkDevice                               par
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->level = alloc_info->level;
+    // Some CommandBufferWrapper's info is initialized in OverrideAllocateCommandBuffers.
 }
 
 inline void InitializePoolObjectState(VkDevice                               parent_handle,

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -3589,19 +3589,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkBeginCommandBuffer(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBeginCommandBuffer>::Dispatch(manager, commandBuffer, pBeginInfo);
 
-    const auto command_buffer_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
-    VkCommandBufferBeginInfo begin_info_copy = *pBeginInfo;
-    // If command buffer level is primary, pInheritanceInfo must be ignored
-    if (command_buffer_wrapper && command_buffer_wrapper->level == VK_COMMAND_BUFFER_LEVEL_PRIMARY && begin_info_copy.pInheritanceInfo != nullptr)
-    {
-        pBeginInfo = &begin_info_copy;
-        begin_info_copy.pInheritanceInfo = nullptr;
-    }
-
-    auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
-    const VkCommandBufferBeginInfo* pBeginInfo_unwrapped = vulkan_wrappers::UnwrapStructPtrHandles(pBeginInfo, handle_unwrap_memory);
-
-    VkResult result = vulkan_wrappers::GetDeviceTable(commandBuffer)->BeginCommandBuffer(commandBuffer, pBeginInfo_unwrapped);
+    VkResult result = manager->OverrideBeginCommandBuffer(commandBuffer, pBeginInfo);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkBeginCommandBuffer);
     if (encoder)

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -3589,6 +3589,15 @@ VKAPI_ATTR VkResult VKAPI_CALL vkBeginCommandBuffer(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBeginCommandBuffer>::Dispatch(manager, commandBuffer, pBeginInfo);
 
+    const auto command_buffer_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+    VkCommandBufferBeginInfo begin_info_copy = *pBeginInfo;
+    // If command buffer level is primary, pInheritanceInfo must be ignored
+    if (command_buffer_wrapper && command_buffer_wrapper->level == VK_COMMAND_BUFFER_LEVEL_PRIMARY && begin_info_copy.pInheritanceInfo != nullptr)
+    {
+        pBeginInfo = &begin_info_copy;
+        begin_info_copy.pInheritanceInfo = nullptr;
+    }
+
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCommandBufferBeginInfo* pBeginInfo_unwrapped = vulkan_wrappers::UnwrapStructPtrHandles(pBeginInfo, handle_unwrap_memory);
 

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -3498,16 +3498,8 @@ VKAPI_ATTR VkResult VKAPI_CALL vkAllocateCommandBuffers(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAllocateCommandBuffers>::Dispatch(manager, device, pAllocateInfo, pCommandBuffers);
 
-    auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
-    const VkCommandBufferAllocateInfo* pAllocateInfo_unwrapped = vulkan_wrappers::UnwrapStructPtrHandles(pAllocateInfo, handle_unwrap_memory);
-
-    VkResult result = vulkan_wrappers::GetDeviceTable(device)->AllocateCommandBuffers(device, pAllocateInfo_unwrapped, pCommandBuffers);
-
-    if (result >= 0)
-    {
-        vulkan_wrappers::CreateWrappedHandles<vulkan_wrappers::DeviceWrapper, vulkan_wrappers::CommandPoolWrapper, vulkan_wrappers::CommandBufferWrapper>(device, pAllocateInfo->commandPool, pCommandBuffers, pAllocateInfo->commandBufferCount, VulkanCaptureManager::GetUniqueId);
-    }
-    else
+    VkResult result = manager->OverrideAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers);
+    if (result < 0)
     {
         omit_output_data = true;
     }

--- a/framework/generated/khronos_generators/vulkan_generators/capture_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/capture_overrides.json
@@ -16,6 +16,7 @@
         "vkCmdCopyAccelerationStructureKHR": "manager->OverrideCmdCopyAccelerationStructureKHR",
         "vkCmdWriteAccelerationStructuresPropertiesKHR": "manager->OverrideCmdWriteAccelerationStructuresPropertiesKHR",
         "vkGetPhysicalDeviceProperties2": "manager->OverrideGetPhysicalDeviceProperties2",
-        "vkGetPhysicalDeviceProperties2KHR": "manager->OverrideGetPhysicalDeviceProperties2"
+        "vkGetPhysicalDeviceProperties2KHR": "manager->OverrideGetPhysicalDeviceProperties2",
+        "vkBeginCommandBuffer": "manager->OverrideBeginCommandBuffer"
     }
 }

--- a/framework/generated/khronos_generators/vulkan_generators/capture_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/capture_overrides.json
@@ -17,6 +17,7 @@
         "vkCmdWriteAccelerationStructuresPropertiesKHR": "manager->OverrideCmdWriteAccelerationStructuresPropertiesKHR",
         "vkGetPhysicalDeviceProperties2": "manager->OverrideGetPhysicalDeviceProperties2",
         "vkGetPhysicalDeviceProperties2KHR": "manager->OverrideGetPhysicalDeviceProperties2",
+        "vkAllocateCommandBuffers": "manager->OverrideAllocateCommandBuffers",
         "vkBeginCommandBuffer": "manager->OverrideBeginCommandBuffer"
     }
 }

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -90,9 +90,6 @@ class VulkanApiCallEncodersBodyGenerator(VulkanBaseGenerator, KhronosApiCallEnco
     # Functions that can activate trimming from a post call command.
     POSTCALL_TRIM_TRIGGERS = ['vkQueueSubmit', 'vkQueueSubmit2', 'vkQueueSubmit2KHR', 'vkQueuePresentKHR', 'vkFrameBoundaryANDROID']
 
-    # Functions that need to sanitize parameters
-    SANITIZE_PARAMETERS = ['vkBeginCommandBuffer']
-
     def __init__(
         self, err_file=sys.stderr, warn_file=sys.stderr, diag_file=sys.stdout
     ):
@@ -145,20 +142,6 @@ class VulkanApiCallEncodersBodyGenerator(VulkanBaseGenerator, KhronosApiCallEnco
             dispatchfunc = '{}::GetDeviceTable'.format(wrapper_prefix)
 
         return [call_setup_expr, '{}({})->{}({})'.format(dispatchfunc, object_name, name[2:], arg_list)]
-
-    def sanitize_parameters(self, name, indent):
-        body = ''
-        if name == 'vkBeginCommandBuffer':
-            body += indent + 'const auto command_buffer_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);\n'
-            body += indent + 'VkCommandBufferBeginInfo begin_info_copy = *pBeginInfo;\n'
-            body += indent + '// If command buffer level is primary, pInheritanceInfo must be ignored\n'
-            body += indent + 'if (command_buffer_wrapper && command_buffer_wrapper->level == VK_COMMAND_BUFFER_LEVEL_PRIMARY && begin_info_copy.pInheritanceInfo != nullptr)\n'
-            body += indent + '{\n'
-            body += indent + '    pBeginInfo = &begin_info_copy;\n'
-            body += indent + '    begin_info_copy.pInheritanceInfo = nullptr;\n'
-            body += indent + '}\n'
-            body += '\n'
-        return body
 
     def make_cmd_body(self, return_type, name, values):
         """Command definition."""
@@ -216,9 +199,6 @@ class VulkanApiCallEncodersBodyGenerator(VulkanBaseGenerator, KhronosApiCallEnco
             )
 
         body += '\n'
-
-        if name in self.SANITIZE_PARAMETERS:
-            body += self.sanitize_parameters(name, indent)
 
         if is_override:
             # Capture overrides simply call the override function without handle unwrap/wrap


### PR DESCRIPTION
From the spec:

> pInheritanceInfo is a pointer to a VkCommandBufferInheritanceInfo structure, used if commandBuffer is a secondary command buffer. If this is a primary command buffer, then this value is ignored.

This would crash if pInheritanceInfo is pointing to invalid memory.