### PR TITLE
Initialize Device Info From AGS

### DIFF
--- a/framework/decode/custom_ags_replay_consumer.cpp
+++ b/framework/decode/custom_ags_replay_consumer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -201,7 +201,16 @@ void AgsReplayConsumer::Process_agsDriverExtensionsDX12_CreateDevice(
         DxObjectInfo object_info{};
         object_info.capture_id = pReturnParams->GetMetaStructPointer()->pDevice;
         object_info.object     = returned_parameters.pDevice;
-        object_info.extra_info = std::move(std::make_unique<D3D12DeviceInfo>());
+
+        auto device_info = std::make_unique<D3D12DeviceInfo>();
+        graphics::dx12::GetAdapterAndIndexbyDevice(returned_parameters.pDevice,
+                                                   device_info->adapter3,
+                                                   device_info->adapter_node_index,
+                                                   dx12_replay_consumer_->GetAdaptersMap());
+        device_info->is_uma = graphics::dx12::IsUma(returned_parameters.pDevice);
+        graphics::dx12::MarkActiveAdapter(returned_parameters.pDevice, dx12_replay_consumer_->GetAdaptersMap());
+        object_info.extra_info = std::move(device_info);
+
         dx12_replay_consumer_->AddObject(&(object_info.capture_id),
                                          reinterpret_cast<void**>(&(object_info.object)),
                                          std::move(object_info),

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021-2022 LunarG, Inc.
-** Copyright (c) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -282,6 +282,8 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     IDXGIAdapter* GetAdapter();
 
+    graphics::dx12::ActiveAdapterMap& GetAdaptersMap() { return adapters_; }
+
   protected:
     void MapGpuDescriptorHandle(D3D12_GPU_DESCRIPTOR_HANDLE& handle);
 
@@ -455,7 +457,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                  D3D12_RENDER_PASS_FLAGS                                             Flags);
 
     template <typename T>
-    void SetResourceSamplerFeedbackMipRegion(D3D12_RESOURCE_DESC1& desc_dest, T* desc_src){};
+    void SetResourceSamplerFeedbackMipRegion(D3D12_RESOURCE_DESC1& desc_dest, T* desc_src) {};
 
     template <>
     void SetResourceSamplerFeedbackMipRegion(D3D12_RESOURCE_DESC1& desc_dest, D3D12_RESOURCE_DESC1* desc_src)


### PR DESCRIPTION
The D3D12 device could be created by AGS calls.
So the device info structure have to be set as well.