### PR TITLE
Optimizer: Mark all buffers targets of GetBufferDeviceAddress as used

### DIFF
--- a/framework/decode/referenced_resource_table.cpp
+++ b/framework/decode/referenced_resource_table.cpp
@@ -473,5 +473,14 @@ bool ReferencedResourceTable::IsUsed(const ResourceInfo* resource_info) const
     return false;
 }
 
+void ReferencedResourceTable::MarkResourceAsUsed(format::HandleId resource)
+{
+    auto resource_entry = resources_.find(resource);
+    if (resource_entry != resources_.end())
+    {
+        resource_entry->second->used = true;
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/referenced_resource_table.h
+++ b/framework/decode/referenced_resource_table.h
@@ -89,6 +89,8 @@ class ReferencedResourceTable
     void GetReferencedResourceIds(std::unordered_set<format::HandleId>* referenced_ids,
                                   std::unordered_set<format::HandleId>* unreferenced_ids) const;
 
+    void MarkResourceAsUsed(format::HandleId resource);
+
   private:
     // Track the referenced/used state of a resource (buffer, image, view, framebuffer).
     struct ResourceInfo

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -1158,5 +1158,39 @@ void VulkanReferencedResourceConsumerBase::PushDescriptorSetWithTemplate(format:
     }
 }
 
+void VulkanReferencedResourceConsumerBase::Process_vkGetBufferDeviceAddress(
+    const ApiCallInfo&                                       call_info,
+    VkDeviceAddress                                          returnValue,
+    format::HandleId                                         device,
+    StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
+{
+    if (pInfo != nullptr && pInfo->GetMetaStructPointer() != nullptr)
+    {
+        const auto* buffer_device_address = pInfo->GetMetaStructPointer();
+        if (buffer_device_address != nullptr)
+        {
+            table_.MarkResourceAsUsed(buffer_device_address->buffer);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkGetBufferDeviceAddressKHR(
+    const ApiCallInfo&                                       call_info,
+    VkDeviceAddress                                          returnValue,
+    format::HandleId                                         device,
+    StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
+{
+    Process_vkGetBufferDeviceAddress(call_info, returnValue, device, pInfo);
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkGetBufferDeviceAddressEXT(
+    const ApiCallInfo&                                       call_info,
+    VkDeviceAddress                                          returnValue,
+    format::HandleId                                         device,
+    StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
+{
+    Process_vkGetBufferDeviceAddress(call_info, returnValue, device, pInfo);
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -258,6 +258,24 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
 
     bool WasNotOptimizable() { return not_optimizable_; }
 
+    virtual void
+    Process_vkGetBufferDeviceAddress(const ApiCallInfo&                                       call_info,
+                                     VkDeviceAddress                                          returnValue,
+                                     format::HandleId                                         device,
+                                     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
+
+    virtual void
+    Process_vkGetBufferDeviceAddressKHR(const ApiCallInfo&                                       call_info,
+                                        VkDeviceAddress                                          returnValue,
+                                        format::HandleId                                         device,
+                                        StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
+
+    virtual void
+    Process_vkGetBufferDeviceAddressEXT(const ApiCallInfo&                                       call_info,
+                                        VkDeviceAddress                                          returnValue,
+                                        format::HandleId                                         device,
+                                        StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
+
   protected:
     bool IsStateLoading() const { return loading_state_; }
 


### PR DESCRIPTION
Device addresses can end up in places where the optimizer cannot (currently) detect and as a result can optimize out buffers that are actually used by an application.