### PR TITLE
Fix CommonObjectInfoTable reference count

### DIFF
--- a/framework/decode/common_object_info_table.cpp
+++ b/framework/decode/common_object_info_table.cpp
@@ -36,6 +36,11 @@ CommonObjectInfoTable* CommonObjectInfoTable::GetSingleton()
         singleton_          = new CommonObjectInfoTable();
         singleton_refcount_ = 1;
     }
+    else
+    {
+        assert(singleton_refcount_ > 0);
+        singleton_refcount_++;
+    }
     return singleton_;
 }
 


### PR DESCRIPTION
Fix crash on used cases where multiple replay consumers are created and deleted.