### PR TITLE
Fix a regression when using inline-uniform-blocks

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -653,6 +653,9 @@ struct VulkanDescriptorSetLayoutInfo : public VulkanObjectInfo<VkDescriptorSetLa
         uint32_t           binding;
         VkDescriptorType   type;
         VkShaderStageFlags stage_flags;
+
+        // used primarily to keep track of inline-uniform-block sizes.
+        uint32_t count;
     };
 
     std::vector<DescriptorBindingLayout> bindings_layout;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4270,6 +4270,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorSetLayout(
             for (uint32_t i = 0; i < binding_count; ++i)
             {
                 layout_info->bindings_layout[i].type        = p_bindings[i].descriptorType;
+                layout_info->bindings_layout[i].count       = p_bindings[i].descriptorCount;
                 layout_info->bindings_layout[i].binding     = p_bindings[i].binding;
                 layout_info->bindings_layout[i].stage_flags = p_bindings[i].stageFlags;
             }
@@ -4462,6 +4463,13 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
 
                     new_entry.first->second.desc_type   = layout_binding.type;
                     new_entry.first->second.stage_flags = layout_binding.stage_flags;
+
+                    // NOTE: unlike other descriptor-arrays, inline-uniform-block arrays are never sparse.
+                    // we need to set their size appropriately.
+                    if (layout_binding.type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK)
+                    {
+                        new_entry.first->second.inline_uniform_block.resize(layout_binding.count);
+                    }
                 }
             }
         }


### PR DESCRIPTION
- surfaced together with either dump-resources or `-m rebind`
- Re-add the count-member to decode::VulkanDescriptorSetLayoutInfo::DescriptorBindingLayout
- Restores behavior: Resize inline-uniform-block arrays appropriately

one of the symptoms, we started hitting an assert here:
https://github.com/LunarG/gfxreconstruct/blob/223a12fc10bb295ad3d365d304b539044a13c222/framework/decode/vulkan_replay_consumer_base.cpp#L10022

to reproduce the issue this example can be used: https://github.com/SaschaWillems/Vulkan/blob/master/examples/inlineuniformblocks/inlineuniformblocks.cpp