### PR TITLE
Add debug_set_objects_name capture option

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -268,6 +268,7 @@ bool CommonCaptureManager::Initialize(format::ApiFamilyId                   api_
     force_file_flush_                = trace_settings.force_flush;
     debug_layer_                     = trace_settings.debug_layer;
     debug_device_lost_               = trace_settings.debug_device_lost;
+    debug_set_objects_name_          = trace_settings.debug_set_objects_name;
     screenshots_enabled_             = !trace_settings.screenshot_ranges.empty();
     screenshot_format_               = trace_settings.screenshot_format;
     screenshot_indices_              = CalcScreenshotIndices(trace_settings.screenshot_ranges);

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -236,6 +236,7 @@ class CommonCaptureManager
     auto                                GetTrimDrawCalls() const { return trim_draw_calls_; }
     auto                                GetQueueSubmitCount() const { return queue_submit_count_; }
     bool                                GetUseAssetFile() const { return use_asset_file_; }
+    bool                                GetDebugSetObjectsName() const { return debug_set_objects_name_; }
 
     util::Compressor*      GetCompressor() { return compressor_.get(); }
     std::mutex&            GetMappedMemoryLock() { return mapped_memory_lock_; }
@@ -385,6 +386,7 @@ class CommonCaptureManager
     bool                                    write_assets_;
     bool                                    previous_write_assets_;
     bool                                    write_state_files_;
+    bool                                    debug_set_objects_name_;
 
     struct
     {

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -123,6 +123,8 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 #define DEBUG_LAYER_UPPER                                    "DEBUG_LAYER"
 #define DEBUG_DEVICE_LOST_LOWER                              "debug_device_lost"
 #define DEBUG_DEVICE_LOST_UPPER                              "DEBUG_DEVICE_LOST"
+#define DEBUG_SET_OBJECTS_NAME_LOWER                         "debug_set_objects_name"
+#define DEBUG_SET_OBJECTS_NAME_UPPER                         "DEBUG_SET_OBJECTS_NAME"
 #define DISABLE_DXR_LOWER                                    "disable_dxr"
 #define DISABLE_DXR_UPPER                                    "DISABLE_DXR"
 #define ACCEL_STRUCT_PADDING_LOWER                           "accel_struct_padding"
@@ -188,6 +190,7 @@ const char kPageGuardSignalHandlerWatcherEnvVar[]            = GFXRECON_ENV_VAR_
 const char kPageGuardSignalHandlerWatcherMaxRestoresEnvVar[] = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SIGNAL_HANDLER_WATCHER_MAX_RESTORES_LOWER;
 const char kDebugLayerEnvVar[]                               = GFXRECON_ENV_VAR_PREFIX DEBUG_LAYER_LOWER;
 const char kDebugDeviceLostEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX DEBUG_DEVICE_LOST_LOWER;
+const char kDebugSetObjectsNameEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX DEBUG_SET_OBJECTS_NAME_LOWER;
 const char kCaptureAndroidTriggerEnvVar[]                    = GFXRECON_ENV_VAR_PREFIX CAPTURE_ANDROID_TRIGGER_LOWER;
 const char kCaptureAndroidDumpAssetsEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX CAPTURE_ANDROID_DUMP_ASSETS_LOWER;
 const char kDisableDxrEnvVar[]                               = GFXRECON_ENV_VAR_PREFIX DISABLE_DXR_LOWER;
@@ -245,6 +248,7 @@ const char kCaptureIUnknownWrappingEnvVar[]                  = GFXRECON_ENV_VAR_
 const char kCaptureQueueSubmitsEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX CAPTURE_QUEUE_SUBMITS_UPPER;
 const char kDebugLayerEnvVar[]                               = GFXRECON_ENV_VAR_PREFIX DEBUG_LAYER_UPPER;
 const char kDebugDeviceLostEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX DEBUG_DEVICE_LOST_UPPER;
+const char kDebugSetObjectsNameEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX DEBUG_SET_OBJECTS_NAME_UPPER;
 const char kDisableDxrEnvVar[]                               = GFXRECON_ENV_VAR_PREFIX DISABLE_DXR_UPPER;
 const char kAccelStructPaddingEnvVar[]                       = GFXRECON_ENV_VAR_PREFIX ACCEL_STRUCT_PADDING_UPPER;
 const char kForceCommandSerializationEnvVar[]                = GFXRECON_ENV_VAR_PREFIX FORCE_COMMAND_SERIALIZATION_UPPER;
@@ -299,6 +303,7 @@ const std::string kOptionKeyPageGuardSignalHandlerWatcher            = std::stri
 const std::string kOptionKeyPageGuardSignalHandlerWatcherMaxRestores = std::string(kSettingsFilter) + std::string(PAGE_GUARD_SIGNAL_HANDLER_WATCHER_MAX_RESTORES_LOWER);
 const std::string kDebugLayer                                        = std::string(kSettingsFilter) + std::string(DEBUG_LAYER_LOWER);
 const std::string kDebugDeviceLost                                   = std::string(kSettingsFilter) + std::string(DEBUG_DEVICE_LOST_LOWER);
+const std::string kDebugSetObjectsName                               = std::string(kSettingsFilter) + std::string(DEBUG_SET_OBJECTS_NAME_LOWER);
 const std::string kOptionDisableDxr                                  = std::string(kSettingsFilter) + std::string(DISABLE_DXR_LOWER);
 const std::string kOptionAccelStructPadding                          = std::string(kSettingsFilter) + std::string(ACCEL_STRUCT_PADDING_LOWER);
 const std::string kOptionForceCommandSerialization                   = std::string(kSettingsFilter) + std::string(FORCE_COMMAND_SERIALIZATION_LOWER);
@@ -455,6 +460,7 @@ void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
     // Debug environment variables
     LoadSingleOptionEnvVar(options, kDebugLayerEnvVar, kDebugLayer);
     LoadSingleOptionEnvVar(options, kDebugDeviceLostEnvVar, kDebugDeviceLost);
+    LoadSingleOptionEnvVar(options, kDebugSetObjectsNameEnvVar, kDebugSetObjectsName);
 
     // Screenshot environment variables
     LoadSingleOptionEnvVar(options, kScreenshotDirEnvVar, kOptionKeyScreenshotDir);

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -124,6 +124,7 @@ class CaptureSettings
         bool                         page_guard_signal_handler_watcher{ false };
         bool                         debug_layer{ false };
         bool                         debug_device_lost{ false };
+        bool                         debug_set_objects_name{ false };
         bool                         disable_dxr{ false };
         uint32_t                     accel_struct_padding{ 0 };
         bool                         force_command_serialization{ false };

--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -1710,6 +1710,226 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSetDebugUtilsObjectTag
     }
 };
 
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDevice>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateDevice(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSemaphore>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateSemaphore(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateCommandBuffers>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkAllocateCommandBuffers(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateFence>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateFence(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateMemory>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkAllocateMemory(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBuffer>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateBuffer(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImage>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateImage(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateEvent>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateEvent(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateQueryPool>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateQueryPool(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBufferView>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateBufferView(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImageView>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateImageView(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateShaderModule>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateShaderModule(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePipelineCache>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreatePipelineCache(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePipelineLayout>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreatePipelineLayout(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateRenderPass(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateGraphicsPipelines>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateGraphicsPipelines(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateDescriptorSetLayout(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSampler>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateSampler(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorPool>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateDescriptorPool(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateDescriptorSets>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkAllocateDescriptorSets(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateFramebuffer>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateFramebuffer(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateCommandPool>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkCreateCommandPool(args...);
+    }
+};
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -3186,8 +3186,7 @@ void VulkanCaptureManager::PostProcess_vkCreateShaderModule(VkDevice            
     }
 }
 
-void VulkanCaptureManager::PostProcess_vkCreateGraphicsPipelines(VkResult                            result,
-                                                                 VkDevice                            device,
+void VulkanCaptureManager::PostProcess_vkCreateGraphicsPipelines(VkDevice                            device,
                                                                  VkPipelineCache                     pipelineCache,
                                                                  uint32_t                            createInfoCount,
                                                                  const VkGraphicsPipelineCreateInfo* pCreateInfos,

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -36,6 +36,7 @@
 #include "encode/vulkan_capture_common.h"
 #include "format/format_util.h"
 #include "generated/generated_vulkan_struct_handle_wrappers.h"
+#include "generated/generated_vulkan_api_call_encoders.h"
 #include "graphics/vulkan_check_buffer_references.h"
 #include "graphics/vulkan_device_util.h"
 #include "graphics/vulkan_struct_get_pnext.h"
@@ -63,6 +64,25 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 
 VulkanCaptureManager* VulkanCaptureManager::singleton_ = nullptr;
 VulkanLayerTable      VulkanCaptureManager::vulkan_layer_table_;
+
+template <typename WrapperType>
+void SetObjectName(VkDevice device, typename WrapperType::HandleType handle)
+{
+    VkObjectType  object_type               = vulkan_wrappers::GetObjectType<WrapperType>();
+    uint64_t      wrappedId                 = vulkan_wrappers::GetWrappedId<WrapperType>(handle);
+    std::string   object_type_str           = util::ToString<VkObjectType>(object_type);
+    constexpr int vk_object_type_prefix_len = 15;
+    object_type_str.erase(0, vk_object_type_prefix_len);
+    object_type_str.append(" ");
+    object_type_str.append(std::to_string(wrappedId));
+    VkDebugUtilsObjectNameInfoEXT name_info;
+    name_info.pNext        = nullptr;
+    name_info.sType        = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+    name_info.objectHandle = (uint64_t)handle;
+    name_info.pObjectName  = object_type_str.c_str();
+    name_info.objectType   = object_type;
+    encode::vkSetDebugUtilsObjectNameEXT(device, &name_info);
+}
 
 bool VulkanCaptureManager::CreateInstance()
 {
@@ -929,6 +949,11 @@ VulkanCaptureManager::OverrideCreateAccelerationStructureKHR(VkDevice           
                                              vulkan_wrappers::NoParentWrapper,
                                              vulkan_wrappers::AccelerationStructureKHRWrapper>(
             device, vulkan_wrappers::NoParentWrapper::kHandleValue, pAccelerationStructureKHR, GetUniqueId);
+
+        if (common_manager_->GetDebugSetObjectsName())
+        {
+            SetObjectName<vulkan_wrappers::AccelerationStructureKHRWrapper>(device, *pAccelerationStructureKHR);
+        }
 
         auto accel_struct_wrapper =
             vulkan_wrappers::GetWrapper<vulkan_wrappers::AccelerationStructureKHRWrapper>(*pAccelerationStructureKHR);
@@ -3037,6 +3062,231 @@ void VulkanCaptureManager::PreProcess_vkBindImageMemory2(VkDevice               
                                       "might occur. In that case set "
                                       "Page Guard Align Buffer Sizes env variable to true.");
         }
+    }
+}
+
+void VulkanCaptureManager::PostProcess_vkCreateDevice(VkPhysicalDevice             physicalDevice,
+                                                      const VkDeviceCreateInfo*    pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator,
+                                                      VkDevice*                    pDevice)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::DeviceWrapper>(*pDevice, *pDevice);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateSemaphore(VkDevice                     device,
+                                                         const VkSemaphoreCreateInfo* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator,
+                                                         VkSemaphore*                 pSemaphore)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::SemaphoreWrapper>(device, *pSemaphore);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkAllocateCommandBuffers(VkDevice                           device,
+                                                                const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                                                VkCommandBuffer*                   pCommandBuffers)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::CommandBufferWrapper>(device, *pCommandBuffers);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateFence(VkDevice                     device,
+                                                     const VkFenceCreateInfo*     pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator,
+                                                     VkFence*                     pFence)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::FenceWrapper>(device, *pFence);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkAllocateMemory(VkDevice                     device,
+                                                        const VkMemoryAllocateInfo*  pAllocateInfo,
+                                                        const VkAllocationCallbacks* pAllocator,
+                                                        VkDeviceMemory*              pMemory)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::DeviceMemoryWrapper>(device, *pMemory);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateBuffer(VkDevice                     device,
+                                                      const VkBufferCreateInfo*    pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator,
+                                                      VkBuffer*                    pBuffer)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::BufferWrapper>(device, *pBuffer);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateImage(VkDevice                     device,
+                                                     const VkImageCreateInfo*     pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator,
+                                                     VkImage*                     pImage)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::ImageWrapper>(device, *pImage);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateEvent(VkDevice                     device,
+                                                     const VkEventCreateInfo*     pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator,
+                                                     VkEvent*                     pEvent)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::EventWrapper>(device, *pEvent);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateQueryPool(VkDevice                     device,
+                                                         const VkQueryPoolCreateInfo* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator,
+                                                         VkQueryPool*                 pQueryPool)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::QueryPoolWrapper>(device, *pQueryPool);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateBufferView(VkDevice                      device,
+                                                          const VkBufferViewCreateInfo* pCreateInfo,
+                                                          const VkAllocationCallbacks*  pAllocator,
+                                                          VkBufferView*                 pView)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::BufferViewWrapper>(device, *pView);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateImageView(VkDevice                     device,
+                                                         const VkImageViewCreateInfo* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator,
+                                                         VkImageView*                 pView)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::ImageViewWrapper>(device, *pView);
+    }
+}
+
+void VulkanCaptureManager::PostProcess_vkCreateShaderModule(VkDevice                        device,
+                                                            const VkShaderModuleCreateInfo* pCreateInfo,
+                                                            const VkAllocationCallbacks*    pAllocator,
+                                                            VkShaderModule*                 pShaderModule)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::ShaderModuleWrapper>(device, *pShaderModule);
+    }
+}
+
+void VulkanCaptureManager::PostProcess_vkCreateGraphicsPipelines(VkResult                            result,
+                                                                 VkDevice                            device,
+                                                                 VkPipelineCache                     pipelineCache,
+                                                                 uint32_t                            createInfoCount,
+                                                                 const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                                 const VkAllocationCallbacks*        pAllocator,
+                                                                 VkPipeline*                         pPipelines)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::PipelineWrapper>(device, *pPipelines);
+    }
+}
+
+void VulkanCaptureManager::PostProcess_vkCreatePipelineCache(VkDevice                         device,
+                                                             const VkPipelineCacheCreateInfo* pCreateInfo,
+                                                             const VkAllocationCallbacks*     pAllocator,
+                                                             VkPipelineCache*                 pPipelineCache)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::PipelineCacheWrapper>(device, *pPipelineCache);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreatePipelineLayout(VkDevice                          device,
+                                                              const VkPipelineLayoutCreateInfo* pCreateInfo,
+                                                              const VkAllocationCallbacks*      pAllocator,
+                                                              VkPipelineLayout*                 pPipelineLayout)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::PipelineLayoutWrapper>(device, *pPipelineLayout);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateRenderPass(VkDevice                      device,
+                                                          const VkRenderPassCreateInfo* pCreateInfo,
+                                                          const VkAllocationCallbacks*  pAllocator,
+                                                          VkRenderPass*                 pRenderPass)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::RenderPassWrapper>(device, *pRenderPass);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateDescriptorSetLayout(VkDevice                               device,
+                                                                   const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                                   const VkAllocationCallbacks*           pAllocator,
+                                                                   VkDescriptorSetLayout*                 pSetLayout)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::DescriptorSetLayoutWrapper>(device, *pSetLayout);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateSampler(VkDevice                     device,
+                                                       const VkSamplerCreateInfo*   pCreateInfo,
+                                                       const VkAllocationCallbacks* pAllocator,
+                                                       VkSampler*                   pSampler)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::SamplerWrapper>(device, *pSampler);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateDescriptorPool(VkDevice                          device,
+                                                              const VkDescriptorPoolCreateInfo* pCreateInfo,
+                                                              const VkAllocationCallbacks*      pAllocator,
+                                                              VkDescriptorPool*                 pDescriptorPool)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::DescriptorPoolWrapper>(device, *pDescriptorPool);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkAllocateDescriptorSets(VkDevice                           device,
+                                                                const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                                                VkDescriptorSet*                   pDescriptorSets)
+{
+    if (*pDescriptorSets != VK_NULL_HANDLE && common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::DescriptorSetWrapper>(device, *pDescriptorSets);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateFramebuffer(VkDevice                       device,
+                                                           const VkFramebufferCreateInfo* pCreateInfo,
+                                                           const VkAllocationCallbacks*   pAllocator,
+                                                           VkFramebuffer*                 pFramebuffer)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::FramebufferWrapper>(device, *pFramebuffer);
+    }
+}
+void VulkanCaptureManager::PostProcess_vkCreateCommandPool(VkDevice                       device,
+                                                           const VkCommandPoolCreateInfo* pCreateInfo,
+                                                           const VkAllocationCallbacks*   pAllocator,
+                                                           VkCommandPool*                 pCommandPool)
+{
+    if (common_manager_->GetDebugSetObjectsName())
+    {
+        SetObjectName<vulkan_wrappers::CommandPoolWrapper>(device, *pCommandPool);
     }
 }
 

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -39,6 +39,7 @@
 #include "format/platform_types.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "generated/generated_vulkan_command_buffer_util.h"
+#include "generated/generated_vulkan_enum_to_string.h"
 #include "util/defines.h"
 
 #include "vulkan/vulkan.h"
@@ -1534,6 +1535,102 @@ class VulkanCaptureManager : public ApiCaptureManager
     void PostProcess_vkSetDebugUtilsObjectTagEXT(VkResult                            result,
                                                  VkDevice                            device,
                                                  const VkDebugUtilsObjectTagInfoEXT* pTagInfo);
+
+    void PostProcess_vkCreateDevice(VkPhysicalDevice             physicalDevice,
+                                    const VkDeviceCreateInfo*    pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator,
+                                    VkDevice*                    pDevice);
+    void PostProcess_vkCreateSemaphore(VkDevice                     device,
+                                       const VkSemaphoreCreateInfo* pCreateInfo,
+                                       const VkAllocationCallbacks* pAllocator,
+                                       VkSemaphore*                 pSemaphore);
+    void PostProcess_vkAllocateCommandBuffers(VkDevice                           device,
+                                              const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                              VkCommandBuffer*                   pCommandBuffers);
+    void PostProcess_vkCreateFence(VkDevice                     device,
+                                   const VkFenceCreateInfo*     pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator,
+                                   VkFence*                     pFence);
+    void PostProcess_vkAllocateMemory(VkDevice                     device,
+                                      const VkMemoryAllocateInfo*  pAllocateInfo,
+                                      const VkAllocationCallbacks* pAllocator,
+                                      VkDeviceMemory*              pMemory);
+    void PostProcess_vkCreateBuffer(VkDevice                     device,
+                                    const VkBufferCreateInfo*    pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator,
+                                    VkBuffer*                    pBuffer);
+    void PostProcess_vkCreateImage(VkDevice                     device,
+                                   const VkImageCreateInfo*     pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator,
+                                   VkImage*                     pImage);
+    void PostProcess_vkCreateEvent(VkDevice                     device,
+                                   const VkEventCreateInfo*     pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator,
+                                   VkEvent*                     pEvent);
+    void PostProcess_vkCreateQueryPool(VkDevice                     device,
+                                       const VkQueryPoolCreateInfo* pCreateInfo,
+                                       const VkAllocationCallbacks* pAllocator,
+                                       VkQueryPool*                 pQueryPool);
+    void PostProcess_vkCreateBufferView(VkDevice                      device,
+                                        const VkBufferViewCreateInfo* pCreateInfo,
+                                        const VkAllocationCallbacks*  pAllocator,
+                                        VkBufferView*                 pView);
+    void PostProcess_vkCreateImageView(VkDevice                     device,
+                                       const VkImageViewCreateInfo* pCreateInfo,
+                                       const VkAllocationCallbacks* pAllocator,
+                                       VkImageView*                 pView);
+    void PostProcess_vkCreatePipelineCache(VkDevice                         device,
+                                           const VkPipelineCacheCreateInfo* pCreateInfo,
+                                           const VkAllocationCallbacks*     pAllocator,
+                                           VkPipelineCache*                 pPipelineCache);
+    void PostProcess_vkCreateShaderModule(VkDevice                        device,
+                                          const VkShaderModuleCreateInfo* pCreateInfo,
+                                          const VkAllocationCallbacks*    pAllocator,
+                                          VkShaderModule*                 pShaderModule);
+    void PostProcess_vkCreateGraphicsPipelines(VkResult                            result,
+                                               VkDevice                            device,
+                                               VkPipelineCache                     pipelineCache,
+                                               uint32_t                            createInfoCount,
+                                               const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                               const VkAllocationCallbacks*        pAllocator,
+                                               VkPipeline*                         pPipelines);
+    void PostProcess_vkCreatePipelineLayout(VkDevice                          device,
+                                            const VkPipelineLayoutCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks*      pAllocator,
+                                            VkPipelineLayout*                 pPipelineLayout);
+    void PostProcess_vkCreateRenderPass(VkDevice                      device,
+                                        const VkRenderPassCreateInfo* pCreateInfo,
+                                        const VkAllocationCallbacks*  pAllocator,
+                                        VkRenderPass*                 pRenderPass);
+    void PostProcess_vkCreateGraphicsPipelines(VkDevice                            device,
+                                               VkPipelineCache                     pipelineCache,
+                                               uint32_t                            createInfoCount,
+                                               const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                               const VkAllocationCallbacks*        pAllocator,
+                                               VkPipeline*                         pPipelines);
+    void PostProcess_vkCreateDescriptorSetLayout(VkDevice                               device,
+                                                 const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks*           pAllocator,
+                                                 VkDescriptorSetLayout*                 pSetLayout);
+    void PostProcess_vkCreateSampler(VkDevice                     device,
+                                     const VkSamplerCreateInfo*   pCreateInfo,
+                                     const VkAllocationCallbacks* pAllocator,
+                                     VkSampler*                   pSampler);
+    void PostProcess_vkCreateDescriptorPool(VkDevice                          device,
+                                            const VkDescriptorPoolCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks*      pAllocator,
+                                            VkDescriptorPool*                 pDescriptorPool);
+    void PostProcess_vkAllocateDescriptorSets(VkDevice                           device,
+                                              const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                              VkDescriptorSet*                   pDescriptorSets);
+    void PostProcess_vkCreateFramebuffer(VkDevice                       device,
+                                         const VkFramebufferCreateInfo* pCreateInfo,
+                                         const VkAllocationCallbacks*   pAllocator,
+                                         VkFramebuffer*                 pFramebuffer);
+    void PostProcess_vkCreateCommandPool(VkDevice                       device,
+                                         const VkCommandPoolCreateInfo* pCreateInfo,
+                                         const VkAllocationCallbacks*   pAllocator,
+                                         VkCommandPool*                 pCommandPool);
 
 #if defined(__ANDROID__)
     void OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1587,13 +1587,6 @@ class VulkanCaptureManager : public ApiCaptureManager
                                           const VkShaderModuleCreateInfo* pCreateInfo,
                                           const VkAllocationCallbacks*    pAllocator,
                                           VkShaderModule*                 pShaderModule);
-    void PostProcess_vkCreateGraphicsPipelines(VkResult                            result,
-                                               VkDevice                            device,
-                                               VkPipelineCache                     pipelineCache,
-                                               uint32_t                            createInfoCount,
-                                               const VkGraphicsPipelineCreateInfo* pCreateInfos,
-                                               const VkAllocationCallbacks*        pAllocator,
-                                               VkPipeline*                         pPipelines);
     void PostProcess_vkCreatePipelineLayout(VkDevice                          device,
                                             const VkPipelineLayoutCreateInfo* pCreateInfo,
                                             const VkAllocationCallbacks*      pAllocator,

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -218,6 +218,247 @@ uint64_t GetWrappedId(uint64_t object, VkDebugReportObjectTypeEXT object_type)
     }
 }
 
+template <>
+VkObjectType GetObjectType<InstanceWrapper>()
+{
+    return VK_OBJECT_TYPE_INSTANCE;
+}
+template <>
+VkObjectType GetObjectType<PhysicalDeviceWrapper>()
+{
+    return VK_OBJECT_TYPE_PHYSICAL_DEVICE;
+}
+template <>
+VkObjectType GetObjectType<DeviceWrapper>()
+{
+    return VK_OBJECT_TYPE_DEVICE;
+}
+template <>
+VkObjectType GetObjectType<QueueWrapper>()
+{
+    return VK_OBJECT_TYPE_QUEUE;
+}
+template <>
+VkObjectType GetObjectType<SemaphoreWrapper>()
+{
+    return VK_OBJECT_TYPE_SEMAPHORE;
+}
+template <>
+VkObjectType GetObjectType<CommandBufferWrapper>()
+{
+    return VK_OBJECT_TYPE_COMMAND_BUFFER;
+}
+template <>
+VkObjectType GetObjectType<FenceWrapper>()
+{
+    return VK_OBJECT_TYPE_FENCE;
+}
+template <>
+VkObjectType GetObjectType<DeviceMemoryWrapper>()
+{
+    return VK_OBJECT_TYPE_DEVICE_MEMORY;
+}
+template <>
+VkObjectType GetObjectType<BufferWrapper>()
+{
+    return VK_OBJECT_TYPE_BUFFER;
+}
+template <>
+VkObjectType GetObjectType<ImageWrapper>()
+{
+    return VK_OBJECT_TYPE_IMAGE;
+}
+template <>
+VkObjectType GetObjectType<EventWrapper>()
+{
+    return VK_OBJECT_TYPE_EVENT;
+}
+template <>
+VkObjectType GetObjectType<BufferViewWrapper>()
+{
+    return VK_OBJECT_TYPE_BUFFER_VIEW;
+}
+template <>
+VkObjectType GetObjectType<ImageViewWrapper>()
+{
+    return VK_OBJECT_TYPE_IMAGE_VIEW;
+}
+template <>
+VkObjectType GetObjectType<ShaderModuleWrapper>()
+{
+    return VK_OBJECT_TYPE_SHADER_MODULE;
+}
+template <>
+VkObjectType GetObjectType<PipelineCacheWrapper>()
+{
+    return VK_OBJECT_TYPE_PIPELINE_CACHE;
+}
+template <>
+VkObjectType GetObjectType<PipelineLayoutWrapper>()
+{
+    return VK_OBJECT_TYPE_PIPELINE_LAYOUT;
+}
+template <>
+VkObjectType GetObjectType<RenderPassWrapper>()
+{
+    return VK_OBJECT_TYPE_RENDER_PASS;
+}
+template <>
+VkObjectType GetObjectType<PipelineWrapper>()
+{
+    return VK_OBJECT_TYPE_PIPELINE;
+}
+template <>
+VkObjectType GetObjectType<DescriptorSetLayoutWrapper>()
+{
+    return VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT;
+}
+template <>
+VkObjectType GetObjectType<SamplerWrapper>()
+{
+    return VK_OBJECT_TYPE_SAMPLER;
+}
+template <>
+VkObjectType GetObjectType<DescriptorPoolWrapper>()
+{
+    return VK_OBJECT_TYPE_DESCRIPTOR_POOL;
+}
+template <>
+VkObjectType GetObjectType<DescriptorSetWrapper>()
+{
+    return VK_OBJECT_TYPE_DESCRIPTOR_SET;
+}
+template <>
+VkObjectType GetObjectType<FramebufferWrapper>()
+{
+    return VK_OBJECT_TYPE_FRAMEBUFFER;
+}
+template <>
+VkObjectType GetObjectType<CommandPoolWrapper>()
+{
+    return VK_OBJECT_TYPE_COMMAND_POOL;
+}
+template <>
+VkObjectType GetObjectType<QueryPoolWrapper>()
+{
+    return VK_OBJECT_TYPE_QUERY_POOL;
+}
+template <>
+VkObjectType GetObjectType<AccelerationStructureKHRWrapper>()
+{
+    return VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR;
+}
+template <>
+VkObjectType GetObjectType<SamplerYcbcrConversionWrapper>()
+{
+    return VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION;
+}
+template <>
+VkObjectType GetObjectType<DescriptorUpdateTemplateWrapper>()
+{
+    return VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE;
+}
+template <>
+VkObjectType GetObjectType<PrivateDataSlotWrapper>()
+{
+    return VK_OBJECT_TYPE_PRIVATE_DATA_SLOT;
+}
+template <>
+VkObjectType GetObjectType<SurfaceKHRWrapper>()
+{
+    return VK_OBJECT_TYPE_SURFACE_KHR;
+}
+template <>
+VkObjectType GetObjectType<SwapchainKHRWrapper>()
+{
+    return VK_OBJECT_TYPE_SWAPCHAIN_KHR;
+}
+template <>
+VkObjectType GetObjectType<DisplayKHRWrapper>()
+{
+    return VK_OBJECT_TYPE_DISPLAY_KHR;
+}
+template <>
+VkObjectType GetObjectType<DisplayModeKHRWrapper>()
+{
+    return VK_OBJECT_TYPE_DISPLAY_MODE_KHR;
+}
+template <>
+VkObjectType GetObjectType<DebugReportCallbackEXTWrapper>()
+{
+    return VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT;
+}
+template <>
+VkObjectType GetObjectType<VideoSessionKHRWrapper>()
+{
+    return VK_OBJECT_TYPE_VIDEO_SESSION_KHR;
+}
+template <>
+VkObjectType GetObjectType<VideoSessionParametersKHRWrapper>()
+{
+    return VK_OBJECT_TYPE_VIDEO_SESSION_PARAMETERS_KHR;
+}
+template <>
+VkObjectType GetObjectType<DebugUtilsMessengerEXTWrapper>()
+{
+    return VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT;
+}
+template <>
+VkObjectType GetObjectType<ValidationCacheEXTWrapper>()
+{
+    return VK_OBJECT_TYPE_VALIDATION_CACHE_EXT;
+}
+template <>
+VkObjectType GetObjectType<AccelerationStructureNVWrapper>()
+{
+    return VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV;
+}
+template <>
+VkObjectType GetObjectType<PerformanceConfigurationINTELWrapper>()
+{
+    return VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL;
+}
+template <>
+VkObjectType GetObjectType<DeferredOperationKHRWrapper>()
+{
+    return VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR;
+}
+template <>
+VkObjectType GetObjectType<IndirectCommandsLayoutNVWrapper>()
+{
+    return VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV;
+}
+template <>
+VkObjectType GetObjectType<MicromapEXTWrapper>()
+{
+    return VK_OBJECT_TYPE_MICROMAP_EXT;
+}
+template <>
+VkObjectType GetObjectType<OpticalFlowSessionNVWrapper>()
+{
+    return VK_OBJECT_TYPE_OPTICAL_FLOW_SESSION_NV;
+}
+template <>
+VkObjectType GetObjectType<ShaderEXTWrapper>()
+{
+    return VK_OBJECT_TYPE_SHADER_EXT;
+}
+template <>
+VkObjectType GetObjectType<PipelineBinaryKHRWrapper>()
+{
+    return VK_OBJECT_TYPE_PIPELINE_BINARY_KHR;
+}
+template <>
+VkObjectType GetObjectType<IndirectExecutionSetEXTWrapper>()
+{
+    return VK_OBJECT_TYPE_INDIRECT_EXECUTION_SET_EXT;
+}
+template <>
+VkObjectType GetObjectType<IndirectCommandsLayoutEXTWrapper>()
+{
+    return VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_EXT;
+}
+
 GFXRECON_END_NAMESPACE(vulkan_wrappers)
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -69,6 +69,9 @@ inline format::HandleId GetTempWrapperId<CommandPoolWrapper>(const VkCommandPool
     return 0;
 }
 
+template <typename WrapperType>
+VkObjectType GetObjectType();
+
 template <typename Wrapper>
 format::HandleId GetWrappedId(const typename Wrapper::HandleType& handle, bool log_warning = true)
 {


### PR DESCRIPTION
When enabled calls vkSetDebugUtilsObjectNameEXT for every created object during capture.
Sets the name as <ObjectType> + associated handle_id.
This helps to keep track of objects in trimmed traces and debugging tools.
