### PR TITLE
Batch queue-submissions in ProcessBufferMemory / ProcessImageMemory

### DIFF
--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -332,21 +332,24 @@ void VulkanAddressReplacer::ProcessCmdPushConstants(const VulkanCommandBufferInf
     {
         auto* pipeline_info = object_table_->GetVkPipelineInfo(pipeline_id);
         GFXRECON_ASSERT(pipeline_info != nullptr);
-        for (const auto& buffer_ref_info : pipeline_info->buffer_reference_infos)
+        if (pipeline_info != nullptr)
         {
-            if (buffer_ref_info.source == util::SpirVParsingUtil::BufferReferenceLocation::PUSH_CONSTANT_BLOCK)
+            for (const auto& buffer_ref_info : pipeline_info->buffer_reference_infos)
             {
-                // find addresses in push-constant memory and replace in-place.
-                auto* address = reinterpret_cast<VkDeviceAddress*>(static_cast<uint8_t*>(data) + offset +
-                                                                   buffer_ref_info.buffer_offset);
-
-                auto* buffer_info = address_tracker.GetBufferByCaptureDeviceAddress(*address);
-                if (buffer_info != nullptr && buffer_info->replay_address != 0)
+                if (buffer_ref_info.source == util::SpirVParsingUtil::BufferReferenceLocation::PUSH_CONSTANT_BLOCK)
                 {
-                    GFXRECON_LOG_INFO_ONCE("VulkanAddressReplacer::ProcessCmdPushConstants(): Replay is adjusting "
-                                           "mismatching buffer-device-addresses in push-constants");
-                    uint32_t address_offset = *address - buffer_info->capture_address;
-                    *address                = buffer_info->replay_address + address_offset;
+                    // find addresses in push-constant memory and replace in-place.
+                    auto* address = reinterpret_cast<VkDeviceAddress*>(static_cast<uint8_t*>(data) + offset +
+                                                                       buffer_ref_info.buffer_offset);
+
+                    auto* buffer_info = address_tracker.GetBufferByCaptureDeviceAddress(*address);
+                    if (buffer_info != nullptr && buffer_info->replay_address != 0)
+                    {
+                        GFXRECON_LOG_INFO_ONCE("VulkanAddressReplacer::ProcessCmdPushConstants(): Replay is adjusting "
+                                               "mismatching buffer-device-addresses in push-constants");
+                        uint32_t address_offset = *address - buffer_info->capture_address;
+                        *address                = buffer_info->replay_address + address_offset;
+                    }
                 }
             }
         }
@@ -1365,6 +1368,9 @@ bool VulkanAddressReplacer::init_queue_assets()
         GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal command-buffer creation failed");
         return false;
     }
+
+    // Because this command buffer was not allocated through the loader, it must be assigned a dispatch table.
+    *reinterpret_cast<void**>(command_buffer_) = *reinterpret_cast<void**>(device_);
 
     VkFenceCreateInfo fence_create_info;
     fence_create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -477,41 +477,53 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
         std::vector<uint8_t>  data;
         std::vector<uint64_t> subresource_offsets;
         std::vector<uint64_t> subresource_sizes;
-        bool                  scaled;
 
-        VkResult res = resource_util.ReadFromImageResourceStaging(
-            image_info->handle,
-            image_info->format,
-            image_info->type,
-            image_info->extent,
-            image_info->level_count,
-            image_info->layer_count,
-            image_info->tiling,
-            image_info->sample_count,
-            (layout == VK_IMAGE_LAYOUT_MAX_ENUM) ? image_info->intermediate_layout : layout,
-            image_info->queue_family_index,
-            image_info->external_format,
-            image_info->size,
-            aspect,
-            data,
-            subresource_offsets,
-            subresource_sizes,
-            scaled,
-            false,
-            scale,
-            dst_format);
+        graphics::VulkanResourcesUtil::ImageResource image_resource = {};
+        image_resource.image                                        = image_info->handle;
+        image_resource.format                                       = image_info->format;
+        image_resource.type                                         = image_info->type;
+        image_resource.extent                                       = image_info->extent;
+        image_resource.mip_levels                                   = image_info->level_count;
+        image_resource.array_layers                                 = image_info->layer_count;
+        image_resource.tiling                                       = image_info->tiling;
+        image_resource.samples                                      = image_info->sample_count;
+        image_resource.layout                                       = image_info->current_layout;
+        image_resource.queue_family_index                           = image_info->queue_family_index;
+        image_resource.external_format                              = image_info->external_format;
+        image_resource.size                                         = image_info->size;
+        image_resource.level_sizes                                  = &subresource_sizes;
+        image_resource.aspect                                       = aspect;
+        image_resource.all_layers_per_level                         = false;
+
+        image_resource.resource_size = resource_util.GetImageResourceSizesOptimal(image_resource.image,
+                                                                                  image_resource.format,
+                                                                                  image_resource.type,
+                                                                                  image_resource.extent,
+                                                                                  image_resource.mip_levels,
+                                                                                  image_resource.array_layers,
+                                                                                  image_resource.tiling,
+                                                                                  aspect,
+                                                                                  &subresource_offsets,
+                                                                                  &subresource_sizes,
+                                                                                  image_resource.all_layers_per_level);
+        VkResult result              = resource_util.ReadImageResource(image_resource, data);
 
         assert(!subresource_offsets.empty());
         assert(!subresource_sizes.empty());
 
-        scaling_supported[i] = scaled;
+        scaling_supported[i] = resource_util.IsScalingSupported(image_resource.format,
+                                                                image_resource.tiling,
+                                                                dst_format,
+                                                                image_resource.type,
+                                                                image_resource.extent,
+                                                                scale);
 
-        if (res != VK_SUCCESS)
+        if (result != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR("Reading from image resource %" PRIu64 " failed (%s)",
                                image_info->capture_id,
-                               util::ToString<VkResult>(res).c_str())
-            return res;
+                               util::ToString<VkResult>(result).c_str())
+            return result;
         }
 
         const DumpedImageFormat output_image_format = GetDumpedImageFormat(device_info,
@@ -528,7 +540,7 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
         {
             for (uint32_t layer = 0; layer < image_info->layer_count; ++layer)
             {
-                std::string filename = filenames[f++];
+                const std::string& filename = filenames[f++];
 
                 // We don't support stencil output yet
                 if (aspects[i] == VK_IMAGE_ASPECT_STENCIL_BIT)
@@ -545,7 +557,7 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
                     assert(image_writer_format != util::imagewriter::DataFormats::kFormat_UNSPECIFIED);
 
                     VkExtent3D scaled_extent;
-                    if (scale != 1.0f && scaled)
+                    if (scale != 1.0f && scaling_supported[i])
                     {
                         scaled_extent.width  = std::max(image_info->extent.width * scale, 1.0f);
                         scaled_extent.height = std::max(image_info->extent.height * scale, 1.0f);
@@ -634,7 +646,6 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
     }
 
     assert(f == total_files);
-
     return VK_SUCCESS;
 }
 

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -483,24 +483,26 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
         image_resource.format                                       = image_info->format;
         image_resource.type                                         = image_info->type;
         image_resource.extent                                       = image_info->extent;
-        image_resource.mip_levels                                   = image_info->level_count;
-        image_resource.array_layers                                 = image_info->layer_count;
+        image_resource.level_count                                  = image_info->level_count;
+        image_resource.layer_count                                  = image_info->layer_count;
         image_resource.tiling                                       = image_info->tiling;
-        image_resource.samples                                      = image_info->sample_count;
-        image_resource.layout                                       = image_info->current_layout;
-        image_resource.queue_family_index                           = image_info->queue_family_index;
-        image_resource.external_format                              = image_info->external_format;
-        image_resource.size                                         = image_info->size;
-        image_resource.level_sizes                                  = &subresource_sizes;
-        image_resource.aspect                                       = aspect;
-        image_resource.all_layers_per_level                         = false;
+        image_resource.sample_count                                 = image_info->sample_count;
+        image_resource.layout = (layout == VK_IMAGE_LAYOUT_MAX_ENUM) ? image_info->intermediate_layout : layout;
+        image_resource.queue_family_index   = image_info->queue_family_index;
+        image_resource.external_format      = image_info->external_format;
+        image_resource.size                 = image_info->size;
+        image_resource.level_sizes          = &subresource_sizes;
+        image_resource.aspect               = aspect;
+        image_resource.scale                = scale;
+        image_resource.dst_format           = dst_format;
+        image_resource.all_layers_per_level = false;
 
         image_resource.resource_size = resource_util.GetImageResourceSizesOptimal(image_resource.image,
                                                                                   image_resource.format,
                                                                                   image_resource.type,
                                                                                   image_resource.extent,
-                                                                                  image_resource.mip_levels,
-                                                                                  image_resource.array_layers,
+                                                                                  image_resource.level_count,
+                                                                                  image_resource.layer_count,
                                                                                   image_resource.tiling,
                                                                                   aspect,
                                                                                   &subresource_offsets,
@@ -508,8 +510,8 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
                                                                                   image_resource.all_layers_per_level);
         VkResult result              = resource_util.ReadImageResource(image_resource, data);
 
-        assert(!subresource_offsets.empty());
-        assert(!subresource_sizes.empty());
+        GFXRECON_ASSERT(!subresource_offsets.empty());
+        GFXRECON_ASSERT(!subresource_sizes.empty());
 
         scaling_supported[i] = resource_util.IsScalingSupported(image_resource.format,
                                                                 image_resource.tiling,

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1936,8 +1936,8 @@ void VulkanCaptureManager::ProcessImportFdForImage(VkDevice device, VkImage imag
                                                                                 img.format,
                                                                                 img.type,
                                                                                 img.extent,
-                                                                                img.mip_levels,
-                                                                                img.array_layers,
+                                                                                img.level_count,
+                                                                                img.layer_count,
                                                                                 img.tiling,
                                                                                 img.aspect,
                                                                                 nullptr,
@@ -1951,7 +1951,7 @@ void VulkanCaptureManager::ProcessImportFdForImage(VkDevice device, VkImage imag
                                                   img.handle_id,
                                                   img.aspect,
                                                   img.layout,
-                                                  img.mip_levels,
+                                                  img.level_count,
                                                   level_sizes,
                                                   resource_size,
                                                   data);
@@ -1966,10 +1966,10 @@ void VulkanCaptureManager::ProcessImportFdForImage(VkDevice device, VkImage imag
         image_resource.format               = image_wrapper->format;
         image_resource.type                 = image_wrapper->image_type;
         image_resource.extent               = image_wrapper->extent;
-        image_resource.mip_levels           = image_wrapper->mip_levels;
-        image_resource.array_layers         = image_wrapper->array_layers;
+        image_resource.level_count          = image_wrapper->mip_levels;
+        image_resource.layer_count          = image_wrapper->array_layers;
         image_resource.tiling               = image_wrapper->tiling;
-        image_resource.samples              = image_wrapper->samples;
+        image_resource.sample_count         = image_wrapper->samples;
         image_resource.layout               = image_wrapper->current_layout;
         image_resource.queue_family_index   = image_wrapper->queue_family_index;
         image_resource.external_format      = image_wrapper->external_format;

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1924,61 +1924,61 @@ void VulkanCaptureManager::ProcessImportFdForImage(VkDevice device, VkImage imag
     std::vector<VkImageAspectFlagBits> aspects;
     graphics::GetFormatAspects(image_wrapper->format, &aspects);
 
+    using ImageResource = graphics::VulkanResourcesUtil::ImageResource;
+    std::vector<ImageResource> image_resources;
+
+    auto write_init_image_cmd = [this, &resource_util, device_wrapper](const ImageResource& img, const void* data) {
+        // Combined size of all layers in a mip level.
+        std::vector<uint64_t> level_sizes;
+
+        uint64_t resource_size = resource_util.GetImageResourceSizesOptimal(img.image,
+                                                                            img.format,
+                                                                            img.type,
+                                                                            img.extent,
+                                                                            img.mip_levels,
+                                                                            img.array_layers,
+                                                                            img.tiling,
+                                                                            img.aspect,
+                                                                            nullptr,
+                                                                            &level_sizes,
+                                                                            true);
+
+        WriteBeginResourceInitCmd(device_wrapper->handle_id, resource_size);
+        GetCommandWriter()->WriteInitImageCmd(api_family_,
+                                              device_wrapper->handle_id,
+                                              img.handle_id,
+                                              img.aspect,
+                                              img.layout,
+                                              img.mip_levels,
+                                              level_sizes,
+                                              resource_size,
+                                              data);
+        WriteEndResourceInitCmd(device_wrapper->handle_id);
+    };
+
     for (auto aspect : aspects)
     {
-        std::vector<uint8_t>  data;
-        std::vector<uint64_t> subresource_offsets;
-        std::vector<uint64_t> subresource_sizes;
-        bool                  scaling_supported;
-
-        VkResult result = resource_util.ReadFromImageResourceStaging(image,
-                                                                     image_wrapper->format,
-                                                                     image_wrapper->image_type,
-                                                                     image_wrapper->extent,
-                                                                     image_wrapper->mip_levels,
-                                                                     image_wrapper->array_layers,
-                                                                     image_wrapper->tiling,
-                                                                     image_wrapper->samples,
-                                                                     image_wrapper->current_layout,
-                                                                     image_wrapper->queue_family_index,
-                                                                     image_wrapper->external_format,
-                                                                     image_wrapper->size,
-                                                                     aspect,
-                                                                     data,
-                                                                     subresource_offsets,
-                                                                     subresource_sizes,
-                                                                     scaling_supported,
-                                                                     true);
-        if (result == VK_SUCCESS)
-        {
-            // Combined size of all layers in a mip level.
-            std::vector<uint64_t> level_sizes;
-
-            uint64_t resource_size = resource_util.GetImageResourceSizesOptimal(image_wrapper->handle,
-                                                                                image_wrapper->format,
-                                                                                image_wrapper->image_type,
-                                                                                image_wrapper->extent,
-                                                                                image_wrapper->mip_levels,
-                                                                                image_wrapper->array_layers,
-                                                                                image_wrapper->tiling,
-                                                                                aspect,
-                                                                                nullptr,
-                                                                                &level_sizes,
-                                                                                true);
-
-            WriteBeginResourceInitCmd(device_wrapper->handle_id, resource_size);
-            GetCommandWriter()->WriteInitImageCmd(api_family_,
-                                                  device_wrapper->handle_id,
-                                                  image_wrapper->handle_id,
-                                                  aspect,
-                                                  image_wrapper->current_layout,
-                                                  image_wrapper->mip_levels,
-                                                  level_sizes,
-                                                  resource_size,
-                                                  data.data());
-            WriteEndResourceInitCmd(device_wrapper->handle_id);
-        }
+        auto& image_resource                = image_resources.emplace_back();
+        image_resource.handle_id            = image_wrapper->handle_id;
+        image_resource.image                = image_wrapper->handle;
+        image_resource.format               = image_wrapper->format;
+        image_resource.type                 = image_wrapper->image_type;
+        image_resource.extent               = image_wrapper->extent;
+        image_resource.mip_levels           = image_wrapper->mip_levels;
+        image_resource.array_layers         = image_wrapper->array_layers;
+        image_resource.tiling               = image_wrapper->tiling;
+        image_resource.samples              = image_wrapper->samples;
+        image_resource.layout               = image_wrapper->current_layout;
+        image_resource.queue_family_index   = image_wrapper->queue_family_index;
+        image_resource.external_format      = image_wrapper->external_format;
+        image_resource.size                 = image_wrapper->size;
+        image_resource.aspect               = aspect;
+        image_resource.external_format      = image_wrapper->external_format;
+        image_resource.all_layers_per_level = true;
     }
+
+    // batch process image-downloads requiring staging
+    resource_util.ReadImageResources(image_resources, write_init_image_cmd);
 }
 
 void VulkanCaptureManager::PostProcess_vkBindBufferMemory(

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1980,7 +1980,7 @@ void VulkanCaptureManager::ProcessImportFdForImage(VkDevice device, VkImage imag
     }
 
     // batch process image-downloads requiring staging, use 32MB staging-mem
-    constexpr uint32_t staging_buffer_size = 16U << 20U;
+    constexpr uint32_t staging_buffer_size = 32U << 20U;
     resource_util.ReadImageResources(image_resources, write_init_image_cmd, staging_buffer_size);
 }
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2270,7 +2270,7 @@ void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper*
     image_resources.reserve(image_snapshot_infos.size());
 
     auto write_init_image_cmd = [this, device_wrapper](const ImageResource& img, const void* data) {
-        GFXRECON_LOG_INFO("image: %d x %d (%d kB)", img.extent.width, img.extent.height, img.resource_size >> 10);
+//        GFXRECON_LOG_INFO("image: %d x %d (%d kB)", img.extent.width, img.extent.height, img.resource_size >> 10);
 
         command_writer_.WriteInitImageCmd(format::ApiFamilyId::ApiFamily_Vulkan,
                                           device_wrapper->handle_id,

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2287,7 +2287,7 @@ void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper*
                                           img.handle_id,
                                           img.aspect,
                                           img.layout,
-                                          img.mip_levels,
+                                          img.level_count,
                                           *img.level_sizes,
                                           num_bytes,
                                           data);
@@ -2313,10 +2313,10 @@ void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper*
         image_resource.format               = image_wrapper->format;
         image_resource.type                 = image_wrapper->image_type;
         image_resource.extent               = image_wrapper->extent;
-        image_resource.mip_levels           = image_wrapper->mip_levels;
-        image_resource.array_layers         = image_wrapper->array_layers;
+        image_resource.level_count          = image_wrapper->mip_levels;
+        image_resource.layer_count          = image_wrapper->array_layers;
         image_resource.tiling               = image_wrapper->tiling;
-        image_resource.samples              = image_wrapper->samples;
+        image_resource.sample_count         = image_wrapper->samples;
         image_resource.layout               = image_wrapper->current_layout;
         image_resource.queue_family_index   = image_wrapper->queue_family_index;
         image_resource.external_format      = image_wrapper->external_format;
@@ -2417,7 +2417,7 @@ void VulkanStateWriter::ProcessImageMemoryWithAssetFile(const vulkan_wrappers::D
 
             // Store uncompressed data size in packet.
             upload_cmd.data_size   = data_size;
-            upload_cmd.level_count = img.mip_levels;
+            upload_cmd.level_count = img.level_count;
 
             if (compressor_ != nullptr)
             {
@@ -2492,10 +2492,10 @@ void VulkanStateWriter::ProcessImageMemoryWithAssetFile(const vulkan_wrappers::D
             image_resource.format                                       = image_wrapper->format;
             image_resource.type                                         = image_wrapper->image_type;
             image_resource.extent                                       = image_wrapper->extent;
-            image_resource.mip_levels                                   = image_wrapper->mip_levels;
-            image_resource.array_layers                                 = image_wrapper->array_layers;
+            image_resource.level_count                                  = image_wrapper->mip_levels;
+            image_resource.layer_count                                  = image_wrapper->array_layers;
             image_resource.tiling                                       = image_wrapper->tiling;
-            image_resource.samples                                      = image_wrapper->samples;
+            image_resource.sample_count                                 = image_wrapper->samples;
             image_resource.layout                                       = image_wrapper->current_layout;
             image_resource.queue_family_index                           = image_wrapper->queue_family_index;
             image_resource.external_format                              = image_wrapper->external_format;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2403,7 +2403,7 @@ void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper*
 }
 
 void VulkanStateWriter::ProcessImageMemoryWithAssetFile(const vulkan_wrappers::DeviceWrapper* device_wrapper,
-                                                        const std::vector<ImageSnapshotInfo>& image_snapshot_info,
+                                                        const std::vector<ImageSnapshotInfo>& image_snapshot_infos,
                                                         graphics::VulkanResourcesUtil&        resource_util)
 {
     GFXRECON_ASSERT(device_wrapper != nullptr);
@@ -2412,6 +2412,7 @@ void VulkanStateWriter::ProcessImageMemoryWithAssetFile(const vulkan_wrappers::D
 
     using ImageResource = graphics::VulkanResourcesUtil::ImageResource;
     std::vector<ImageResource> image_resources;
+    image_resources.reserve(image_snapshot_infos.size());
 
     auto write_init_image_cmd = [this, device_wrapper](const ImageResource& img, const void* data, size_t num_bytes) {
         format::InitImageCommandHeader upload_cmd;
@@ -2484,7 +2485,7 @@ void VulkanStateWriter::ProcessImageMemoryWithAssetFile(const vulkan_wrappers::D
         }
     };
 
-    for (const auto& snapshot_entry : image_snapshot_info)
+    for (const auto& snapshot_entry : image_snapshot_infos)
     {
         vulkan_wrappers::ImageWrapper*              image_wrapper  = snapshot_entry.image_wrapper;
         const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper = snapshot_entry.memory_wrapper;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2281,7 +2281,7 @@ void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper*
     std::vector<ImageResource> image_resources;
     image_resources.reserve(image_snapshot_infos.size());
 
-    auto write_init_image_cmd = [this, device_wrapper](const ImageResource& img, const void* data, uint32_t num_bytes) {
+    auto write_init_image_cmd = [this, device_wrapper](const ImageResource& img, const void* data, size_t num_bytes) {
         command_writer_.WriteInitImageCmd(format::ApiFamilyId::ApiFamily_Vulkan,
                                           device_wrapper->handle_id,
                                           img.handle_id,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -173,7 +173,7 @@ class VulkanStateWriter
                              graphics::VulkanResourcesUtil&         resource_util);
 
     void ProcessBufferMemoryWithAssetFile(const vulkan_wrappers::DeviceWrapper*  device_wrapper,
-                                          const std::vector<BufferSnapshotInfo>& buffer_snapshot_info,
+                                          const std::vector<BufferSnapshotInfo>& buffer_snapshot_infos,
                                           graphics::VulkanResourcesUtil&         resource_util);
 
     void ProcessImageMemory(const vulkan_wrappers::DeviceWrapper* device_wrapper,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -169,7 +169,7 @@ class VulkanStateWriter
     void WriteDeferredOperationJoinCommand(format::HandleId device_id, format::HandleId deferred_operation_id);
 
     void ProcessBufferMemory(const vulkan_wrappers::DeviceWrapper*  device_wrapper,
-                             const std::vector<BufferSnapshotInfo>& buffer_snapshot_info,
+                             const std::vector<BufferSnapshotInfo>& buffer_snapshot_infos,
                              graphics::VulkanResourcesUtil&         resource_util);
 
     void ProcessBufferMemoryWithAssetFile(const vulkan_wrappers::DeviceWrapper*  device_wrapper,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -181,7 +181,7 @@ class VulkanStateWriter
                             graphics::VulkanResourcesUtil&        resource_util);
 
     void ProcessImageMemoryWithAssetFile(const vulkan_wrappers::DeviceWrapper* device_wrapper,
-                                         const std::vector<ImageSnapshotInfo>& image_snapshot_info,
+                                         const std::vector<ImageSnapshotInfo>& image_snapshot_infos,
                                          graphics::VulkanResourcesUtil&        resource_util);
 
     void WriteBufferMemoryState(const VulkanStateTable& state_table,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -177,7 +177,7 @@ class VulkanStateWriter
                                           graphics::VulkanResourcesUtil&         resource_util);
 
     void ProcessImageMemory(const vulkan_wrappers::DeviceWrapper* device_wrapper,
-                            const std::vector<ImageSnapshotInfo>& image_snapshot_info,
+                            const std::vector<ImageSnapshotInfo>& image_snapshot_infos,
                             graphics::VulkanResourcesUtil&        resource_util);
 
     void ProcessImageMemoryWithAssetFile(const vulkan_wrappers::DeviceWrapper* device_wrapper,

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -1591,49 +1591,14 @@ VkResult VulkanResourcesUtil::ResolveImage(VkCommandBuffer   command_buffer,
     return result;
 }
 
-VkResult VulkanResourcesUtil::ResolveImage(VkCommandBuffer   command_buffer,
-                                           VkImage           image,
-                                           VkFormat          format,
-                                           VkImageType       type,
-                                           const VkExtent3D& extent,
-                                           uint32_t          array_layers,
-                                           VkImageLayout     current_layout,
-                                           VkQueue           queue,
-                                           uint32_t          queue_family_index,
-                                           VkImage*          resolved_image,
-                                           VkDeviceMemory*   resolved_image_memory)
-{
-    VkResult result = ResolveImage(command_buffer,
-                                   image,
-                                   format,
-                                   type,
-                                   extent,
-                                   array_layers,
-                                   current_layout,
-                                   resolved_image,
-                                   resolved_image_memory);
-
-    if (result == VK_SUCCESS)
-    {
-        result = SubmitCommandBuffer(command_buffer, queue);
-    }
-
-    if (result != VK_SUCCESS)
-    {
-        GFXRECON_LOG_ERROR("Failed to resolve multisample image");
-        device_table_.DestroyImage(device_, *resolved_image, nullptr);
-        device_table_.FreeMemory(device_, *resolved_image_memory, nullptr);
-
-        *resolved_image        = VK_NULL_HANDLE;
-        *resolved_image_memory = VK_NULL_HANDLE;
-    }
-    return result;
-}
-
 VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource>&   image_resources,
                                                  const ReadImageResourcesCallbackFn& call_back,
                                                  size_t                              staging_buffer_size)
 {
+    if (image_resources.empty())
+    {
+        return VK_SUCCESS;
+    }
     // aggregate to store temporary data during batch-processing
     struct image_resource_tmp_data_t
     {
@@ -1997,6 +1962,10 @@ void VulkanResourcesUtil::ReadBufferResources(const std::vector<BufferResource>&
                                               const VulkanResourcesUtil::ReadBufferResourcesCallbackFn& callback,
                                               size_t staging_buffer_size)
 {
+    if (buffer_resources.empty())
+    {
+        return;
+    }
     std::vector<VkDeviceSize> staging_offsets(buffer_resources.size());
 
     uint32_t current_batch_size = 0;

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -43,7 +43,7 @@ static constexpr bool IsMemoryCoherent(VkMemoryPropertyFlags property_flags)
 
 void GetFormatAspects(VkFormat format, std::vector<VkImageAspectFlagBits>* aspects, bool* combined_depth_stencil)
 {
-    assert(aspects != nullptr);
+    GFXRECON_ASSERT(aspects != nullptr);
 
     bool combined = false;
 
@@ -163,7 +163,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                assert(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
+                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
                 return VK_FORMAT_S8_UINT;
             }
         case VK_FORMAT_D24_UNORM_S8_UINT:
@@ -174,7 +174,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                assert(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
+                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
                 return VK_FORMAT_S8_UINT;
             }
         case VK_FORMAT_D32_SFLOAT_S8_UINT:
@@ -184,7 +184,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                assert(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
+                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
                 return VK_FORMAT_S8_UINT;
             }
         // Per-aspect/plane compatible formats as defined by the "Plane Format Compatibility Table" from the
@@ -203,7 +203,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                assert(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
+                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
                 return VK_FORMAT_R8G8_UNORM;
             }
         case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16:
@@ -220,7 +220,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                assert(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
+                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
                 return VK_FORMAT_R10X6G10X6_UNORM_2PACK16;
             }
         case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16:
@@ -237,7 +237,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                assert(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
+                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
                 return VK_FORMAT_R12X4G12X4_UNORM_2PACK16;
             }
         case VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM:
@@ -254,12 +254,12 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                assert(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
+                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
                 return VK_FORMAT_R16G16_UNORM;
             }
         default:
-            assert((aspect == VK_IMAGE_ASPECT_COLOR_BIT) || (aspect == VK_IMAGE_ASPECT_DEPTH_BIT) ||
-                   (aspect == VK_IMAGE_ASPECT_STENCIL_BIT));
+            GFXRECON_ASSERT((aspect == VK_IMAGE_ASPECT_COLOR_BIT) || (aspect == VK_IMAGE_ASPECT_DEPTH_BIT) ||
+                            (aspect == VK_IMAGE_ASPECT_STENCIL_BIT));
             return format;
     }
 }
@@ -272,7 +272,7 @@ bool FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properti
 {
     bool found = false;
 
-    assert(memory_properties.memoryTypeCount > 0);
+    GFXRECON_ASSERT(memory_properties.memoryTypeCount > 0);
 
     for (uint32_t i = 0; i < memory_properties.memoryTypeCount; ++i)
     {
@@ -784,9 +784,9 @@ VulkanResourcesUtil::VulkanResourcesUtil(VkDevice                               
     device_table_(device_table), physical_device_(physical_device), instance_table_(instance_table),
     memory_properties_(memory_properties)
 {
-    assert(device != VK_NULL_HANDLE);
-    assert(memory_properties.memoryHeapCount <= VK_MAX_MEMORY_HEAPS);
-    assert(memory_properties.memoryTypeCount <= VK_MAX_MEMORY_TYPES);
+    GFXRECON_ASSERT(device != VK_NULL_HANDLE);
+    GFXRECON_ASSERT(memory_properties.memoryHeapCount <= VK_MAX_MEMORY_HEAPS);
+    GFXRECON_ASSERT(memory_properties.memoryTypeCount <= VK_MAX_MEMORY_TYPES);
 
     set_debug_utils_object_name_fn_ = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(
         device_table_.GetDeviceProcAddr(device_, "vkSetDebugUtilsObjectNameEXT"));
@@ -823,7 +823,7 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkImage              
                                                            std::vector<uint64_t>* subresource_sizes,
                                                            bool                   all_layers_per_level)
 {
-    assert(mip_levels <= 1 + floor(log2(std::max(std::max(extent.width, extent.height), extent.depth))));
+    GFXRECON_ASSERT(mip_levels <= 1 + floor(log2(std::max(std::max(extent.width, extent.height), extent.depth))));
 
     if (subresource_sizes != nullptr)
     {
@@ -909,7 +909,7 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkImage              
 
 VkResult VulkanResourcesUtil::CreateStagingBuffer(VkDeviceSize size)
 {
-    assert(size);
+    GFXRECON_ASSERT(size > 0);
 
     if (staging_buffer_.buffer != VK_NULL_HANDLE)
     {
@@ -923,7 +923,7 @@ VkResult VulkanResourcesUtil::CreateStagingBuffer(VkDeviceSize size)
         }
     }
 
-    assert(staging_buffer_.buffer == VK_NULL_HANDLE && staging_buffer_.size == 0);
+    GFXRECON_ASSERT(staging_buffer_.buffer == VK_NULL_HANDLE && staging_buffer_.size == 0);
 
     VkBufferCreateInfo create_info    = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
     create_info.pNext                 = nullptr;
@@ -1011,9 +1011,9 @@ VkResult VulkanResourcesUtil::CreateStagingBuffer(VkDeviceSize size)
 
 VkResult VulkanResourcesUtil::MapStagingBuffer()
 {
-    assert(staging_buffer_.buffer != VK_NULL_HANDLE);
-    assert(staging_buffer_.memory != VK_NULL_HANDLE);
-    assert(staging_buffer_.size);
+    GFXRECON_ASSERT(staging_buffer_.buffer != VK_NULL_HANDLE);
+    GFXRECON_ASSERT(staging_buffer_.memory != VK_NULL_HANDLE);
+    GFXRECON_ASSERT(staging_buffer_.size);
 
     VkResult result = VK_SUCCESS;
 
@@ -1035,9 +1035,9 @@ void VulkanResourcesUtil::UnmapStagingBuffer()
 {
     if (staging_buffer_.mapped_ptr != nullptr)
     {
-        assert(staging_buffer_.buffer != VK_NULL_HANDLE);
-        assert(staging_buffer_.memory != VK_NULL_HANDLE);
-        assert(staging_buffer_.size);
+        GFXRECON_ASSERT(staging_buffer_.buffer != VK_NULL_HANDLE);
+        GFXRECON_ASSERT(staging_buffer_.memory != VK_NULL_HANDLE);
+        GFXRECON_ASSERT(staging_buffer_.size);
 
         device_table_.UnmapMemory(device_, staging_buffer_.memory);
         staging_buffer_.mapped_ptr = nullptr;
@@ -1046,13 +1046,13 @@ void VulkanResourcesUtil::UnmapStagingBuffer()
 
 void VulkanResourcesUtil::InvalidateStagingBuffer()
 {
-    assert(staging_buffer_.buffer != VK_NULL_HANDLE);
-    assert(staging_buffer_.memory != VK_NULL_HANDLE);
-    assert(staging_buffer_.size);
+    GFXRECON_ASSERT(staging_buffer_.buffer != VK_NULL_HANDLE);
+    GFXRECON_ASSERT(staging_buffer_.memory != VK_NULL_HANDLE);
+    GFXRECON_ASSERT(staging_buffer_.size);
 
     if (!IsMemoryCoherent(staging_buffer_.memory_property_flags))
     {
-        assert(staging_buffer_.mapped_ptr != nullptr);
+        GFXRECON_ASSERT(staging_buffer_.mapped_ptr != nullptr);
 
         const VkMappedMemoryRange range{
             VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, nullptr, staging_buffer_.memory, 0, staging_buffer_.size
@@ -1082,7 +1082,7 @@ void VulkanResourcesUtil::DestroyStagingBuffer()
     staging_buffer_.size                  = 0;
 }
 
-VkCommandBuffer VulkanResourcesUtil::CreateCommandBuffer(uint32_t queue_family_index)
+VkCommandBuffer VulkanResourcesUtil::CreateCommandBufferAndBegin(uint32_t queue_family_index)
 {
     auto& command_asset = command_asset_map_[queue_family_index];
 
@@ -1257,7 +1257,7 @@ void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_b
 
     const uint32_t n_subresources = all_layers_per_level ? mip_levels : mip_levels * array_layers;
 
-    assert(sizes.size() == n_subresources);
+    GFXRECON_ASSERT(sizes.size() == n_subresources);
 
     std::vector<VkBufferImageCopy> copy_regions;
 
@@ -1293,7 +1293,7 @@ void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_b
             }
         }
     }
-    assert(sr == n_subresources);
+    GFXRECON_ASSERT(sr == n_subresources);
 
     if (copy_direction == kImageToBuffer)
     {
@@ -1306,7 +1306,7 @@ void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_b
     }
     else
     {
-        assert(copy_direction == kBufferToImage);
+        GFXRECON_ASSERT(copy_direction == kBufferToImage);
 
         device_table_.CmdCopyBufferToImage(command_buffer,
                                            buffer,
@@ -1613,6 +1613,45 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
         VkExtent3D                scaled_extent       = {};
         VkImageAspectFlags        transition_aspect   = VK_IMAGE_ASPECT_NONE;
         std::vector<VkDeviceSize> level_sizes;
+
+        VkDevice                         device       = VK_NULL_HANDLE;
+        const encode::VulkanDeviceTable* device_table = nullptr;
+
+        image_resource_tmp_data_t& operator=(image_resource_tmp_data_t other)
+        {
+            std::swap(resource_size, other.resource_size);
+            std::swap(staging_offset, other.staging_offset);
+            std::swap(resolve_image, other.resolve_image);
+            std::swap(resolve_memory, other.resolve_memory);
+            std::swap(scaled_image, other.scaled_image);
+            std::swap(scaled_image_memory, other.scaled_image_memory);
+            std::swap(use_blit, other.use_blit);
+            std::swap(scaling_supported, other.scaling_supported);
+            std::swap(scaled_extent, other.scaled_extent);
+            std::swap(transition_aspect, other.transition_aspect);
+            std::swap(level_sizes, other.level_sizes);
+            std::swap(device, other.device);
+            std::swap(device_table, other.device_table);
+            return *this;
+        }
+
+        ~image_resource_tmp_data_t()
+        {
+            if (device_table != nullptr && device != VK_NULL_HANDLE)
+            {
+                if (resolve_image != VK_NULL_HANDLE)
+                {
+                    device_table->DestroyImage(device, resolve_image, nullptr);
+                    device_table->FreeMemory(device, resolve_memory, nullptr);
+                }
+
+                if (scaled_image != VK_NULL_HANDLE)
+                {
+                    device_table->DestroyImage(device, scaled_image, nullptr);
+                    device_table->FreeMemory(device, scaled_image_memory, nullptr);
+                }
+            }
+        }
     };
     std::vector<image_resource_tmp_data_t> tmp_data(image_resources.size());
     uint32_t                               current_batch_size = 0;
@@ -1624,6 +1663,10 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
     for (uint32_t i = 0; i < image_resources.size(); ++i)
     {
         const auto& img = image_resources[i];
+
+        // allow temporary data to cleanup after itself
+        tmp_data[i].device       = device_;
+        tmp_data[i].device_table = &device_table_;
 
         VkFormat dst_format = img.dst_format == VK_FORMAT_UNDEFINED ? img.dst_format : img.format;
 
@@ -1713,7 +1756,7 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
             auto            cmd_buf_it     = command_buffer_map.find(img.queue_family_index);
             if (cmd_buf_it == command_buffer_map.end())
             {
-                command_buffer                             = CreateCommandBuffer(img.queue_family_index);
+                command_buffer                             = CreateCommandBufferAndBegin(img.queue_family_index);
                 command_buffer_map[img.queue_family_index] = command_buffer;
             }
             else
@@ -1874,17 +1917,8 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
                 call_back(img, out_ptr, tmp_data[i].resource_size);
             }
 
-            if (tmp_data[i].resolve_image != VK_NULL_HANDLE)
-            {
-                device_table_.DestroyImage(device_, tmp_data[i].resolve_image, nullptr);
-                device_table_.FreeMemory(device_, tmp_data[i].resolve_memory, nullptr);
-            }
-
-            if (tmp_data[i].scaled_image != VK_NULL_HANDLE)
-            {
-                device_table_.DestroyImage(device_, tmp_data[i].scaled_image, nullptr);
-                device_table_.FreeMemory(device_, tmp_data[i].scaled_image_memory, nullptr);
-            }
+            // free potential temporary resources
+            tmp_data[i] = {};
         } // current batch, consume staging-buffer
 
         UnmapStagingBuffer();
@@ -1914,8 +1948,8 @@ VkResult VulkanResourcesUtil::ReadImageResource(const VulkanResourcesUtil::Image
 VkResult VulkanResourcesUtil::ReadFromBufferResource(
     VkBuffer buffer, uint64_t size, uint64_t offset, uint32_t queue_family_index, std::vector<uint8_t>& data)
 {
-    assert(buffer != VK_NULL_HANDLE);
-    assert(size);
+    GFXRECON_ASSERT(buffer != VK_NULL_HANDLE);
+    GFXRECON_ASSERT(size);
 
     VkQueue queue = GetQueue(queue_family_index, 0);
     if (queue == VK_NULL_HANDLE)
@@ -1929,7 +1963,7 @@ VkResult VulkanResourcesUtil::ReadFromBufferResource(
         return result;
     }
 
-    VkCommandBuffer command_buffer = CreateCommandBuffer(queue_family_index);
+    VkCommandBuffer command_buffer = CreateCommandBufferAndBegin(queue_family_index);
     GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
     if (command_buffer == VK_NULL_HANDLE)
     {
@@ -2019,7 +2053,7 @@ void VulkanResourcesUtil::ReadBufferResources(const std::vector<BufferResource>&
             auto            cmd_buf_it     = command_buffer_map.find(buf.queue_family_index);
             if (cmd_buf_it == command_buffer_map.end())
             {
-                command_buffer                             = CreateCommandBuffer(buf.queue_family_index);
+                command_buffer                             = CreateCommandBufferAndBegin(buf.queue_family_index);
                 command_buffer_map[buf.queue_family_index] = command_buffer;
             }
             else
@@ -2310,7 +2344,7 @@ VkResult VulkanResourcesUtil::BlitImage(VkCommandBuffer       command_buffer,
     blit_region.dstOffsets[0].y = 0;
     blit_region.dstOffsets[0].z = 0;
 
-    assert(mip_levels);
+    GFXRECON_ASSERT(mip_levels);
     // assert(dst_img_mip_levels);
     std::vector<VkImageBlit> blit_regions(mip_levels);
     for (uint32_t i = 0; i < mip_levels; ++i)

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -1938,7 +1938,7 @@ VkResult VulkanResourcesUtil::ReadImageResource(const VulkanResourcesUtil::Image
 {
     return ReadImageResources(
         { image_resource },
-        [&out_data](const ImageResource& img, const void* data, uint32_t num_bytes) {
+        [&out_data](const ImageResource& img, const void* data, size_t num_bytes) {
             const auto* ptr = reinterpret_cast<const uint8_t*>(data);
             out_data.clear();
             out_data.insert(out_data.end(), ptr, ptr + num_bytes);

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -1662,7 +1662,7 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
 
         VkFormat dst_format = img.dst_format == VK_FORMAT_UNDEFINED ? img.dst_format : img.format;
 
-        GFXRECON_ASSERT(img.mip_levels <=
+        GFXRECON_ASSERT(img.level_count <=
                         1 + floor(log2(std::max(std::max(img.extent.width, img.extent.height), img.extent.depth))));
         GFXRECON_ASSERT((img.aspect == VK_IMAGE_ASPECT_COLOR_BIT) || (img.aspect == VK_IMAGE_ASPECT_DEPTH_BIT) ||
                         (img.aspect == VK_IMAGE_ASPECT_STENCIL_BIT));
@@ -1693,8 +1693,8 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
                                                          tmp_data[i].use_blit ? dst_format : img.format,
                                                          img.type,
                                                          tmp_data[i].use_blit ? tmp_data[i].scaled_extent : img.extent,
-                                                         img.mip_levels,
-                                                         img.array_layers,
+                                                         img.level_count,
+                                                         img.layer_count,
                                                          img.tiling,
                                                          img.aspect,
                                                          nullptr,
@@ -1758,14 +1758,14 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
 
             VkImage copy_image = tmp_data[i].resolve_image != VK_NULL_HANDLE ? tmp_data[i].resolve_image : img.image;
 
-            if (img.samples != VK_SAMPLE_COUNT_1_BIT)
+            if (img.sample_count != VK_SAMPLE_COUNT_1_BIT)
             {
                 result = ResolveImage(command_buffer,
                                       img.image,
                                       img.format,
                                       img.type,
                                       img.extent,
-                                      img.array_layers,
+                                      img.layer_count,
                                       img.layout,
                                       &tmp_data[i].resolve_image,
                                       &tmp_data[i].resolve_memory);
@@ -1784,7 +1784,7 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
                 tmp_data[i].transition_aspect = GetFormatAspectMask(img.format);
             }
 
-            if (img.samples == VK_SAMPLE_COUNT_1_BIT && img.layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
+            if (img.sample_count == VK_SAMPLE_COUNT_1_BIT && img.layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
             {
                 TransitionImageToTransferOptimal(command_buffer,
                                                  img.image,
@@ -1808,8 +1808,8 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
                                    img.tiling,
                                    img.extent,
                                    tmp_data[i].scaled_extent,
-                                   img.mip_levels,
-                                   img.array_layers,
+                                   img.level_count,
+                                   img.layer_count,
                                    img.aspect,
                                    img.queue_family_index,
                                    img.scale,
@@ -1832,8 +1832,8 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
                                 staging_buffer_.buffer,
                                 tmp_data[i].staging_offset,
                                 tmp_data[i].scaled_extent,
-                                img.mip_levels,
-                                img.array_layers,
+                                img.level_count,
+                                img.layer_count,
                                 img.aspect,
                                 img.level_sizes != nullptr ? *img.level_sizes : tmp_data[i].level_sizes,
                                 img.all_layers_per_level,
@@ -1863,7 +1863,7 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
                                              0,
                                              nullptr);
 
-            if ((img.samples == VK_SAMPLE_COUNT_1_BIT) && (img.layout != VK_IMAGE_LAYOUT_UNDEFINED) &&
+            if ((img.sample_count == VK_SAMPLE_COUNT_1_BIT) && (img.layout != VK_IMAGE_LAYOUT_UNDEFINED) &&
                 (img.layout != VK_IMAGE_LAYOUT_PREINITIALIZED) && (img.layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL))
             {
                 TransitionImageFromTransferOptimal(command_buffer,

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -82,6 +82,7 @@ class VulkanResourcesUtil
                                           std::vector<uint64_t>* subresource_sizes    = nullptr,
                                           bool                   all_layers_per_level = false);
 
+    //! aggregate type to group information about an image-resource
     struct ImageResource
     {
         format::HandleId                 handle_id            = format::kNullHandleId;
@@ -104,9 +105,22 @@ class VulkanResourcesUtil
         float                            scale                = 1.0f;
         VkFormat                         dst_format           = VK_FORMAT_UNDEFINED;
     };
+
+    //! signature for a callback-function, providing an image-resource and a corresponding data-pointer
     using ReadImageResourcesCallbackFn = std::function<void(const ImageResource& img_resource, const void* data)>;
+
+    /**
+     * @brief   ReadImageResources processes an array of ImageResources in batches
+     *          and will download data from GPU-memory using a staging-buffer.
+     *
+     * @param   image_resources     an array of ImageResource-structs
+     * @param   call_back           a callback-function, consuming data from staging-buffer
+     * @param   staging_buffer_size target size for the staging-buffer (default is 128MB).
+     *                              we might allocate a larger buffer, depending on largest resource-size
+     */
     void ReadImageResources(const std::vector<ImageResource>&   image_resources,
-                            const ReadImageResourcesCallbackFn& call_back);
+                            const ReadImageResourcesCallbackFn& call_back,
+                            size_t                              staging_buffer_size = 128U << 20U);
 
     // Use this function to dump an image sub resources into data vector.
     // This function is intented to be used when accessing the image content directly is not possible

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -235,23 +235,9 @@ class VulkanResourcesUtil
                           VkImage*          resolve_image,
                           VkDeviceMemory*   resolve_memory);
 
-    VkResult ResolveImage(VkCommandBuffer   command_buffer,
-                          VkImage           image,
-                          VkFormat          format,
-                          VkImageType       type,
-                          const VkExtent3D& extent,
-                          uint32_t          array_layers,
-                          VkImageLayout     current_layout,
-                          VkQueue           queue,
-                          uint32_t          queue_family_index,
-                          VkImage*          resolve_image,
-                          VkDeviceMemory*   resolve_memory);
-
     VkQueue GetQueue(uint32_t queue_family_index, uint32_t queue_index);
 
     VkResult SubmitCommandBuffer(VkCommandBuffer command_buffer, VkQueue queue);
-
-    //    void InvalidateMappedMemoryRange(VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size);
 
     VkResult BlitImage(VkCommandBuffer       command_buffer,
                        VkImage               image,

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -85,25 +85,30 @@ class VulkanResourcesUtil
     //! aggregate type to group information about an image-resource
     struct ImageResource
     {
-        format::HandleId                 handle_id            = format::kNullHandleId;
-        VkImage                          image                = VK_NULL_HANDLE;
-        VkFormat                         format               = VK_FORMAT_UNDEFINED;
-        VkImageType                      type                 = VK_IMAGE_TYPE_2D;
-        VkExtent3D                       extent               = {};
-        uint32_t                         mip_levels           = 0;
-        uint32_t                         array_layers         = 0;
-        VkImageTiling                    tiling               = VK_IMAGE_TILING_MAX_ENUM;
-        VkSampleCountFlags               samples              = 0;
-        VkImageLayout                    layout               = VK_IMAGE_LAYOUT_UNDEFINED;
-        uint32_t                         queue_family_index   = 0;
-        bool                             external_format      = false;
-        VkDeviceSize                     size                 = 0;
-        VkDeviceSize                     resource_size        = 0;
-        const std::vector<VkDeviceSize>* level_sizes          = nullptr;
-        VkImageAspectFlagBits            aspect               = VK_IMAGE_ASPECT_NONE;
-        bool                             all_layers_per_level = false;
-        float                            scale                = 1.0f;
-        VkFormat                         dst_format           = VK_FORMAT_UNDEFINED;
+        format::HandleId   handle_id          = format::kNullHandleId;
+        VkImage            image              = VK_NULL_HANDLE;
+        VkFormat           format             = VK_FORMAT_UNDEFINED;
+        VkImageType        type               = VK_IMAGE_TYPE_2D;
+        VkExtent3D         extent             = {};
+        uint32_t           mip_levels         = 0;
+        uint32_t           array_layers       = 0;
+        VkImageTiling      tiling             = VK_IMAGE_TILING_MAX_ENUM;
+        VkSampleCountFlags samples            = 0;
+        VkImageLayout      layout             = VK_IMAGE_LAYOUT_UNDEFINED;
+        uint32_t           queue_family_index = 0;
+        bool               external_format    = false;
+        VkDeviceSize       size               = 0;
+
+        //! optionally provide resource_size
+        VkDeviceSize resource_size = 0;
+
+        //! optionally provide sizes of sub-resources (mipmap-levels)
+        const std::vector<VkDeviceSize>* level_sizes = nullptr;
+
+        VkImageAspectFlagBits aspect               = VK_IMAGE_ASPECT_NONE;
+        bool                  all_layers_per_level = false;
+        float                 scale                = 1.0f;
+        VkFormat              dst_format           = VK_FORMAT_UNDEFINED;
     };
 
     //! signature for a callback-function, providing an image-resource and a corresponding data-pointer
@@ -115,7 +120,7 @@ class VulkanResourcesUtil
      *
      * @param   image_resources     an array of ImageResource-structs
      * @param   call_back           a callback-function, consuming data from staging-buffer
-     * @param   staging_buffer_size target size for the staging-buffer (default is 128MB).
+     * @param   staging_buffer_size target size for the staging-buffer in bytes (default is 128MB).
      *                              we might allocate a larger buffer, depending on largest resource-size
      */
     void ReadImageResources(const std::vector<ImageResource>&   image_resources,

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -178,7 +178,7 @@ class VulkanResourcesUtil
                             float             scale) const;
 
   private:
-    VkCommandBuffer CreateCommandBuffer(uint32_t queue_family_index);
+    VkCommandBuffer CreateCommandBufferAndBegin(uint32_t queue_family_index);
 
     void ResetCommandBuffer(VkCommandBuffer command_buffer);
 

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -90,10 +90,10 @@ class VulkanResourcesUtil
         VkFormat           format             = VK_FORMAT_UNDEFINED;
         VkImageType        type               = VK_IMAGE_TYPE_2D;
         VkExtent3D         extent             = {};
-        uint32_t           mip_levels         = 0;
-        uint32_t           array_layers       = 0;
+        uint32_t           level_count        = 0;
+        uint32_t           layer_count        = 0;
         VkImageTiling      tiling             = VK_IMAGE_TILING_MAX_ENUM;
-        VkSampleCountFlags samples            = 0;
+        VkSampleCountFlags sample_count       = 0;
         VkImageLayout      layout             = VK_IMAGE_LAYOUT_UNDEFINED;
         uint32_t           queue_family_index = 0;
         bool               external_format    = false;

--- a/framework/util/compressor.h
+++ b/framework/util/compressor.h
@@ -36,20 +36,20 @@ GFXRECON_BEGIN_NAMESPACE(util)
 class Compressor
 {
   public:
-    Compressor() {}
+    Compressor() = default;
 
-    virtual ~Compressor() {}
+    virtual ~Compressor() = default;
 
     // If needed, compressed_data will be resized to fit the compressed data + compressed_data_offset.
-    virtual size_t Compress(const size_t          uncompressed_size,
+    virtual size_t Compress(size_t                uncompressed_size,
                             const uint8_t*        uncompressed_data,
                             std::vector<uint8_t>* compressed_data,
-                            size_t                compressed_data_offset) = 0;
+                            size_t                compressed_data_offset) const = 0;
 
-    virtual size_t Decompress(const size_t                compressed_size,
+    virtual size_t Decompress(size_t                      compressed_size,
                               const std::vector<uint8_t>& compressed_data,
-                              const size_t                expected_uncompressed_size,
-                              std::vector<uint8_t>*       uncompressed_data) = 0;
+                              size_t                      expected_uncompressed_size,
+                              std::vector<uint8_t>*       uncompressed_data) const = 0;
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/lz4_compressor.cpp
+++ b/framework/util/lz4_compressor.cpp
@@ -35,7 +35,7 @@ GFXRECON_BEGIN_NAMESPACE(util)
 size_t Lz4Compressor::Compress(const size_t          uncompressed_size,
                                const uint8_t*        uncompressed_data,
                                std::vector<uint8_t>* compressed_data,
-                               size_t                compressed_data_offset)
+                               size_t                compressed_data_offset) const
 {
     size_t data_size = 0;
 
@@ -69,7 +69,7 @@ size_t Lz4Compressor::Compress(const size_t          uncompressed_size,
 size_t Lz4Compressor::Decompress(const size_t                compressed_size,
                                  const std::vector<uint8_t>& compressed_data,
                                  const size_t                expected_uncompressed_size,
-                                 std::vector<uint8_t>*       uncompressed_data)
+                                 std::vector<uint8_t>*       uncompressed_data) const
 {
     size_t data_size = 0;
 

--- a/framework/util/lz4_compressor.h
+++ b/framework/util/lz4_compressor.h
@@ -32,19 +32,19 @@ GFXRECON_BEGIN_NAMESPACE(util)
 class Lz4Compressor : public Compressor
 {
   public:
-    Lz4Compressor() {}
+    Lz4Compressor() = default;
 
-    virtual ~Lz4Compressor() override {}
+    ~Lz4Compressor() override = default;
 
-    virtual size_t Compress(const size_t          uncompressed_size,
-                            const uint8_t*        uncompressed_data,
-                            std::vector<uint8_t>* compressed_data,
-                            size_t                compressed_data_offset) override;
+    size_t Compress(size_t                uncompressed_size,
+                    const uint8_t*        uncompressed_data,
+                    std::vector<uint8_t>* compressed_data,
+                    size_t                compressed_data_offset) const override;
 
-    virtual size_t Decompress(const size_t                compressed_size,
-                              const std::vector<uint8_t>& compressed_data,
-                              const size_t                expected_uncompressed_size,
-                              std::vector<uint8_t>*       uncompressed_data) override;
+    size_t Decompress(size_t                      compressed_size,
+                      const std::vector<uint8_t>& compressed_data,
+                      size_t                      expected_uncompressed_size,
+                      std::vector<uint8_t>*       uncompressed_data) const override;
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/zlib_compressor.cpp
+++ b/framework/util/zlib_compressor.cpp
@@ -33,7 +33,7 @@ GFXRECON_BEGIN_NAMESPACE(util)
 size_t ZlibCompressor::Compress(const size_t          uncompressed_size,
                                 const uint8_t*        uncompressed_data,
                                 std::vector<uint8_t>* compressed_data,
-                                size_t                compressed_data_offset)
+                                size_t                compressed_data_offset) const
 {
     size_t copy_size = 0;
 
@@ -74,7 +74,7 @@ size_t ZlibCompressor::Compress(const size_t          uncompressed_size,
 size_t ZlibCompressor::Decompress(const size_t                compressed_size,
                                   const std::vector<uint8_t>& compressed_data,
                                   const size_t                expected_uncompressed_size,
-                                  std::vector<uint8_t>*       uncompressed_data)
+                                  std::vector<uint8_t>*       uncompressed_data) const
 {
     size_t copy_size = 0;
 

--- a/framework/util/zlib_compressor.h
+++ b/framework/util/zlib_compressor.h
@@ -32,19 +32,19 @@ GFXRECON_BEGIN_NAMESPACE(util)
 class ZlibCompressor : public Compressor
 {
   public:
-    ZlibCompressor() {}
+    ZlibCompressor() = default;
 
-    virtual ~ZlibCompressor() override {}
+    ~ZlibCompressor() override = default;
 
-    virtual size_t Compress(const size_t          uncompressed_size,
-                            const uint8_t*        uncompressed_data,
-                            std::vector<uint8_t>* compressed_data,
-                            size_t                compressed_data_offset) override;
+    size_t Compress(size_t                uncompressed_size,
+                    const uint8_t*        uncompressed_data,
+                    std::vector<uint8_t>* compressed_data,
+                    size_t                compressed_data_offset) const override;
 
-    virtual size_t Decompress(const size_t                compressed_size,
-                              const std::vector<uint8_t>& compressed_data,
-                              const size_t                expected_uncompressed_size,
-                              std::vector<uint8_t>*       uncompressed_data) override;
+    size_t Decompress(size_t                      compressed_size,
+                      const std::vector<uint8_t>& compressed_data,
+                      size_t                      expected_uncompressed_size,
+                      std::vector<uint8_t>*       uncompressed_data) const override;
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/zstd_compressor.cpp
+++ b/framework/util/zstd_compressor.cpp
@@ -36,7 +36,7 @@ GFXRECON_BEGIN_NAMESPACE(util)
 size_t ZstdCompressor::Compress(const size_t          uncompressed_size,
                                 const uint8_t*        uncompressed_data,
                                 std::vector<uint8_t>* compressed_data,
-                                size_t                compressed_data_offset)
+                                size_t                compressed_data_offset) const
 {
     size_t data_size = 0;
 
@@ -74,7 +74,7 @@ size_t ZstdCompressor::Compress(const size_t          uncompressed_size,
 size_t ZstdCompressor::Decompress(const size_t                compressed_size,
                                   const std::vector<uint8_t>& compressed_data,
                                   const size_t                expected_uncompressed_size,
-                                  std::vector<uint8_t>*       uncompressed_data)
+                                  std::vector<uint8_t>*       uncompressed_data) const
 {
     size_t data_size = 0;
 

--- a/framework/util/zstd_compressor.h
+++ b/framework/util/zstd_compressor.h
@@ -31,19 +31,19 @@ GFXRECON_BEGIN_NAMESPACE(util)
 class ZstdCompressor : public Compressor
 {
   public:
-    ZstdCompressor() {}
+    ZstdCompressor() = default;
 
-    virtual ~ZstdCompressor() override {}
+    ~ZstdCompressor() override = default;
 
-    virtual size_t Compress(const size_t          uncompressed_size,
-                            const uint8_t*        uncompressed_data,
-                            std::vector<uint8_t>* compressed_data,
-                            size_t                compressed_data_offset) override;
+    size_t Compress(size_t                uncompressed_size,
+                    const uint8_t*        uncompressed_data,
+                    std::vector<uint8_t>* compressed_data,
+                    size_t                compressed_data_offset) const override;
 
-    virtual size_t Decompress(const size_t                compressed_size,
-                              const std::vector<uint8_t>& compressed_data,
-                              const size_t                expected_uncompressed_size,
-                              std::vector<uint8_t>*       uncompressed_data) override;
+    size_t Decompress(size_t                      compressed_size,
+                      const std::vector<uint8_t>& compressed_data,
+                      size_t                      expected_uncompressed_size,
+                      std::vector<uint8_t>*       uncompressed_data) const override;
 };
 
 GFXRECON_END_NAMESPACE(util)


### PR DESCRIPTION
Instead of sequentially processing image/buffer-copies (each time doing a queue-submit + sync),
we can batch them together using a provided target-size for a combined staging-buffer.

This can drastically reduce the number of queue-submissions and improves scalability 
when processing larger quantities of textures and/or buffers.

The target-size for staging-buffers is set to `min(128Mb, total_num_staging_bytes)`, which might increase
memory-footprint during state-writes (don't think this a problem).

additional:
- Add debug-lables to internal resources in VulkanResourceUtil via `vkSetDebugUtilsObjectNameEXT`
- Remove dead code in VulkanResourcesUtil
- Add a nullptr check in VulkanAddressReplacer
- Add const-qualifiers to util::Compressor's API