### PR TITLE
Fix shadow memory size

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1944,7 +1944,8 @@ void VulkanCaptureManager::PostProcess_vkMapMemory(VkResult         result,
                     else if (IsPageGuardMemoryModeShadowPersistent() &&
                              (wrapper->shadow_allocation == util::PageGuardManager::kNullShadowHandle))
                     {
-                        wrapper->shadow_allocation = manager->AllocatePersistentShadowMemory(static_cast<size_t>(size));
+                        wrapper->shadow_allocation =
+                            manager->AllocatePersistentShadowMemory(static_cast<size_t>(wrapper->allocation_size));
                     }
 
                     // Return the pointer provided by the pageguard manager, which may be a pointer to shadow memory,


### PR DESCRIPTION
Shadow memory size must match that in page guard manager, or it can result in oob access when memory is mapped with an offset.

To demonstrate the problem:
```
VkMemoryAllocateInfo memoryAllocateInfo;
memoryAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
memoryAllocateInfo.pNext = NULL;
memoryAllocateInfo.allocationSize = 65536;
memoryAllocateInfo.memoryTypeIndex = 0; // Host visible

VkDeviceMemory memory;
vkAllocateMemory(vk->device, &memoryAllocateInfo, NULL, &memory);

void* data;
vkMapMemory(vk->device, memory, 32768, 32768, 0u, &data);
```

This currently asserts as index in vector access in page_guard_manager.cpp:1115
`shadow_memory_info->page_loaded[page_index]`
is out of bounds.

Currently shadow memory is only allocated from the mapped size, not the entire memory size.
`total_shadow_pages` is the case above results in 8, meanwhile `total_pages` in `PageGuardManager::AddTrackedMemory`
are calcuated with the entire memory allocation size, which gives 16. In page_guard_manager.cpp:1115 is a for loop from 0 to `total_pages` and that index is used to access 
`shadow_memory_info->page_loaded`, which leads to oob access.