### PR TITLE
Add ImageHasUsage() utility function and call it where appropriate

### DIFF
--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -2036,7 +2036,7 @@ VmaMemoryUsage VulkanRebindAllocator::GetImageMemoryUsage(VkImageUsageFlags     
     capture_properties &= ~(VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD | VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD);
 
     if (((capture_properties & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) == VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) &&
-        ((image_usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) == VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT))
+        graphics::ImageHasUsage(image_usage, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT))
     {
         // If the resource was bound to memory with the LAZILY_ALLOCATED property, and had TRANSIENT_ATTACHMENT
         // usage, attempt to make it LAZILY_ALLOCATED.

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2492,8 +2492,7 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
                     auto image_info      = object_info_table_->GetVkImageInfo(image_view_info->image_id);
 
                     // Only screenshot images that are color attachments.
-                    if ((image_info->usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) !=
-                        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
+                    if (!graphics::ImageHasUsage(image_info->usage, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT))
                     {
                         continue;
                     }

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -25,6 +25,7 @@
 
 #include "decode/copy_shaders.h"
 #include "decode/decoder_util.h"
+#include "graphics/vulkan_util.h"
 #include "util/platform.h"
 
 #include <algorithm>
@@ -185,16 +186,14 @@ VkResult VulkanResourceInitializer::InitializeImage(VkDeviceSize             dat
 
         if (result == VK_SUCCESS)
         {
-            bool use_transfer = ((usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == VK_IMAGE_USAGE_TRANSFER_DST_BIT) &&
+            bool use_transfer = graphics::ImageHasUsage(usage, VK_IMAGE_USAGE_TRANSFER_DST_BIT) &&
                                 (sample_count == VK_SAMPLE_COUNT_1_BIT);
             bool use_color_write =
-                ((usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) == VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) &&
+            graphics::ImageHasUsage(usage, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) &&
                 (aspect == VK_IMAGE_ASPECT_COLOR_BIT);
-            bool use_depth_write = ((usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ==
-                                    VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
+            bool use_depth_write = graphics::ImageHasUsage(usage, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
                                    (aspect == VK_IMAGE_ASPECT_DEPTH_BIT);
-            bool use_stencil_write = ((usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ==
-                                      VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
+            bool use_stencil_write = graphics::ImageHasUsage(usage, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
                                      (aspect == VK_IMAGE_ASPECT_STENCIL_BIT) && have_shader_stencil_write_;
 
             if (!use_transfer && (use_color_write || use_depth_write || use_stencil_write) &&

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -188,9 +188,8 @@ VkResult VulkanResourceInitializer::InitializeImage(VkDeviceSize             dat
         {
             bool use_transfer = graphics::ImageHasUsage(usage, VK_IMAGE_USAGE_TRANSFER_DST_BIT) &&
                                 (sample_count == VK_SAMPLE_COUNT_1_BIT);
-            bool use_color_write =
-            graphics::ImageHasUsage(usage, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) &&
-                (aspect == VK_IMAGE_ASPECT_COLOR_BIT);
+            bool use_color_write = graphics::ImageHasUsage(usage, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) &&
+                                   (aspect == VK_IMAGE_ASPECT_COLOR_BIT);
             bool use_depth_write = graphics::ImageHasUsage(usage, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
                                    (aspect == VK_IMAGE_ASPECT_DEPTH_BIT);
             bool use_stencil_write = graphics::ImageHasUsage(usage, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&

--- a/framework/graphics/vulkan_util.cpp
+++ b/framework/graphics/vulkan_util.cpp
@@ -40,5 +40,9 @@ void ReleaseLoader(util::platform::LibraryHandle loader_handle)
     }
 }
 
+bool ImageHasUsage(VkImageUsageFlags usage_flags, VkImageUsageFlagBits bit) {
+    return (usage_flags & bit) == bit;
+}
+
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/vulkan_util.cpp
+++ b/framework/graphics/vulkan_util.cpp
@@ -40,7 +40,8 @@ void ReleaseLoader(util::platform::LibraryHandle loader_handle)
     }
 }
 
-bool ImageHasUsage(VkImageUsageFlags usage_flags, VkImageUsageFlagBits bit) {
+bool ImageHasUsage(VkImageUsageFlags usage_flags, VkImageUsageFlagBits bit)
+{
     return (usage_flags & bit) == bit;
 }
 

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -54,6 +54,8 @@ util::platform::LibraryHandle InitializeLoader();
 
 void ReleaseLoader(util::platform::LibraryHandle loader_handle);
 
+bool ImageHasUsage(VkImageUsageFlags usage_flags, VkImageUsageFlagBits bit);
+
 [[maybe_unused]] static const char* kVulkanVrFrameDelimiterString = "vr-marker,frame_end,type,application";
 
 GFXRECON_END_NAMESPACE(graphics)


### PR DESCRIPTION
Fixes #2097 

This is a simple PR to add a utility function for checking if an image has certain usage bits.