### PR TITLE
Remove retired swapchain images immediately

### DIFF
--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -236,7 +236,17 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>
     template <typename... Args>
     static void Dispatch(VulkanCaptureManager* manager, Args... args)
     {
-        manager->PreProcess_vkCreateSwapchain(args...);
+        manager->PreProcess_vkCreateSwapchainKHR(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCreateSwapchainKHR(args...);
     }
 };
 

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -479,10 +479,16 @@ class VulkanCaptureManager : public ApiCaptureManager
                                               const VkAllocationCallbacks*         pAllocator,
                                               VkSurfaceKHR*                        pSurface);
 
-    void PreProcess_vkCreateSwapchain(VkDevice                        device,
-                                      const VkSwapchainCreateInfoKHR* pCreateInfo,
-                                      const VkAllocationCallbacks*    pAllocator,
-                                      VkSwapchainKHR*                 pSwapchain);
+    void PreProcess_vkCreateSwapchainKHR(VkDevice                        device,
+                                         const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                         const VkAllocationCallbacks*    pAllocator,
+                                         VkSwapchainKHR*                 pSwapchain);
+
+    void PostProcess_vkCreateSwapchainKHR(VkResult                        result,
+                                          VkDevice                        device,
+                                          const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                          const VkAllocationCallbacks*    pAllocator,
+                                          VkSwapchainKHR*                 pSwapchain);
 
     void PostProcess_vkAcquireNextImageKHR(VkResult result,
                                            VkDevice,

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -202,7 +202,7 @@ void CreateWrappedDispatchHandle(typename ParentWrapper::HandleType parent,
         {
             auto existing_wrapper = state_handle_table_.GetWrapper<Wrapper>(wrapper->handle);
             GFXRECON_LOG_WARNING("Cannot add duplicate entry to VulkanStateHandleTable for handle 0x%" PRIx64
-                                 " with ID %d. This handle is already wrapped with ID %d.",
+                                 " with ID %" PRIu64 ". This handle is already wrapped with ID %" PRIu64 ".",
                                  wrapper->handle,
                                  wrapper->handle_id,
                                  existing_wrapper->handle_id);
@@ -224,7 +224,7 @@ void CreateWrappedNonDispatchHandle(typename Wrapper::HandleType* handle, PFN_Ge
         {
             auto existing_wrapper = state_handle_table_.GetWrapper<Wrapper>(wrapper->handle);
             GFXRECON_LOG_WARNING("Cannot add duplicate entry to VulkanStateHandleTable for handle 0x%" PRIx64
-                                 " with ID %d. This handle is already wrapped with ID %d.",
+                                 " with ID %" PRIu64 ". This handle is already wrapped with ID %" PRIu64 ".",
                                  wrapper->handle,
                                  wrapper->handle_id,
                                  existing_wrapper->handle_id);

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -200,9 +200,12 @@ void CreateWrappedDispatchHandle(typename ParentWrapper::HandleType parent,
         }
         if (!state_handle_table_.InsertWrapper(wrapper))
         {
-            GFXRECON_LOG_WARNING("Create a duplicated Handle: %" PRIu64
-                                 ". This wrapper can't be written into VulkanStateHandleTable.",
-                                 *handle);
+            auto existing_wrapper = state_handle_table_.GetWrapper<Wrapper>(wrapper->handle);
+            GFXRECON_LOG_WARNING("Cannot add duplicate entry to VulkanStateHandleTable for handle 0x%" PRIx64
+                                 " with ID %d. This handle is already wrapped with ID %d.",
+                                 wrapper->handle,
+                                 wrapper->handle_id,
+                                 existing_wrapper->handle_id);
         }
     }
 }
@@ -219,9 +222,12 @@ void CreateWrappedNonDispatchHandle(typename Wrapper::HandleType* handle, PFN_Ge
         wrapper->handle_id = get_id();
         if (!state_handle_table_.InsertWrapper(wrapper))
         {
-            GFXRECON_LOG_WARNING("Create a duplicated Handle: %" PRIu64
-                                 ". This wrapper can't be written into VulkanStateHandleTable.",
-                                 *handle);
+            auto existing_wrapper = state_handle_table_.GetWrapper<Wrapper>(wrapper->handle);
+            GFXRECON_LOG_WARNING("Cannot add duplicate entry to VulkanStateHandleTable for handle 0x%" PRIx64
+                                 " with ID %d. This handle is already wrapped with ID %d.",
+                                 wrapper->handle,
+                                 wrapper->handle_id,
+                                 existing_wrapper->handle_id);
         }
     }
 }
@@ -441,7 +447,9 @@ inline void CreateWrappedHandle<DeviceWrapper,
 
     auto parent_wrapper = GetWrapper<SwapchainKHRWrapper>(co_parent);
 
-    // Filter duplicate display retrieval.
+    GFXRECON_ASSERT(!parent_wrapper->retired);
+
+    // Filter duplicate image retrieval.
     ImageWrapper* wrapper = nullptr;
     for (auto entry : parent_wrapper->child_images)
     {
@@ -457,7 +465,6 @@ inline void CreateWrappedHandle<DeviceWrapper,
         CreateWrappedNonDispatchHandle<ImageWrapper>(handle, get_id);
         wrapper                     = GetWrapper<ImageWrapper>(*handle);
         wrapper->is_swapchain_image = true;
-        wrapper->parent_swapchains.insert(co_parent);
         parent_wrapper->child_images.push_back(wrapper);
     }
 }
@@ -649,12 +656,8 @@ inline void DestroyWrappedHandle<SwapchainKHRWrapper>(VkSwapchainKHR handle)
 
         for (auto image_wrapper : wrapper->child_images)
         {
-            image_wrapper->parent_swapchains.erase(handle);
-            if (image_wrapper->parent_swapchains.empty())
-            {
-                RemoveWrapper<ImageWrapper>(image_wrapper);
-                delete image_wrapper;
-            }
+            RemoveWrapper<ImageWrapper>(image_wrapper);
+            delete image_wrapper;
         }
 
         RemoveWrapper<SwapchainKHRWrapper>(wrapper);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -227,7 +227,6 @@ struct ImageWrapper : public HandleWrapper<VkImage>, AssetWrapperBase
     VkImageTiling            tiling{};
     VkImageLayout            current_layout{ VK_IMAGE_LAYOUT_UNDEFINED };
     bool                     is_swapchain_image{ false };
-    std::set<VkSwapchainKHR> parent_swapchains;
 
     std::set<ImageViewWrapper*> image_views;
 };
@@ -530,6 +529,7 @@ struct SwapchainKHRWrapper : public HandleWrapper<VkSwapchainKHR>
 {
     // Members for general wrapper support.
     std::vector<ImageWrapper*> child_images;
+    bool                       retired{ false };
 
     // Members for trimming state tracking.
     DeviceWrapper*                                    device{ nullptr };

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1285,7 +1285,12 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
             encoder_.EncodeHandleIdValue(device_wrapper->handle_id);
             encoder_.EncodeHandleIdValue(wrapper->handle_id);
             encoder_.EncodeUInt32Ptr(&image_count, false);
-            encoder_.EncodeHandleIdArray(nullptr, 0, false);
+            auto handle_array = std::vector<format::HandleId>(wrapper->child_images.size());
+            for (int i = 0; i < wrapper->child_images.size(); ++i)
+            {
+                handle_array[i] = wrapper->child_images[i]->handle_id;
+            }
+            encoder_.EncodeHandleIdArray(handle_array.data(), handle_array.size(), false);
             encoder_.EncodeEnumValue(result);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR, &parameter_stream_);

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -326,6 +326,16 @@ class VulkanStateWriter
     {
         std::set<util::MemoryOutputStream*> processed;
         state_table.VisitWrappers([&](const Wrapper* wrapper) {
+            // Skip create call for swapchain images, i.e. vkGetSwapchainImagesKHR
+            // This call is already emitted by the state setup for the parent swapchain
+            if constexpr (std::is_same<Wrapper, vulkan_wrappers::ImageWrapper>::value)
+            {
+                auto image_wrapper = reinterpret_cast<const vulkan_wrappers::ImageWrapper*>(wrapper);
+                if (image_wrapper->is_swapchain_image)
+                {
+                    return;
+                }
+            }
             // Filter duplicate entries for calls that create multiple objects, where objects created by the same call
             // all reference the same parameter buffer.
             if (processed.find(wrapper->create_parameters.get()) == processed.end())


### PR DESCRIPTION
The implementation is allowed to destroy and reuse handles for non-acquired swapchain images as soon as the parent swapchain is retired. Update the handle tracking logic to treat these handles as destroyed, so that if they are reused, we don't get collisions in the handle tables.

Android is particularly sensitive to this as it will often immediately reuse image handles from retired swapchains, even before the retired swapchain is destroyed.