### PR TITLE
Link to gfxr's d3d12.lib and dxgi.lib

### DIFF
--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -219,8 +219,8 @@ if (${RUN_TESTS})
     target_link_libraries(gfxrecon_util_test
                         PRIVATE
                             gfxrecon_util
-                            $<$<BOOL:${D3D12_SUPPORT}>:d3d12.lib>
-                            $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>)
+                            $<$<BOOL:${D3D12_SUPPORT}>:d3d12>
+                            $<$<BOOL:${D3D12_SUPPORT}>:dxgi>)
     if (MSVC)
         # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
         # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.

--- a/tools/optimize/CMakeLists.txt
+++ b/tools/optimize/CMakeLists.txt
@@ -64,8 +64,8 @@ target_link_libraries(gfxrecon-optimize
                           gfxrecon_format
                           gfxrecon_util
                           platform_specific
-                          $<$<BOOL:${D3D12_SUPPORT}>:d3d12.lib>
-                          $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>
+                          $<$<BOOL:${D3D12_SUPPORT}>:d3d12>
+                          $<$<BOOL:${D3D12_SUPPORT}>:dxgi>
                           $<$<BOOL:${DXC_FOUND}>:${DXC_LIBRARY_PATH}>)
 
 common_build_directives(gfxrecon-optimize)

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -48,8 +48,8 @@ target_link_libraries(gfxrecon-replay
                           gfxrecon_format
                           gfxrecon_util
                           platform_specific
-                          $<$<BOOL:${D3D12_SUPPORT}>:d3d12.lib>
-                          $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>
+                          $<$<BOOL:${D3D12_SUPPORT}>:d3d12>
+                          $<$<BOOL:${D3D12_SUPPORT}>:dxgi>
                           $<$<BOOL:${DXC_FOUND}>:${DXC_LIBRARY_PATH}>)
 
 target_link_options(gfxrecon-replay PUBLIC "-rdynamic")


### PR DESCRIPTION
The original code linked to WindowsSDK's libs. It added `d3d12.lib` and `dxgi.lib` in `AdditionalLibraryDirectories`, and it linked to WindowsSDK. This PR changed to add `..\..\layer\d3d12\Debug\d3d12.lib` and `..\..\layer\dxgi\Debug\dxgi.lib` in `AdditionalLibraryDirectories`.