### PR TITLE
Fix shader wrapper assert when pipeline binaries are used

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2779,14 +2779,18 @@ void VulkanCaptureManager::PostProcess_vkCreateGraphicsPipelines(VkResult       
                 vulkan_wrappers::GetWrapper<vulkan_wrappers::PipelineWrapper>(pPipelines[p]);
             assert(ppl_wrapper != nullptr);
 
-            for (uint32_t s = 0; s < pCreateInfos[p].stageCount; ++s)
+            const auto binary_info = graphics::vulkan_struct_get_pnext<VkPipelineBinaryInfoKHR>(&pCreateInfos[p]);
+            if (binary_info == nullptr || !binary_info->binaryCount)
             {
-                const vulkan_wrappers::ShaderModuleWrapper* shader_wrapper =
-                    vulkan_wrappers::GetWrapper<vulkan_wrappers::ShaderModuleWrapper>(
-                        pCreateInfos[p].pStages[s].module);
-                assert(shader_wrapper != nullptr);
+                for (uint32_t s = 0; s < pCreateInfos[p].stageCount; ++s)
+                {
+                    const vulkan_wrappers::ShaderModuleWrapper* shader_wrapper =
+                        vulkan_wrappers::GetWrapper<vulkan_wrappers::ShaderModuleWrapper>(
+                            pCreateInfos[p].pStages[s].module);
+                    assert(shader_wrapper != nullptr);
 
-                ppl_wrapper->bound_shaders.push_back(*shader_wrapper);
+                    ppl_wrapper->bound_shaders.push_back(*shader_wrapper);
+                }
             }
         }
     }
@@ -2808,11 +2812,15 @@ void VulkanCaptureManager::PostProcess_vkCreateComputePipelines(VkResult        
                 vulkan_wrappers::GetWrapper<vulkan_wrappers::PipelineWrapper>(pPipelines[p]);
             assert(ppl_wrapper != nullptr);
 
-            const vulkan_wrappers::ShaderModuleWrapper* shader_wrapper =
-                vulkan_wrappers::GetWrapper<vulkan_wrappers::ShaderModuleWrapper>(pCreateInfos[p].stage.module);
-            assert(shader_wrapper != nullptr);
+            const auto binary_info = graphics::vulkan_struct_get_pnext<VkPipelineBinaryInfoKHR>(&pCreateInfos[p]);
+            if (binary_info == nullptr || !binary_info->binaryCount)
+            {
+                const vulkan_wrappers::ShaderModuleWrapper* shader_wrapper =
+                    vulkan_wrappers::GetWrapper<vulkan_wrappers::ShaderModuleWrapper>(pCreateInfos[p].stage.module);
+                assert(shader_wrapper != nullptr);
 
-            ppl_wrapper->bound_shaders.push_back(*shader_wrapper);
+                ppl_wrapper->bound_shaders.push_back(*shader_wrapper);
+            }
         }
     }
 }
@@ -2835,14 +2843,18 @@ void VulkanCaptureManager::PostProcess_vkCreateRayTracingPipelinesKHR(
                 vulkan_wrappers::GetWrapper<vulkan_wrappers::PipelineWrapper>(pPipelines[p]);
             assert(ppl_wrapper != nullptr);
 
-            for (uint32_t s = 0; s < pCreateInfos[p].stageCount; ++s)
+            const auto binary_info = graphics::vulkan_struct_get_pnext<VkPipelineBinaryInfoKHR>(&pCreateInfos[p]);
+            if (binary_info == nullptr || !binary_info->binaryCount)
             {
-                const vulkan_wrappers::ShaderModuleWrapper* shader_wrapper =
-                    vulkan_wrappers::GetWrapper<vulkan_wrappers::ShaderModuleWrapper>(
-                        pCreateInfos[p].pStages[s].module);
-                assert(shader_wrapper != nullptr);
+                for (uint32_t s = 0; s < pCreateInfos[p].stageCount; ++s)
+                {
+                    const vulkan_wrappers::ShaderModuleWrapper* shader_wrapper =
+                        vulkan_wrappers::GetWrapper<vulkan_wrappers::ShaderModuleWrapper>(
+                            pCreateInfos[p].pStages[s].module);
+                    assert(shader_wrapper != nullptr);
 
-                ppl_wrapper->bound_shaders.push_back(*shader_wrapper);
+                    ppl_wrapper->bound_shaders.push_back(*shader_wrapper);
+                }
             }
         }
     }


### PR DESCRIPTION
From the spec:

> If a VkPipelineBinaryInfoKHR structure with a binaryCount greater than 0 is included in the pNext chain of any Vk*PipelineCreateInfo structure when creating a pipeline, implementations must use the data in pPipelineBinaries instead of recalculating it. Any shader module identifiers or shader modules declared in VkPipelineShaderStageCreateInfo instances are ignored.