### PR TITLE
Skip Invalid PlacedResource

### DIFF
--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -326,6 +326,10 @@ void D3D12CaptureManager::InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    
     info->layout          = layout;
     info->heap_offset     = heap_offset;
     info->heap_wrapper    = heap_wrapper;
+    if (heap_wrapper != nullptr)
+    {
+        info->heap_id = heap_wrapper->GetCaptureId();
+    }
 
     if (dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
     {

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -423,6 +423,7 @@ struct ID3D12ResourceInfo : public DxWrapperInfo
 
     ID3D12Heap_Wrapper* heap_wrapper{ nullptr };
     uint64_t            heap_offset;
+    uint64_t            heap_id{ format::kNullHandleId };
 
     IDXGISwapChain_Wrapper* swapchain_wrapper{ nullptr };
 };

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -568,12 +568,18 @@ void Dx12StateWriter::WriteResourceCreationState(
         assert(resource_wrapper->GetWrappedObject() != nullptr);
         assert(resource_wrapper->GetObjectInfo() != nullptr);
         assert(resource_wrapper->GetObjectInfo()->create_parameters != nullptr);
+        assert(resource_wrapper->GetObjectInfo()->create_object_id != format::kNullHandleId);
 
         auto        resource      = resource_wrapper->GetWrappedObjectAs<ID3D12Resource>();
         auto        resource_info = resource_wrapper->GetObjectInfo();
         const auto& resource_desc = resource->GetDesc();
 
-        assert(resource_info->create_object_id != format::kNullHandleId);
+        if (!CheckResourceObject(resource_info.get(), state_table))
+        {
+            // Skipping invalid resource data capture.
+            GFXRECON_LOG_WARNING_ONCE("Encountered invalid resource during state write");
+            return;
+        }
 
         // Write the resource creation call to capture file.
         StandardCreateWrite(resource_wrapper);
@@ -1300,6 +1306,20 @@ bool Dx12StateWriter::CheckDescriptorObjects(const DxDescriptorInfo& descriptor_
     }
 
     return true;
+}
+
+bool Dx12StateWriter::CheckResourceObject(const ID3D12ResourceInfo* resource_info, const Dx12StateTable& state_table)
+{
+    switch (resource_info->create_call_id)
+    {
+        case format::ApiCall_ID3D12Device_CreatePlacedResource:
+        case format::ApiCall_ID3D12Device8_CreatePlacedResource1:
+        case format::ApiCall_ID3D12Device10_CreatePlacedResource2:
+            // Placed resource have to have valid Heap object.
+            return (state_table.GetID3D12Heap_Wrapper(resource_info->heap_id) != nullptr);
+        default:
+            return true;
+    }
 }
 
 void Dx12StateWriter::WriteSwapChainState(const Dx12StateTable& state_table)

--- a/framework/encode/dx12_state_writer.h
+++ b/framework/encode/dx12_state_writer.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -165,6 +165,8 @@ class Dx12StateWriter
     bool CheckGpuVa(D3D12_GPU_VIRTUAL_ADDRESS address);
 
     bool CheckDescriptorObjects(const DxDescriptorInfo& descriptor_info, const Dx12StateTable& state_table);
+
+    bool CheckResourceObject(const ID3D12ResourceInfo* resource_info, const Dx12StateTable& state_table);
 
     void WriteSwapChainState(const Dx12StateTable& state_table);
 


### PR DESCRIPTION
Problem:
Application might release heap before it release PlacedResource.

Solution:
GFXR should discard all invalid resource while dump resource.