### PR TITLE
Fix Android multi-window surface recreation

### DIFF
--- a/android/tools/multi-win-replay/src/main/com/lunarg/gfxreconstruct/replay/ReplayActivity.java
+++ b/android/tools/multi-win-replay/src/main/com/lunarg/gfxreconstruct/replay/ReplayActivity.java
@@ -78,14 +78,12 @@ public class ReplayActivity extends NativeActivity
 
         @Override public void surfaceDestroyed(SurfaceHolder holder)
         {
-            mSurface = holder.getSurface();
-            Log.i(TAG, "SurfaceHolder.Callback: surfaceDestroyed:" + mSurface);
+            Log.i(TAG, "SurfaceHolder.Callback: surfaceDestroyed:" + holder.getSurface());
         }
 
         @Override public void surfaceChanged(SurfaceHolder holder, int format, int w, int h)
         {
-            mSurface = holder.getSurface();
-            Log.i(TAG, "SurfaceHolder.Callback: surfaceChanged:" + mSurface + " " + w + " " + h);
+            Log.i(TAG, "SurfaceHolder.Callback: surfaceChanged:" + holder.getSurface() + " " + w + " " + h);
         }
     }
 

--- a/framework/application/android_jni.cpp
+++ b/framework/application/android_jni.cpp
@@ -34,7 +34,7 @@ extern "C" JNIEXPORT void JNICALL Java_com_lunarg_gfxreconstruct_replay_ReplayAc
                                                                                                   jobject surface)
 {
     gfxrecon::application::tmp_window = ANativeWindow_fromSurface(env, surface);
-    GFXRECON_LOG_INFO("Created new window %p", gfxrecon::application::tmp_window);
+    GFXRECON_LOG_INFO("Created new window %p from surface %p", gfxrecon::application::tmp_window, surface);
 }
 
 #endif // GFXR_MULTI_WINDOW_REPLAY

--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -186,8 +186,21 @@ decode::Window* AndroidWindowFactory::Create(
 void AndroidWindowFactory::Destroy(decode::Window* window)
 {
 #ifdef GFXR_MULTI_WINDOW_REPLAY
-    int32_t windowidx = created_window_.at(window);
-    android_context_->destroyNativeWindow(windowidx);
+    if (window)
+    {
+        ANativeWindow* native_window = nullptr;
+        if (window->GetNativeHandle(decode::Window::kAndroidNativeWindow, reinterpret_cast<void**>(&native_window)))
+        {
+            ANativeWindow_release(native_window);
+        }
+        else
+        {
+            GFXRECON_LOG_ERROR("Couldn't retrieve Android native window from window %p for destruction", window)
+        }
+
+        int32_t window_index = created_window_.at(window);
+        android_context_->destroyNativeWindow(window_index);
+    }
 #else // !GFXR_MULTI_WINDOW_REPLAY
     // Standard replay app only has a single window whose lifetime is managed by AndroidContext.
     GFXRECON_UNREFERENCED_PARAMETER(window);


### PR DESCRIPTION
This commit fixes two bugs.

The first is a simple forgotten call to `ANativeWindow_release` on window destruction.

The second is a synchronization issue in the Java code: During window recreation, a destroy call and a create call closely follow each other. Each of these calls is sent to the UI thread, that will then trigger the callbacks `surfaceDestroyed` and `surfaceCreated` later.
If the call to `addNewView` happens before the UI thread calls `surfaceDestroyed`, then `mSurface` is set to the destroyed surface (which is not null), which allows `addNewView` to return with the incorrect surface set, which results in a failed surface recreation.
I propose to solve this bug by simply not setting `mSurface` in `surfaceDestroyed` and `surfaceChanged` callbacks, as `mSurface` is exclusively used to detect newly created surfaces.