### PR TITLE
VDR: Initialize multiview flag

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -656,7 +656,7 @@ struct VulkanRenderPassInfo : public VulkanObjectInfo<VkRenderPass>
     std::vector<VkSubpassDependency> dependencies;
 
     // Multiview info
-    bool has_multiview;
+    bool has_multiview{ false };
 
     struct
     {

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5393,6 +5393,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass(
     }
 
     // Copy multiview information
+    render_pass_info->has_multiview  = false;
     const VkBaseInStructure* current = reinterpret_cast<const VkBaseInStructure*>(create_info->pNext);
     while (current != nullptr)
     {


### PR DESCRIPTION
Missing variable initialization was causing multiview structure to be added when creating render passes even when there was not multiview in play.