### PR TITLE
Reorder Member Variable Initializers

### DIFF
--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -65,8 +65,8 @@ Application::Application(const std::string&     name,
                          const std::string&     cli_wsi_extension,
                          decode::FileProcessor* file_processor) :
     name_(name),
-    file_processor_(file_processor), cli_wsi_extension_(cli_wsi_extension), running_(false), paused_(false),
-    pause_frame_(0), fps_info_(nullptr)
+    file_processor_(file_processor), running_(false), paused_(false), pause_frame_(0),
+    cli_wsi_extension_(cli_wsi_extension), fps_info_(nullptr)
 {
     if (!cli_wsi_extension_.empty())
     {

--- a/framework/application/metal_window.mm
+++ b/framework/application/metal_window.mm
@@ -102,7 +102,7 @@ static NSString* NSStringFromStdString(const std::string& std_string)
 }
 
 MetalWindow::MetalWindow(MetalContext* metal_context) :
-    metal_context_(metal_context), window_(nil), window_delegate_(nil), layer_(nil), width_(0), height_(0)
+    window_delegate_(nil), metal_context_(metal_context), window_(nil), layer_(nil), width_(0), height_(0)
 {}
 
 MetalWindow::~MetalWindow() = default;

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -61,7 +61,8 @@ struct QueueSubmitHelper
                       VkCommandBuffer                  command_buffer_,
                       VkQueue                          queue_,
                       VkFence                          fence_) :
-        device(device_), device_table(device_table_), command_buffer(command_buffer_), fence(fence_), queue(queue_)
+        device_table(device_table_),
+        device(device_), command_buffer(command_buffer_), fence(fence_), queue(queue_)
     {
         MarkInjectedCommandsHelper mark_injected_commands_helper;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -173,10 +173,10 @@ static uint32_t GetHardwareBufferFormatBpp(uint32_t format)
 
 VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::Application> application,
                                                    const VulkanReplayOptions&                options) :
-    loader_handle_(nullptr),
-    get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr), application_(application), options_(options),
-    loading_trim_state_(false), replaying_trimmed_capture_(false), have_imported_semaphores_(false), fps_info_(nullptr),
-    omitted_pipeline_cache_data_(false)
+    options_(options),
+    loader_handle_(nullptr), get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr),
+    application_(application), loading_trim_state_(false), replaying_trimmed_capture_(false), fps_info_(nullptr),
+    have_imported_semaphores_(false), omitted_pipeline_cache_data_(false)
 {
     object_info_table_ = CommonObjectInfoTable::GetSingleton();
     assert(object_info_table_);

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -50,8 +50,8 @@ VulkanReplayDumpResourcesBase::VulkanReplayDumpResourcesBase(const VulkanReplayO
                                                              CommonObjectInfoTable*     object_info_table) :
     QueueSubmit_indices_(options.QueueSubmit_Indices),
     recording_(false), dump_resources_before_(options.dump_resources_before), object_info_table_(object_info_table),
-    output_json_per_command(options.dump_resources_json_per_command), user_delegate_(nullptr),
-    active_delegate_(nullptr), default_delegate_(nullptr)
+    output_json_per_command(options.dump_resources_json_per_command), default_delegate_(nullptr),
+    user_delegate_(nullptr), active_delegate_(nullptr)
 {
     capture_filename = std::filesystem::path(options.capture_filename).stem().string();
 

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -55,11 +55,11 @@ DispatchTraceRaysDumpingContext::DispatchTraceRaysDumpingContext(const std::vect
                                                                  VulkanDumpResourcesDelegate& delegate) :
     original_command_buffer_info(nullptr),
     DR_command_buffer(VK_NULL_HANDLE), dispatch_indices(dispatch_indices), trace_rays_indices(trace_rays_indices),
-    dump_resources_before(options.dump_resources_before), device_table(nullptr), parent_device(VK_NULL_HANDLE),
-    instance_table(nullptr), object_info_table(object_info_table), replay_device_phys_mem_props(nullptr),
-    current_dispatch_index(0), current_trace_rays_index(0), delegate_(delegate),
-    dump_immutable_resources(options.dump_resources_dump_immutable_resources), reached_end_command_buffer(false),
-    bound_pipeline_compute(nullptr), bound_pipeline_trace_rays(nullptr)
+    dump_resources_before(options.dump_resources_before), delegate_(delegate),
+    dump_immutable_resources(options.dump_resources_dump_immutable_resources), bound_pipeline_compute(nullptr),
+    bound_pipeline_trace_rays(nullptr), device_table(nullptr), parent_device(VK_NULL_HANDLE), instance_table(nullptr),
+    object_info_table(object_info_table), replay_device_phys_mem_props(nullptr), current_dispatch_index(0),
+    current_trace_rays_index(0), reached_end_command_buffer(false)
 {}
 
 DispatchTraceRaysDumpingContext::~DispatchTraceRaysDumpingContext()

--- a/framework/decode/vulkan_replay_dump_resources_delegate.h
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.h
@@ -123,7 +123,7 @@ class DefaultVulkanDumpResourcesDelegate : public VulkanDumpResourcesDelegate
                                        CommonObjectInfoTable&     object_info_table,
                                        const std::string          capture_filename) :
         VulkanDumpResourcesDelegate(options, capture_filename),
-        options_(options), object_info_table_(object_info_table), dump_json_(options),
+        dump_json_(options), options_(options), object_info_table_(object_info_table),
         capture_filename_(capture_filename)
     {}
     virtual ~DefaultVulkanDumpResourcesDelegate() {}

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -63,12 +63,13 @@ DrawCallsDumpingContext::DrawCallsDumpingContext(const std::vector<uint64_t>&   
     original_command_buffer_info(nullptr),
     current_cb_index(0), dc_indices(dc_indices), RP_indices(rp_indices), active_renderpass(nullptr),
     active_framebuffer(nullptr), bound_gr_pipeline{ nullptr }, current_renderpass(0), current_subpass(0),
-    dump_resources_before(options.dump_resources_before), aux_command_buffer(VK_NULL_HANDLE), aux_fence(VK_NULL_HANDLE),
-    device_table(nullptr), instance_table(nullptr), object_info_table(object_info_table),
-    replay_device_phys_mem_props(nullptr), delegate_(delegate), dump_depth(options.dump_resources_dump_depth),
+    dump_resources_before(options.dump_resources_before), delegate_(delegate),
+    dump_depth(options.dump_resources_dump_depth),
     color_attachment_to_dump(options.dump_resources_color_attachment_index),
     dump_vertex_index_buffers(options.dump_resources_dump_vertex_index_buffer),
-    dump_immutable_resources(options.dump_resources_dump_immutable_resources), current_render_pass_type(kNone)
+    dump_immutable_resources(options.dump_resources_dump_immutable_resources), current_render_pass_type(kNone),
+    aux_command_buffer(VK_NULL_HANDLE), aux_fence(VK_NULL_HANDLE), device_table(nullptr), instance_table(nullptr),
+    object_info_table(object_info_table), replay_device_phys_mem_props(nullptr)
 {
     must_backup_resources = (dc_indices.size() > 1);
 

--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -41,8 +41,8 @@ const std::vector<std::string> kLoaderLibNames = {
 
 VulkanResourceTrackingConsumer::VulkanResourceTrackingConsumer(
     const VulkanReplayOptions& options, VulkanTrackedObjectInfoTable* tracked_object_info_table) :
-    options_(options),
-    loader_handle_(nullptr), get_instance_proc_addr_(nullptr), create_instance_function_(nullptr),
+    loader_handle_(nullptr),
+    create_instance_function_(nullptr), get_instance_proc_addr_(nullptr), options_(options),
     tracked_object_info_table_(tracked_object_info_table)
 {
     assert(tracked_object_info_table != nullptr);


### PR DESCRIPTION
This prevents errors with CLANG in strict
environments e.g. "warnings as errors"