### PR TITLE
Copy ahb without CPU read mask v2

### DIFF
--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -8,6 +8,8 @@ target_sources(gfxrecon_graphics
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_check_buffer_references.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.cpp
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_instance_util.h
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_instance_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_resources_util.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_resources_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.h

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -106,6 +106,7 @@ class ApiDecoder
 
     virtual void
     DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
+                                        format::HandleId                                    device_id,
                                         format::HandleId                                    memory_id,
                                         uint64_t                                            buffer_id,
                                         uint32_t                                            format,

--- a/framework/decode/custom_ags_decoder.h
+++ b/framework/decode/custom_ags_decoder.h
@@ -80,6 +80,7 @@ class AgsDecoder : public ApiDecoder
 
     virtual void
     DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
+                                        format::HandleId                                    device_id,
                                         format::HandleId                                    memory_id,
                                         uint64_t                                            buffer_id,
                                         uint32_t                                            format,

--- a/framework/decode/dx12_decoder_base.cpp
+++ b/framework/decode/dx12_decoder_base.cpp
@@ -109,6 +109,7 @@ void Dx12DecoderBase::DispatchResizeWindowCommand2(
 
 void Dx12DecoderBase::DispatchCreateHardwareBufferCommand(
     format::ThreadId                                    thread_id,
+    format::HandleId                                    device_id,
     format::HandleId                                    memory_id,
     uint64_t                                            buffer_id,
     uint32_t                                            format,
@@ -124,7 +125,7 @@ void Dx12DecoderBase::DispatchCreateHardwareBufferCommand(
     for (auto consumer : consumers_)
     {
         consumer->ProcessCreateHardwareBufferCommand(
-            memory_id, buffer_id, format, width, height, stride, usage, layers, plane_info);
+            device_id, memory_id, buffer_id, format, width, height, stride, usage, layers, plane_info);
     }
 }
 

--- a/framework/decode/dx12_decoder_base.h
+++ b/framework/decode/dx12_decoder_base.h
@@ -125,6 +125,7 @@ class Dx12DecoderBase : public ApiDecoder
 
     virtual void
     DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
+                                        format::HandleId                                    device_id,
                                         format::HandleId                                    memory_id,
                                         uint64_t                                            buffer_id,
                                         uint32_t                                            format,

--- a/framework/decode/info_decoder.h
+++ b/framework/decode/info_decoder.h
@@ -100,6 +100,7 @@ class InfoDecoder : public ApiDecoder
 
     virtual void
     DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
+                                        format::HandleId                                    device_id,
                                         format::HandleId                                    memory_id,
                                         uint64_t                                            buffer_id,
                                         uint32_t                                            format,

--- a/framework/decode/metadata_consumer_base.h
+++ b/framework/decode/metadata_consumer_base.h
@@ -47,7 +47,8 @@ class MetadataConsumerBase
     virtual void
     ProcessResizeWindowCommand2(format::HandleId surface_id, uint32_t width, uint32_t height, uint32_t pre_transform)
     {}
-    virtual void ProcessCreateHardwareBufferCommand(format::HandleId                                    memory_id,
+    virtual void ProcessCreateHardwareBufferCommand(format::HandleId                                    device_id,
+                                                    format::HandleId                                    memory_id,
                                                     uint64_t                                            buffer_id,
                                                     uint32_t                                            format,
                                                     uint32_t                                            width,

--- a/framework/decode/metadata_json_consumer.h
+++ b/framework/decode/metadata_json_consumer.h
@@ -121,7 +121,8 @@ class MetadataJsonConsumer : public Base
     }
 
     virtual void
-    ProcessCreateHardwareBufferCommand(format::HandleId                                    memory_id,
+    ProcessCreateHardwareBufferCommand(format::HandleId                                    device_id,
+                                       format::HandleId                                    memory_id,
                                        uint64_t                                            buffer_id,
                                        uint32_t                                            format,
                                        uint32_t                                            width,
@@ -133,6 +134,7 @@ class MetadataJsonConsumer : public Base
     {
         const util::JsonOptions& json_options = GetOptions();
         auto&                    jdata        = WriteMetaCommandStart("CreateHardwareBufferCommand");
+        HandleToJson(jdata["device_id"], device_id, json_options);
         HandleToJson(jdata["memory_id"], memory_id, json_options);
         HandleToJson(jdata["buffer_id"], buffer_id, json_options);
         FieldToJson(jdata["format"], format, json_options);

--- a/framework/decode/stat_decoder_base.h
+++ b/framework/decode/stat_decoder_base.h
@@ -100,6 +100,7 @@ class StatDecoderBase : public ApiDecoder
 
     virtual void
     DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
+                                        format::HandleId                                    device_id,
                                         format::HandleId                                    memory_id,
                                         uint64_t                                            buffer_id,
                                         uint32_t                                            format,

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -181,7 +181,7 @@ VulkanAddressReplacer::VulkanAddressReplacer(const VulkanDeviceInfo*            
     GFXRECON_ASSERT(physical_device_info_ != nullptr);
     device_                = device_info->handle;
     resource_allocator_    = device_info->allocator.get();
-    get_device_address_fn_ = physical_device_info_->parent_api_version >= VK_API_VERSION_1_2
+    get_device_address_fn_ = physical_device_info_->parent_info.api_version >= VK_API_VERSION_1_2
                                  ? device_table->GetBufferDeviceAddress
                                  : device_table->GetBufferDeviceAddressKHR;
 

--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -3208,6 +3208,7 @@ void VulkanCppConsumerBase::ProcessResizeWindowCommand2(format::HandleId surface
 }
 
 void VulkanCppConsumerBase::ProcessCreateHardwareBufferCommand(
+    format::HandleId                                    device_id,
     format::HandleId                                    memory_id,
     uint64_t                                            buffer_id,
     uint32_t                                            format,

--- a/framework/decode/vulkan_cpp_consumer_base.h
+++ b/framework/decode/vulkan_cpp_consumer_base.h
@@ -656,7 +656,8 @@ class VulkanCppConsumerBase : public VulkanConsumer
                                              uint32_t         height,
                                              uint32_t         pre_transform) override;
     virtual void
-    ProcessCreateHardwareBufferCommand(format::HandleId                                    memory_id,
+    ProcessCreateHardwareBufferCommand(format::HandleId                                    device_id,
+                                       format::HandleId                                    memory_id,
                                        uint64_t                                            buffer_id,
                                        uint32_t                                            format,
                                        uint32_t                                            width,

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -126,6 +126,7 @@ void VulkanDecoderBase::DispatchResizeWindowCommand2(
 
 void VulkanDecoderBase::DispatchCreateHardwareBufferCommand(
     format::ThreadId                                    thread_id,
+    format::HandleId                                    device_id,
     format::HandleId                                    memory_id,
     uint64_t                                            buffer_id,
     uint32_t                                            format,
@@ -141,7 +142,7 @@ void VulkanDecoderBase::DispatchCreateHardwareBufferCommand(
     for (auto consumer : consumers_)
     {
         consumer->ProcessCreateHardwareBufferCommand(
-            memory_id, buffer_id, format, width, height, stride, usage, layers, plane_info);
+            device_id, memory_id, buffer_id, format, width, height, stride, usage, layers, plane_info);
     }
 }
 

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -107,6 +107,7 @@ class VulkanDecoderBase : public ApiDecoder
 
     virtual void
     DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
+                                        format::HandleId                                    device_id,
                                         format::HandleId                                    memory_id,
                                         uint64_t                                            buffer_id,
                                         uint32_t                                            format,

--- a/framework/decode/vulkan_feature_util.cpp
+++ b/framework/decode/vulkan_feature_util.cpp
@@ -161,6 +161,22 @@ bool IsSupportedExtension(const std::vector<const char*>& extensions_names, cons
     return false;
 }
 
+bool EnableExtensionIfSupported(const std::vector<VkExtensionProperties>& properties,
+                                std::vector<const char*>*                 extensions,
+                                const char*                               extension)
+{
+    GFXRECON_ASSERT(extensions != nullptr);
+    GFXRECON_ASSERT(extension != nullptr);
+
+    if (IsSupportedExtension(properties, extension))
+    {
+        extensions->push_back(extension);
+        return true;
+    }
+
+    return false;
+}
+
 bool IsIgnorableExtension(const char* extension)
 {
     return kIgnorableExtensions.count(extension) > 0;

--- a/framework/decode/vulkan_feature_util.h
+++ b/framework/decode/vulkan_feature_util.h
@@ -48,6 +48,10 @@ VkResult GetDeviceExtensions(VkPhysicalDevice                         physical_d
 bool IsSupportedExtension(const std::vector<VkExtensionProperties>& properties, const char* extension);
 bool IsSupportedExtension(const std::vector<const char*>& extensions_names, const char* extension);
 
+bool EnableExtensionIfSupported(const std::vector<VkExtensionProperties>& properties,
+                                std::vector<const char*>*                 extensions,
+                                const char*                               extension);
+
 void RemoveUnsupportedExtensions(const std::vector<VkExtensionProperties>& properties,
                                  std::vector<const char*>*                 extensions);
 

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -30,6 +30,7 @@
 #include "format/format.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "graphics/vulkan_device_util.h"
+#include "graphics/vulkan_instance_util.h"
 #include "graphics/vulkan_shader_group_handle.h"
 #include "util/defines.h"
 #include "util/spirv_parsing_util.h"
@@ -255,8 +256,7 @@ typedef VulkanObjectInfo<VkIndirectExecutionSetEXT>   VulkanIndirectExecutionSet
 
 struct VulkanInstanceInfo : public VulkanObjectInfo<VkInstance>
 {
-    uint32_t                             api_version{ VK_MAKE_VERSION(1, 0, 0) };
-    std::vector<std::string>             enabled_extensions;
+    graphics::VulkanInstanceUtilInfo     util_info{};
     std::unordered_map<uint32_t, size_t> array_counts;
 
     // Capture and replay devices sorted in the order that they were originally retrieved from
@@ -269,9 +269,10 @@ struct VulkanInstanceInfo : public VulkanObjectInfo<VkInstance>
 
 struct VulkanPhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 {
-    VkInstance                           parent{ VK_NULL_HANDLE };
-    uint32_t                             parent_api_version{ 0 };
-    std::vector<std::string>             parent_enabled_extensions;
+    VkInstance parent{ VK_NULL_HANDLE };
+
+    graphics::VulkanInstanceUtilInfo parent_info{};
+
     std::unordered_map<uint32_t, size_t> array_counts;
 
     // Capture device properties.

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -401,6 +401,7 @@ struct VulkanImageInfo : public VulkanObjectInfo<VkImage>
     VkImageType           type{};
     VkFormat              format{};
     bool                  external_format{ false };
+    bool                  external_memory_android{ false };
     VkExtent3D            extent{ 0, 0, 0 };
     VkImageTiling         tiling{};
     VkSampleCountFlagBits sample_count{};

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -107,7 +107,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                              uint32_t         pre_transform) override;
 
     virtual void
-    ProcessCreateHardwareBufferCommand(format::HandleId                                    memory_id,
+    ProcessCreateHardwareBufferCommand(format::HandleId                                    device_id,
+                                       format::HandleId                                    memory_id,
                                        uint64_t                                            buffer_id,
                                        uint32_t                                            format,
                                        uint32_t                                            width,
@@ -190,16 +191,16 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         format::HandleId                                                   commandBuffer,
         StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfo>* pPushDescriptorSetWithTemplateInfo) override;
 
-    void         Process_vkCreateRayTracingPipelinesKHR(
-                const ApiCallInfo&                                               call_info,
-                VkResult                                                         returnValue,
-                format::HandleId                                                 device,
-                format::HandleId                                                 deferredOperation,
-                format::HandleId                                                 pipelineCache,
-                uint32_t                                                         createInfoCount,
-                StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
-                StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
-                HandlePointerDecoder<VkPipeline>*                                pPipelines) override;
+    void Process_vkCreateRayTracingPipelinesKHR(
+        const ApiCallInfo&                                               call_info,
+        VkResult                                                         returnValue,
+        format::HandleId                                                 device,
+        format::HandleId                                                 deferredOperation,
+        format::HandleId                                                 pipelineCache,
+        uint32_t                                                         createInfoCount,
+        StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
+        HandlePointerDecoder<VkPipeline>*                                pPipelines) override;
 
     void ProcessBuildVulkanAccelerationStructuresMetaCommand(
         format::HandleId                                                           device,
@@ -1403,6 +1404,22 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                      VulkanShaderModuleInfo*                                    shader_module_info,
                                      const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
+    VkResult OverrideCreateSamplerYcbcrConversion(
+        PFN_vkCreateSamplerYcbcrConversion                                      func,
+        VkResult                                                                result,
+        const VulkanDeviceInfo*                                                 device_info,
+        const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>*              pAllocator,
+        HandlePointerDecoder<VkSamplerYcbcrConversion>*                         pSampler);
+
+    VkResult OverrideCreateSamplerYcbcrConversionKHR(
+        PFN_vkCreateSamplerYcbcrConversionKHR                                      func,
+        VkResult                                                                   result,
+        const VulkanDeviceInfo*                                                    device_info,
+        const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfoKHR>* pCreateInfo,
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>*                 pAllocator,
+        HandlePointerDecoder<VkSamplerYcbcrConversionKHR>*                         pSampler);
+
     std::function<handle_create_result_t<VkPipeline>()>
     AsyncCreateGraphicsPipelines(PFN_vkCreateGraphicsPipelines                               func,
                                  VkResult                                                    returnValue,
@@ -1627,6 +1644,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     struct HardwareBufferMemoryInfo
     {
         AHardwareBuffer*                     hardware_buffer;
+        format::HandleId                     device_id;
         bool                                 compatible_strides;
         std::vector<HardwareBufferPlaneInfo> plane_info;
     };

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2020 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -1292,7 +1292,8 @@ VkResult VulkanResourceInitializer::PixelShaderImageCopy(uint32_t               
 
         if (result == VK_SUCCESS)
         {
-            VkImageCreateInfo image_info     = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
+            VkImageCreateInfo image_info = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
+
             image_info.pNext                 = nullptr;
             image_info.flags                 = 0;
             image_info.imageType             = type;
@@ -1346,7 +1347,6 @@ VkResult VulkanResourceInitializer::PixelShaderImageCopy(uint32_t               
                         scissor_rect.extent.height = level_copy.imageExtent.height;
 
                         VkImageViewCreateInfo view_info         = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
-                        view_info.pNext                         = nullptr;
                         view_info.flags                         = 0;
                         view_info.viewType                      = VK_IMAGE_VIEW_TYPE_2D;
                         view_info.format                        = format;

--- a/framework/decode/vulkan_resource_initializer.h
+++ b/framework/decode/vulkan_resource_initializer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2020 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/vulkan_capture_common.cpp
+++ b/framework/encode/vulkan_capture_common.cpp
@@ -1,5 +1,5 @@
 /*
- ** Copyright (c) 2024 LunarG, Inc.
+ ** Copyright (c) 2024-2025 LunarG, Inc.
  **
  ** Permission is hereby granted, free of charge, to any person obtaining a
  ** copy of this software and associated documentation files (the "Software"),
@@ -29,12 +29,13 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void CommonWriteCreateHardwareBufferCmd(format::ThreadId                                    thread_id,
-                                        format::HandleId                                    memory_id,
-                                        AHardwareBuffer*                                    hardware_buffer,
-                                        const std::vector<format::HardwareBufferPlaneInfo>& plane_info,
-                                        VulkanCaptureManager*                               vulkan_capture_manager,
-                                        VulkanStateWriter*                                  vulkan_state_writer)
+static void CommonWriteCreateHardwareBufferCmd(format::ThreadId                                    thread_id,
+                                               format::HandleId                                    device_id,
+                                               format::HandleId                                    memory_id,
+                                               AHardwareBuffer*                                    hardware_buffer,
+                                               const std::vector<format::HardwareBufferPlaneInfo>& plane_info,
+                                               VulkanCaptureManager* vulkan_capture_manager,
+                                               VulkanStateWriter*    vulkan_state_writer)
 {
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     if (vulkan_capture_manager && !vulkan_capture_manager->IsCaptureModeWrite())
@@ -50,6 +51,7 @@ void CommonWriteCreateHardwareBufferCmd(format::ThreadId                        
     create_buffer_cmd.meta_header.meta_data_id      = format::MakeMetaDataId(
         format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kCreateHardwareBufferCommand);
     create_buffer_cmd.thread_id = thread_id;
+    create_buffer_cmd.device_id = device_id;
     create_buffer_cmd.memory_id = memory_id;
     create_buffer_cmd.buffer_id = reinterpret_cast<uint64_t>(hardware_buffer);
 
@@ -127,12 +129,13 @@ static void CommonWriteFillMemoryCmd(format::HandleId      memory_id,
     }
 }
 
-void CommonProcessHardwareBuffer(format::ThreadId      thread_id,
-                                 format::HandleId      memory_id,
-                                 AHardwareBuffer*      hardware_buffer,
-                                 size_t                allocation_size,
-                                 VulkanCaptureManager* vulkan_capture_manager,
-                                 VulkanStateWriter*    vulkan_state_writer)
+void CommonProcessHardwareBuffer(format::ThreadId                      thread_id,
+                                 const vulkan_wrappers::DeviceWrapper* device_wrapper,
+                                 format::HandleId                      memory_id,
+                                 AHardwareBuffer*                      hardware_buffer,
+                                 size_t                                allocation_size,
+                                 VulkanCaptureManager*                 vulkan_capture_manager,
+                                 VulkanStateWriter*                    vulkan_state_writer)
 {
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     assert(hardware_buffer != nullptr);
@@ -179,7 +182,7 @@ void CommonProcessHardwareBuffer(format::ThreadId      thread_id,
 
         // Write CreateHardwareBufferCmd with or without the AHB payload
         CommonWriteCreateHardwareBufferCmd(
-            thread_id, memory_id, hardware_buffer, plane_info, vulkan_capture_manager, vulkan_state_writer);
+            thread_id, 0u, memory_id, hardware_buffer, plane_info, vulkan_capture_manager, vulkan_state_writer);
 
         // If AHardwareBuffer_lockPlanes failed (or is not available) try AHardwareBuffer_lock
         if (result != 0)
@@ -233,18 +236,703 @@ void CommonProcessHardwareBuffer(format::ThreadId      thread_id,
     }
     else
     {
-        // The AHB is not CPU-readable
+        // The AHB is not CPU-readable, copy the data into a host visible buffer on the GPU
+        format::HandleId           device_id               = device_wrapper->handle_id;
+        VkDevice                   device                  = device_wrapper->handle;
+        auto                       physical_device_wrapper = device_wrapper->physical_device;
+        auto                       physical_device         = physical_device_wrapper->handle;
+        const VulkanInstanceTable* instance_table          = vulkan_wrappers::GetInstanceTable(physical_device);
+        auto                       device_table            = vulkan_wrappers::GetDeviceTable(device);
+        auto                       memory_properties       = &physical_device_wrapper->memory_properties;
+
+        uint32_t device_queue_index = -1;
+        uint32_t queue_family_index = -1;
+
+        uint32_t queue_family_count;
+        instance_table->GetPhysicalDeviceQueueFamilyProperties(physical_device, &queue_family_count, nullptr);
+        std::vector<VkQueueFamilyProperties> queue_family_properties(queue_family_count);
+        instance_table->GetPhysicalDeviceQueueFamilyProperties(
+            physical_device, &queue_family_count, queue_family_properties.data());
+
+        for (size_t i = 0; i < device_wrapper->queue_family_indices.size(); ++i)
+        {
+            uint32_t qfi = device_wrapper->queue_family_indices[i];
+            if ((queue_family_properties[qfi].queueFlags & VK_QUEUE_COMPUTE_BIT) != 0)
+            {
+                device_queue_index = i;
+                queue_family_index = qfi;
+                break;
+            }
+        }
+
+        if (device_queue_index == -1 || queue_family_index == -1)
+            return;
+
+        auto             queue_wrapper = device_wrapper->child_queues[device_queue_index];
+        format::HandleId queue_id      = queue_wrapper->handle_id;
 
         // Write CreateHardwareBufferCmd without the AHB payload
         CommonWriteCreateHardwareBufferCmd(
-            thread_id, memory_id, hardware_buffer, plane_info, vulkan_capture_manager, vulkan_state_writer);
+            thread_id, device_id, memory_id, hardware_buffer, plane_info, vulkan_capture_manager, vulkan_state_writer);
 
-        // Dump zeros for AHB payload.
-        std::vector<uint8_t> zeros(allocation_size, 0);
-        CommonWriteFillMemoryCmd(memory_id, zeros.size(), zeros.data(), vulkan_capture_manager, vulkan_state_writer);
+        VkResult vk_result = VK_SUCCESS;
 
-        GFXRECON_LOG_WARNING("AHardwareBuffer cannot be read: hardware buffer data will be omitted "
-                             "from the capture file");
+        // Query the AHB size
+        VkAndroidHardwareBufferFormatPropertiesANDROID format_properties;
+        format_properties.sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID;
+        format_properties.pNext = nullptr;
+
+        VkAndroidHardwareBufferPropertiesANDROID properties;
+        properties.sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID;
+        properties.pNext = &format_properties;
+
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->GetAndroidHardwareBufferPropertiesANDROID(device, hardware_buffer, &properties);
+
+        const size_t ahb_size = properties.allocationSize;
+        GFXRECON_ASSERT(ahb_size > 0);
+
+        VkExternalFormatANDROID external_format = {};
+        external_format.sType                   = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID;
+        external_format.pNext                   = nullptr;
+        if (format_properties.format == VK_FORMAT_UNDEFINED)
+        {
+            external_format.externalFormat = format_properties.externalFormat;
+        }
+
+        VkExternalMemoryImageCreateInfo external_memory_image_create_info;
+        external_memory_image_create_info.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+        external_memory_image_create_info.pNext = &external_format;
+        external_memory_image_create_info.handleTypes =
+            VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+
+        VkImageUsageFlags image_usage = 0;
+        if (desc.usage & AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE)
+        {
+            image_usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
+        }
+        if (desc.usage & AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT)
+        {
+            image_usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        }
+        // If the pNext chain includes a VkExternalFormatANDROID structure whose externalFormat member is not 0, usage
+        // must not include any usages except VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+        // or VK_IMAGE_USAGE_SAMPLED_BIT.
+        if (format_properties.format != VK_FORMAT_UNDEFINED)
+        {
+            image_usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        }
+
+        VkImageCreateInfo image_create_info;
+        image_create_info.sType                 = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        image_create_info.pNext                 = &external_memory_image_create_info;
+        image_create_info.flags                 = 0u;
+        image_create_info.imageType             = VK_IMAGE_TYPE_2D;
+        image_create_info.format                = format_properties.format;
+        image_create_info.extent                = { desc.width, desc.height, 1u };
+        image_create_info.mipLevels             = 1u;
+        image_create_info.arrayLayers           = 1u;
+        image_create_info.samples               = VK_SAMPLE_COUNT_1_BIT;
+        image_create_info.tiling                = VK_IMAGE_TILING_OPTIMAL;
+        image_create_info.usage                 = image_usage;
+        image_create_info.sharingMode           = VK_SHARING_MODE_EXCLUSIVE;
+        image_create_info.queueFamilyIndexCount = 0u;
+        image_create_info.pQueueFamilyIndices   = nullptr;
+        image_create_info.initialLayout         = VK_IMAGE_LAYOUT_UNDEFINED;
+
+        VkImage ahb_image;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->CreateImage(device, &image_create_info, nullptr, &ahb_image);
+
+        VkImportAndroidHardwareBufferInfoANDROID import_ahb_info;
+        import_ahb_info.sType  = VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID;
+        import_ahb_info.pNext  = nullptr;
+        import_ahb_info.buffer = hardware_buffer;
+
+        VkMemoryDedicatedAllocateInfo memory_dedicated_allocate_info;
+        memory_dedicated_allocate_info.sType  = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+        memory_dedicated_allocate_info.pNext  = &import_ahb_info;
+        memory_dedicated_allocate_info.image  = ahb_image;
+        memory_dedicated_allocate_info.buffer = VK_NULL_HANDLE;
+
+        VkMemoryAllocateInfo memory_allocate_info;
+        memory_allocate_info.sType          = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        memory_allocate_info.pNext          = &memory_dedicated_allocate_info;
+        memory_allocate_info.allocationSize = properties.allocationSize;
+
+        uint32_t memory_index = memory_properties->memoryTypeCount;
+        for (uint32_t i = 0; i < memory_properties->memoryTypeCount; ++i)
+        {
+            if ((properties.memoryTypeBits & (1 << i)) &&
+                (memory_properties->memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) > 0)
+            {
+                memory_index = i;
+                break;
+            }
+        }
+        GFXRECON_ASSERT(memory_index < memory_properties->memoryTypeCount);
+        memory_allocate_info.memoryTypeIndex = memory_index;
+
+        VkDeviceMemory image_memory;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->AllocateMemory(device, &memory_allocate_info, nullptr, &image_memory);
+
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->BindImageMemory(device, ahb_image, image_memory, 0);
+
+        VkSamplerYcbcrConversionCreateInfo sampler_ycbcr_conversion_create_info;
+        sampler_ycbcr_conversion_create_info.sType         = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
+        sampler_ycbcr_conversion_create_info.pNext         = &external_format;
+        sampler_ycbcr_conversion_create_info.format        = format_properties.format;
+        sampler_ycbcr_conversion_create_info.ycbcrModel    = format_properties.suggestedYcbcrModel;
+        sampler_ycbcr_conversion_create_info.ycbcrRange    = format_properties.suggestedYcbcrRange;
+        sampler_ycbcr_conversion_create_info.components    = format_properties.samplerYcbcrConversionComponents;
+        sampler_ycbcr_conversion_create_info.xChromaOffset = format_properties.suggestedXChromaOffset;
+        sampler_ycbcr_conversion_create_info.yChromaOffset = format_properties.suggestedYChromaOffset;
+        sampler_ycbcr_conversion_create_info.chromaFilter  = VK_FILTER_LINEAR;
+        sampler_ycbcr_conversion_create_info.forceExplicitReconstruction = VK_FALSE;
+
+        VkSamplerYcbcrConversion ycbcr_conversion;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->CreateSamplerYcbcrConversion(
+                device, &sampler_ycbcr_conversion_create_info, nullptr, &ycbcr_conversion);
+
+        VkSamplerYcbcrConversionInfo sampler_ycbcr_conversion_info = {};
+        sampler_ycbcr_conversion_info.sType                        = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO;
+        sampler_ycbcr_conversion_info.pNext                        = nullptr;
+        sampler_ycbcr_conversion_info.conversion                   = ycbcr_conversion;
+
+        VkImageViewCreateInfo image_view_create_info;
+        image_view_create_info.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        image_view_create_info.pNext                           = &sampler_ycbcr_conversion_info;
+        image_view_create_info.flags                           = 0u;
+        image_view_create_info.image                           = ahb_image;
+        image_view_create_info.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
+        image_view_create_info.format                          = format_properties.format;
+        image_view_create_info.components.r                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        image_view_create_info.components.g                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        image_view_create_info.components.b                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        image_view_create_info.components.a                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        image_view_create_info.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+        image_view_create_info.subresourceRange.baseMipLevel   = 0u;
+        image_view_create_info.subresourceRange.levelCount     = 1u;
+        image_view_create_info.subresourceRange.baseArrayLayer = 0u;
+        image_view_create_info.subresourceRange.layerCount     = 1u;
+
+        VkImageView image_view;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->CreateImageView(device, &image_view_create_info, nullptr, &image_view);
+
+        VkSamplerCreateInfo sampler_create_info;
+        sampler_create_info.sType                   = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        sampler_create_info.pNext                   = &sampler_ycbcr_conversion_info;
+        sampler_create_info.flags                   = 0u;
+        sampler_create_info.magFilter               = VK_FILTER_LINEAR;
+        sampler_create_info.minFilter               = VK_FILTER_LINEAR;
+        sampler_create_info.mipmapMode              = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        sampler_create_info.addressModeU            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampler_create_info.addressModeV            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampler_create_info.addressModeW            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampler_create_info.mipLodBias              = 0.0f;
+        sampler_create_info.anisotropyEnable        = VK_FALSE;
+        sampler_create_info.maxAnisotropy           = 1.0f;
+        sampler_create_info.compareEnable           = VK_FALSE;
+        sampler_create_info.compareOp               = VK_COMPARE_OP_NEVER;
+        sampler_create_info.minLod                  = 0.0f;
+        sampler_create_info.maxLod                  = 0.0f;
+        sampler_create_info.borderColor             = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+        sampler_create_info.unnormalizedCoordinates = VK_FALSE;
+        VkSampler sampler;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->CreateSampler(device, &sampler_create_info, nullptr, &sampler);
+
+        VkImageUsageFlags host_image_usage  = VK_IMAGE_USAGE_STORAGE_BIT;
+        VkFormat          host_image_format = format_properties.format;
+        if (format_properties.format == VK_FORMAT_UNDEFINED)
+        {
+            host_image_format = VK_FORMAT_R8G8B8A8_UNORM;
+        }
+        else
+        {
+            host_image_usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        }
+
+        VkImageCreateInfo host_image_create_info{ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, nullptr };
+        host_image_create_info.flags                 = 0u;
+        host_image_create_info.imageType             = VK_IMAGE_TYPE_2D;
+        host_image_create_info.format                = host_image_format;
+        host_image_create_info.extent                = { desc.width, desc.height, 1u };
+        host_image_create_info.mipLevels             = 1u;
+        host_image_create_info.arrayLayers           = 1u;
+        host_image_create_info.samples               = VK_SAMPLE_COUNT_1_BIT;
+        host_image_create_info.tiling                = VK_IMAGE_TILING_LINEAR;
+        host_image_create_info.usage                 = host_image_usage;
+        host_image_create_info.sharingMode           = VK_SHARING_MODE_EXCLUSIVE;
+        host_image_create_info.queueFamilyIndexCount = 0u;
+        host_image_create_info.pQueueFamilyIndices   = nullptr;
+        host_image_create_info.initialLayout         = VK_IMAGE_LAYOUT_UNDEFINED;
+
+        VkImage host_image = VK_NULL_HANDLE;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->CreateImage(device, &host_image_create_info, nullptr, &host_image);
+
+        VkMemoryRequirements host_readable_memory_requirements;
+        device_table->GetImageMemoryRequirements(device, host_image, &host_readable_memory_requirements);
+
+        VkMemoryAllocateInfo host_readable_allocate_info;
+        host_readable_allocate_info.sType          = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        host_readable_allocate_info.pNext          = nullptr;
+        host_readable_allocate_info.allocationSize = host_readable_memory_requirements.size;
+
+        memory_index = memory_properties->memoryTypeCount;
+        for (uint32_t i = 0; i < memory_properties->memoryTypeCount; ++i)
+        {
+            if ((host_readable_memory_requirements.memoryTypeBits & (1 << i)) &&
+                (memory_properties->memoryTypes[i].propertyFlags &
+                 (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) ==
+                    (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
+            {
+                memory_index = i;
+                break;
+            }
+        }
+        GFXRECON_ASSERT(memory_index < memory_properties->memoryTypeCount);
+        host_readable_allocate_info.memoryTypeIndex = memory_index;
+
+        VkDeviceMemory host_image_memory = VK_NULL_HANDLE;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->AllocateMemory(device, &host_readable_allocate_info, nullptr, &host_image_memory);
+
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->BindImageMemory(device, host_image, host_image_memory, 0);
+
+        VkImageViewCreateInfo host_image_view_create_info{ VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, nullptr };
+        host_image_view_create_info.flags                           = 0u;
+        host_image_view_create_info.image                           = host_image;
+        host_image_view_create_info.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
+        host_image_view_create_info.format                          = host_image_create_info.format;
+        host_image_view_create_info.components.r                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        host_image_view_create_info.components.g                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        host_image_view_create_info.components.b                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        host_image_view_create_info.components.a                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        host_image_view_create_info.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+        host_image_view_create_info.subresourceRange.baseMipLevel   = 0u;
+        host_image_view_create_info.subresourceRange.levelCount     = 1u;
+        host_image_view_create_info.subresourceRange.baseArrayLayer = 0u;
+        host_image_view_create_info.subresourceRange.layerCount     = 1u;
+
+        VkImageView host_image_view;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->CreateImageView(device, &host_image_view_create_info, nullptr, &host_image_view);
+
+        VkCommandPoolCreateInfo command_pool_create_info;
+        command_pool_create_info.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        command_pool_create_info.pNext            = nullptr;
+        command_pool_create_info.flags            = 0u;
+        command_pool_create_info.queueFamilyIndex = queue_family_index;
+
+        VkCommandPool command_pool;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->CreateCommandPool(device, &command_pool_create_info, nullptr, &command_pool);
+
+        VkCommandBufferAllocateInfo command_buffer_allocate_info;
+        command_buffer_allocate_info.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        command_buffer_allocate_info.pNext              = nullptr;
+        command_buffer_allocate_info.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        command_buffer_allocate_info.commandPool        = command_pool;
+        command_buffer_allocate_info.commandBufferCount = 1u;
+
+        VkCommandBuffer command_buffer;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->AllocateCommandBuffers(device, &command_buffer_allocate_info, &command_buffer);
+
+        VkCommandBufferBeginInfo command_buffer_begin_info;
+        command_buffer_begin_info.sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        command_buffer_begin_info.pNext            = nullptr;
+        command_buffer_begin_info.flags            = 0u;
+        command_buffer_begin_info.pInheritanceInfo = nullptr;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->BeginCommandBuffer(command_buffer, &command_buffer_begin_info);
+
+        VkShaderModule        compute_shader_module = VK_NULL_HANDLE;
+        VkDescriptorSetLayout descriptor_set_layout = VK_NULL_HANDLE;
+        VkPipelineLayout      pipeline_layout       = VK_NULL_HANDLE;
+        VkPipeline            compute_pipeline      = VK_NULL_HANDLE;
+        VkDescriptorPool      descriptor_pool       = VK_NULL_HANDLE;
+        VkDescriptorSet       descriptor_set        = VK_NULL_HANDLE;
+
+        if (format_properties.format != VK_FORMAT_UNDEFINED)
+        {
+            VkImageMemoryBarrier barriers[2]            = {};
+            barriers[0].sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            barriers[0].pNext                           = nullptr;
+            barriers[0].srcAccessMask                   = 0u;
+            barriers[0].dstAccessMask                   = VK_ACCESS_MEMORY_READ_BIT;
+            barriers[0].oldLayout                       = VK_IMAGE_LAYOUT_UNDEFINED;
+            barriers[0].newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            barriers[0].srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+            barriers[0].dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+            barriers[0].image                           = ahb_image;
+            barriers[0].subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+            barriers[0].subresourceRange.baseMipLevel   = 0u;
+            barriers[0].subresourceRange.levelCount     = 1u;
+            barriers[0].subresourceRange.baseArrayLayer = 0u;
+            barriers[0].subresourceRange.layerCount     = 1u;
+            barriers[1].sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            barriers[1].pNext                           = nullptr;
+            barriers[1].srcAccessMask                   = 0u;
+            barriers[1].dstAccessMask                   = VK_ACCESS_MEMORY_READ_BIT;
+            barriers[1].oldLayout                       = VK_IMAGE_LAYOUT_UNDEFINED;
+            barriers[1].newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            barriers[1].srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+            barriers[1].dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+            barriers[1].image                           = host_image;
+            barriers[1].subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+            barriers[1].subresourceRange.baseMipLevel   = 0u;
+            barriers[1].subresourceRange.levelCount     = 1u;
+            barriers[1].subresourceRange.baseArrayLayer = 0u;
+            barriers[1].subresourceRange.layerCount     = 1u;
+
+            device_table->CmdPipelineBarrier(command_buffer,
+                                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                             0,
+                                             0,
+                                             nullptr,
+                                             0,
+                                             nullptr,
+                                             2,
+                                             barriers);
+
+            VkImageCopy copy_region               = {};
+            copy_region.dstSubresource.layerCount = 1;
+            copy_region.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            copy_region.extent                    = { desc.width, desc.height, 1 };
+            copy_region.srcSubresource.layerCount = 1;
+            copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+
+            device_table->CmdCopyImage(command_buffer,
+                                       ahb_image,
+                                       VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                       host_image,
+                                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                       1,
+                                       &copy_region);
+        }
+        else
+        {
+            // #version 450
+            //
+            // layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+            //
+            // layout(set = 0, binding = 0) uniform sampler2D ahb_image;
+            // layout(set = 0, binding = 1, rgba8) uniform writeonly image2D host_image;
+            //
+            // void main() {
+            //     int id_x = int(gl_GlobalInvocationID.x);
+            //     int id_y = int(gl_GlobalInvocationID.y);
+            //
+            //     ivec2 image_size = textureSize(ahb_image, 0);
+            //
+            //     if (id_x >= image_size.x || id_y >= image_size.y) {
+            //         return;
+            //     }
+            //
+            //     vec2 coords = vec2(
+            //         float(id_x) / float(image_size.x),
+            //         float(id_y) / float(image_size.y)
+            //     );
+            //
+            //     vec4 color = texture(ahb_image, coords);
+            //     imageStore(host_image, ivec2(id_x, id_y), color);
+            // }
+
+            std::vector<uint32_t> shader = {
+                0x07230203, 0x00010000, 0x0008000b, 0x00000054, 0x00000000, 0x00020011, 0x00000001, 0x00020011,
+                0x00000032, 0x0006000b, 0x00000001, 0x4c534c47, 0x6474732e, 0x3035342e, 0x00000000, 0x0003000e,
+                0x00000000, 0x00000001, 0x0006000f, 0x00000005, 0x00000004, 0x6e69616d, 0x00000000, 0x0000000c,
+                0x00060010, 0x00000004, 0x00000011, 0x00000010, 0x00000010, 0x00000001, 0x00030003, 0x00000002,
+                0x000001c2, 0x00040005, 0x00000004, 0x6e69616d, 0x00000000, 0x00040005, 0x00000008, 0x785f6469,
+                0x00000000, 0x00080005, 0x0000000c, 0x475f6c67, 0x61626f6c, 0x766e496c, 0x7461636f, 0x496e6f69,
+                0x00000044, 0x00040005, 0x00000012, 0x795f6469, 0x00000000, 0x00050005, 0x00000019, 0x67616d69,
+                0x69735f65, 0x0000657a, 0x00050005, 0x0000001e, 0x5f626861, 0x67616d69, 0x00000065, 0x00040005,
+                0x00000035, 0x726f6f63, 0x00007364, 0x00040005, 0x00000045, 0x6f6c6f63, 0x00000072, 0x00050005,
+                0x0000004c, 0x74736f68, 0x616d695f, 0x00006567, 0x00040047, 0x0000000c, 0x0000000b, 0x0000001c,
+                0x00040047, 0x0000001e, 0x00000021, 0x00000000, 0x00040047, 0x0000001e, 0x00000022, 0x00000000,
+                0x00030047, 0x0000004c, 0x00000019, 0x00040047, 0x0000004c, 0x00000021, 0x00000001, 0x00040047,
+                0x0000004c, 0x00000022, 0x00000000, 0x00040047, 0x00000053, 0x0000000b, 0x00000019, 0x00020013,
+                0x00000002, 0x00030021, 0x00000003, 0x00000002, 0x00040015, 0x00000006, 0x00000020, 0x00000001,
+                0x00040020, 0x00000007, 0x00000007, 0x00000006, 0x00040015, 0x00000009, 0x00000020, 0x00000000,
+                0x00040017, 0x0000000a, 0x00000009, 0x00000003, 0x00040020, 0x0000000b, 0x00000001, 0x0000000a,
+                0x0004003b, 0x0000000b, 0x0000000c, 0x00000001, 0x0004002b, 0x00000009, 0x0000000d, 0x00000000,
+                0x00040020, 0x0000000e, 0x00000001, 0x00000009, 0x0004002b, 0x00000009, 0x00000013, 0x00000001,
+                0x00040017, 0x00000017, 0x00000006, 0x00000002, 0x00040020, 0x00000018, 0x00000007, 0x00000017,
+                0x00030016, 0x0000001a, 0x00000020, 0x00090019, 0x0000001b, 0x0000001a, 0x00000001, 0x00000000,
+                0x00000000, 0x00000000, 0x00000001, 0x00000000, 0x0003001b, 0x0000001c, 0x0000001b, 0x00040020,
+                0x0000001d, 0x00000000, 0x0000001c, 0x0004003b, 0x0000001d, 0x0000001e, 0x00000000, 0x0004002b,
+                0x00000006, 0x00000020, 0x00000000, 0x00020014, 0x00000023, 0x00040017, 0x00000033, 0x0000001a,
+                0x00000002, 0x00040020, 0x00000034, 0x00000007, 0x00000033, 0x00040017, 0x00000043, 0x0000001a,
+                0x00000004, 0x00040020, 0x00000044, 0x00000007, 0x00000043, 0x0004002b, 0x0000001a, 0x00000048,
+                0x00000000, 0x00090019, 0x0000004a, 0x0000001a, 0x00000001, 0x00000000, 0x00000000, 0x00000000,
+                0x00000002, 0x00000004, 0x00040020, 0x0000004b, 0x00000000, 0x0000004a, 0x0004003b, 0x0000004b,
+                0x0000004c, 0x00000000, 0x0004002b, 0x00000009, 0x00000052, 0x00000010, 0x0006002c, 0x0000000a,
+                0x00000053, 0x00000052, 0x00000052, 0x00000013, 0x00050036, 0x00000002, 0x00000004, 0x00000000,
+                0x00000003, 0x000200f8, 0x00000005, 0x0004003b, 0x00000007, 0x00000008, 0x00000007, 0x0004003b,
+                0x00000007, 0x00000012, 0x00000007, 0x0004003b, 0x00000018, 0x00000019, 0x00000007, 0x0004003b,
+                0x00000034, 0x00000035, 0x00000007, 0x0004003b, 0x00000044, 0x00000045, 0x00000007, 0x00050041,
+                0x0000000e, 0x0000000f, 0x0000000c, 0x0000000d, 0x0004003d, 0x00000009, 0x00000010, 0x0000000f,
+                0x0004007c, 0x00000006, 0x00000011, 0x00000010, 0x0003003e, 0x00000008, 0x00000011, 0x00050041,
+                0x0000000e, 0x00000014, 0x0000000c, 0x00000013, 0x0004003d, 0x00000009, 0x00000015, 0x00000014,
+                0x0004007c, 0x00000006, 0x00000016, 0x00000015, 0x0003003e, 0x00000012, 0x00000016, 0x0004003d,
+                0x0000001c, 0x0000001f, 0x0000001e, 0x00040064, 0x0000001b, 0x00000021, 0x0000001f, 0x00050067,
+                0x00000017, 0x00000022, 0x00000021, 0x00000020, 0x0003003e, 0x00000019, 0x00000022, 0x0004003d,
+                0x00000006, 0x00000024, 0x00000008, 0x00050041, 0x00000007, 0x00000025, 0x00000019, 0x0000000d,
+                0x0004003d, 0x00000006, 0x00000026, 0x00000025, 0x000500af, 0x00000023, 0x00000027, 0x00000024,
+                0x00000026, 0x000400a8, 0x00000023, 0x00000028, 0x00000027, 0x000300f7, 0x0000002a, 0x00000000,
+                0x000400fa, 0x00000028, 0x00000029, 0x0000002a, 0x000200f8, 0x00000029, 0x0004003d, 0x00000006,
+                0x0000002b, 0x00000012, 0x00050041, 0x00000007, 0x0000002c, 0x00000019, 0x00000013, 0x0004003d,
+                0x00000006, 0x0000002d, 0x0000002c, 0x000500af, 0x00000023, 0x0000002e, 0x0000002b, 0x0000002d,
+                0x000200f9, 0x0000002a, 0x000200f8, 0x0000002a, 0x000700f5, 0x00000023, 0x0000002f, 0x00000027,
+                0x00000005, 0x0000002e, 0x00000029, 0x000300f7, 0x00000031, 0x00000000, 0x000400fa, 0x0000002f,
+                0x00000030, 0x00000031, 0x000200f8, 0x00000030, 0x000100fd, 0x000200f8, 0x00000031, 0x0004003d,
+                0x00000006, 0x00000036, 0x00000008, 0x0004006f, 0x0000001a, 0x00000037, 0x00000036, 0x00050041,
+                0x00000007, 0x00000038, 0x00000019, 0x0000000d, 0x0004003d, 0x00000006, 0x00000039, 0x00000038,
+                0x0004006f, 0x0000001a, 0x0000003a, 0x00000039, 0x00050088, 0x0000001a, 0x0000003b, 0x00000037,
+                0x0000003a, 0x0004003d, 0x00000006, 0x0000003c, 0x00000012, 0x0004006f, 0x0000001a, 0x0000003d,
+                0x0000003c, 0x00050041, 0x00000007, 0x0000003e, 0x00000019, 0x00000013, 0x0004003d, 0x00000006,
+                0x0000003f, 0x0000003e, 0x0004006f, 0x0000001a, 0x00000040, 0x0000003f, 0x00050088, 0x0000001a,
+                0x00000041, 0x0000003d, 0x00000040, 0x00050050, 0x00000033, 0x00000042, 0x0000003b, 0x00000041,
+                0x0003003e, 0x00000035, 0x00000042, 0x0004003d, 0x0000001c, 0x00000046, 0x0000001e, 0x0004003d,
+                0x00000033, 0x00000047, 0x00000035, 0x00070058, 0x00000043, 0x00000049, 0x00000046, 0x00000047,
+                0x00000002, 0x00000048, 0x0003003e, 0x00000045, 0x00000049, 0x0004003d, 0x0000004a, 0x0000004d,
+                0x0000004c, 0x0004003d, 0x00000006, 0x0000004e, 0x00000008, 0x0004003d, 0x00000006, 0x0000004f,
+                0x00000012, 0x00050050, 0x00000017, 0x00000050, 0x0000004e, 0x0000004f, 0x0004003d, 0x00000043,
+                0x00000051, 0x00000045, 0x00040063, 0x0000004d, 0x00000050, 0x00000051, 0x000100fd, 0x00010038,
+            };
+
+            VkShaderModuleCreateInfo shader_module_create_info;
+            shader_module_create_info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+            shader_module_create_info.pNext    = nullptr;
+            shader_module_create_info.flags    = 0u;
+            shader_module_create_info.codeSize = shader.size() * sizeof(uint32_t);
+            shader_module_create_info.pCode    = shader.data();
+            if (vk_result == VK_SUCCESS)
+                vk_result = device_table->CreateShaderModule(
+                    device, &shader_module_create_info, nullptr, &compute_shader_module);
+
+            VkPipelineShaderStageCreateInfo shader_stage_create_info;
+            shader_stage_create_info.sType               = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+            shader_stage_create_info.pNext               = nullptr;
+            shader_stage_create_info.flags               = 0u;
+            shader_stage_create_info.stage               = VK_SHADER_STAGE_COMPUTE_BIT;
+            shader_stage_create_info.module              = compute_shader_module;
+            shader_stage_create_info.pName               = "main";
+            shader_stage_create_info.pSpecializationInfo = nullptr;
+
+            VkDescriptorSetLayoutBinding bindings[2];
+            bindings[0].binding            = 0u;
+            bindings[0].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            bindings[0].descriptorCount    = 1u;
+            bindings[0].stageFlags         = VK_SHADER_STAGE_COMPUTE_BIT;
+            bindings[0].pImmutableSamplers = &sampler;
+            bindings[1].binding            = 1u;
+            bindings[1].descriptorType     = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+            bindings[1].descriptorCount    = 1u;
+            bindings[1].stageFlags         = VK_SHADER_STAGE_COMPUTE_BIT;
+            bindings[1].pImmutableSamplers = nullptr;
+
+            VkDescriptorSetLayoutCreateInfo descriptor_set_layout_create_info;
+            descriptor_set_layout_create_info.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+            descriptor_set_layout_create_info.pNext        = nullptr;
+            descriptor_set_layout_create_info.flags        = 0u;
+            descriptor_set_layout_create_info.bindingCount = 2u;
+            descriptor_set_layout_create_info.pBindings    = bindings;
+
+            if (vk_result == VK_SUCCESS)
+                vk_result = device_table->CreateDescriptorSetLayout(
+                    device, &descriptor_set_layout_create_info, nullptr, &descriptor_set_layout);
+
+            VkPipelineLayoutCreateInfo pipeline_layout_create_info;
+            pipeline_layout_create_info.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+            pipeline_layout_create_info.pNext                  = nullptr;
+            pipeline_layout_create_info.flags                  = 0u;
+            pipeline_layout_create_info.setLayoutCount         = 1u;
+            pipeline_layout_create_info.pSetLayouts            = &descriptor_set_layout;
+            pipeline_layout_create_info.pushConstantRangeCount = 0u;
+            pipeline_layout_create_info.pPushConstantRanges    = nullptr;
+
+            if (vk_result == VK_SUCCESS)
+                vk_result =
+                    device_table->CreatePipelineLayout(device, &pipeline_layout_create_info, nullptr, &pipeline_layout);
+
+            VkComputePipelineCreateInfo compute_pipeline_create_info;
+            compute_pipeline_create_info.sType              = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+            compute_pipeline_create_info.pNext              = nullptr;
+            compute_pipeline_create_info.flags              = 0u;
+            compute_pipeline_create_info.stage              = shader_stage_create_info;
+            compute_pipeline_create_info.layout             = pipeline_layout;
+            compute_pipeline_create_info.basePipelineHandle = VK_NULL_HANDLE;
+            compute_pipeline_create_info.basePipelineIndex  = -1;
+
+            device_table->CreateComputePipelines(
+                device, VK_NULL_HANDLE, 1u, &compute_pipeline_create_info, nullptr, &compute_pipeline);
+
+            VkDescriptorPoolSize pool_sizes[2];
+            pool_sizes[0].type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            pool_sizes[0].descriptorCount = 1u;
+            pool_sizes[1].type            = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+            pool_sizes[1].descriptorCount = 1u;
+
+            VkDescriptorPoolCreateInfo descriptor_pool_create_info;
+            descriptor_pool_create_info.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+            descriptor_pool_create_info.pNext         = nullptr;
+            descriptor_pool_create_info.flags         = 0u;
+            descriptor_pool_create_info.maxSets       = 1u;
+            descriptor_pool_create_info.poolSizeCount = 2u;
+            descriptor_pool_create_info.pPoolSizes    = pool_sizes;
+
+            if (vk_result == VK_SUCCESS)
+                vk_result =
+                    device_table->CreateDescriptorPool(device, &descriptor_pool_create_info, nullptr, &descriptor_pool);
+
+            VkDescriptorSetAllocateInfo descriptor_set_allocate_info;
+            descriptor_set_allocate_info.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+            descriptor_set_allocate_info.pNext              = nullptr;
+            descriptor_set_allocate_info.descriptorPool     = descriptor_pool;
+            descriptor_set_allocate_info.descriptorSetCount = 1u;
+            descriptor_set_allocate_info.pSetLayouts        = &descriptor_set_layout;
+
+            if (vk_result == VK_SUCCESS)
+                vk_result =
+                    device_table->AllocateDescriptorSets(device, &descriptor_set_allocate_info, &descriptor_set);
+
+            VkDescriptorImageInfo image_info = {};
+            image_info.sampler               = sampler;
+            image_info.imageView             = image_view;
+            image_info.imageLayout           = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkDescriptorImageInfo host_image_info = {};
+            host_image_info.imageView             = host_image_view;
+            host_image_info.imageLayout           = VK_IMAGE_LAYOUT_GENERAL;
+
+            VkWriteDescriptorSet descriptor_writes[2] = {};
+            descriptor_writes[0].sType                = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            descriptor_writes[0].dstSet               = descriptor_set;
+            descriptor_writes[0].dstBinding           = 0u;
+            descriptor_writes[0].dstArrayElement      = 0u;
+            descriptor_writes[0].descriptorCount      = 1u;
+            descriptor_writes[0].descriptorType       = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            descriptor_writes[0].pImageInfo           = &image_info;
+            descriptor_writes[1].sType                = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            descriptor_writes[1].dstSet               = descriptor_set;
+            descriptor_writes[1].dstBinding           = 1u;
+            descriptor_writes[1].dstArrayElement      = 0u;
+            descriptor_writes[1].descriptorCount      = 1u;
+            descriptor_writes[1].descriptorType       = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+            descriptor_writes[1].pImageInfo           = &host_image_info;
+
+            device_table->UpdateDescriptorSets(device, 2u, descriptor_writes, 0u, nullptr);
+
+            if (vk_result == VK_SUCCESS)
+            {
+                VkImageMemoryBarrier barriers[2]            = {};
+                barriers[0].sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                barriers[0].srcAccessMask                   = 0u;
+                barriers[0].dstAccessMask                   = VK_ACCESS_SHADER_READ_BIT;
+                barriers[0].oldLayout                       = VK_IMAGE_LAYOUT_UNDEFINED;
+                barriers[0].newLayout                       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                barriers[0].srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                barriers[0].dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                barriers[0].image                           = ahb_image;
+                barriers[0].subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+                barriers[0].subresourceRange.baseMipLevel   = 0u;
+                barriers[0].subresourceRange.levelCount     = 1u;
+                barriers[0].subresourceRange.baseArrayLayer = 0u;
+                barriers[0].subresourceRange.layerCount     = 1u;
+                barriers[1].sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                barriers[1].srcAccessMask                   = 0u;
+                barriers[1].dstAccessMask                   = VK_ACCESS_SHADER_WRITE_BIT;
+                barriers[1].oldLayout                       = VK_IMAGE_LAYOUT_UNDEFINED;
+                barriers[1].newLayout                       = VK_IMAGE_LAYOUT_GENERAL;
+                barriers[1].srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                barriers[1].dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                barriers[1].image                           = host_image;
+                barriers[1].subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+                barriers[1].subresourceRange.baseMipLevel   = 0u;
+                barriers[1].subresourceRange.levelCount     = 1u;
+                barriers[1].subresourceRange.baseArrayLayer = 0u;
+                barriers[1].subresourceRange.layerCount     = 1u;
+
+                device_table->CmdPipelineBarrier(command_buffer,
+                                                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                                 VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 0,
+                                                 nullptr,
+                                                 2,
+                                                 barriers);
+
+                device_table->CmdBindPipeline(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipeline);
+                device_table->CmdBindDescriptorSets(
+                    command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1, &descriptor_set, 0, nullptr);
+                device_table->CmdDispatch(command_buffer, (desc.width + 15) / 16, (desc.height + 15) / 16, 1u);
+            }
+        }
+
+        device_table->EndCommandBuffer(command_buffer);
+
+        VkSubmitInfo submit_info;
+        submit_info.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submit_info.pNext                = nullptr;
+        submit_info.waitSemaphoreCount   = 0u;
+        submit_info.pWaitSemaphores      = nullptr;
+        submit_info.pWaitDstStageMask    = nullptr;
+        submit_info.commandBufferCount   = 1u;
+        submit_info.pCommandBuffers      = &command_buffer;
+        submit_info.signalSemaphoreCount = 0u;
+        submit_info.pSignalSemaphores    = nullptr;
+
+        VkFenceCreateInfo fence_create_info;
+        fence_create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        fence_create_info.pNext = nullptr;
+        fence_create_info.flags = 0u;
+
+        VkFence fence;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->CreateFence(device, &fence_create_info, nullptr, &fence);
+
+        auto queue = device_wrapper->child_queues[device_queue_index]->handle;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->QueueSubmit(queue, 1, &submit_info, fence);
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->WaitForFences(device, 1u, &fence, VK_TRUE, UINT64_MAX);
+
+        void*  data;
+        size_t data_size = host_readable_memory_requirements.size;
+        if (vk_result == VK_SUCCESS)
+            vk_result = device_table->MapMemory(device, host_image_memory, 0u, data_size, 0u, &data);
+
+        if (vk_result == VK_SUCCESS)
+        {
+            CommonWriteFillMemoryCmd(memory_id, data_size, data, vulkan_capture_manager, vulkan_state_writer);
+        }
+
+        device_table->DestroyFence(device, fence, nullptr);
+        device_table->DestroyCommandPool(device, command_pool, nullptr);
+        device_table->DestroyDescriptorPool(device, descriptor_pool, nullptr);
+        device_table->DestroyPipeline(device, compute_pipeline, nullptr);
+        device_table->DestroyDescriptorSetLayout(device, descriptor_set_layout, nullptr);
+        device_table->DestroyPipelineLayout(device, pipeline_layout, nullptr);
+        device_table->DestroyShaderModule(device, compute_shader_module, nullptr);
+        device_table->FreeMemory(device, host_image_memory, nullptr);
+        device_table->FreeMemory(device, image_memory, nullptr);
+        device_table->DestroyImage(device, ahb_image, nullptr);
+        device_table->DestroyImage(device, host_image, nullptr);
+
+        if (vk_result != VK_SUCCESS)
+            GFXRECON_LOG_ERROR("Failed to copy data from AHardwareBuffer that is not cpu readable");
     }
 #else
     GFXRECON_UNREFERENCED_PARAMETER(thread_id);

--- a/framework/encode/vulkan_capture_common.h
+++ b/framework/encode/vulkan_capture_common.h
@@ -33,19 +33,13 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void CommonWriteCreateHardwareBufferCmd(format::ThreadId                                    thread_id,
-                                        format::HandleId                                    memory_id,
-                                        AHardwareBuffer*                                    hardware_buffer,
-                                        const std::vector<format::HardwareBufferPlaneInfo>& plane_info,
-                                        VulkanCaptureManager*                               vulkan_capture_manager,
-                                        VulkanStateWriter*                                  vulkan_state_writer);
-
-void CommonProcessHardwareBuffer(format::ThreadId      thread_id,
-                                 format::HandleId      memory_id,
-                                 AHardwareBuffer*      hardware_buffer,
-                                 size_t                allocation_size,
-                                 VulkanCaptureManager* vulkan_capture_manager,
-                                 VulkanStateWriter*    vulkan_state_writer);
+void CommonProcessHardwareBuffer(format::ThreadId                      thread_id,
+                                 const vulkan_wrappers::DeviceWrapper* device_wrapper,
+                                 format::HandleId                      memory_id,
+                                 AHardwareBuffer*                      hardware_buffer,
+                                 size_t                                allocation_size,
+                                 VulkanCaptureManager*                 vulkan_capture_manager,
+                                 VulkanStateWriter*                    vulkan_state_writer);
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -640,7 +640,7 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
 
     graphics::VulkanDeviceUtil                device_util;
     graphics::VulkanDevicePropertyFeatureInfo property_feature_info = device_util.EnableRequiredPhysicalDeviceFeatures(
-        physical_device_wrapper->instance_api_version, instance_table, physicalDevice, pCreateInfo_unwrapped);
+        physical_device_wrapper->instance_info, instance_table, physicalDevice, pCreateInfo_unwrapped);
 
     // TODO: Only enable KHR_external_memory_capabilities for 1.0 API version.
     size_t                   extension_count = pCreateInfo_unwrapped->enabledExtensionCount;
@@ -835,7 +835,7 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
             info.buffer                    = buffer_wrapper->handle;
             uint64_t opaque_address        = 0;
 
-            if (device_wrapper->physical_device->instance_api_version >= VK_MAKE_VERSION(1, 2, 0))
+            if (device_wrapper->physical_device->instance_info.api_version >= VK_MAKE_VERSION(1, 2, 0))
             {
                 opaque_address = device_table->GetBufferOpaqueCaptureAddress(device_unwrapped, &info);
             }
@@ -1103,7 +1103,7 @@ VkResult VulkanCaptureManager::OverrideAllocateMemory(VkDevice                  
                                                          memory_wrapper->handle };
 
             uint64_t address = 0;
-            if (device_wrapper->physical_device->instance_api_version >= VK_MAKE_VERSION(1, 2, 0))
+            if (device_wrapper->physical_device->instance_info.api_version >= VK_MAKE_VERSION(1, 2, 0))
             {
                 address = vulkan_wrappers::GetDeviceTable(device)->GetDeviceMemoryOpaqueCaptureAddress(device_unwrapped,
                                                                                                        &info);
@@ -1168,7 +1168,7 @@ void VulkanCaptureManager::OverrideGetPhysicalDeviceProperties2(VkPhysicalDevice
     auto physical_device_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
     GFXRECON_ASSERT(physical_device_wrapper != nullptr)
 
-    if (physical_device_wrapper->instance_api_version >= VK_MAKE_VERSION(1, 1, 0))
+    if (physical_device_wrapper->instance_info.api_version >= VK_MAKE_VERSION(1, 1, 0))
     {
         vulkan_wrappers::GetInstanceTable(physicalDevice)->GetPhysicalDeviceProperties2(physicalDevice, pProperties);
     }
@@ -1698,7 +1698,7 @@ void VulkanCaptureManager::ProcessEnumeratePhysicalDevices(VkResult          res
                     physical_device_wrapper->memory_properties = std::move(memory_properties);
                 }
 
-                physical_device_wrapper->instance_api_version = instance_wrapper->api_version;
+                physical_device_wrapper->instance_info.api_version = instance_wrapper->api_version;
 
                 WriteSetDevicePropertiesCommand(physical_device_id, properties);
                 WriteSetDeviceMemoryPropertiesCommand(physical_device_id, physical_device_wrapper->memory_properties);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -170,6 +170,7 @@ struct DeviceWrapper : public HandleWrapper<VkDevice>
     // Physical device property & feature state at device creation
     graphics::VulkanDevicePropertyFeatureInfo              property_feature_info;
     std::unordered_map<uint32_t, VkDeviceQueueCreateFlags> queue_family_creation_flags;
+    std::vector<uint32_t>                                  queue_family_indices;
 };
 
 struct FenceWrapper : public HandleWrapper<VkFence>
@@ -219,6 +220,7 @@ struct ImageWrapper : public HandleWrapper<VkImage>, AssetWrapperBase
     VkImageType           image_type{ VK_IMAGE_TYPE_2D };
     VkFormat              format{ VK_FORMAT_UNDEFINED };
     bool                  external_format{ false };
+    bool                  external_memory_android{ false };
     VkExtent3D            extent{ 0, 0, 0 };
     uint32_t              mip_levels{ 0 };
     uint32_t              array_layers{ 0 };

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -30,6 +30,7 @@
 #include "format/format.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "graphics/vulkan_device_util.h"
+#include "graphics/vulkan_instance_util.h"
 #include "util/defines.h"
 #include "util/memory_output_stream.h"
 #include "util/page_guard_manager.h"
@@ -127,9 +128,9 @@ struct DisplayKHRWrapper : public HandleWrapper<VkDisplayKHR>
 // handle wrapper, which will filter duplicate handle retrievals and ensure that the wrapper is destroyed.
 struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 {
-    VulkanInstanceTable*            layer_table_ref{ nullptr };
-    std::vector<DisplayKHRWrapper*> child_displays;
-    uint32_t                        instance_api_version{ 0 };
+    VulkanInstanceTable*             layer_table_ref{ nullptr };
+    std::vector<DisplayKHRWrapper*>  child_displays;
+    graphics::VulkanInstanceUtilInfo instance_info{};
 
     // Track memory types for use when creating snapshots of buffer and image resource memory content.
     VkPhysicalDeviceMemoryProperties memory_properties{};
@@ -215,16 +216,16 @@ struct BufferWrapper : public HandleWrapper<VkBuffer>, AssetWrapperBase
 struct ImageViewWrapper;
 struct ImageWrapper : public HandleWrapper<VkImage>, AssetWrapperBase
 {
-    VkImageType              image_type{ VK_IMAGE_TYPE_2D };
-    VkFormat                 format{ VK_FORMAT_UNDEFINED };
-    bool                     external_format{ false };
-    VkExtent3D               extent{ 0, 0, 0 };
-    uint32_t                 mip_levels{ 0 };
-    uint32_t                 array_layers{ 0 };
-    VkSampleCountFlagBits    samples{};
-    VkImageTiling            tiling{};
-    VkImageLayout            current_layout{ VK_IMAGE_LAYOUT_UNDEFINED };
-    bool                     is_swapchain_image{ false };
+    VkImageType           image_type{ VK_IMAGE_TYPE_2D };
+    VkFormat              format{ VK_FORMAT_UNDEFINED };
+    bool                  external_format{ false };
+    VkExtent3D            extent{ 0, 0, 0 };
+    uint32_t              mip_levels{ 0 };
+    uint32_t              array_layers{ 0 };
+    VkSampleCountFlagBits samples{};
+    VkImageTiling         tiling{};
+    VkImageLayout         current_layout{ VK_IMAGE_LAYOUT_UNDEFINED };
+    bool                  is_swapchain_image{ false };
 
     std::set<ImageViewWrapper*> image_views;
 };

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -609,7 +609,7 @@ void VulkanStateTracker::TrackImageMemoryBinding(
     }
 
     // AHB image memory requirements can only be queried after the memory is bound
-    if (wrapper->external_format)
+    if (wrapper->external_format || wrapper->external_memory_android)
     {
         const VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(device);
         VkMemoryRequirements     image_mem_reqs;

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -647,11 +647,19 @@ inline void InitializeState<VkDevice, vulkan_wrappers::ImageWrapper, VkImageCrea
         wrapper->queue_family_index = create_info->pQueueFamilyIndices[0];
     }
 
-    auto* external_format_android = graphics::vulkan_struct_get_pnext<VkExternalFormatANDROID>(create_info);
-    if (external_format_android != nullptr && external_format_android->externalFormat != 0)
+    auto* external_memory = graphics::vulkan_struct_get_pnext<VkExternalMemoryImageCreateInfo>(create_info);
+    wrapper->external_memory_android =
+        (external_memory != nullptr) &&
+        ((external_memory->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) ==
+         VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID);
+
+    auto* external_format    = graphics::vulkan_struct_get_pnext<VkExternalFormatANDROID>(create_info);
+    wrapper->external_format = (external_format != nullptr) && (external_format->externalFormat != 0);
+
+    if (wrapper->external_memory_android || wrapper->external_format)
     {
-        wrapper->external_format = true;
-        wrapper->size            = 0;
+        // Can not get image memory requirements before binding memory
+        wrapper->size = 0;
     }
     else
     {

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -465,7 +465,7 @@ void VulkanStateWriter::WriteSemaphoreState(const VulkanStateTable& state_table)
             // Query current semaphore value
             uint64_t          semaphore_value;
             format::ApiCallId signal_call_id;
-            if (device_wrapper->physical_device->instance_api_version >= VK_MAKE_VERSION(1, 2, 0))
+            if (device_wrapper->physical_device->instance_info.api_version >= VK_MAKE_VERSION(1, 2, 0))
             {
                 device_wrapper->layer_table.GetSemaphoreCounterValue(
                     device_wrapper->handle, wrapper->handle, &semaphore_value);
@@ -1398,9 +1398,9 @@ void VulkanStateWriter::WriteBufferDeviceAddressState(const VulkanStateTable& st
         if ((wrapper->device_id != format::kNullHandleId) && (wrapper->address != 0))
         {
             auto physical_device_wrapper = wrapper->bind_device->physical_device;
-            auto call_id                 = physical_device_wrapper->instance_api_version >= VK_MAKE_VERSION(1, 2, 0)
-                                               ? format::ApiCall_vkGetBufferDeviceAddress
-                                               : format::ApiCall_vkGetBufferDeviceAddressKHR;
+            auto call_id = physical_device_wrapper->instance_info.api_version >= VK_MAKE_VERSION(1, 2, 0)
+                               ? format::ApiCall_vkGetBufferDeviceAddress
+                               : format::ApiCall_vkGetBufferDeviceAddressKHR;
 
             parameter_stream_.Clear();
             encoder_.EncodeHandleIdValue(wrapper->bind_device->handle_id);
@@ -1513,7 +1513,7 @@ void VulkanStateWriter::WriteASInputMemoryState(ASInputBuffer& buffer)
     };
 
     uint64_t address = 0;
-    if (device_wrapper->physical_device->instance_api_version >= VK_MAKE_VERSION(1, 2, 0))
+    if (device_wrapper->physical_device->instance_info.api_version >= VK_MAKE_VERSION(1, 2, 0))
     {
         buffer.actual_address =
             device_wrapper->layer_table.GetBufferDeviceAddress(device_wrapper->handle, &buffer_address_info);
@@ -1554,7 +1554,7 @@ void VulkanStateWriter::WriteASInputMemoryState(ASInputBuffer& buffer)
     EncodePNextStruct(&encoder_, buffer_address_info.pNext);
     encoder_.EncodeHandleIdValue(buffer.handle_id);
     encoder_.EncodeVkDeviceAddressValue(buffer.actual_address);
-    auto call_id = device_wrapper->physical_device->instance_api_version >= VK_MAKE_VERSION(1, 2, 0)
+    auto call_id = device_wrapper->physical_device->instance_info.api_version >= VK_MAKE_VERSION(1, 2, 0)
                        ? format::ApiCall_vkGetBufferDeviceAddress
                        : format::ApiCall_vkGetBufferDeviceAddressKHR;
     WriteFunctionCall(call_id, &parameter_stream_);

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -122,42 +122,42 @@ enum AdapterType
 
 enum class MetaDataType : uint16_t
 {
-    kUnknownMetaDataType                    = 0,
-    kDisplayMessageCommand                  = 1,
-    kFillMemoryCommand                      = 2,
-    kResizeWindowCommand                    = 3,
-    kSetSwapchainImageStateCommand          = 4,
-    kBeginResourceInitCommand               = 5,
-    kEndResourceInitCommand                 = 6,
-    kInitBufferCommand                      = 7,
-    kInitImageCommand                       = 8,
-    kCreateHardwareBufferCommand_deprecated = 9,
-    kDestroyHardwareBufferCommand           = 10,
-    kSetDevicePropertiesCommand             = 11,
-    kSetDeviceMemoryPropertiesCommand       = 12,
-    kResizeWindowCommand2                   = 13,
-    kSetOpaqueAddressCommand                = 14,
-    kSetRayTracingShaderGroupHandlesCommand = 15,
-    kCreateHeapAllocationCommand            = 16,
-    kInitSubresourceCommand                 = 17,
-    kExeFileInfoCommand                     = 18,
-    kInitDx12AccelerationStructureCommand   = 19,
-    kFillMemoryResourceValueCommand         = 20,
-    kDxgiAdapterInfoCommand                 = 21,
-    kDriverInfoCommand                      = 22,
-    kReserved23                             = 23,
-    kCreateHardwareBufferCommand            = 24,
-    kReserved25                             = 25,
-    kDx12RuntimeInfoCommand                 = 26,
-    kParentToChildDependency                = 27,
+    kUnknownMetaDataType                                = 0,
+    kDisplayMessageCommand                              = 1,
+    kFillMemoryCommand                                  = 2,
+    kResizeWindowCommand                                = 3,
+    kSetSwapchainImageStateCommand                      = 4,
+    kBeginResourceInitCommand                           = 5,
+    kEndResourceInitCommand                             = 6,
+    kInitBufferCommand                                  = 7,
+    kInitImageCommand                                   = 8,
+    kCreateHardwareBufferCommand_deprecated             = 9,
+    kDestroyHardwareBufferCommand                       = 10,
+    kSetDevicePropertiesCommand                         = 11,
+    kSetDeviceMemoryPropertiesCommand                   = 12,
+    kResizeWindowCommand2                               = 13,
+    kSetOpaqueAddressCommand                            = 14,
+    kSetRayTracingShaderGroupHandlesCommand             = 15,
+    kCreateHeapAllocationCommand                        = 16,
+    kInitSubresourceCommand                             = 17,
+    kExeFileInfoCommand                                 = 18,
+    kInitDx12AccelerationStructureCommand               = 19,
+    kFillMemoryResourceValueCommand                     = 20,
+    kDxgiAdapterInfoCommand                             = 21,
+    kDriverInfoCommand                                  = 22,
+    kReserved23                                         = 23,
+    kCreateHardwareBufferCommand_deprecated2            = 24,
+    kReserved25                                         = 25,
+    kDx12RuntimeInfoCommand                             = 26,
+    kParentToChildDependency                            = 27,
     kVulkanBuildAccelerationStructuresCommand           = 28,
     kVulkanCopyAccelerationStructuresCommand            = 29,
     kVulkanWriteAccelerationStructuresPropertiesCommand = 30,
-    kReserved31                             = 31,
-    kSetEnvironmentVariablesCommand         = 32,
-    kViewRelativeLocation                   = 33,
-    kExecuteBlocksFromFile                  = 34,
-    kReserved35                             = 35
+    kReserved31                                         = 31,
+    kSetEnvironmentVariablesCommand                     = 32,
+    kViewRelativeLocation                               = 33,
+    kExecuteBlocksFromFile                              = 34,
+    kCreateHardwareBufferCommand                        = 35,
 };
 
 // MetaDataId is stored in the capture file and its type must be uint32_t to avoid breaking capture file compatibility.
@@ -406,10 +406,27 @@ struct CreateHardwareBufferCommandHeader_deprecated
                            // HardwareBufferLayerInfo records.  When unavailable, 'planes' is zero.
 };
 
+struct CreateHardwareBufferCommandHeader_deprecated2
+{
+    MetaDataHeader meta_header;
+    ThreadId       thread_id;
+    HandleId       memory_id; // Globally unique ID assigned to the buffer for tracking memory modifications.
+    uint64_t       buffer_id; // Address of the buffer object.
+    uint32_t       format;
+    uint32_t       width;
+    uint32_t       height;
+    uint32_t       stride; // Size of a row in pixels.
+    uint64_t       usage;
+    uint32_t       layers;
+    uint32_t       planes; // When additional multi-plane data is available, header is followed by 'planes' count
+                           // HardwareBufferLayerInfo records.  When unavailable, 'planes' is zero.
+};
+
 struct CreateHardwareBufferCommandHeader
 {
     MetaDataHeader meta_header;
     ThreadId       thread_id;
+    HandleId       device_id;
     HandleId       memory_id; // Globally unique ID assigned to the buffer for tracking memory modifications.
     uint64_t       buffer_id; // Address of the buffer object.
     uint32_t       format;

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -2576,16 +2576,15 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversion(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
-    const VkSamplerYcbcrConversionCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
+    auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
     if (!pYcbcrConversion->IsNull()) { pYcbcrConversion->SetHandleLength(1); }
-    VkSamplerYcbcrConversion* out_pYcbcrConversion = pYcbcrConversion->GetHandlePointer();
+    VulkanSamplerYcbcrConversionInfo handle_info;
+    pYcbcrConversion->SetConsumerData(0, &handle_info);
 
-    VkResult replay_result = GetDeviceTable(in_device)->CreateSamplerYcbcrConversion(in_device, in_pCreateInfo, in_pAllocator, out_pYcbcrConversion);
+    VkResult replay_result = OverrideCreateSamplerYcbcrConversion(GetDeviceTable(in_device->handle)->CreateSamplerYcbcrConversion, returnValue, in_device, pCreateInfo, pAllocator, pYcbcrConversion);
     CheckResult("vkCreateSamplerYcbcrConversion", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &CommonObjectInfoTable::AddVkSamplerYcbcrConversionInfo);
+    AddHandle<VulkanSamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), pYcbcrConversion->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSamplerYcbcrConversionInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversion(
@@ -5416,16 +5415,15 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
-    const VkSamplerYcbcrConversionCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
+    auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
     if (!pYcbcrConversion->IsNull()) { pYcbcrConversion->SetHandleLength(1); }
-    VkSamplerYcbcrConversion* out_pYcbcrConversion = pYcbcrConversion->GetHandlePointer();
+    VulkanSamplerYcbcrConversionInfo handle_info;
+    pYcbcrConversion->SetConsumerData(0, &handle_info);
 
-    VkResult replay_result = GetDeviceTable(in_device)->CreateSamplerYcbcrConversionKHR(in_device, in_pCreateInfo, in_pAllocator, out_pYcbcrConversion);
+    VkResult replay_result = OverrideCreateSamplerYcbcrConversionKHR(GetDeviceTable(in_device->handle)->CreateSamplerYcbcrConversionKHR, returnValue, in_device, pCreateInfo, pAllocator, pYcbcrConversion);
     CheckResult("vkCreateSamplerYcbcrConversionKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VulkanSamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &CommonObjectInfoTable::AddVkSamplerYcbcrConversionInfo);
+    AddHandle<VulkanSamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), pYcbcrConversion->GetHandlePointer(), std::move(handle_info), &CommonObjectInfoTable::AddVkSamplerYcbcrConversionInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversionKHR(

--- a/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
@@ -137,6 +137,8 @@
     "vkCmdBindDescriptorSets" : "OverrideCmdBindDescriptorSets",
     "vkCmdBindDescriptorSets2KHR" : "OverrideCmdBindDescriptorSets2",
     "vkCmdBindDescriptorSets2" : "OverrideCmdBindDescriptorSets2",
-    "vkCmdExecuteCommands" : "OverrideCmdExecuteCommands"
+    "vkCmdExecuteCommands" : "OverrideCmdExecuteCommands",
+    "vkCreateSamplerYcbcrConversion": "OverrideCreateSamplerYcbcrConversion",
+    "vkCreateSamplerYcbcrConversionKHR": "OverrideCreateSamplerYcbcrConversionKHR"
   }
 }

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -48,6 +48,8 @@ target_sources(gfxrecon_graphics
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_resources_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_util.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_instance_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_instance_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_deep_copy.h

--- a/framework/graphics/vulkan_device_util.h
+++ b/framework/graphics/vulkan_device_util.h
@@ -37,9 +37,17 @@ struct VulkanReplayDeviceInfo;
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
+struct VulkanInstanceUtilInfo;
+
 uint32_t GetMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properties,
                             uint32_t                                type_bits,
                             VkMemoryPropertyFlags                   property_flags);
+
+struct VulkanInstanceVersionExtensionInfo
+{
+    uint32_t                 api_version{ VK_MAKE_VERSION(1, 0, 0) };
+    std::vector<std::string> enabled_extensions;
+};
 
 struct VulkanDevicePropertyFeatureInfo
 {
@@ -59,7 +67,7 @@ class VulkanDeviceUtil
     // to revert incoming data to original values (e.g., prior to writing to the capture file).
     // feature_* property_* members store the state of the features/properties after this call.
     VulkanDevicePropertyFeatureInfo
-    EnableRequiredPhysicalDeviceFeatures(uint32_t                           instance_api_version,
+    EnableRequiredPhysicalDeviceFeatures(const VulkanInstanceUtilInfo&      instance_info,
                                          const encode::VulkanInstanceTable* instance_table,
                                          const VkPhysicalDevice             physical_device,
                                          const VkDeviceCreateInfo*          create_info);
@@ -68,14 +76,14 @@ class VulkanDeviceUtil
     void RestoreModifiedPhysicalDeviceFeatures();
 
     // Populates various property-structs in the provided replay_device_info
-    static void GetReplayDeviceProperties(uint32_t                           instance_api_version,
+    static void GetReplayDeviceProperties(const VulkanInstanceUtilInfo&      instance_info,
                                           const encode::VulkanInstanceTable* instance_table,
                                           VkPhysicalDevice                   physical_device,
                                           decode::VulkanReplayDeviceInfo*    replay_device_info);
 
   private:
     template <typename T>
-    VkBool32 EnableRequiredBufferDeviceAddressFeatures(uint32_t                           instance_api_version,
+    VkBool32 EnableRequiredBufferDeviceAddressFeatures(const VulkanInstanceUtilInfo&      instance_info,
                                                        const encode::VulkanInstanceTable* instance_table,
                                                        const VkPhysicalDevice             physical_device,
                                                        T*                                 feature_struct);

--- a/framework/graphics/vulkan_device_util.h
+++ b/framework/graphics/vulkan_device_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -57,6 +57,8 @@ struct VulkanDevicePropertyFeatureInfo
     VkBool32 feature_bufferDeviceAddressCaptureReplay{ VK_FALSE };
     VkBool32 feature_accelerationStructureCaptureReplay{ VK_FALSE };
     VkBool32 feature_rayTracingPipelineShaderGroupHandleCaptureReplay{ VK_FALSE };
+
+    VkBool32 feature_samplerYcbcrConversion{ VK_FALSE };
 };
 
 class VulkanDeviceUtil
@@ -88,6 +90,12 @@ class VulkanDeviceUtil
                                                        const VkPhysicalDevice             physical_device,
                                                        T*                                 feature_struct);
 
+    template <typename T>
+    VkBool32 EnableSamplerYcbcrConversionFeatures(const VulkanInstanceUtilInfo&      instance_info,
+                                                  const encode::VulkanInstanceTable* instance_table,
+                                                  const VkPhysicalDevice             physical_device,
+                                                  T*                                 feature_struct);
+
   private:
     // VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressCaptureReplay
     VkBool32* bufferDeviceAddressCaptureReplay_ptr{ nullptr };
@@ -100,6 +108,10 @@ class VulkanDeviceUtil
     // VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipelineShaderGroupHandleCaptureReplay
     VkBool32* rayTracingPipelineShaderGroupHandleCaptureReplay_ptr{ nullptr };
     VkBool32  rayTracingPipelineShaderGroupHandleCaptureReplay_original{ VK_FALSE };
+
+    // VkPhysicalDeviceSamplerYcbcrConversionFeatures
+    VkBool32* samplerYcbcrConversion_ptr{ nullptr };
+    VkBool32  samplerYcbcrConversion_original{ VK_FALSE };
 };
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/framework/graphics/vulkan_instance_util.cpp
+++ b/framework/graphics/vulkan_instance_util.cpp
@@ -1,0 +1,46 @@
+/*
+** Copyright (c) 2025 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "graphics/vulkan_instance_util.h"
+
+#include "util/platform.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+bool VulkanInstanceUtilInfo::IsEnabledExtension(const char* extension) const
+{
+    GFXRECON_ASSERT(extension != nullptr);
+
+    for (const auto& name : enabled_extensions)
+    {
+        if (util::platform::StringCompare(name.c_str(), extension) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/vulkan_instance_util.h
+++ b/framework/graphics/vulkan_instance_util.h
@@ -1,0 +1,45 @@
+/*
+** Copyright (c) 2025 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_GRAPHICS_VULKAN_INSTANCE_UTIL_H
+#define GFXRECON_GRAPHICS_VULKAN_INSTANCE_UTIL_H
+
+#include "generated/generated_vulkan_dispatch_table.h"
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+struct VulkanInstanceUtilInfo
+{
+    uint32_t                 api_version{ VK_MAKE_VERSION(1, 0, 0) };
+    std::vector<std::string> enabled_extensions{};
+
+    bool IsEnabledExtension(const char* extension) const;
+};
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_GRAPHICS_VULKAN_INSTANCE_UTIL_H


### PR DESCRIPTION
This is built on top of Ziga's https://github.com/LunarG/gfxreconstruct/pull/1812

Key changes:
- encode: copy AHB by Ycbcr sampling Vulkan image, then stores RGBA8 (no legal way to copy original external formatted data).
- decode: fills memory for the AHB by copying data to Vulkan image via ResourceInitializer. It also gets rid of references to the original external format as it is now expected to be RGBA8.