### PR TITLE
Change SetSpuAffinity qualification to inline

### DIFF
--- a/framework/util/platform.h
+++ b/framework/util/platform.h
@@ -643,7 +643,7 @@ inline std::string GetCpuAffinity()
     return affinity;
 }
 
-static bool SetCpuAffinity(const std::string& affinity)
+inline bool SetCpuAffinity(const std::string& affinity)
 {
 #ifdef __linux__
     cpu_set_t mask;


### PR DESCRIPTION
It has no reason to be static and should be inline the same way all other functions in the file are.