### PR TITLE
Fix JSON conversion of `PointerDecoder`

### DIFF
--- a/framework/decode/decode_json_util.cpp
+++ b/framework/decode/decode_json_util.cpp
@@ -96,14 +96,14 @@ void FieldToJson(nlohmann::ordered_json&                   jdata,
     {
         const auto decoded_value = data.GetPointer();
         const auto length        = data.GetLength();
-        if (length > 1)
+        if (data.IsArray())
         {
             for (size_t i = 0; i < length; ++i)
             {
                 jdata[i] = decoded_value[i];
             }
         }
-        else
+        else if (length == 1)
         {
             jdata = *decoded_value;
         }
@@ -119,14 +119,14 @@ void FieldToJson(nlohmann::ordered_json&                 jdata,
     {
         const auto decoded_value = data.GetPointer();
         const auto length        = data.GetLength();
-        if (length > 1)
+        if (data.IsArray())
         {
             for (size_t i = 0; i < length; ++i)
             {
                 jdata[i] = decoded_value[i];
             }
         }
-        else
+        else if (length == 1)
         {
             jdata = *decoded_value;
         }
@@ -142,14 +142,14 @@ void FieldToJson(nlohmann::ordered_json&                   jdata,
     {
         const auto decoded_value = data.GetPointer();
         const auto length        = data.GetLength();
-        if (length > 1)
+        if (data.IsArray())
         {
             for (size_t i = 0; i < length; ++i)
             {
                 jdata[i] = decoded_value[i];
             }
         }
-        else
+        else if (length == 1)
         {
             jdata = *decoded_value;
         }
@@ -165,14 +165,14 @@ void FieldToJson(nlohmann::ordered_json&                 jdata,
     {
         const auto decoded_value = data.GetPointer();
         const auto length        = data.GetLength();
-        if (length > 1)
+        if (data.IsArray())
         {
             for (size_t i = 0; i < length; ++i)
             {
                 jdata[i] = decoded_value[i];
             }
         }
-        else
+        else if (length == 1)
         {
             jdata = *decoded_value;
         }


### PR DESCRIPTION
When a `PointerDecoder` didn't contain any value (because it was a nullptr) the value was still read by `FieldToJson` and written to the output of `gfxrecon-convert`.

The reason to that bug is that the test was:
```
if (len > 1)
    output a JSON array
else
    output a JSON integer
```
leaving begind the case where `len` is `0`.

This commit fixes this issue by implementing the same condition as in `HandleToJson` for `HandlePointerDecoder`.

For the following struct:
```
{
    int* x = {1, 2, 3};
    int* y = {1};
    int* z = nullptr;
}
```
The output was:
```
{
    "x": [1, 2, 3],
    "y": 1,
    "z": some garbage value
}
```
The output is now:
```
{
    "x": [1, 2, 3],
    "y": [1],
    "z": null
}
```