### PR TITLE
Update Vulkan Headers to v1.4.304

### DIFF
--- a/framework/generated/generated_vulkan_enum_to_json.cpp
+++ b/framework/generated/generated_vulkan_enum_to_json.cpp
@@ -3372,8 +3372,8 @@ void FieldToJson(nlohmann::ordered_json& jdata, const VkDriverId& value, const J
         case VK_DRIVER_ID_MESA_HONEYKRISP:
             jdata = "VK_DRIVER_ID_MESA_HONEYKRISP";
             break;
-        case VK_DRIVER_ID_RESERVED_27:
-            jdata = "VK_DRIVER_ID_RESERVED_27";
+        case VK_DRIVER_ID_VULKAN_SC_EMULATION_ON_VULKAN:
+            jdata = "VK_DRIVER_ID_VULKAN_SC_EMULATION_ON_VULKAN";
             break;
         default:
             jdata = to_hex_fixed_width(value);

--- a/framework/generated/generated_vulkan_enum_to_string.cpp
+++ b/framework/generated/generated_vulkan_enum_to_string.cpp
@@ -3728,7 +3728,7 @@ template <> std::string ToString<VkDriverId>(const VkDriverId& value, ToStringFl
     case VK_DRIVER_ID_MESA_NVK: return "VK_DRIVER_ID_MESA_NVK";
     case VK_DRIVER_ID_IMAGINATION_OPEN_SOURCE_MESA: return "VK_DRIVER_ID_IMAGINATION_OPEN_SOURCE_MESA";
     case VK_DRIVER_ID_MESA_HONEYKRISP: return "VK_DRIVER_ID_MESA_HONEYKRISP";
-    case VK_DRIVER_ID_RESERVED_27: return "VK_DRIVER_ID_RESERVED_27";
+    case VK_DRIVER_ID_VULKAN_SC_EMULATION_ON_VULKAN: return "VK_DRIVER_ID_VULKAN_SC_EMULATION_ON_VULKAN";
     default: break;
     }
     return "Unhandled VkDriverId";


### PR DESCRIPTION
This is another header update, but the changes are very minor. Regarding GFXR, it looks like the only effect was renaming one enumerant.