### PR TITLE
Fix: Revert a change affecting RT-feature selection

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -8206,7 +8206,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
 
     // NOTE: as of early 2025, rayTracingPipelineShaderGroupHandleCaptureReplay is not widely supported.
     // e.g. newest nvidia desktop-drivers do not support this feature
-    if (device_info->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
+    if (device_info->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay &&
+        !UseAddressReplacement(device_info))
     {
         // Modify pipeline create infos with capture replay flag and data.
         std::vector<VkRayTracingPipelineCreateInfoKHR>                 modified_create_infos;

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -203,7 +203,8 @@ VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(uint32_t                 
                 rayTracingPipelineShaderGroupHandleCaptureReplay_original =
                     rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay;
 
-                if (rt_pipeline_features->rayTracingPipeline)
+                if (rt_pipeline_features->rayTracingPipeline &&
+                    !rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay)
                 {
                     VkPhysicalDeviceRayTracingPipelineFeaturesKHR supported_features{
                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR, nullptr
@@ -211,10 +212,12 @@ VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(uint32_t                 
                     GetPhysicalDeviceFeatures(
                         instance_api_version, instance_table, physical_device, supported_features);
 
-                    result.feature_rayTracingPipelineShaderGroupHandleCaptureReplay =
-                        rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay &&
+                    rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay =
                         supported_features.rayTracingPipelineShaderGroupHandleCaptureReplay;
                 }
+
+                result.feature_rayTracingPipelineShaderGroupHandleCaptureReplay =
+                    rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay;
 
                 // retrieve raytracing-pipeline-properties
                 VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_properties{


### PR DESCRIPTION
- a change got introduced with https://github.com/LunarG/gfxreconstruct/pull/1955
and influences under which conditions the `rayTracingPipelineShaderGroupHandleCaptureReplay`
is used.
- motivation for that change was a validation-warning/error when replaying with `-m rebind`. 
we now make a different attempt to prevent this.
- this PR reverts behavior and fixes issues with gfxrecon-replay / raytracing on some devices 