### PR TITLE
BuildAS Input Data In Multi-Resources

### DIFF
--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -851,7 +851,6 @@ void Dx12StateTracker::TrackBuildRaytracingAccelerationStructure(
             // Add CopyBufferRegion(s) and ResourceBarrier(s) to command list to save the build input resource data.
             auto curr_entry_iter = inputs_buffer_entries.begin();
             auto end_entry_iter  = inputs_buffer_entries.end();
-
             while (!build_info.is_tlas_with_array_of_pointers && curr_entry_iter != end_entry_iter)
             {
                 ID3D12Resource_Wrapper* src_resource_wrapper = nullptr;
@@ -924,19 +923,18 @@ void Dx12StateTracker::TrackBuildRaytracingAccelerationStructure(
                 {
                     gfxrecon::util::GpuVaRange range       = { *curr_entry_iter->desc_gpu_va,
                                                                *curr_entry_iter->desc_gpu_va + curr_entry_iter->size - 1 };
-                    auto                       curr_gpu_va = *curr_entry_iter->desc_gpu_va;
-                    auto                       dst_offset  = curr_entry_iter->offset;
-                    auto                       num_bytes   = curr_entry_iter->size;
-                    auto                       src_offset  = curr_gpu_va - src_resource_info->gpu_va;
-                    ++curr_entry_iter;
                     if (DoesResourceCoverGpuVaRange(src_resource_info.get(), range))
                     {
-
+                        auto curr_gpu_va = *curr_entry_iter->desc_gpu_va;
+                        auto dst_offset  = curr_entry_iter->offset;
+                        auto num_bytes   = curr_entry_iter->size;
+                        auto src_offset  = curr_gpu_va - src_resource_info->gpu_va;
                         list_wrapper->CopyBufferRegion(inputs_data_resource,
                                                        dst_offset,
                                                        src_resource_wrapper->GetWrappedObjectAs<ID3D12Resource>(),
                                                        src_offset,
                                                        num_bytes);
+                        ++curr_entry_iter;
                     }
                     else
                     {

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -272,7 +272,7 @@ class Dx12StateTracker
     // Track root signatures associated with state object.
     void TrackRootSignatureWithStateObject(const D3D12_STATE_OBJECT_DESC* desc, void** state_object_void_ptr);
 
-    bool DoesResourceCoverGpuVaRange(ID3D12Resource_Wrapper* resource_wrapper, gfxrecon::util::GpuVaRange& range);
+    bool DoesResourceCoverGpuVaRange(ID3D12ResourceInfo* resource_info, gfxrecon::util::GpuVaRange& range);
 
 #ifdef GFXRECON_AGS_SUPPORT
     void AddAgsInitializeEntry(AGSContext*                     context,

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -33,6 +33,7 @@
 #include "generated/generated_dx12_wrapper_creators.h"
 #include "generated/generated_dx12_add_entries.h"
 #include "util/defines.h"
+#include "util/gpu_va_range.h"
 
 #include <guiddef.h>
 #include <mutex>
@@ -270,6 +271,8 @@ class Dx12StateTracker
 
     // Track root signatures associated with state object.
     void TrackRootSignatureWithStateObject(const D3D12_STATE_OBJECT_DESC* desc, void** state_object_void_ptr);
+
+    bool DoesResourceCoverGpuVaRange(ID3D12Resource_Wrapper* resource_wrapper, gfxrecon::util::GpuVaRange& range);
 
 #ifdef GFXRECON_AGS_SUPPORT
     void AddAgsInitializeEntry(AGSContext*                     context,


### PR DESCRIPTION
Problem:
Game could put input geomtory data into a few of resources instead of one resource.

Solution:
GFXR should locate each resource and its offset, then copy over to stagging buffer.