### PR TITLE
Fix issues building without tests on CMake 3.22

### DIFF
--- a/cmake/FindDXC.cmake
+++ b/cmake/FindDXC.cmake
@@ -28,7 +28,7 @@ if (${D3D12_SUPPORT})
         set(DXC_SDK_URL "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2407/dxc_2024_07_31.zip")
         
         # Suppress warning on newer versions of CMake related to FetchContent file timestamp behavior.
-        if (${CMAKE_VERSION} VERSION_GREATER "3.24")
+        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
             cmake_policy(SET CMP0135 NEW)
         endif()
 
@@ -38,7 +38,6 @@ if (${D3D12_SUPPORT})
           DXC_SDK
           URL        ${DXC_SDK_URL}
           SOURCE_DIR ${DXC_SDK_DIR}
-          DOWNLOAD_EXTRACT_TIMESTAMP OFF
         )
         FetchContent_MakeAvailable(DXC_SDK)
         


### PR DESCRIPTION
extend CMP0135 to CMake 3.24 and remove directive causing an issue