### PR TITLE
Fix issues around async pipeline-handle assignment/cleanup

### DIFF
--- a/framework/decode/common_handle_mapping_util.h
+++ b/framework/decode/common_handle_mapping_util.h
@@ -48,22 +48,12 @@ static typename T::HandleType MapHandle(format::HandleId             id,
         if (info != nullptr)
         {
             handle = info->handle;
-
-            if constexpr (has_handle_future_v<T>)
-            {
-                if (info->handle == VK_NULL_HANDLE && info->future.valid())
-                {
-                    const auto& [result, async_handles] = info->future.get();
-                    handle                              = async_handles[info->future_handle_index];
-                }
-            }
         }
         else
         {
             GFXRECON_LOG_WARNING("Failed to map handle for object id %" PRIu64, id);
         }
     }
-
     return handle;
 }
 
@@ -206,32 +196,6 @@ static void AddHandleArrayAsync(format::HandleId        parent_id,
                                 const format::HandleId* ids,
                                 size_t                  ids_len,
                                 CommonObjectInfoTable*  object_info_table,
-                                void (CommonObjectInfoTable::*AddFunc)(T&&),
-                                std::shared_future<handle_create_result_t<typename T::HandleType>> future)
-{
-    static_assert(has_handle_future_v<T>, "handle-type does not support asynchronous creation");
-    assert(object_info_table != nullptr);
-
-    if (ids != nullptr)
-    {
-        for (size_t i = 0; i < ids_len; ++i)
-        {
-            T info;
-            info.handle              = VK_NULL_HANDLE; // handle does not yet exist
-            info.capture_id          = ids[i];
-            info.parent_id           = parent_id;
-            info.future              = future;
-            info.future_handle_index = i;
-            (object_info_table->*AddFunc)(std::move(info));
-        }
-    }
-}
-
-template <typename T>
-static void AddHandleArrayAsync(format::HandleId        parent_id,
-                                const format::HandleId* ids,
-                                size_t                  ids_len,
-                                CommonObjectInfoTable*  object_info_table,
                                 std::vector<T>&&        initial_infos,
                                 void (CommonObjectInfoTable::*AddFunc)(T&&),
                                 std::shared_future<handle_create_result_t<typename T::HandleType>> future)
@@ -245,13 +209,13 @@ static void AddHandleArrayAsync(format::HandleId        parent_id,
 
         for (size_t i = 0; i < ids_len; ++i)
         {
-            auto info_iter                 = std::next(initial_infos.begin(), i);
-            info_iter->handle              = VK_NULL_HANDLE; // handle does not yet exist
-            info_iter->capture_id          = ids[i];
-            info_iter->parent_id           = parent_id;
-            info_iter->future              = future;
-            info_iter->future_handle_index = i;
-            (object_info_table->*AddFunc)(std::move(*info_iter));
+            auto& initial_info               = initial_infos[i];
+            initial_info.handle              = VK_NULL_HANDLE; // handle does not yet exist
+            initial_info.capture_id          = ids[i];
+            initial_info.parent_id           = parent_id;
+            initial_info.future              = future;
+            initial_info.future_handle_index = i;
+            (object_info_table->*AddFunc)(std::move(initial_info));
         }
     }
 }

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -1301,6 +1301,16 @@ bool VulkanAddressReplacer::init_pipeline()
             GFXRECON_LOG_ERROR("VulkanAddressReplacer: pipeline creation failed");
         }
 
+        if (set_debug_utils_object_name_fn_)
+        {
+            VkDebugUtilsObjectNameInfoEXT object_name_info = {};
+            object_name_info.sType                         = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+            object_name_info.objectType                    = VK_OBJECT_TYPE_PIPELINE;
+            object_name_info.objectHandle                  = VK_HANDLE_TO_UINT64(out_pipeline);
+            object_name_info.pObjectName                   = "VulkanAddressReplacer internal pipeline";
+            set_debug_utils_object_name_fn_(device_, &object_name_info);
+        }
+
         if (compute_module != VK_NULL_HANDLE)
         {
             device_table_->DestroyShaderModule(device_, compute_module, nullptr);

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -74,7 +74,13 @@ void FreeChildObjects(CommonObjectInfoTable* table,
     // Visit all table entries and sort them by parent ID.  Using unordered_map to filter duplicate handles.
     std::unordered_map<format::HandleId, std::unordered_map<typename T::HandleType, const T*>> objects;
 
-    (table->*VisitFunc)([&](const T* info) { AddChildObject(&objects, info); });
+    (table->*VisitFunc)([&](const T* info) {
+        if constexpr (has_handle_future_v<T>)
+        {
+            sync_handle(const_cast<T*>(info));
+        }
+        AddChildObject(&objects, info);
+    });
 
     for (const auto& entry : objects)
     {

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -410,26 +410,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void AddHandlesAsync(format::HandleId        parent_id,
                          const format::HandleId* ids,
                          size_t                  ids_len,
-                         void (CommonObjectInfoTable::*AddFunc)(T&&),
-                         std::function<handle_create_result_t<typename T::HandleType>()> create_function)
-    {
-        if (create_function)
-        {
-            std::shared_future<handle_create_result_t<typename T::HandleType>> result_future =
-                background_queue_.post(std::move(create_function));
-
-            // poll in case there are no worker-threads
-            background_queue_.poll();
-
-            handle_mapping::AddHandleArrayAsync(
-                parent_id, ids, ids_len, object_info_table_, AddFunc, std::move(result_future));
-        }
-    }
-
-    template <typename T>
-    void AddHandlesAsync(format::HandleId        parent_id,
-                         const format::HandleId* ids,
-                         size_t                  ids_len,
                          std::vector<T>&&        initial_infos,
                          void (CommonObjectInfoTable::*AddFunc)(T&&),
                          std::function<handle_create_result_t<typename T::HandleType>()> create_function)


### PR DESCRIPTION
changes to pipeline handle-synchronization when using async compilation.

- fixes issues in combination with `-m rebind` option and address-replacement
- fixes validation-errors for pipeline-handle leaks when using asynchronous pipeline-compilation (`--pcj X`)
- found and removed some dead code
- added debug-labels to internal VkPipelines in VulkanAddressReplacer during debugging

to reproduce the reported issue with address-replacement this sample can be used:
https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/extensions/ray_tracing_reflection
`gfxrecon-replay -m rebind --pcj -1 ray_tracing_reflection.gfxr`