### PR TITLE
Fix generic handle ids in the json consumer

### DIFF
--- a/framework/generated/generated_vulkan_json_consumer.cpp
+++ b/framework/generated/generated_vulkan_json_consumer.cpp
@@ -6523,7 +6523,7 @@ void VulkanExportJsonConsumer::Process_vkDebugReportMessageEXT(
         HandleToJson(args["instance"], instance, json_options);
         FieldToJson(VkDebugReportFlagsEXT_t(), args["flags"], flags, json_options);
         FieldToJson(args["objectType"], objectType, json_options);
-        FieldToJson(args["object"], object, json_options);
+        HandleToJson(args["object"], object, json_options);
         FieldToJson(args["location"], location, json_options);
         FieldToJson(args["messageCode"], messageCode, json_options);
         FieldToJson(args["pLayerPrefix"], pLayerPrefix, json_options);

--- a/framework/generated/generated_vulkan_struct_to_json.cpp
+++ b/framework/generated/generated_vulkan_struct_to_json.cpp
@@ -10529,7 +10529,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugMarkerObjec
 
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["objectType"], decoded_value.objectType, options);
-        FieldToJson(jdata["object"], decoded_value.object, options);
+        HandleToJson(jdata["object"], meta_struct.object, options);
         FieldToJson(jdata["pObjectName"], &meta_struct.pObjectName, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
     }
@@ -10544,7 +10544,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugMarkerObjec
 
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["objectType"], decoded_value.objectType, options);
-        FieldToJson(jdata["object"], decoded_value.object, options);
+        HandleToJson(jdata["object"], meta_struct.object, options);
         FieldToJson(jdata["tagName"], decoded_value.tagName, options);
         FieldToJson(jdata["tagSize"], decoded_value.tagSize, options);
         FieldToJson(jdata["pTag"], meta_struct.pTag, options);

--- a/framework/generated/khronos_generators/khronos_json_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_json_consumer_body_generator.py
@@ -82,7 +82,7 @@ class KhronosExportJsonConsumerBodyGenerator():
         """Method may be overriden"""
         return False
 
-    def decode_as_handle(self, value):
+    def decode_as_handle(self, command, value):
         """Method may be overridden.
         Indicates that the given type should be decoded as a handle."""
         return self.is_handle_like(value.base_type)
@@ -138,7 +138,7 @@ class KhronosExportJsonConsumerBodyGenerator():
                     to_json = 'Bool32ToJson(args["{0}"], {0}, json_options)'
                 elif value.name == 'ppData' or self.decode_as_hex(value):
                     to_json = 'FieldToJsonAsHex(args["{0}"], {0}, json_options)'
-                elif self.decode_as_handle(value):
+                elif self.decode_as_handle(name, value):
                     to_json = 'HandleToJson(args["{0}"], {0}, json_options)'
                 elif self.is_flags(value.base_type):
                     if value.base_type in self.flags_type_aliases:

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_json_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_json_consumer_body_generator.py
@@ -89,11 +89,6 @@ class VulkanExportJsonConsumerBodyGenerator(VulkanBaseGenerator, KhronosExportJs
             'VkDeviceAddress',
         }
 
-        # Parameters using this name should be output as handles even though they are uint64_t
-        self.formatAsHandle = {
-            'objectHandle',
-        }
-
         self.queueSubmit = {
             "vkQueueSubmit",
             "vkQueueSubmit2",
@@ -129,14 +124,12 @@ class VulkanExportJsonConsumerBodyGenerator(VulkanBaseGenerator, KhronosExportJs
         """Method override"""
         return command in self.customImplementationRequired
 
-    def decode_as_handle(self, value):
+    def decode_as_handle(self, command, value):
         """Method override
         Indicates that the given type should be decoded as a handle."""
         return (
-            (
-                self.is_handle_like(value.base_type)
-                or value.name in self.formatAsHandle
-            )
+            self.is_handle_like(value.base_type)
+            or self.is_generic_cmd_handle_value(command, value.name)
         )
 
     def decode_as_hex(self, value):

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_to_json_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_to_json_body_generator.py
@@ -86,16 +86,6 @@ class VulkanStructToJsonBodyGenerator(VulkanBaseGenerator, KhronosStructToJsonBo
             'VkDeviceAddress',
         }
 
-        # Fields using this name should be output as handles even though they are uint64_t
-        self.formatAsHandle = {
-            'objectHandle',
-        }
-
-        # Struct types here do not have decoded fields.
-        self.notDecoded = {
-            'VkDeviceMemoryReportCallbackDataEXT',
-        }
-
     def should_decode_struct(self, struct):
         """Method indended to be overridden.
         Indicates that the provided struct is a struct we want to decode"""
@@ -105,10 +95,8 @@ class VulkanStructToJsonBodyGenerator(VulkanBaseGenerator, KhronosStructToJsonBo
         """Method indended to be overridden.
         Indicates that the given type should be decoded as a handle."""
         return (
-            (
-                self.is_handle(member.base_type)
-                or member.name in self.formatAsHandle
-            ) and not (parent_type in self.notDecoded)
+            self.is_handle(member.base_type)
+            or self.is_generic_struct_handle_value(parent_type, member.name)
         )
 
     # Method override


### PR DESCRIPTION
Instead of hard-coding handle names in the json generators, use the `is_generic_cmd_handle_value`/`is_generic_struct_handle_value` from the `KhronosBaseGenerator`. This fixes handle values from VK_EXT_debug_report and VK_EXT_debug_marker which were previously displayed incorrectly in the json output.