### PR TITLE
Include <chrono> for high_resolution_clock

### DIFF
--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <chrono>
 #include <cstdint>
 #include <limits>
 #include <unordered_map>


### PR DESCRIPTION
Add `<chrono>` include to file using std::chrono::high_resolucion_clock to fix the VS 17.13.0 build.