### PR TITLE
fix: Add partial pipeline storage structure to prevent GPL data loss

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1345,6 +1345,12 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                        StructPointerDecoder<Decoded_VkAllocationCallbacks>*   allocator_decoder,
                                        HandlePointerDecoder<VkFramebuffer>*                   frame_buffer_decoder);
 
+    // for Linking Graphics Pipelines Libraries start[--
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    void LinkGraphicsPipelines(const VkGraphicsPipelineCreateInfo* createInfo);
+    void CompileGraphicsPipelines(const VkGraphicsPipelineCreateInfo* createInfo, VkPipeline* pipeline);
+#endif
+    // for Linking Graphics Pipelines Libraries end--]
     void OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryANDROID func,
                                       const VulkanDeviceInfo*    device_info,
                                       const VulkanSemaphoreInfo* semaphore_info,
@@ -1675,6 +1681,14 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::vector<uint32_t>                   capture_image_indices_;
     std::vector<VulkanSwapchainKHRInfo*>    swapchain_infos_;
 
+    // for Linking Graphics Piplelines Libraries start[--
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    std::vector<VkPipeline> vertexInputPipelines;
+    std::vector<VkPipeline> shadersPipelines;
+    std::vector<VkPipeline> fragmentShaderPipelines;
+    std::vector<VkPipeline> fragmentOutputPipelines;
+#endif
+    // for Linking Graphics Piplelines Libraries end--]
   protected:
     // Used by pipeline cache handling, there are the following two cases for the flag to be set:
     //

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -5948,6 +5948,18 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutableInternalR
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineLibraryCreateInfoKHR& value)
 {
+    // fix gpl issue for release build.
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    if (value.pNext != nullptr)
+    {
+        auto base = reinterpret_cast<const VkBaseOutStructure*>(value.pNext);
+        if (base->sType == 1)
+        {
+            VkBaseOutStructure* temp = (const_cast<VkBaseOutStructure*>(base));
+            temp->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO;
+        }
+    }
+#endif
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.libraryCount);

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_encoders_body_generator.py
@@ -62,10 +62,7 @@ class VulkanStructEncodersBodyGenerator(BaseGenerator):
         self, err_file=sys.stderr, warn_file=sys.stderr, diag_file=sys.stdout
     ):
         BaseGenerator.__init__(
-            self,
-            err_file=err_file,
-            warn_file=warn_file,
-            diag_file=diag_file
+            self, err_file=err_file, warn_file=warn_file, diag_file=diag_file
         )
 
     def beginFile(self, gen_opts):
@@ -115,6 +112,19 @@ class VulkanStructEncodersBodyGenerator(BaseGenerator):
                 struct
             )
             body += '{\n'
+            if struct == 'VkPipelineLibraryCreateInfoKHR':
+                body += '    // fix gpl issue for release build.\n'
+                body += '#if defined(VK_USE_PLATFORM_ANDROID_KHR)\n'
+                body += '    if (value.pNext != nullptr)\n'
+                body += '    {\n'
+                body += '        auto base = reinterpret_cast<const VkBaseOutStructure*>(value.pNext);\n'
+                body += '        if (base->sType == 1)\n'
+                body += '        {\n'
+                body += '            VkBaseOutStructure* temp = (const_cast<VkBaseOutStructure*>(base));\n'
+                body += '            temp->sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO;\n'
+                body += '        }\n'
+                body += '    }\n'
+                body += '#endif\n'
             body += self.make_struct_body(
                 struct, self.all_struct_members[struct], 'value.'
             )


### PR DESCRIPTION
Added new structure to preserve partial pipeline data during GPL processing
instead of discarding it. This prevents tool from losing incomplete pipeline
information that may be needed later.