### PR TITLE
if file was not opened, say so

### DIFF
--- a/tools/replay/parse_dump_resources_cli.cpp
+++ b/tools/replay/parse_dump_resources_cli.cpp
@@ -258,6 +258,13 @@ bool parse_dump_resources_arg(gfxrecon::decode::VulkanReplayOptions& vulkan_repl
         try
         {
             std::ifstream          dr_json_file(vulkan_replay_options.dump_resources, std::ifstream::binary);
+            if(!dr_json_file.is_open())
+            {
+                GFXRECON_LOG_ERROR("Could not open \"%s\" for input", vulkan_replay_options.dump_resources.c_str());
+                vulkan_replay_options.dumping_resources = false;
+                return false;
+            }
+
             nlohmann::ordered_json jargs;
             dr_json_file >> jargs;
 


### PR DESCRIPTION
Ran into this attempting to run some tests - if the specified dump-resources file does not exist, it's reported as a parse error.  If it actually was not opened, print something more specific.