### PR TITLE
Catch Exceptions by Reference to Avoid Slicing

### DIFF
--- a/test/test_apps/host-image-copy/app.cpp
+++ b/test/test_apps/host-image-copy/app.cpp
@@ -483,7 +483,7 @@ int main(int argc, char* argv[])
         app.run("host image copy");
         return 0;
     }
-    catch (std::exception e)
+    catch (std::exception& e)
     {
         std::cout << e.what() << std::endl;
         return -1;

--- a/test/test_apps/multisample-depth/app.cpp
+++ b/test/test_apps/multisample-depth/app.cpp
@@ -670,7 +670,7 @@ int main(int argc, char* argv[])
         app.run("multisample depth");
         return 0;
     }
-    catch (std::exception e)
+    catch (std::exception& e)
     {
         std::cout << e.what() << std::endl;
         return -1;

--- a/test/test_apps/pipeline-binaries/app.cpp
+++ b/test/test_apps/pipeline-binaries/app.cpp
@@ -311,7 +311,7 @@ int main(int argc, char* argv[])
         app.run("pipeline binaries");
         return 0;
     }
-    catch (std::exception e)
+    catch (std::exception& e)
     {
         std::cout << e.what() << std::endl;
         return -1;

--- a/test/test_apps/shader-objects/app.cpp
+++ b/test/test_apps/shader-objects/app.cpp
@@ -475,7 +475,7 @@ int main(int argc, char* argv[])
         app.run("shader objects");
         return 0;
     }
-    catch (std::exception e)
+    catch (std::exception& e)
     {
         std::cout << e.what() << std::endl;
         return -1;

--- a/test/test_apps/triangle/app.cpp
+++ b/test/test_apps/triangle/app.cpp
@@ -489,7 +489,7 @@ int main(int argc, char* argv[])
         app.run("triangle");
         return 0;
     }
-    catch (std::exception e)
+    catch (std::exception& e)
     {
         std::cout << e.what() << std::endl;
         return -1;

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -231,7 +231,7 @@ void android_main(struct android_app* app)
                 }
             }
         }
-        catch (std::runtime_error error)
+        catch (std::runtime_error& error)
         {
             GFXRECON_WRITE_CONSOLE("Replay failed with error message: %s", error.what());
         }


### PR DESCRIPTION
Preserve messages from derived exceptions for more informative logging.

Catching them by value means making a copy of the thrown exception, and if it was actually derived from the type named at the catch point, that will be a slicing copy, throwing away the fields of the derived type which might contain information it uses to provide a helpful `what()` message. Indeed, the virtual `what()` function will resolve to the base class version, returning an empty string in the cases of the test apps.

[Ref: C++ Core Guidelines, E.15: Throw by value, catch exceptions from a hierarchy by reference.](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#e15-throw-by-value-catch-exceptions-from-a-hierarchy-by-reference)
