### PR TITLE
Run PreProcess if needed

### DIFF
--- a/android/tools/replay/CMakeLists.txt
+++ b/android/tools/replay/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(gfxrecon-replay
                 ${GFXRECON_SOURCE_DIR}/tools/replay/parse_dump_resources_cli.h
                 ${GFXRECON_SOURCE_DIR}/tools/replay/parse_dump_resources_cli.cpp
                 ${GFXRECON_SOURCE_DIR}/tools/replay/replay_settings.h
+                ${GFXRECON_SOURCE_DIR}/tools/replay/replay_pre_processing.h
                 ${GFXRECON_SOURCE_DIR}/tools/replay/android_main.cpp)
 
 target_include_directories(gfxrecon-replay

--- a/framework/decode/dx12_pre_process_consumer.h
+++ b/framework/decode/dx12_pre_process_consumer.h
@@ -235,12 +235,6 @@ struct TrackDumpCommandList
 // It runs tasks that need to be completed before replay.
 class Dx12PreProcessConsumer : public Dx12Consumer
 {
-#define CHECK_DX12_CONSUMER_USAGE() \
-    if (!dx12_consumer_usage_)      \
-    {                               \
-        return;                     \
-    }
-
   public:
     Dx12PreProcessConsumer() {}
 
@@ -311,7 +305,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                         Decoded_GUID                 riid,
                                                         HandlePointerDecoder<void*>* ppCommandList) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         InitializeTracking(call_info, *ppCommandList->GetPointer());
     }
 
@@ -321,7 +314,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                          format::HandleId   pAllocator,
                                                          format::HandleId   pInitialState) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         InitializeTracking(call_info, object_id);
     }
 
@@ -333,7 +325,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         StructPointerDecoder<Decoded_D3D12_RENDER_PASS_DEPTH_STENCIL_DESC>* pDepthStencil,
         D3D12_RENDER_PASS_FLAGS                                             Flags) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -348,7 +339,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
     virtual void Process_ID3D12GraphicsCommandList4_EndRenderPass(const ApiCallInfo& call_info,
                                                                   format::HandleId   object_id) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -373,7 +363,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         BOOL                                                       RTsSingleHandleToDescriptorRange,
         StructPointerDecoder<Decoded_D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -389,7 +378,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                                            format::HandleId   object_id,
                                                                            format::HandleId   pRootSignature) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -404,7 +392,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                                             format::HandleId   object_id,
                                                                             format::HandleId   pRootSignature) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -422,7 +409,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         UINT                                                    NumViews,
         StructPointerDecoder<Decoded_D3D12_VERTEX_BUFFER_VIEW>* pViews) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -443,7 +429,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         format::HandleId                                       object_id,
         StructPointerDecoder<Decoded_D3D12_INDEX_BUFFER_VIEW>* pView) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -468,7 +453,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         UINT                                         NumDescriptorHeaps,
         HandlePointerDecoder<ID3D12DescriptorHeap*>* ppDescriptorHeaps) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -490,7 +474,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         UINT                                RootParameterIndex,
         Decoded_D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -510,7 +493,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         UINT                                RootParameterIndex,
         Decoded_D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -530,7 +512,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                                                UINT               SrcData,
                                                                                UINT DestOffsetIn32BitValues) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -549,7 +530,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                                                 UINT               SrcData,
                                                                                 UINT DestOffsetIn32BitValues) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -569,7 +549,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                                                 PointerDecoder<uint8_t>* pSrcData,
                                                                                 UINT DestOffsetIn32BitValues) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -589,7 +568,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                                                  PointerDecoder<uint8_t>* pSrcData,
                                                                                  UINT DestOffsetIn32BitValues) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -608,7 +586,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         UINT                      RootParameterIndex,
         D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -628,7 +605,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         UINT                      RootParameterIndex,
         D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -648,7 +624,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         UINT                      RootParameterIndex,
         D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -668,7 +643,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         UINT                      RootParameterIndex,
         D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -688,7 +662,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         UINT                      RootParameterIndex,
         D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -708,7 +681,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
         UINT                      RootParameterIndex,
         D3D12_GPU_VIRTUAL_ADDRESS BufferLocation) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -729,7 +701,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                                  UINT               StartVertexLocation,
                                                                  UINT               StartInstanceLocation) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         TrackTargetDrawCall(call_info, object_id, DumpDrawCallType::kDraw);
     }
 
@@ -741,7 +712,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                                         INT                BaseVertexLocation,
                                                                         UINT StartInstanceLocation) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         TrackTargetDrawCall(call_info, object_id, DumpDrawCallType::kDraw);
     }
 
@@ -751,7 +721,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                             UINT               ThreadGroupCountY,
                                                             UINT               ThreadGroupCountZ) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         TrackTargetDrawCall(call_info, object_id, DumpDrawCallType::kDispatch);
     }
 
@@ -764,7 +733,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                                    format::HandleId   pCountBuffer,
                                                                    UINT64             CountBufferOffset) override
     {
-        CHECK_DX12_CONSUMER_USAGE()
         TrackTargetDrawCall(call_info,
                             object_id,
                             DumpDrawCallType::kIndirect,
@@ -778,7 +746,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                                  format::HandleId   object_id,
                                                                  format::HandleId   pCommandList) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         TrackTargetDrawCall(call_info,
                             object_id,
                             DumpDrawCallType::kBundle,
@@ -793,7 +760,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                          format::HandleId   object_id,
                                                          HRESULT            return_value) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             auto it = track_commandlist_infos_.find(object_id);
@@ -813,7 +779,6 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                                                    UINT                                      NumCommandLists,
                                                    HandlePointerDecoder<ID3D12CommandList*>* ppCommandLists) override
     {
-        CHECK_DX12_CONSUMER_USAGE();
         if (target_command_list_ == format::kNullHandleId)
         {
             if (track_submit_index_ == dump_resources_target_.submit_index)

--- a/framework/decode/vulkan_pre_process_consumer.h
+++ b/framework/decode/vulkan_pre_process_consumer.h
@@ -83,13 +83,6 @@ struct VkTrackDumpCommandBuffer
 // It runs tasks that need to be completed before replay.
 class VulkanPreProcessConsumer : public VulkanConsumer
 {
-
-#define CHECK_VULKAN_CONSUMER_USAGE() \
-    if (!vulkan_consumer_usage_)      \
-    {                                 \
-        return;                       \
-    }
-
   public:
     VulkanPreProcessConsumer() {}
 
@@ -179,7 +172,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                      StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
                                      HandlePointerDecoder<VkCommandBuffer>* pCommandBuffers) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         auto                     cmd_buf_handle_id = pCommandBuffers->GetPointer();
         VkTrackDumpCommandBuffer cmd_buf_info{};
         track_cmd_buf_infos_[*cmd_buf_handle_id] = cmd_buf_info;
@@ -190,7 +182,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                               format::HandleId          commandBuffer,
                                               VkCommandBufferResetFlags flags) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         auto it = track_cmd_buf_infos_.find(commandBuffer);
         if (it != track_cmd_buf_infos_.end())
         {
@@ -204,7 +195,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                  format::HandleId                                        commandBuffer,
                                  StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         auto it = track_cmd_buf_infos_.find(commandBuffer);
         if (it != track_cmd_buf_infos_.end())
         {
@@ -217,7 +207,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                               StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
                                               VkSubpassContents                                    contents) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         BeginRenderPass(commandBuffer, call_info.index);
     }
 
@@ -227,14 +216,11 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                   StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
                                   StructPointerDecoder<Decoded_VkSubpassBeginInfo>*    pSubpassBeginInfo) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         BeginRenderPass(commandBuffer, call_info.index);
     }
 
     virtual void Process_vkCmdEndRenderPass(const ApiCallInfo& call_info, format::HandleId commandBuffer) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
-
         EndRenderPass(commandBuffer, call_info.index);
     }
 
@@ -242,7 +228,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                              format::HandleId                                commandBuffer,
                                              StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         EndRenderPass(commandBuffer, call_info.index);
     }
 
@@ -250,7 +235,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                           format::HandleId   commandBuffer,
                                           VkSubpassContents  contents) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         NextSubpass(commandBuffer, call_info.index);
     }
 
@@ -259,7 +243,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                            StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
                                            StructPointerDecoder<Decoded_VkSubpassEndInfo>*   pSubpassEndInfo) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         NextSubpass(commandBuffer, call_info.index);
     }
 
@@ -270,7 +253,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                        StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
                                        format::HandleId                            fence) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         std::vector<format::HandleId> cmd_bufs;
         auto                          submit_info_data = pSubmits->GetMetaStructPointer();
         for (auto i = 0; i < submitCount; ++i)
@@ -292,7 +274,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                         StructPointerDecoder<Decoded_VkSubmitInfo2>* pSubmits,
                                         format::HandleId                             fence) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         std::vector<format::HandleId> cmd_bufs;
         auto                          submit_info_data = pSubmits->GetMetaStructPointer();
         for (auto i = 0; i < submitCount; ++i)
@@ -314,7 +295,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                            StructPointerDecoder<Decoded_VkSubmitInfo2>* pSubmits,
                                            format::HandleId                             fence) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         std::vector<format::HandleId> cmd_bufs;
         auto                          submit_info_data = pSubmits->GetMetaStructPointer();
         for (auto i = 0; i < submitCount; ++i)
@@ -336,7 +316,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                    uint32_t           firstVertex,
                                    uint32_t           firstInstance) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -348,7 +327,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                           int32_t            vertexOffset,
                                           uint32_t           firstInstance) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -359,7 +337,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                            uint32_t           drawCount,
                                            uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -370,7 +347,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                   uint32_t           drawCount,
                                                   uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -383,7 +359,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                 uint32_t           maxDrawCount,
                                                 uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -396,7 +371,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                    uint32_t           maxDrawCount,
                                                    uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -409,7 +383,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                        uint32_t           maxDrawCount,
                                                        uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -422,7 +395,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                           uint32_t           maxDrawCount,
                                                           uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -435,7 +407,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                        uint32_t           counterOffset,
                                                        uint32_t           vertexStride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -448,7 +419,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                    uint32_t           maxDrawCount,
                                                    uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -461,7 +431,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                           uint32_t           maxDrawCount,
                                                           uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -471,7 +440,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                uint32_t           groupCountY,
                                                uint32_t           groupCountZ) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -480,7 +448,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                               uint32_t           taskCount,
                                               uint32_t           firstTask) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -491,7 +458,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                        uint32_t           drawCount,
                                                        uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -502,7 +468,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                       uint32_t           drawCount,
                                                       uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -515,7 +480,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                             uint32_t           maxDrawCount,
                                                             uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -528,7 +492,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                            uint32_t           maxDrawCount,
                                                            uint32_t           stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -540,7 +503,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                            uint32_t                                          firstInstance,
                                            uint32_t                                          stride) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -553,7 +515,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                   uint32_t                 stride,
                                                   PointerDecoder<int32_t>* pVertexOffset) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -563,7 +524,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                 uint32_t           groupCountY,
                                                 uint32_t           groupCountZ) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -572,7 +532,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                         format::HandleId   buffer,
                                                         VkDeviceSize       offset) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDraw);
     }
 
@@ -582,7 +541,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                        uint32_t           groupCountY,
                                        uint32_t           groupCountZ) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDispatch);
     }
 
@@ -591,7 +549,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                format::HandleId   buffer,
                                                VkDeviceSize       offset) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDispatch);
     }
 
@@ -604,7 +561,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                            uint32_t           groupCountY,
                                            uint32_t           groupCountZ) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDispatch);
     }
 
@@ -617,7 +573,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                               uint32_t           groupCountY,
                                               uint32_t           groupCountZ) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kDispatch);
     }
 
@@ -632,7 +587,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
         uint32_t                                                       height,
         uint32_t                                                       depth) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kTraceRays);
     }
 
@@ -653,7 +607,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                           uint32_t           height,
                                           uint32_t           depth) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kTraceRays);
     }
 
@@ -666,7 +619,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pCallableShaderBindingTable,
         VkDeviceAddress                                                indirectDeviceAddress) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kTraceRays);
     }
 
@@ -674,7 +626,6 @@ class VulkanPreProcessConsumer : public VulkanConsumer
                                                     format::HandleId   commandBuffer,
                                                     VkDeviceAddress    indirectDeviceAddress) override
     {
-        CHECK_VULKAN_CONSUMER_USAGE();
         DrawCall(commandBuffer, call_info.index, VkDumpDrawCallType::kTraceRays);
     }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1068,8 +1068,10 @@ void VulkanReplayConsumerBase::ProcessInitImageCommand(format::HandleId         
 void VulkanReplayConsumerBase::SetFatalErrorHandler(std::function<void(const char*)> handler)
 {
     fatal_error_handler_ = handler;
-    assert(resource_dumper_);
-    resource_dumper_->DumpResourcesSetFatalErrorHandler(handler);
+    if (resource_dumper_)
+    {
+        resource_dumper_->DumpResourcesSetFatalErrorHandler(handler);
+    }
 }
 
 void VulkanReplayConsumerBase::RaiseFatalError(const char* message) const

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(gfxrecon-replay
                PRIVATE
                     ${CMAKE_CURRENT_LIST_DIR}/../tool_settings.h
                     ${CMAKE_CURRENT_LIST_DIR}/replay_settings.h
+                    ${CMAKE_CURRENT_LIST_DIR}/replay_pre_processing.h
                     ${CMAKE_CURRENT_LIST_DIR}/desktop_main.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/parse_dump_resources_cli.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -37,6 +37,7 @@
 #include "util/logging.h"
 #include "util/platform.h"
 #include "parse_dump_resources_cli.h"
+#include "replay_pre_processing.h"
 
 #include <android_native_app_glue.h>
 #include <android/log.h>
@@ -61,73 +62,6 @@ int32_t     ProcessInputEvent(struct android_app* app, AInputEvent* event);
 void        DestroyActivity(struct android_app* app);
 
 static std::unique_ptr<gfxrecon::decode::FileProcessor> file_processor;
-
-struct ApiReplayOptions
-{
-    gfxrecon::decode::VulkanReplayOptions* vk_replay_options{ nullptr };
-};
-
-struct ApiReplayConsumer
-{
-    gfxrecon::decode::VulkanReplayConsumer* vk_replay_consumer{ nullptr };
-};
-
-bool IsRunPreProcessConsumer(ApiReplayOptions& replay_options)
-{
-    GFXRECON_ASSERT(replay_options.vk_replay_options != nullptr);
-
-    if (replay_options.vk_replay_options->enable_dump_resources)
-    {
-        return true;
-    }
-    return false;
-}
-
-void RunPreProcessConsumer(const std::string& input_filename,
-                           ApiReplayOptions&  replay_options,
-                           ApiReplayConsumer& replay_consumer)
-{
-    GFXRECON_ASSERT(replay_options.vk_replay_options != nullptr && replay_consumer.vk_replay_consumer != nullptr);
-
-    gfxrecon::decode::FileProcessor file_processor;
-    if (file_processor.Initialize(input_filename))
-    {
-        gfxrecon::decode::VulkanPreProcessConsumer vk_pre_process_consumer;
-
-        if (replay_options.vk_replay_options->using_dump_resources_target)
-        {
-            vk_pre_process_consumer.EnableDumpResources(replay_options.vk_replay_options->dump_resources_target);
-        }
-
-        gfxrecon::decode::VulkanDecoder vk_decoder;
-        vk_decoder.AddConsumer(&vk_pre_process_consumer);
-        file_processor.AddDecoder(&vk_decoder);
-
-        file_processor.ProcessAllFrames();
-
-        replay_options.vk_replay_options->enable_vulkan = vk_pre_process_consumer.WasVulkanAPIDetected();
-
-        if (replay_options.vk_replay_options->enable_vulkan)
-        {
-            if (replay_options.vk_replay_options->using_dump_resources_target)
-            {
-                replay_options.vk_replay_options->dump_resources_block_indices =
-                    vk_pre_process_consumer.GetDumpResourcesBlockIndices();
-            }
-
-            if (replay_options.vk_replay_options->enable_dump_resources)
-            {
-                // Process --dump-resources block indices arg.
-                if (!gfxrecon::parse_dump_resources::parse_dump_resources_arg(*replay_options.vk_replay_options))
-                {
-                    GFXRECON_LOG_FATAL("There was an error while parsing dump resources indices. Terminating.");
-                    exit(0);
-                }
-                replay_consumer.vk_replay_consumer->InitializeReplayDumpResources();
-            }
-        }
-    }
-}
 
 extern "C"
 {

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -62,46 +62,60 @@ void        DestroyActivity(struct android_app* app);
 
 static std::unique_ptr<gfxrecon::decode::FileProcessor> file_processor;
 
-void RunVulkanPreProcessConsumer(const std::string&                      input_filename,
-                                 gfxrecon::decode::VulkanReplayOptions&  replay_options,
-                                 gfxrecon::decode::VulkanReplayConsumer& replay_consumer)
+struct ApiReplayOptions
 {
+    gfxrecon::decode::VulkanReplayOptions* vk_replay_options{ nullptr };
+};
+
+struct ApiReplayConsumer
+{
+    gfxrecon::decode::VulkanReplayConsumer* vk_replay_consumer{ nullptr };
+};
+
+void RunPreProcessConsumer(const std::string& input_filename,
+                           ApiReplayOptions&  replay_options,
+                           ApiReplayConsumer& replay_consumer)
+{
+    GFXRECON_ASSERT(replay_options.vk_replay_options != nullptr && replay_consumer.vk_replay_consumer != nullptr);
+
     gfxrecon::decode::FileProcessor file_processor;
     if (file_processor.Initialize(input_filename))
     {
-        gfxrecon::decode::VulkanPreProcessConsumer pre_process_consumer;
+        gfxrecon::decode::VulkanPreProcessConsumer vk_pre_process_consumer;
 
-        if (replay_options.using_dump_resources_target)
+        if (replay_options.vk_replay_options->using_dump_resources_target)
         {
-            pre_process_consumer.EnableDumpResources(replay_options.dump_resources_target);
+            vk_pre_process_consumer.EnableDumpResources(replay_options.vk_replay_options->dump_resources_target);
         }
 
-        gfxrecon::decode::VulkanDecoder decoder;
-        decoder.AddConsumer(&pre_process_consumer);
-        file_processor.AddDecoder(&decoder);
+        gfxrecon::decode::VulkanDecoder vk_decoder;
+        vk_decoder.AddConsumer(&vk_pre_process_consumer);
+        file_processor.AddDecoder(&vk_decoder);
+
         file_processor.ProcessAllFrames();
 
-        replay_options.enable_vulkan = pre_process_consumer.WasVulkanAPIDetected();
+        replay_options.vk_replay_options->enable_vulkan = vk_pre_process_consumer.WasVulkanAPIDetected();
 
-        if (replay_options.enable_vulkan)
+        if (replay_options.vk_replay_options->enable_vulkan)
         {
-            if (replay_options.using_dump_resources_target)
+            if (replay_options.vk_replay_options->using_dump_resources_target)
             {
-                replay_options.dump_resources_block_indices = pre_process_consumer.GetDumpResourcesBlockIndices();
+                replay_options.vk_replay_options->dump_resources_block_indices =
+                    vk_pre_process_consumer.GetDumpResourcesBlockIndices();
             }
 
-            if (replay_options.enable_dump_resources)
+            if (replay_options.vk_replay_options->enable_dump_resources)
             {
                 // Process --dump-resources block indices arg.
-                if (!gfxrecon::parse_dump_resources::parse_dump_resources_arg(replay_options))
+                if (!gfxrecon::parse_dump_resources::parse_dump_resources_arg(*replay_options.vk_replay_options))
                 {
                     GFXRECON_LOG_FATAL("There was an error while parsing dump resources indices. Terminating.");
                     exit(0);
                 }
+                replay_consumer.vk_replay_consumer->InitializeReplayDumpResources();
             }
         }
     }
-    replay_consumer.InitializeReplayDumpResources();
 }
 
 extern "C"
@@ -178,14 +192,15 @@ void android_main(struct android_app* app)
                 gfxrecon::decode::VulkanReplayOptions          replay_options =
                     GetVulkanReplayOptions(arg_parser, filename, &tracked_object_info_table);
 
-                file_processor->SetPrintBlockInfoFlag(replay_options.enable_print_block_info,
-                                                      replay_options.block_index_from,
-                                                      replay_options.block_index_to);
-
                 gfxrecon::decode::VulkanReplayConsumer vulkan_replay_consumer(application, replay_options);
                 gfxrecon::decode::VulkanDecoder        vulkan_decoder;
 
-                RunVulkanPreProcessConsumer(filename, replay_options, vulkan_replay_consumer);
+                ApiReplayOptions  api_replay_options;
+                ApiReplayConsumer api_replay_consumer;
+                api_replay_options.vk_replay_options   = &replay_options;
+                api_replay_consumer.vk_replay_consumer = &vulkan_replay_consumer;
+
+                RunPreProcessConsumer(filename, api_replay_options, api_replay_consumer);
 
                 uint32_t                               start_frame, end_frame;
                 bool        has_mfr = GetMeasurementFrameRange(arg_parser, start_frame, end_frame);
@@ -223,6 +238,10 @@ void android_main(struct android_app* app)
                 vulkan_decoder.AddConsumer(&vulkan_replay_consumer);
 
                 file_processor->AddDecoder(&vulkan_decoder);
+
+                file_processor->SetPrintBlockInfoFlag(replay_options.enable_print_block_info,
+                    replay_options.block_index_from,
+                    replay_options.block_index_to);
 
                 application->SetPauseFrame(GetPauseFrame(arg_parser));
 

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -72,6 +72,17 @@ struct ApiReplayConsumer
     gfxrecon::decode::VulkanReplayConsumer* vk_replay_consumer{ nullptr };
 };
 
+bool IsRunPreProcessConsumer(ApiReplayOptions& replay_options)
+{
+    GFXRECON_ASSERT(replay_options.vk_replay_options != nullptr);
+
+    if (replay_options.vk_replay_options->enable_dump_resources)
+    {
+        return true;
+    }
+    return false;
+}
+
 void RunPreProcessConsumer(const std::string& input_filename,
                            ApiReplayOptions&  replay_options,
                            ApiReplayConsumer& replay_consumer)
@@ -200,7 +211,10 @@ void android_main(struct android_app* app)
                 api_replay_options.vk_replay_options   = &replay_options;
                 api_replay_consumer.vk_replay_consumer = &vulkan_replay_consumer;
 
-                RunPreProcessConsumer(filename, api_replay_options, api_replay_consumer);
+                if (IsRunPreProcessConsumer(api_replay_options))
+                {
+                    RunPreProcessConsumer(filename, api_replay_options, api_replay_consumer);
+                }
 
                 uint32_t                               start_frame, end_frame;
                 bool        has_mfr = GetMeasurementFrameRange(arg_parser, start_frame, end_frame);

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -49,6 +49,7 @@
 #include "graphics/dx12_util.h"
 #endif
 #include "parse_dump_resources_cli.h"
+#include "replay_pre_processing.h"
 
 #include <exception>
 #include <memory>
@@ -88,118 +89,6 @@ void WaitForExit() {}
 #endif
 
 const char kLayerEnvVar[] = "VK_INSTANCE_LAYERS";
-
-struct ApiReplayOptions
-{
-    gfxrecon::decode::VulkanReplayOptions* vk_replay_options{ nullptr };
-
-#if defined(D3D12_SUPPORT)
-    gfxrecon::decode::DxReplayOptions* dx12_replay_options{ nullptr };
-#endif
-};
-
-struct ApiReplayConsumer
-{
-    gfxrecon::decode::VulkanReplayConsumer* vk_replay_consumer{ nullptr };
-
-#if defined(D3D12_SUPPORT)
-    gfxrecon::decode::Dx12ReplayConsumer* dx12_replay_consumer{ nullptr };
-#endif
-};
-
-bool IsRunPreProcessConsumer(ApiReplayOptions& replay_options)
-{
-    GFXRECON_ASSERT(replay_options.vk_replay_options != nullptr);
-
-    if (replay_options.vk_replay_options->enable_dump_resources)
-    {
-        return true;
-    }
-
-#if defined(D3D12_SUPPORT)
-    GFXRECON_ASSERT(replay_options.dx12_replay_options != nullptr);
-
-    if (replay_options.dx12_replay_options->enable_dump_resources)
-    {
-        return true;
-    }
-#endif
-    return false;
-}
-
-void RunPreProcessConsumer(const std::string& input_filename,
-                           ApiReplayOptions&  replay_options,
-                           ApiReplayConsumer& replay_consumer)
-{
-    GFXRECON_ASSERT(replay_options.vk_replay_options != nullptr && replay_consumer.vk_replay_consumer != nullptr);
-
-    gfxrecon::decode::FileProcessor file_processor;
-    if (file_processor.Initialize(input_filename))
-    {
-        gfxrecon::decode::VulkanPreProcessConsumer vk_pre_process_consumer;
-
-        if (replay_options.vk_replay_options->using_dump_resources_target)
-        {
-            vk_pre_process_consumer.EnableDumpResources(replay_options.vk_replay_options->dump_resources_target);
-        }
-
-        gfxrecon::decode::VulkanDecoder vk_decoder;
-        vk_decoder.AddConsumer(&vk_pre_process_consumer);
-        file_processor.AddDecoder(&vk_decoder);
-
-#if defined(D3D12_SUPPORT)
-        GFXRECON_ASSERT(replay_options.dx12_replay_options != nullptr &&
-                        replay_consumer.dx12_replay_consumer != nullptr);
-
-        gfxrecon::decode::Dx12PreProcessConsumer dx12_pre_process_consumer;
-        if (replay_options.dx12_replay_options->enable_dump_resources)
-        {
-            dx12_pre_process_consumer.EnableDumpResources(replay_options.dx12_replay_options->dump_resources_target);
-        }
-        gfxrecon::decode::Dx12Decoder dx12_decoder;
-        dx12_decoder.AddConsumer(&dx12_pre_process_consumer);
-        file_processor.AddDecoder(&dx12_decoder);
-#endif
-
-        file_processor.ProcessAllFrames();
-
-        replay_options.vk_replay_options->enable_vulkan = vk_pre_process_consumer.WasVulkanAPIDetected();
-
-        if (replay_options.vk_replay_options->enable_vulkan)
-        {
-            if (replay_options.vk_replay_options->using_dump_resources_target)
-            {
-                replay_options.vk_replay_options->dump_resources_block_indices =
-                    vk_pre_process_consumer.GetDumpResourcesBlockIndices();
-            }
-
-            if (replay_options.vk_replay_options->enable_dump_resources)
-            {
-                // Process --dump-resources block indices arg.
-                if (!gfxrecon::parse_dump_resources::parse_dump_resources_arg(*replay_options.vk_replay_options))
-                {
-                    GFXRECON_LOG_FATAL("There was an error while parsing dump resources indices. Terminating.");
-                    exit(0);
-                }
-                replay_consumer.vk_replay_consumer->InitializeReplayDumpResources();
-            }
-        }
-
-#if defined(D3D12_SUPPORT)
-        replay_options.dx12_replay_options->enable_d3d12 = dx12_pre_process_consumer.WasD3D12APIDetected();
-
-        if (replay_options.dx12_replay_options->enable_d3d12)
-        {
-            if (replay_options.dx12_replay_options->enable_dump_resources)
-            {
-                auto track_dump_target = dx12_pre_process_consumer.GetTrackDumpTarget();
-                GFXRECON_ASSERT(track_dump_target != nullptr);
-                replay_consumer.dx12_replay_consumer->SetDumpTarget(*track_dump_target);
-            }
-        }
-#endif
-    }
-}
 
 int main(int argc, const char** argv)
 {

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -89,82 +89,97 @@ void WaitForExit() {}
 
 const char kLayerEnvVar[] = "VK_INSTANCE_LAYERS";
 
-void RunVulkanPreProcessConsumer(const std::string&                      input_filename,
-                                 gfxrecon::decode::VulkanReplayOptions&  replay_options,
-                                 gfxrecon::decode::VulkanReplayConsumer& replay_consumer)
+struct ApiReplayOptions
 {
+    gfxrecon::decode::VulkanReplayOptions* vk_replay_options{ nullptr };
+
+#if defined(D3D12_SUPPORT)
+    gfxrecon::decode::DxReplayOptions* dx12_replay_options{ nullptr };
+#endif
+};
+
+struct ApiReplayConsumer
+{
+    gfxrecon::decode::VulkanReplayConsumer* vk_replay_consumer{ nullptr };
+
+#if defined(D3D12_SUPPORT)
+    gfxrecon::decode::Dx12ReplayConsumer* dx12_replay_consumer{ nullptr };
+#endif
+};
+
+void RunPreProcessConsumer(const std::string& input_filename,
+                           ApiReplayOptions&  replay_options,
+                           ApiReplayConsumer& replay_consumer)
+{
+    GFXRECON_ASSERT(replay_options.vk_replay_options != nullptr && replay_consumer.vk_replay_consumer != nullptr);
+
     gfxrecon::decode::FileProcessor file_processor;
     if (file_processor.Initialize(input_filename))
     {
-        gfxrecon::decode::VulkanPreProcessConsumer pre_process_consumer;
+        gfxrecon::decode::VulkanPreProcessConsumer vk_pre_process_consumer;
 
-        if (replay_options.using_dump_resources_target)
+        if (replay_options.vk_replay_options->using_dump_resources_target)
         {
-            pre_process_consumer.EnableDumpResources(replay_options.dump_resources_target);
+            vk_pre_process_consumer.EnableDumpResources(replay_options.vk_replay_options->dump_resources_target);
         }
 
-        gfxrecon::decode::VulkanDecoder decoder;
-        decoder.AddConsumer(&pre_process_consumer);
-        file_processor.AddDecoder(&decoder);
+        gfxrecon::decode::VulkanDecoder vk_decoder;
+        vk_decoder.AddConsumer(&vk_pre_process_consumer);
+        file_processor.AddDecoder(&vk_decoder);
+
+#if defined(D3D12_SUPPORT)
+        GFXRECON_ASSERT(replay_options.dx12_replay_options != nullptr &&
+                        replay_consumer.dx12_replay_consumer != nullptr);
+
+        gfxrecon::decode::Dx12PreProcessConsumer dx12_pre_process_consumer;
+        if (replay_options.dx12_replay_options->enable_dump_resources)
+        {
+            dx12_pre_process_consumer.EnableDumpResources(replay_options.dx12_replay_options->dump_resources_target);
+        }
+        gfxrecon::decode::Dx12Decoder dx12_decoder;
+        dx12_decoder.AddConsumer(&dx12_pre_process_consumer);
+        file_processor.AddDecoder(&dx12_decoder);
+#endif
+
         file_processor.ProcessAllFrames();
 
-        replay_options.enable_vulkan = pre_process_consumer.WasVulkanAPIDetected();
+        replay_options.vk_replay_options->enable_vulkan = vk_pre_process_consumer.WasVulkanAPIDetected();
 
-        if (replay_options.enable_vulkan)
+        if (replay_options.vk_replay_options->enable_vulkan)
         {
-            if (replay_options.using_dump_resources_target)
+            if (replay_options.vk_replay_options->using_dump_resources_target)
             {
-                replay_options.dump_resources_block_indices = pre_process_consumer.GetDumpResourcesBlockIndices();
+                replay_options.vk_replay_options->dump_resources_block_indices =
+                    vk_pre_process_consumer.GetDumpResourcesBlockIndices();
             }
 
-            if (replay_options.enable_dump_resources)
+            if (replay_options.vk_replay_options->enable_dump_resources)
             {
                 // Process --dump-resources block indices arg.
-                if (!gfxrecon::parse_dump_resources::parse_dump_resources_arg(replay_options))
+                if (!gfxrecon::parse_dump_resources::parse_dump_resources_arg(*replay_options.vk_replay_options))
                 {
                     GFXRECON_LOG_FATAL("There was an error while parsing dump resources indices. Terminating.");
                     exit(0);
                 }
+                replay_consumer.vk_replay_consumer->InitializeReplayDumpResources();
             }
         }
-    }
-    replay_consumer.InitializeReplayDumpResources();
-}
 
 #if defined(D3D12_SUPPORT)
-void RunDx12PreProcessConsumer(const std::string&                    input_filename,
-                               gfxrecon::decode::DxReplayOptions&    replay_options,
-                               gfxrecon::decode::Dx12ReplayConsumer& replay_consumer)
-{
-    gfxrecon::decode::FileProcessor file_processor;
-    if (file_processor.Initialize(input_filename))
-    {
-        gfxrecon::decode::Dx12PreProcessConsumer pre_process_consumer;
+        replay_options.dx12_replay_options->enable_d3d12 = dx12_pre_process_consumer.WasD3D12APIDetected();
 
-        if (replay_options.enable_dump_resources)
+        if (replay_options.dx12_replay_options->enable_d3d12)
         {
-            pre_process_consumer.EnableDumpResources(replay_options.dump_resources_target);
-        }
-
-        gfxrecon::decode::Dx12Decoder decoder;
-        decoder.AddConsumer(&pre_process_consumer);
-        file_processor.AddDecoder(&decoder);
-        file_processor.ProcessAllFrames();
-
-        replay_options.enable_d3d12 = pre_process_consumer.WasD3D12APIDetected();
-
-        if (replay_options.enable_d3d12)
-        {
-            if (replay_options.enable_dump_resources)
+            if (replay_options.dx12_replay_options->enable_dump_resources)
             {
-                auto track_dump_target = pre_process_consumer.GetTrackDumpTarget();
+                auto track_dump_target = dx12_pre_process_consumer.GetTrackDumpTarget();
                 GFXRECON_ASSERT(track_dump_target != nullptr);
-                replay_consumer.SetDumpTarget(*track_dump_target);
+                replay_consumer.dx12_replay_consumer->SetDumpTarget(*track_dump_target);
             }
         }
+#endif
     }
 }
-#endif
 
 int main(int argc, const char** argv)
 {
@@ -275,7 +290,26 @@ int main(int argc, const char** argv)
             gfxrecon::decode::VulkanReplayConsumer vulkan_replay_consumer(application, vulkan_replay_options);
             gfxrecon::decode::VulkanDecoder        vulkan_decoder;
 
-            RunVulkanPreProcessConsumer(filename, vulkan_replay_options, vulkan_replay_consumer);
+            ApiReplayOptions  api_replay_options;
+            ApiReplayConsumer api_replay_consumer;
+            api_replay_options.vk_replay_options   = &vulkan_replay_options;
+            api_replay_consumer.vk_replay_consumer = &vulkan_replay_consumer;
+
+#if defined(D3D12_SUPPORT)
+            gfxrecon::decode::DxReplayOptions    dx_replay_options = GetDxReplayOptions(arg_parser, filename);
+            gfxrecon::decode::Dx12ReplayConsumer dx12_replay_consumer(application, dx_replay_options);
+            gfxrecon::decode::Dx12Decoder        dx12_decoder;
+
+            api_replay_options.dx12_replay_options   = &dx_replay_options;
+            api_replay_consumer.dx12_replay_consumer = &dx12_replay_consumer;
+#endif // D3D12_SUPPORT
+
+#ifdef GFXRECON_AGS_SUPPORT
+            gfxrecon::decode::AgsReplayConsumer ags_replay_consumer;
+            gfxrecon::decode::AgsDecoder        ags_decoder;
+#endif // GFXRECON_AGS_SUPPORT
+
+            RunPreProcessConsumer(filename, api_replay_options, api_replay_consumer);
 
             if (vulkan_replay_options.enable_vulkan)
             {
@@ -285,23 +319,13 @@ int main(int argc, const char** argv)
 
                 vulkan_decoder.AddConsumer(&vulkan_replay_consumer);
                 file_processor->AddDecoder(&vulkan_decoder);
+
+                file_processor->SetPrintBlockInfoFlag(vulkan_replay_options.enable_print_block_info,
+                                                      vulkan_replay_options.block_index_from,
+                                                      vulkan_replay_options.block_index_to);
             }
-            file_processor->SetPrintBlockInfoFlag(vulkan_replay_options.enable_print_block_info,
-                                                  vulkan_replay_options.block_index_from,
-                                                  vulkan_replay_options.block_index_to);
 
 #if defined(D3D12_SUPPORT)
-            gfxrecon::decode::DxReplayOptions    dx_replay_options = GetDxReplayOptions(arg_parser, filename);
-            gfxrecon::decode::Dx12ReplayConsumer dx12_replay_consumer(application, dx_replay_options);
-            gfxrecon::decode::Dx12Decoder        dx12_decoder;
-
-#ifdef GFXRECON_AGS_SUPPORT
-            gfxrecon::decode::AgsReplayConsumer ags_replay_consumer;
-            gfxrecon::decode::AgsDecoder        ags_decoder;
-#endif // GFXRECON_AGS_SUPPORT
-
-            RunDx12PreProcessConsumer(filename, dx_replay_options, dx12_replay_consumer);
-
             if (dx_replay_options.enable_d3d12)
             {
                 application->InitializeDx12WsiContext();
@@ -342,7 +366,7 @@ int main(int argc, const char** argv)
                 file_processor->AddDecoder(&ags_decoder);
 #endif // GFXRECON_AGS_SUPPORT
             }
-#endif
+#endif // D3D12_SUPPORT
 
             // Warn if the capture layer is active.
             CheckActiveLayers(gfxrecon::util::platform::GetEnv(kLayerEnvVar));

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -107,6 +107,26 @@ struct ApiReplayConsumer
 #endif
 };
 
+bool IsRunPreProcessConsumer(ApiReplayOptions& replay_options)
+{
+    GFXRECON_ASSERT(replay_options.vk_replay_options != nullptr);
+
+    if (replay_options.vk_replay_options->enable_dump_resources)
+    {
+        return true;
+    }
+
+#if defined(D3D12_SUPPORT)
+    GFXRECON_ASSERT(replay_options.dx12_replay_options != nullptr);
+
+    if (replay_options.dx12_replay_options->enable_dump_resources)
+    {
+        return true;
+    }
+#endif
+    return false;
+}
+
 void RunPreProcessConsumer(const std::string& input_filename,
                            ApiReplayOptions&  replay_options,
                            ApiReplayConsumer& replay_consumer)
@@ -309,7 +329,10 @@ int main(int argc, const char** argv)
             gfxrecon::decode::AgsDecoder        ags_decoder;
 #endif // GFXRECON_AGS_SUPPORT
 
-            RunPreProcessConsumer(filename, api_replay_options, api_replay_consumer);
+            if (IsRunPreProcessConsumer(api_replay_options))
+            {
+                RunPreProcessConsumer(filename, api_replay_options, api_replay_consumer);
+            }
 
             if (vulkan_replay_options.enable_vulkan)
             {

--- a/tools/replay/replay_pre_processing.h
+++ b/tools/replay/replay_pre_processing.h
@@ -1,0 +1,138 @@
+/*
+** Copyright (c) 2025 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_REPLAY_PRE_PROCESSING_H
+#define GFXRECON_REPLAY_PRE_PROCESSING_H
+
+struct ApiReplayOptions
+{
+    gfxrecon::decode::VulkanReplayOptions* vk_replay_options{ nullptr };
+
+#if defined(D3D12_SUPPORT)
+    gfxrecon::decode::DxReplayOptions* dx12_replay_options{ nullptr };
+#endif
+};
+
+struct ApiReplayConsumer
+{
+    gfxrecon::decode::VulkanReplayConsumer* vk_replay_consumer{ nullptr };
+
+#if defined(D3D12_SUPPORT)
+    gfxrecon::decode::Dx12ReplayConsumer* dx12_replay_consumer{ nullptr };
+#endif
+};
+
+bool IsRunPreProcessConsumer(ApiReplayOptions& replay_options)
+{
+    GFXRECON_ASSERT(replay_options.vk_replay_options != nullptr);
+
+    if (replay_options.vk_replay_options->enable_dump_resources)
+    {
+        return true;
+    }
+
+#if defined(D3D12_SUPPORT)
+    GFXRECON_ASSERT(replay_options.dx12_replay_options != nullptr);
+
+    if (replay_options.dx12_replay_options->enable_dump_resources)
+    {
+        return true;
+    }
+#endif
+    return false;
+}
+
+void RunPreProcessConsumer(const std::string& input_filename,
+                           ApiReplayOptions&  replay_options,
+                           ApiReplayConsumer& replay_consumer)
+{
+    GFXRECON_ASSERT(replay_options.vk_replay_options != nullptr && replay_consumer.vk_replay_consumer != nullptr);
+
+    gfxrecon::decode::FileProcessor file_processor;
+    if (file_processor.Initialize(input_filename))
+    {
+        gfxrecon::decode::VulkanPreProcessConsumer vk_pre_process_consumer;
+
+        if (replay_options.vk_replay_options->using_dump_resources_target)
+        {
+            vk_pre_process_consumer.EnableDumpResources(replay_options.vk_replay_options->dump_resources_target);
+        }
+
+        gfxrecon::decode::VulkanDecoder vk_decoder;
+        vk_decoder.AddConsumer(&vk_pre_process_consumer);
+        file_processor.AddDecoder(&vk_decoder);
+
+#if defined(D3D12_SUPPORT)
+        GFXRECON_ASSERT(replay_options.dx12_replay_options != nullptr &&
+                        replay_consumer.dx12_replay_consumer != nullptr);
+
+        gfxrecon::decode::Dx12PreProcessConsumer dx12_pre_process_consumer;
+        if (replay_options.dx12_replay_options->enable_dump_resources)
+        {
+            dx12_pre_process_consumer.EnableDumpResources(replay_options.dx12_replay_options->dump_resources_target);
+        }
+        gfxrecon::decode::Dx12Decoder dx12_decoder;
+        dx12_decoder.AddConsumer(&dx12_pre_process_consumer);
+        file_processor.AddDecoder(&dx12_decoder);
+#endif
+
+        file_processor.ProcessAllFrames();
+
+        replay_options.vk_replay_options->enable_vulkan = vk_pre_process_consumer.WasVulkanAPIDetected();
+
+        if (replay_options.vk_replay_options->enable_vulkan)
+        {
+            if (replay_options.vk_replay_options->using_dump_resources_target)
+            {
+                replay_options.vk_replay_options->dump_resources_block_indices =
+                    vk_pre_process_consumer.GetDumpResourcesBlockIndices();
+            }
+
+            if (replay_options.vk_replay_options->enable_dump_resources)
+            {
+                // Process --dump-resources block indices arg.
+                if (!gfxrecon::parse_dump_resources::parse_dump_resources_arg(*replay_options.vk_replay_options))
+                {
+                    GFXRECON_LOG_FATAL("There was an error while parsing dump resources indices. Terminating.");
+                    exit(0);
+                }
+                replay_consumer.vk_replay_consumer->InitializeReplayDumpResources();
+            }
+        }
+
+#if defined(D3D12_SUPPORT)
+        replay_options.dx12_replay_options->enable_d3d12 = dx12_pre_process_consumer.WasD3D12APIDetected();
+
+        if (replay_options.dx12_replay_options->enable_d3d12)
+        {
+            if (replay_options.dx12_replay_options->enable_dump_resources)
+            {
+                auto track_dump_target = dx12_pre_process_consumer.GetTrackDumpTarget();
+                GFXRECON_ASSERT(track_dump_target != nullptr);
+                replay_consumer.dx12_replay_consumer->SetDumpTarget(*track_dump_target);
+            }
+        }
+#endif
+    }
+}
+
+#endif // GFXRECON_REPLAY_PRE_PROCESSING_H


### PR DESCRIPTION
The original code runs pre processing to check what api uses. Although, it quit the process after it finds `Process_D3D12CreateDevice` and `Process_vkCreateDevice`, but when it can't find either one, it will run the whole file. It could take time.  The PR changes it to only run pre processing when dump resources is enabled. It looks ok if we didn't know what api is used for now when dump resources isn't enabled.