### PR TITLE
Fix CMake warning CMP0175

### DIFF
--- a/tools/capture-vulkan/CMakeLists.txt
+++ b/tools/capture-vulkan/CMakeLists.txt
@@ -1,8 +1,6 @@
-add_custom_target(gfxrecon-capture-vulkan.py ALL)
-
-add_custom_command(TARGET gfxrecon-capture-vulkan.py
-                   DEPENDS ${CMAKE_SOURCE_SOURCE_DIR}/gfxrecon-capture-vulkan.py
-                   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon-capture-vulkan.py ${CMAKE_CURRENT_BINARY_DIR}/gfxrecon-capture-vulkan.py)
+add_custom_target(gfxrecon-capture-vulkan.py ALL
+                  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon-capture-vulkan.py
+                  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon-capture-vulkan.py ${CMAKE_CURRENT_BINARY_DIR}/gfxrecon-capture-vulkan.py)
 
 install(FILES gfxrecon-capture-vulkan.py DESTINATION ${CMAKE_INSTALL_BINDIR} PERMISSIONS
         OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/tools/capture/CMakeLists.txt
+++ b/tools/capture/CMakeLists.txt
@@ -1,8 +1,6 @@
-add_custom_target(gfxrecon-capture.py ALL)
-
-add_custom_command(TARGET gfxrecon-capture.py
-                   DEPENDS ${CMAKE_SOURCE_SOURCE_DIR}/gfxrecon-capture.py
-                   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon-capture.py ${CMAKE_CURRENT_BINARY_DIR}/gfxrecon-capture.py)
+add_custom_target(gfxrecon-capture.py ALL
+                  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon-capture.py
+                  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon-capture.py ${CMAKE_CURRENT_BINARY_DIR}/gfxrecon-capture.py)
 
 install(FILES gfxrecon-capture.py DESTINATION ${CMAKE_INSTALL_BINDIR} PERMISSIONS
         OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/tools/gfxrecon/CMakeLists.txt
+++ b/tools/gfxrecon/CMakeLists.txt
@@ -1,8 +1,6 @@
-add_custom_target(gfxrecon.py ALL)
-
-add_custom_command(TARGET gfxrecon.py
-                   DEPENDS ${CMAKE_SOURCE_SOURCE_DIR}/gfxrecon.py
-                   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon.py ${CMAKE_CURRENT_BINARY_DIR}/gfxrecon.py)
+add_custom_target(gfxrecon.py ALL
+                  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon.py
+                  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon.py ${CMAKE_CURRENT_BINARY_DIR}/gfxrecon.py)
 
 install(FILES gfxrecon.py DESTINATION ${CMAKE_INSTALL_BINDIR} PERMISSIONS
         OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)


### PR DESCRIPTION
Started getting this warning on CMake 3.31+:

```
CMake Warning (dev) at tools/capture-vulkan/CMakeLists.txt:3 (add_custom_command):
  The following keywords are not supported when using
  add_custom_command(TARGET): DEPENDS.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

From `cmake --help-policy CMP0175`:
> CMake 3.30 and earlier silently ignored unsupported keywords and missing or
> invalid arguments for the different forms of the ``add_custom_command()``
> command. CMake 3.31 implements more rigorous argument checking and will flag
> invalid or missing arguments as errors.

The simplest fix seems to be just adding the copy command to the custom target and getting rid of the custom command.