### PR TITLE
Add NO_DEFAULT_PATH

### DIFF
--- a/cmake/FindDXC.cmake
+++ b/cmake/FindDXC.cmake
@@ -45,7 +45,7 @@ if (${D3D12_SUPPORT})
             message("Current DXC_INCLUDE_DIR '${DXC_INCLUDE_DIR}' does not contain 'dxcapi.h'. Resetting DXC_INCLUDE_DIR.")
             unset(DXC_INCLUDE_DIR CACHE)
         endif()
-        find_path(DXC_INCLUDE_DIR NAME "dxcapi.h" PATHS "${DXC_SDK_DIR}/inc")
+        find_path(DXC_INCLUDE_DIR NAME "dxcapi.h" PATHS "${DXC_SDK_DIR}/inc" NO_DEFAULT_PATH)
         mark_as_advanced(DXC_INCLUDE_DIR)
 
         # If the cached library path doesn't exist or arch doesn't match, unset variable.


### PR DESCRIPTION
If using `developer command prompt for visual studio 2022`, it gets `DXC_INCLUDE_DIR:PATH=C:/Program Files (x86)/Windows Kits/10/Include/10.0.20348.0/um`.

If using `command prompt`, it got `DXC_INCLUDE_DIR:PATH=XXXXXX/gfxreconstruct/build/external/DXC/inc`

Adding `NO_DEFAULT_PATH` could always be  `XXXXXX/gfxreconstruct/build/external/DXC/inc`