### PR TITLE
Add missing json fields

### DIFF
--- a/framework/decode/custom_vulkan_struct_to_json.cpp
+++ b/framework/decode/custom_vulkan_struct_to_json.cpp
@@ -462,5 +462,17 @@ void FieldToJson(nlohmann::ordered_json&                               jdata,
     FieldToJson(jdata["offset"], pData->offset, options);
 }
 
+void FieldToJson(nlohmann::ordered_json& jdata, const format::DeviceMemoryType& data, const util::JsonOptions& options)
+{
+    FieldToJson(decode::VkMemoryPropertyFlags_t(), jdata["property_flags"], data.property_flags, options);
+    FieldToJson(jdata["heap_index"], data.heap_index, options);
+}
+
+void FieldToJson(nlohmann::ordered_json& jdata, const format::DeviceMemoryHeap& data, const util::JsonOptions& options)
+{
+    FieldToJson(jdata["size"], data.size, options);
+    FieldToJson(decode::VkMemoryHeapFlags_t(), jdata["flags"], data.flags, options);
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/custom_vulkan_struct_to_json.h
+++ b/framework/decode/custom_vulkan_struct_to_json.h
@@ -123,6 +123,26 @@ void FieldToJson(nlohmann::ordered_json&                               jdata,
                  const Decoded_VkIndirectCommandsLayoutTokenEXT* const pData,
                  const util::JsonOptions&                              options = util::JsonOptions());
 
+void FieldToJson(nlohmann::ordered_json&         jdata,
+                 const format::DeviceMemoryType& data,
+                 const util::JsonOptions&        options = util::JsonOptions());
+
+void FieldToJson(nlohmann::ordered_json&         jdata,
+                 const format::DeviceMemoryHeap& data,
+                 const util::JsonOptions&        options = util::JsonOptions());
+
+template <typename T>
+void FieldToJson(nlohmann::ordered_json&  jdata,
+                 const std::vector<T>&    data,
+                 const util::JsonOptions& options = util::JsonOptions())
+{
+    int i = 0;
+    for (const auto& item : data)
+    {
+        FieldToJson(jdata[i++], item, options);
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/decode/metadata_json_consumer.h
+++ b/framework/decode/metadata_json_consumer.h
@@ -175,17 +175,6 @@ class MetadataJsonConsumer : public Base
     }
 
     virtual void
-    ProcessSetDeviceMemoryPropertiesCommand(format::HandleId                             physical_device_id,
-                                            const std::vector<format::DeviceMemoryType>& memory_types,
-                                            const std::vector<format::DeviceMemoryHeap>& memory_heaps) override
-    {
-        const util::JsonOptions& json_options = GetJsonOptions();
-        auto&                    jdata        = WriteMetaCommandStart("SetDeviceMemoryPropertiesCommand");
-        HandleToJson(jdata["physical_device_id"], physical_device_id, json_options);
-        WriteBlockEnd();
-    }
-
-    virtual void
     ProcessSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address) override
     {
         const JsonOptions& json_options = GetJsonOptions();

--- a/framework/decode/vulkan_json_consumer_base.cpp
+++ b/framework/decode/vulkan_json_consumer_base.cpp
@@ -23,6 +23,8 @@
 #include "decode/vulkan_json_consumer_base.h"
 #include "decode/custom_vulkan_struct_to_json.h"
 
+#include "generated/generated_vulkan_enum_to_json.h"
+
 #include "util/json_util.h"
 #include "util/platform.h"
 #include "util/file_path.h"
@@ -66,6 +68,23 @@ std::string VulkanExportJsonConsumerBase::GenerateFilename(const std::string& fi
 bool VulkanExportJsonConsumerBase::WriteBinaryFile(const std::string& filename, uint64_t data_size, const uint8_t* data)
 {
     return writer_->WriteBinaryFile(filename, data_size, data);
+}
+
+void VulkanExportJsonConsumerBase::ProcessSetDeviceMemoryPropertiesCommand(
+    format::HandleId                             physical_device_id,
+    const std::vector<format::DeviceMemoryType>& memory_types,
+    const std::vector<format::DeviceMemoryHeap>& memory_heaps)
+{
+    const JsonOptions& json_options = GetJsonOptions();
+
+    writer_->SetCurrentBlockIndex(block_index_);
+    auto& jdata = writer_->WriteMetaCommandStart("SetDeviceMemoryPropertiesCommand");
+
+    HandleToJson(jdata["physical_device_id"], physical_device_id, json_options);
+    FieldToJson(jdata["memory_types"], memory_types, json_options);
+    FieldToJson(jdata["memory_heaps"], memory_heaps, json_options);
+
+    WriteBlockEnd();
 }
 
 void VulkanExportJsonConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKHR(

--- a/framework/decode/vulkan_json_consumer_base.h
+++ b/framework/decode/vulkan_json_consumer_base.h
@@ -52,6 +52,11 @@ class VulkanExportJsonConsumerBase : public VulkanConsumer
 
     bool IsValid() const { return writer_ && writer_->IsValid(); }
 
+    virtual void
+    ProcessSetDeviceMemoryPropertiesCommand(format::HandleId                             physical_device_id,
+                                            const std::vector<format::DeviceMemoryType>& memory_types,
+                                            const std::vector<format::DeviceMemoryHeap>& memory_heaps) override;
+
     void Process_vkCmdBuildAccelerationStructuresIndirectKHR(
         const ApiCallInfo&                                                         call_info,
         format::HandleId                                                           commandBuffer,


### PR DESCRIPTION
I was looking at another issue and noticed the json output for SetDeviceMemoryPropertiesCommand was missing some information.

Here's a sample diff with the new output (with `--expand-flags`):

```diff
@@ -197,11 +197,67 @@
 {
   "index": 7,
   "meta": {
     "name": "SetDeviceMemoryPropertiesCommand",
     "args": {
-      "physical_device_id": 2
+      "physical_device_id": 2,
+      "memory_types": [
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT",
+          "heap_index": 1
+        },
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT",
+          "heap_index": 1
+        },
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT",
+          "heap_index": 0
+        },
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT|VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT",
+          "heap_index": 1
+        },
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT|VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT",
+          "heap_index": 1
+        },
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT|VK_MEMORY_PROPERTY_HOST_CACHED_BIT",
+          "heap_index": 0
+        },
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT|VK_MEMORY_PROPERTY_HOST_CACHED_BIT",
+          "heap_index": 0
+        },
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT|VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD|VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD",
+          "heap_index": 1
+        },
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT|VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD|VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD",
+          "heap_index": 0
+        },
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT|VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT|VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD|VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD",
+          "heap_index": 1
+        },
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT|VK_MEMORY_PROPERTY_HOST_CACHED_BIT|VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD|VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD",
+          "heap_index": 0
+        }
+      ],
+      "memory_heaps": [
+        {
+          "size": 11566919680,
+          "flags": "0x00000000"
+        },
+        {
+          "size": 23133847552,
+          "flags": "VK_MEMORY_HEAP_DEVICE_LOCAL_BIT"
+        }
+      ]
     }
   }
 },
@@ -222,11 +278,23 @@
 {
   "index": 9,
   "meta": {
     "name": "SetDeviceMemoryPropertiesCommand",
     "args": {
-      "physical_device_id": 3
+      "physical_device_id": 3,
+      "memory_types": [
+        {
+          "property_flags": "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT|VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT|VK_MEMORY_PROPERTY_HOST_CACHED_BIT",
+          "heap_index": 0
+        }
+      ],
+      "memory_heaps": [
+        {
+          "size": 65106571264,
+          "flags": "VK_MEMORY_HEAP_DEVICE_LOCAL_BIT"
+        }
+      ]
     }
   }
 },
```