### PR TITLE
Macro VERIFY_VK_RESULT no longer evaluates result twice

### DIFF
--- a/test/test_apps/common/test_app_base.h
+++ b/test/test_apps/common/test_app_base.h
@@ -1047,11 +1047,11 @@ VkShaderModule createShaderModule(vkb::DispatchTable const& disp, const std::vec
 
 VkShaderModule readShaderFromFile(vkb::DispatchTable const& disp, const std::string& filename);
 
-#define VERIFY_VK_RESULT(message, result)                            \
-    {                                                                \
-        if (result != VK_SUCCESS) {                                  \
-            throw gfxrecon::test::vulkan_exception(message, result); \
-        }                                                            \
+#define VERIFY_VK_RESULT(message, result)                                             \
+    {                                                                                 \
+        VkResult verify_vk_result_result = result;                                    \
+        if (verify_vk_result_result != VK_SUCCESS)                                    \
+            throw gfxrecon::test::vulkan_exception(message, verify_vk_result_result); \
     }
 
 struct InitInfo

--- a/test/test_apps/common/test_app_base.h
+++ b/test/test_apps/common/test_app_base.h
@@ -1049,9 +1049,9 @@ VkShaderModule readShaderFromFile(vkb::DispatchTable const& disp, const std::str
 
 #define VERIFY_VK_RESULT(message, result)                                             \
     {                                                                                 \
-        VkResult verify_vk_result_result = result;                                    \
+        VkResult verify_vk_result_result = (result);                                    \
         if (verify_vk_result_result != VK_SUCCESS)                                    \
-            throw gfxrecon::test::vulkan_exception(message, verify_vk_result_result); \
+            throw gfxrecon::test::vulkan_exception((message), verify_vk_result_result); \
     }
 
 struct InitInfo


### PR DESCRIPTION
This is a small PR to remove the footgun from the test framework's VERIFY_VK_RESULT() macro by ensuring `result` is evaluated only once.