### PR TITLE
Preserve D3D12 object names while trimming

### DIFF
--- a/framework/encode/custom_dx12_wrapper_commands.h
+++ b/framework/encode/custom_dx12_wrapper_commands.h
@@ -824,6 +824,16 @@ struct CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain4_SetHDRMe
     }
 };
 
+template <>
+struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12Object_SetName>
+{
+    template <typename... Args>
+    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_SetName(args...);
+    }
+};
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -3749,5 +3749,13 @@ void D3D12CaptureManager::PostProcess_IDXGISwapChain4_SetHDRMetaData(
     }
 }
 
+void D3D12CaptureManager::PostProcess_SetName(IUnknown_Wrapper* wrapper, HRESULT result, LPCWSTR Name)
+{
+    if (IsCaptureModeTrack())
+    {
+        state_tracker_->TrackSetName(wrapper, result, Name);
+    }
+}
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -839,6 +839,8 @@ class D3D12CaptureManager : public ApiCaptureManager
     void PostProcess_IDXGISwapChain4_SetHDRMetaData(
         IDXGISwapChain_Wrapper* wrapper, HRESULT result, DXGI_HDR_METADATA_TYPE Type, UINT Size, void* pMetaData);
 
+    void PostProcess_SetName(IUnknown_Wrapper* wrapper, HRESULT result, LPCWSTR Name);
+
   protected:
     D3D12CaptureManager();
 

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -93,6 +93,8 @@ struct DxWrapperInfo
 
     std::unordered_map<const GUID, std::vector<uint8_t>, GUID_Hash, GUID_Equal> private_datas;
 
+    std::wstring object_name{ L"" };
+
   private:
     // A pointer to the wrapper that owns/created this info struct, or nullptr if the wrapper no longer exists.
     const IUnknown_Wrapper* wrapper_ = nullptr;

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -1234,6 +1234,24 @@ void Dx12StateTracker::TrackSetHDRMetaData(
     }
 }
 
+void Dx12StateTracker::TrackSetName(IUnknown_Wrapper* wrapper, HRESULT result, LPCWSTR Name)
+{
+    GFXRECON_ASSERT(wrapper != nullptr);
+
+    auto* info = GetWrapperInfo(wrapper);
+    if (info)
+    {
+        if (Name != nullptr)
+        {
+            info->object_name = Name;
+        }
+        else
+        {
+            info->object_name = L"";
+        }
+    }
+}
+
 #ifdef GFXRECON_AGS_SUPPORT
 void Dx12StateTracker::TrackAgsCalls(void*                           object_ptr,
                                      format::ApiCallId               call_id,

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -231,6 +231,8 @@ class Dx12StateTracker
     void TrackSetHDRMetaData(
         IDXGISwapChain_Wrapper* wrapper, HRESULT result, DXGI_HDR_METADATA_TYPE Type, UINT Size, void* pMetaData);
 
+    void TrackSetName(IUnknown_Wrapper* wrapper, HRESULT result, LPCWSTR Name);
+
 #ifdef GFXRECON_AGS_SUPPORT
     void
     TrackAgsCalls(void* object_ptr, format::ApiCallId call_id, const util::MemoryOutputStream* create_parameter_buffer);

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -216,6 +216,11 @@ void Dx12StateWriter::StandardCreateWrite(format::HandleId object_id, const DxWr
         written_objects_.insert(object_id);
 #endif
 
+        if (wrapper_info.object_name.empty() == false)
+        {
+            WriteSetName(object_id, wrapper_info);
+        }
+
         // Release any temporarily created parent object.
         if (create_temp_object_dependency)
         {
@@ -1769,6 +1774,14 @@ void Dx12StateWriter::WriteStateObjectPropertiesState(const Dx12StateTable& stat
         WritePrivateData(wrapper->GetCaptureId(), *wrapper_info.get());
         WriteAddRefAndReleaseCommands(wrapper);
     });
+}
+
+void Dx12StateWriter::WriteSetName(format::HandleId handle_id, const DxWrapperInfo& wrapper_info)
+{
+    encoder_.EncodeWString(wrapper_info.object_name.c_str());
+    encoder_.EncodeInt32Value(S_OK);
+    WriteMethodCall(format::ApiCallId::ApiCall_ID3D12Object_SetName, handle_id, &parameter_stream_);
+    parameter_stream_.Clear();
 }
 
 #ifdef GFXRECON_AGS_SUPPORT

--- a/framework/encode/dx12_state_writer.h
+++ b/framework/encode/dx12_state_writer.h
@@ -185,6 +185,8 @@ class Dx12StateWriter
                                        const ID3D12StateObjectInfo*          state_object_info,
                                        std::unordered_set<format::HandleId>& written_objs);
 
+    void WriteSetName(format::HandleId handle_id, const DxWrapperInfo& wrapper_info);
+
 #ifdef GFXRECON_AGS_SUPPORT
     void WriteAgsInitialize(const AgsStateTable& ags_state_table);
 


### PR DESCRIPTION
Our trimmed traces don't contain object names. This is because we don't restore `SetName()` calls if the app made them.

This PR makes it D3D12 object names are preserved in trimmed traces. Helps to debug.