### PR TITLE
Update SPIR-V Headers to 1.4.304

### DIFF
--- a/framework/util/spirv_helper.h
+++ b/framework/util/spirv_helper.h
@@ -1402,12 +1402,12 @@ const char* string_SpvOpcode(uint32_t opcode)
             return "OpFragmentFetchAMD";
         case spv::OpReadClockKHR:
             return "OpReadClockKHR";
-        case spv::OpFinalizeNodePayloadsAMDX:
-            return "OpFinalizeNodePayloadsAMDX";
+        case spv::OpEnqueueNodePayloadsAMDX:
+            return "OpEnqueueNodePayloadsAMDX";
         case spv::OpFinishWritingNodePayloadAMDX:
             return "OpFinishWritingNodePayloadAMDX";
-        case spv::OpInitializeNodePayloadsAMDX:
-            return "OpInitializeNodePayloadsAMDX";
+        case spv::OpAllocateNodePayloadsAMDX:
+            return "OpAllocateNodePayloadsAMDX";
         case spv::OpGroupNonUniformQuadAllKHR:
             return "OpGroupNonUniformQuadAllKHR";
         case spv::OpGroupNonUniformQuadAnyKHR:


### PR DESCRIPTION
We should be using 1.4.304, and especially for the `vulkan-1.4.304.0` branch.