### PR TITLE
Revert "Batch queue-submissions in ProcessBufferMemory / ProcessImageMemory"

### DIFF
--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -333,24 +333,21 @@ void VulkanAddressReplacer::ProcessCmdPushConstants(const VulkanCommandBufferInf
     {
         auto* pipeline_info = object_table_->GetVkPipelineInfo(pipeline_id);
         GFXRECON_ASSERT(pipeline_info != nullptr);
-        if (pipeline_info != nullptr)
+        for (const auto& buffer_ref_info : pipeline_info->buffer_reference_infos)
         {
-            for (const auto& buffer_ref_info : pipeline_info->buffer_reference_infos)
+            if (buffer_ref_info.source == util::SpirVParsingUtil::BufferReferenceLocation::PUSH_CONSTANT_BLOCK)
             {
-                if (buffer_ref_info.source == util::SpirVParsingUtil::BufferReferenceLocation::PUSH_CONSTANT_BLOCK)
-                {
-                    // find addresses in push-constant memory and replace in-place.
-                    auto* address = reinterpret_cast<VkDeviceAddress*>(static_cast<uint8_t*>(data) + offset +
-                                                                       buffer_ref_info.buffer_offset);
+                // find addresses in push-constant memory and replace in-place.
+                auto* address = reinterpret_cast<VkDeviceAddress*>(static_cast<uint8_t*>(data) + offset +
+                                                                   buffer_ref_info.buffer_offset);
 
-                    auto* buffer_info = address_tracker.GetBufferByCaptureDeviceAddress(*address);
-                    if (buffer_info != nullptr && buffer_info->replay_address != 0)
-                    {
-                        GFXRECON_LOG_INFO_ONCE("VulkanAddressReplacer::ProcessCmdPushConstants(): Replay is adjusting "
-                                               "mismatching buffer-device-addresses in push-constants");
-                        uint32_t address_offset = *address - buffer_info->capture_address;
-                        *address                = buffer_info->replay_address + address_offset;
-                    }
+                auto* buffer_info = address_tracker.GetBufferByCaptureDeviceAddress(*address);
+                if (buffer_info != nullptr && buffer_info->replay_address != 0)
+                {
+                    GFXRECON_LOG_INFO_ONCE("VulkanAddressReplacer::ProcessCmdPushConstants(): Replay is adjusting "
+                                           "mismatching buffer-device-addresses in push-constants");
+                    uint32_t address_offset = *address - buffer_info->capture_address;
+                    *address                = buffer_info->replay_address + address_offset;
                 }
             }
         }
@@ -1369,9 +1366,6 @@ bool VulkanAddressReplacer::init_queue_assets()
         GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal command-buffer creation failed");
         return false;
     }
-
-    // Because this command buffer was not allocated through the loader, it must be assigned a dispatch table.
-    *reinterpret_cast<void**>(command_buffer_) = *reinterpret_cast<void**>(device_);
 
     VkFenceCreateInfo fence_create_info;
     fence_create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -477,55 +477,41 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
         std::vector<uint8_t>  data;
         std::vector<uint64_t> subresource_offsets;
         std::vector<uint64_t> subresource_sizes;
+        bool                  scaled;
 
-        graphics::VulkanResourcesUtil::ImageResource image_resource = {};
-        image_resource.image                                        = image_info->handle;
-        image_resource.format                                       = image_info->format;
-        image_resource.type                                         = image_info->type;
-        image_resource.extent                                       = image_info->extent;
-        image_resource.level_count                                  = image_info->level_count;
-        image_resource.layer_count                                  = image_info->layer_count;
-        image_resource.tiling                                       = image_info->tiling;
-        image_resource.sample_count                                 = image_info->sample_count;
-        image_resource.layout = (layout == VK_IMAGE_LAYOUT_MAX_ENUM) ? image_info->intermediate_layout : layout;
-        image_resource.queue_family_index   = image_info->queue_family_index;
-        image_resource.external_format      = image_info->external_format;
-        image_resource.size                 = image_info->size;
-        image_resource.level_sizes          = &subresource_sizes;
-        image_resource.aspect               = aspect;
-        image_resource.scale                = scale;
-        image_resource.dst_format           = dst_format;
-        image_resource.all_layers_per_level = false;
+        VkResult res = resource_util.ReadFromImageResourceStaging(
+            image_info->handle,
+            image_info->format,
+            image_info->type,
+            image_info->extent,
+            image_info->level_count,
+            image_info->layer_count,
+            image_info->tiling,
+            image_info->sample_count,
+            (layout == VK_IMAGE_LAYOUT_MAX_ENUM) ? image_info->intermediate_layout : layout,
+            image_info->queue_family_index,
+            image_info->external_format,
+            image_info->size,
+            aspect,
+            data,
+            subresource_offsets,
+            subresource_sizes,
+            scaled,
+            false,
+            scale,
+            dst_format);
 
-        image_resource.resource_size = resource_util.GetImageResourceSizesOptimal(image_resource.image,
-                                                                                  image_resource.format,
-                                                                                  image_resource.type,
-                                                                                  image_resource.extent,
-                                                                                  image_resource.level_count,
-                                                                                  image_resource.layer_count,
-                                                                                  image_resource.tiling,
-                                                                                  aspect,
-                                                                                  &subresource_offsets,
-                                                                                  &subresource_sizes,
-                                                                                  image_resource.all_layers_per_level);
-        VkResult result              = resource_util.ReadImageResource(image_resource, data);
+        assert(!subresource_offsets.empty());
+        assert(!subresource_sizes.empty());
 
-        GFXRECON_ASSERT(!subresource_offsets.empty());
-        GFXRECON_ASSERT(!subresource_sizes.empty());
+        scaling_supported[i] = scaled;
 
-        scaling_supported[i] = resource_util.IsScalingSupported(image_resource.format,
-                                                                image_resource.tiling,
-                                                                dst_format,
-                                                                image_resource.type,
-                                                                image_resource.extent,
-                                                                scale);
-
-        if (result != VK_SUCCESS)
+        if (res != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR("Reading from image resource %" PRIu64 " failed (%s)",
                                image_info->capture_id,
-                               util::ToString<VkResult>(result).c_str())
-            return result;
+                               util::ToString<VkResult>(res).c_str())
+            return res;
         }
 
         const DumpedImageFormat output_image_format = GetDumpedImageFormat(device_info,
@@ -542,7 +528,7 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
         {
             for (uint32_t layer = 0; layer < image_info->layer_count; ++layer)
             {
-                const std::string& filename = filenames[f++];
+                std::string filename = filenames[f++];
 
                 // We don't support stencil output yet
                 if (aspects[i] == VK_IMAGE_ASPECT_STENCIL_BIT)
@@ -559,7 +545,7 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
                     assert(image_writer_format != util::imagewriter::DataFormats::kFormat_UNSPECIFIED);
 
                     VkExtent3D scaled_extent;
-                    if (scale != 1.0f && scaling_supported[i])
+                    if (scale != 1.0f && scaled)
                     {
                         scaled_extent.width  = std::max(image_info->extent.width * scale, 1.0f);
                         scaled_extent.height = std::max(image_info->extent.height * scale, 1.0f);
@@ -648,6 +634,7 @@ VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
     }
 
     assert(f == total_files);
+
     return VK_SUCCESS;
 }
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1924,64 +1924,61 @@ void VulkanCaptureManager::ProcessImportFdForImage(VkDevice device, VkImage imag
     std::vector<VkImageAspectFlagBits> aspects;
     graphics::GetFormatAspects(image_wrapper->format, &aspects);
 
-    using ImageResource = graphics::VulkanResourcesUtil::ImageResource;
-    std::vector<ImageResource> image_resources;
+    for (auto aspect : aspects)
+    {
+        std::vector<uint8_t>  data;
+        std::vector<uint64_t> subresource_offsets;
+        std::vector<uint64_t> subresource_sizes;
+        bool                  scaling_supported;
 
-    auto write_init_image_cmd =
-        [this, &resource_util, device_wrapper](const ImageResource& img, const void* data, size_t num_bytes) {
+        VkResult result = resource_util.ReadFromImageResourceStaging(image,
+                                                                     image_wrapper->format,
+                                                                     image_wrapper->image_type,
+                                                                     image_wrapper->extent,
+                                                                     image_wrapper->mip_levels,
+                                                                     image_wrapper->array_layers,
+                                                                     image_wrapper->tiling,
+                                                                     image_wrapper->samples,
+                                                                     image_wrapper->current_layout,
+                                                                     image_wrapper->queue_family_index,
+                                                                     image_wrapper->external_format,
+                                                                     image_wrapper->size,
+                                                                     aspect,
+                                                                     data,
+                                                                     subresource_offsets,
+                                                                     subresource_sizes,
+                                                                     scaling_supported,
+                                                                     true);
+        if (result == VK_SUCCESS)
+        {
             // Combined size of all layers in a mip level.
             std::vector<uint64_t> level_sizes;
 
-            uint64_t resource_size = resource_util.GetImageResourceSizesOptimal(img.image,
-                                                                                img.format,
-                                                                                img.type,
-                                                                                img.extent,
-                                                                                img.level_count,
-                                                                                img.layer_count,
-                                                                                img.tiling,
-                                                                                img.aspect,
+            uint64_t resource_size = resource_util.GetImageResourceSizesOptimal(image_wrapper->handle,
+                                                                                image_wrapper->format,
+                                                                                image_wrapper->image_type,
+                                                                                image_wrapper->extent,
+                                                                                image_wrapper->mip_levels,
+                                                                                image_wrapper->array_layers,
+                                                                                image_wrapper->tiling,
+                                                                                aspect,
                                                                                 nullptr,
                                                                                 &level_sizes,
                                                                                 true);
-            GFXRECON_ASSERT(resource_size == num_bytes);
 
             WriteBeginResourceInitCmd(device_wrapper->handle_id, resource_size);
             GetCommandWriter()->WriteInitImageCmd(api_family_,
                                                   device_wrapper->handle_id,
-                                                  img.handle_id,
-                                                  img.aspect,
-                                                  img.layout,
-                                                  img.level_count,
+                                                  image_wrapper->handle_id,
+                                                  aspect,
+                                                  image_wrapper->current_layout,
+                                                  image_wrapper->mip_levels,
                                                   level_sizes,
                                                   resource_size,
-                                                  data);
+                                                  data.data());
             WriteEndResourceInitCmd(device_wrapper->handle_id);
-        };
-
-    for (auto aspect : aspects)
-    {
-        auto& image_resource                = image_resources.emplace_back();
-        image_resource.handle_id            = image_wrapper->handle_id;
-        image_resource.image                = image_wrapper->handle;
-        image_resource.format               = image_wrapper->format;
-        image_resource.type                 = image_wrapper->image_type;
-        image_resource.extent               = image_wrapper->extent;
-        image_resource.level_count          = image_wrapper->mip_levels;
-        image_resource.layer_count          = image_wrapper->array_layers;
-        image_resource.tiling               = image_wrapper->tiling;
-        image_resource.sample_count         = image_wrapper->samples;
-        image_resource.layout               = image_wrapper->current_layout;
-        image_resource.queue_family_index   = image_wrapper->queue_family_index;
-        image_resource.external_format      = image_wrapper->external_format;
-        image_resource.size                 = image_wrapper->size;
-        image_resource.aspect               = aspect;
-        image_resource.external_format      = image_wrapper->external_format;
-        image_resource.all_layers_per_level = true;
+        }
     }
-
-    // batch process image-downloads requiring staging, use 32MB staging-mem
-    constexpr uint32_t staging_buffer_size = 32U << 20U;
-    resource_util.ReadImageResources(image_resources, write_init_image_cmd, staging_buffer_size);
 }
 
 void VulkanCaptureManager::PostProcess_vkBindBufferMemory(

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2018,87 +2018,37 @@ bool VulkanStateWriter::OutputStreamWrite(const void* data, size_t len)
 }
 
 void VulkanStateWriter::ProcessBufferMemory(const vulkan_wrappers::DeviceWrapper*  device_wrapper,
-                                            const std::vector<BufferSnapshotInfo>& buffer_snapshot_infos,
+                                            const std::vector<BufferSnapshotInfo>& buffer_snapshot_info,
                                             graphics::VulkanResourcesUtil&         resource_util)
 {
-    GFXRECON_ASSERT(device_wrapper != nullptr);
-    using BufferResource = graphics::VulkanResourcesUtil::BufferResource;
+    assert(device_wrapper != nullptr);
 
     const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
 
-    std::vector<BufferResource> buffer_resources;
-    buffer_resources.reserve(buffer_snapshot_infos.size());
-
-    auto write_init_buffer_cmd = [this, device_wrapper](const BufferResource& buf, const void* data) {
-        if (data != nullptr)
-        {
-
-            GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, buf.size);
-            auto*                           bytes     = reinterpret_cast<const uint8_t*>(data);
-            auto                            data_size = static_cast<size_t>(buf.size);
-            format::InitBufferCommandHeader upload_cmd{};
-
-            upload_cmd.meta_header.block_header.type = format::kMetaDataBlock;
-            upload_cmd.meta_header.meta_data_id =
-                format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kInitBufferCommand);
-            upload_cmd.thread_id = thread_data_->thread_id_;
-            upload_cmd.device_id = device_wrapper->handle_id;
-            upload_cmd.buffer_id = buf.handle_id;
-            upload_cmd.data_size = data_size;
-
-            if (compressor_ != nullptr)
-            {
-
-                size_t compressed_size = compressor_->Compress(data_size, bytes, &compressed_parameter_buffer_, 0);
-
-                if ((compressed_size > 0) && (compressed_size < data_size))
-                {
-                    upload_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
-
-                    bytes     = compressed_parameter_buffer_.data();
-                    data_size = compressed_size;
-                }
-            }
-
-            // Calculate size of packet with compressed or uncompressed data size.
-            upload_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(upload_cmd) + data_size;
-
-            output_stream_->Write(&upload_cmd, sizeof(upload_cmd));
-            output_stream_->Write(bytes, data_size);
-            ++blocks_written_;
-        }
-        else
-        {
-            GFXRECON_LOG_ERROR("Trimming state snapshot failed to retrieve memory content for buffer %" PRIu64,
-                               buf.handle_id);
-        }
-    };
-
-    size_t num_staging_bytes = 0;
-
-    for (const auto& snapshot_entry : buffer_snapshot_infos)
+    for (const auto& snapshot_entry : buffer_snapshot_info)
     {
         const vulkan_wrappers::BufferWrapper*       buffer_wrapper = snapshot_entry.buffer_wrapper;
         const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper = snapshot_entry.memory_wrapper;
-        GFXRECON_ASSERT((buffer_wrapper != nullptr) && (memory_wrapper != nullptr));
+        const uint8_t*                              bytes          = nullptr;
+        std::vector<uint8_t>                        data;
 
-        BufferResource buffer_resource;
-        buffer_resource.handle_id          = buffer_wrapper->handle_id;
-        buffer_resource.buffer             = buffer_wrapper->handle;
-        buffer_resource.size               = buffer_wrapper->size;
-        buffer_resource.offset             = 0;
-        buffer_resource.queue_family_index = buffer_wrapper->queue_family_index;
+        assert((buffer_wrapper != nullptr) && (memory_wrapper != nullptr));
 
         if (snapshot_entry.need_staging_copy)
         {
-            buffer_resources.push_back(buffer_resource);
-            num_staging_bytes += buffer_resource.size;
+            VkResult result = resource_util.ReadFromBufferResource(
+                buffer_wrapper->handle, buffer_wrapper->size, 0, buffer_wrapper->queue_family_index, data);
+
+            if (result == VK_SUCCESS)
+            {
+                bytes = data.data();
+            }
         }
         else
         {
-            GFXRECON_ASSERT((memory_wrapper->mapped_data == nullptr) || (memory_wrapper->mapped_offset == 0));
-            const uint8_t* bytes  = nullptr;
-            VkResult       result = VK_SUCCESS;
+            assert((memory_wrapper->mapped_data == nullptr) || (memory_wrapper->mapped_offset == 0));
+
+            VkResult result = VK_SUCCESS;
 
             if (memory_wrapper->mapped_data == nullptr)
             {
@@ -2125,106 +2075,94 @@ void VulkanStateWriter::ProcessBufferMemory(const vulkan_wrappers::DeviceWrapper
                 InvalidateMappedMemoryRange(
                     device_wrapper, memory_wrapper->handle, buffer_wrapper->bind_offset, buffer_wrapper->size);
             }
+        }
 
-            write_init_buffer_cmd(buffer_resource, bytes);
+        if (bytes != nullptr)
+        {
+            GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, buffer_wrapper->size);
 
-            if (memory_wrapper->mapped_data == nullptr)
+            size_t                          data_size = static_cast<size_t>(buffer_wrapper->size);
+            format::InitBufferCommandHeader upload_cmd;
+
+            upload_cmd.meta_header.block_header.type = format::kMetaDataBlock;
+            upload_cmd.meta_header.meta_data_id =
+                format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kInitBufferCommand);
+            upload_cmd.thread_id = thread_data_->thread_id_;
+            upload_cmd.device_id = device_wrapper->handle_id;
+            upload_cmd.buffer_id = buffer_wrapper->handle_id;
+            upload_cmd.data_size = data_size;
+
+            if (compressor_ != nullptr)
+            {
+                size_t compressed_size = compressor_->Compress(data_size, bytes, &compressed_parameter_buffer_, 0);
+
+                if ((compressed_size > 0) && (compressed_size < data_size))
+                {
+                    upload_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
+
+                    bytes     = compressed_parameter_buffer_.data();
+                    data_size = compressed_size;
+                }
+            }
+
+            // Calculate size of packet with compressed or uncompressed data size.
+            upload_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(upload_cmd) + data_size;
+
+            output_stream_->Write(&upload_cmd, sizeof(upload_cmd));
+            output_stream_->Write(bytes, data_size);
+            ++blocks_written_;
+
+            if (!snapshot_entry.need_staging_copy && memory_wrapper->mapped_data == nullptr)
             {
                 device_table->UnmapMemory(device_wrapper->handle, memory_wrapper->handle);
             }
         }
+        else
+        {
+            GFXRECON_LOG_ERROR("Trimming state snapshot failed to retrieve memory content for buffer %" PRIu64,
+                               buffer_wrapper->handle_id);
+        }
     }
-
-    // batch process buffer-downloads requiring staging, use <128MB staging-mem
-    size_t staging_buffer_size = std::min<size_t>(128U << 20U, num_staging_bytes);
-    resource_util.ReadBufferResources(buffer_resources, write_init_buffer_cmd, staging_buffer_size);
 }
 
 void VulkanStateWriter::ProcessBufferMemoryWithAssetFile(const vulkan_wrappers::DeviceWrapper*  device_wrapper,
-                                                         const std::vector<BufferSnapshotInfo>& buffer_snapshot_infos,
+                                                         const std::vector<BufferSnapshotInfo>& buffer_snapshot_info,
                                                          graphics::VulkanResourcesUtil&         resource_util)
 {
-    GFXRECON_ASSERT(device_wrapper != nullptr);
-    GFXRECON_ASSERT(asset_file_stream_ != nullptr);
+    assert(device_wrapper != nullptr);
+    assert(asset_file_stream_ != nullptr);
 
     const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
 
-    using BufferResource = graphics::VulkanResourcesUtil::BufferResource;
-    std::vector<BufferResource> buffer_resources;
-    buffer_resources.reserve(buffer_snapshot_infos.size());
-
-    auto write_init_buffer_cmd = [this, device_wrapper](const BufferResource& buffer_resource, const void* data) {
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, buffer_resource.size);
-
-        size_t                          data_size = static_cast<size_t>(buffer_resource.size);
-        format::InitBufferCommandHeader upload_cmd;
-        auto*                           bytes = reinterpret_cast<const uint8_t*>(data);
-
-        upload_cmd.meta_header.block_header.type = format::kMetaDataBlock;
-        upload_cmd.meta_header.meta_data_id =
-            format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kInitBufferCommand);
-        upload_cmd.thread_id = thread_data_->thread_id_;
-        upload_cmd.device_id = device_wrapper->handle_id;
-        upload_cmd.buffer_id = buffer_resource.handle_id;
-        upload_cmd.data_size = data_size;
-
-        if (compressor_ != nullptr)
-        {
-            size_t compressed_size = compressor_->Compress(data_size, bytes, &compressed_parameter_buffer_, 0);
-
-            if ((compressed_size > 0) && (compressed_size < data_size))
-            {
-                upload_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
-
-                bytes     = compressed_parameter_buffer_.data();
-                data_size = compressed_size;
-            }
-        }
-
-        // Calculate size of packet with compressed or uncompressed data size.
-        upload_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(upload_cmd) + data_size;
-
-        const int64_t offset = asset_file_stream_->GetOffset();
-        asset_file_stream_->Write(&upload_cmd, sizeof(upload_cmd));
-        asset_file_stream_->Write(bytes, data_size);
-        (*asset_file_offsets_)[buffer_resource.handle_id] = offset;
-
-        if (output_stream_ != nullptr)
-        {
-            WriteExecuteFromFile(asset_file_name_, 1, offset);
-        }
-    };
-
-    size_t num_staging_bytes = 0;
-
-    for (const auto& snapshot_entry : buffer_snapshot_infos)
+    for (const auto& snapshot_entry : buffer_snapshot_info)
     {
         vulkan_wrappers::BufferWrapper*             buffer_wrapper = snapshot_entry.buffer_wrapper;
         const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper = snapshot_entry.memory_wrapper;
-        GFXRECON_ASSERT(buffer_wrapper != nullptr);
+        const uint8_t*                              bytes          = nullptr;
+        std::vector<uint8_t>                        data;
+
+        assert((buffer_wrapper != nullptr));
 
         if (buffer_wrapper->dirty)
         {
-            GFXRECON_ASSERT(memory_wrapper != nullptr);
+            assert(memory_wrapper != nullptr);
             buffer_wrapper->dirty = false;
-
-            BufferResource buffer_resource;
-            buffer_resource.handle_id          = buffer_wrapper->handle_id;
-            buffer_resource.buffer             = buffer_wrapper->handle;
-            buffer_resource.size               = buffer_wrapper->size;
-            buffer_resource.offset             = 0;
-            buffer_resource.queue_family_index = buffer_wrapper->queue_family_index;
 
             if (snapshot_entry.need_staging_copy)
             {
-                buffer_resources.push_back(buffer_resource);
-                num_staging_bytes += buffer_resource.size;
+                VkResult result = resource_util.ReadFromBufferResource(
+                    buffer_wrapper->handle, buffer_wrapper->size, 0, buffer_wrapper->queue_family_index, data);
+
+                if (result == VK_SUCCESS)
+                {
+                    bytes = data.data();
+                }
             }
             else
             {
-                GFXRECON_ASSERT((memory_wrapper->mapped_data == nullptr) || (memory_wrapper->mapped_offset == 0));
-                VkResult       result = VK_SUCCESS;
-                const uint8_t* bytes  = nullptr;
+                assert((memory_wrapper->mapped_data == nullptr) || (memory_wrapper->mapped_offset == 0));
+
+                VkResult result = VK_SUCCESS;
 
                 if (memory_wrapper->mapped_data == nullptr)
                 {
@@ -2251,22 +2189,60 @@ void VulkanStateWriter::ProcessBufferMemoryWithAssetFile(const vulkan_wrappers::
                     InvalidateMappedMemoryRange(
                         device_wrapper, memory_wrapper->handle, buffer_wrapper->bind_offset, buffer_wrapper->size);
                 }
+            }
 
-                GFXRECON_ASSERT(bytes);
-                if (bytes != nullptr)
+            assert(bytes);
+
+            if (bytes != nullptr)
+            {
+                GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, buffer_wrapper->size);
+
+                size_t                          data_size = static_cast<size_t>(buffer_wrapper->size);
+                format::InitBufferCommandHeader upload_cmd;
+
+                upload_cmd.meta_header.block_header.type = format::kMetaDataBlock;
+                upload_cmd.meta_header.meta_data_id      = format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_Vulkan,
+                                                                             format::MetaDataType::kInitBufferCommand);
+                upload_cmd.thread_id                     = thread_data_->thread_id_;
+                upload_cmd.device_id                     = device_wrapper->handle_id;
+                upload_cmd.buffer_id                     = buffer_wrapper->handle_id;
+                upload_cmd.data_size                     = data_size;
+
+                if (compressor_ != nullptr)
                 {
-                    write_init_buffer_cmd(buffer_resource, bytes);
+                    size_t compressed_size = compressor_->Compress(data_size, bytes, &compressed_parameter_buffer_, 0);
+
+                    if ((compressed_size > 0) && (compressed_size < data_size))
+                    {
+                        upload_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
+
+                        bytes     = compressed_parameter_buffer_.data();
+                        data_size = compressed_size;
+                    }
                 }
-                else
+
+                // Calculate size of packet with compressed or uncompressed data size.
+                upload_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(upload_cmd) + data_size;
+
+                const int64_t offset = asset_file_stream_->GetOffset();
+                asset_file_stream_->Write(&upload_cmd, sizeof(upload_cmd));
+                asset_file_stream_->Write(bytes, data_size);
+                (*asset_file_offsets_)[buffer_wrapper->handle_id] = offset;
+
+                if (output_stream_ != nullptr)
                 {
-                    GFXRECON_LOG_ERROR("Trimming state snapshot failed to retrieve memory content for buffer %" PRIu64,
-                                       buffer_wrapper->handle_id);
+                    WriteExecuteFromFile(asset_file_name_, 1, offset);
                 }
 
                 if (!snapshot_entry.need_staging_copy && memory_wrapper->mapped_data == nullptr)
                 {
                     device_table->UnmapMemory(device_wrapper->handle, memory_wrapper->handle);
                 }
+            }
+            else
+            {
+                GFXRECON_LOG_ERROR("Trimming state snapshot failed to retrieve memory content for buffer %" PRIu64,
+                                   buffer_wrapper->handle_id);
             }
         }
         else
@@ -2279,70 +2255,25 @@ void VulkanStateWriter::ProcessBufferMemoryWithAssetFile(const vulkan_wrappers::
             }
         }
     }
-
-    // batch process buffer-downloads requiring staging, use <128MB staging-mem
-    size_t staging_buffer_size = std::min<size_t>(128U << 20U, num_staging_bytes);
-    resource_util.ReadBufferResources(buffer_resources, write_init_buffer_cmd, staging_buffer_size);
 }
 
 void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper* device_wrapper,
-                                           const std::vector<ImageSnapshotInfo>& image_snapshot_infos,
+                                           const std::vector<ImageSnapshotInfo>& image_snapshot_info,
                                            graphics::VulkanResourcesUtil&        resource_util)
 {
-    using ImageResource = graphics::VulkanResourcesUtil::ImageResource;
-    GFXRECON_ASSERT(device_wrapper != nullptr);
+    assert(device_wrapper != nullptr);
 
     const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
 
-    std::vector<ImageResource> image_resources;
-    image_resources.reserve(image_snapshot_infos.size());
-
-    auto write_init_image_cmd = [this, device_wrapper](const ImageResource& img, const void* data, size_t num_bytes) {
-        command_writer_.WriteInitImageCmd(format::ApiFamilyId::ApiFamily_Vulkan,
-                                          device_wrapper->handle_id,
-                                          img.handle_id,
-                                          img.aspect,
-                                          img.layout,
-                                          img.level_count,
-                                          *img.level_sizes,
-                                          num_bytes,
-                                          data);
-        ++blocks_written_;
-    };
-
-    size_t num_staging_bytes = 0;
-
-    for (const auto& snapshot_entry : image_snapshot_infos)
+    for (const auto& snapshot_entry : image_snapshot_info)
     {
         const vulkan_wrappers::ImageWrapper*        image_wrapper  = snapshot_entry.image_wrapper;
         const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper = snapshot_entry.memory_wrapper;
         const uint8_t*                              bytes          = nullptr;
         std::vector<uint8_t>                        data;
 
-        GFXRECON_ASSERT((image_wrapper != nullptr) &&
-                        ((image_wrapper->is_swapchain_image && memory_wrapper == nullptr) ||
-                         (!image_wrapper->is_swapchain_image && memory_wrapper != nullptr)));
-
-        GFXRECON_ASSERT(snapshot_entry.resource_size > 0);
-
-        ImageResource image_resource        = {};
-        image_resource.handle_id            = image_wrapper->handle_id;
-        image_resource.image                = image_wrapper->handle;
-        image_resource.format               = image_wrapper->format;
-        image_resource.type                 = image_wrapper->image_type;
-        image_resource.extent               = image_wrapper->extent;
-        image_resource.level_count          = image_wrapper->mip_levels;
-        image_resource.layer_count          = image_wrapper->array_layers;
-        image_resource.tiling               = image_wrapper->tiling;
-        image_resource.sample_count         = image_wrapper->samples;
-        image_resource.layout               = image_wrapper->current_layout;
-        image_resource.queue_family_index   = image_wrapper->queue_family_index;
-        image_resource.external_format      = image_wrapper->external_format;
-        image_resource.size                 = image_wrapper->size;
-        image_resource.resource_size        = snapshot_entry.resource_size;
-        image_resource.level_sizes          = &snapshot_entry.level_sizes;
-        image_resource.aspect               = snapshot_entry.aspect;
-        image_resource.all_layers_per_level = true;
+        assert((image_wrapper != nullptr) && ((image_wrapper->is_swapchain_image && memory_wrapper == nullptr) ||
+                                              (!image_wrapper->is_swapchain_image && memory_wrapper != nullptr)));
 
         if (image_wrapper->external_memory_android)
         {
@@ -2352,8 +2283,33 @@ void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper*
 
         if (snapshot_entry.need_staging_copy)
         {
-            image_resources.emplace_back(image_resource);
-            num_staging_bytes += image_resource.resource_size;
+            std::vector<uint64_t> subresource_offsets;
+            std::vector<uint64_t> subresource_sizes;
+            bool                  scaling_supported;
+
+            VkResult result = resource_util.ReadFromImageResourceStaging(image_wrapper->handle,
+                                                                         image_wrapper->format,
+                                                                         image_wrapper->image_type,
+                                                                         image_wrapper->extent,
+                                                                         image_wrapper->mip_levels,
+                                                                         image_wrapper->array_layers,
+                                                                         image_wrapper->tiling,
+                                                                         image_wrapper->samples,
+                                                                         image_wrapper->current_layout,
+                                                                         image_wrapper->queue_family_index,
+                                                                         image_wrapper->external_format,
+                                                                         image_wrapper->size,
+                                                                         snapshot_entry.aspect,
+                                                                         data,
+                                                                         subresource_offsets,
+                                                                         subresource_sizes,
+                                                                         scaling_supported,
+                                                                         true);
+
+            if (result == VK_SUCCESS)
+            {
+                bytes = data.data();
+            }
         }
         else if (!image_wrapper->is_swapchain_image)
         {
@@ -2387,111 +2343,47 @@ void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper*
                 InvalidateMappedMemoryRange(
                     device_wrapper, memory_wrapper->handle, image_wrapper->bind_offset, snapshot_entry.resource_size);
             }
+        }
 
-            write_init_image_cmd(image_resource, bytes, snapshot_entry.resource_size);
+        if (!image_wrapper->is_swapchain_image)
+        {
+            command_writer_.WriteInitImageCmd(format::ApiFamilyId::ApiFamily_Vulkan,
+                                              device_wrapper->handle_id,
+                                              image_wrapper->handle_id,
+                                              snapshot_entry.aspect,
+                                              image_wrapper->current_layout,
+                                              image_wrapper->mip_levels,
+                                              snapshot_entry.level_sizes,
+                                              snapshot_entry.resource_size,
+                                              bytes);
 
-            if (memory_wrapper->mapped_data == nullptr)
+            if (!snapshot_entry.need_staging_copy && memory_wrapper->mapped_data == nullptr)
             {
                 device_table->UnmapMemory(device_wrapper->handle, memory_wrapper->handle);
             }
+
+            ++blocks_written_;
         }
     }
-
-    // batch process buffer-downloads requiring staging, use <128MB staging-mem
-    size_t staging_buffer_size = std::min<size_t>(128U << 20U, num_staging_bytes);
-    resource_util.ReadImageResources(image_resources, write_init_image_cmd, staging_buffer_size);
 }
 
 void VulkanStateWriter::ProcessImageMemoryWithAssetFile(const vulkan_wrappers::DeviceWrapper* device_wrapper,
-                                                        const std::vector<ImageSnapshotInfo>& image_snapshot_infos,
+                                                        const std::vector<ImageSnapshotInfo>& image_snapshot_info,
                                                         graphics::VulkanResourcesUtil&        resource_util)
 {
-    GFXRECON_ASSERT(device_wrapper != nullptr);
-    GFXRECON_ASSERT(asset_file_stream_ != nullptr);
+    assert(device_wrapper != nullptr);
+    assert(asset_file_stream_ != nullptr);
+
     const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
 
-    using ImageResource = graphics::VulkanResourcesUtil::ImageResource;
-    std::vector<ImageResource> image_resources;
-    image_resources.reserve(image_snapshot_infos.size());
-
-    auto write_init_image_cmd = [this, device_wrapper](const ImageResource& img, const void* data, size_t num_bytes) {
-        format::InitImageCommandHeader upload_cmd;
-
-        // Packet size without the resource data.
-        upload_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(upload_cmd);
-        upload_cmd.meta_header.block_header.type = format::kMetaDataBlock;
-        upload_cmd.meta_header.meta_data_id =
-            format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kInitImageCommand);
-        upload_cmd.thread_id = thread_data_->thread_id_;
-        upload_cmd.device_id = device_wrapper->handle_id;
-        upload_cmd.image_id  = img.handle_id;
-        upload_cmd.aspect    = img.aspect;
-        upload_cmd.layout    = img.layout;
-
-        if (data != nullptr)
-        {
-            auto* bytes = reinterpret_cast<const uint8_t*>(data);
-            GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, img.resource_size);
-
-            auto data_size = static_cast<size_t>(num_bytes);
-
-            // Store uncompressed data size in packet.
-            upload_cmd.data_size   = data_size;
-            upload_cmd.level_count = img.level_count;
-
-            if (compressor_ != nullptr)
-            {
-                size_t compressed_size = compressor_->Compress(data_size, bytes, &compressed_parameter_buffer_, 0);
-
-                if ((compressed_size > 0) && (compressed_size < data_size))
-                {
-                    upload_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
-
-                    bytes     = compressed_parameter_buffer_.data();
-                    data_size = compressed_size;
-                }
-            }
-
-            // Calculate size of packet with compressed or uncompressed data size.
-            GFXRECON_ASSERT(img.level_sizes != nullptr && !img.level_sizes->empty() &&
-                            (img.level_sizes->size() == upload_cmd.level_count));
-            size_t levels_size = img.level_sizes->size() * sizeof(img.level_sizes->front());
-
-            upload_cmd.meta_header.block_header.size += levels_size + data_size;
-
-            const int64_t offset                  = asset_file_stream_->GetOffset();
-            (*asset_file_offsets_)[img.handle_id] = offset;
-            asset_file_stream_->Write(&upload_cmd, sizeof(upload_cmd));
-            asset_file_stream_->Write(img.level_sizes->data(), levels_size);
-            asset_file_stream_->Write(bytes, data_size);
-
-            if (output_stream_ != nullptr)
-            {
-                WriteExecuteFromFile(asset_file_name_, 1, offset);
-            }
-        }
-        else
-        {
-            if (output_stream_ != nullptr)
-            {
-                // Write a packet without resource data; replay must still perform a layout transition at image
-                // initialization.
-                upload_cmd.data_size   = 0;
-                upload_cmd.level_count = 0;
-
-                output_stream_->Write(&upload_cmd, sizeof(upload_cmd));
-                ++blocks_written_;
-            }
-        }
-    };
-
-    for (const auto& snapshot_entry : image_snapshot_infos)
+    for (const auto& snapshot_entry : image_snapshot_info)
     {
         vulkan_wrappers::ImageWrapper*              image_wrapper  = snapshot_entry.image_wrapper;
         const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper = snapshot_entry.memory_wrapper;
         const uint8_t*                              bytes          = nullptr;
+        std::vector<uint8_t>                        data;
 
-        GFXRECON_ASSERT(image_wrapper != nullptr);
+        assert(image_wrapper != nullptr);
 
         if (image_wrapper->external_memory_android)
         {
@@ -2501,39 +2393,45 @@ void VulkanStateWriter::ProcessImageMemoryWithAssetFile(const vulkan_wrappers::D
 
         if (image_wrapper->dirty)
         {
-            GFXRECON_ASSERT((image_wrapper->is_swapchain_image && memory_wrapper == nullptr) ||
-                            (!image_wrapper->is_swapchain_image && memory_wrapper != nullptr));
+            assert((image_wrapper->is_swapchain_image && memory_wrapper == nullptr) ||
+                   (!image_wrapper->is_swapchain_image && memory_wrapper != nullptr));
 
             image_wrapper->dirty = false;
 
-            graphics::VulkanResourcesUtil::ImageResource image_resource = {};
-            image_resource.handle_id                                    = image_wrapper->handle_id;
-            image_resource.image                                        = image_wrapper->handle;
-            image_resource.format                                       = image_wrapper->format;
-            image_resource.type                                         = image_wrapper->image_type;
-            image_resource.extent                                       = image_wrapper->extent;
-            image_resource.level_count                                  = image_wrapper->mip_levels;
-            image_resource.layer_count                                  = image_wrapper->array_layers;
-            image_resource.tiling                                       = image_wrapper->tiling;
-            image_resource.sample_count                                 = image_wrapper->samples;
-            image_resource.layout                                       = image_wrapper->current_layout;
-            image_resource.queue_family_index                           = image_wrapper->queue_family_index;
-            image_resource.external_format                              = image_wrapper->external_format;
-            image_resource.size                                         = image_wrapper->size;
-            image_resource.resource_size                                = snapshot_entry.resource_size;
-            image_resource.level_sizes                                  = &snapshot_entry.level_sizes;
-            image_resource.aspect                                       = snapshot_entry.aspect;
-            image_resource.external_format                              = image_wrapper->external_format;
-            image_resource.all_layers_per_level                         = true;
-
             if (snapshot_entry.need_staging_copy)
             {
-                image_resources.push_back(image_resource);
+                std::vector<uint64_t> subresource_offsets;
+                std::vector<uint64_t> subresource_sizes;
+                bool                  scaling_supported;
+
+                VkResult result = resource_util.ReadFromImageResourceStaging(image_wrapper->handle,
+                                                                             image_wrapper->format,
+                                                                             image_wrapper->image_type,
+                                                                             image_wrapper->extent,
+                                                                             image_wrapper->mip_levels,
+                                                                             image_wrapper->array_layers,
+                                                                             image_wrapper->tiling,
+                                                                             image_wrapper->samples,
+                                                                             image_wrapper->current_layout,
+                                                                             image_wrapper->queue_family_index,
+                                                                             image_wrapper->external_format,
+                                                                             image_wrapper->size,
+                                                                             snapshot_entry.aspect,
+                                                                             data,
+                                                                             subresource_offsets,
+                                                                             subresource_sizes,
+                                                                             scaling_supported,
+                                                                             true);
+
+                if (result == VK_SUCCESS)
+                {
+                    bytes = data.data();
+                }
             }
             else if (!image_wrapper->is_swapchain_image)
             {
-                GFXRECON_ASSERT((memory_wrapper != nullptr) &&
-                                ((memory_wrapper->mapped_data == nullptr) || (memory_wrapper->mapped_offset == 0)));
+                assert((memory_wrapper != nullptr) &&
+                       ((memory_wrapper->mapped_data == nullptr) || (memory_wrapper->mapped_offset == 0)));
 
                 VkResult result = VK_SUCCESS;
 
@@ -2564,12 +2462,82 @@ void VulkanStateWriter::ProcessImageMemoryWithAssetFile(const vulkan_wrappers::D
                                                 image_wrapper->bind_offset,
                                                 snapshot_entry.resource_size);
                 }
+            }
 
-                write_init_image_cmd(image_resource, bytes, snapshot_entry.resource_size);
+            if (!image_wrapper->is_swapchain_image)
+            {
+                format::InitImageCommandHeader upload_cmd;
 
-                if (memory_wrapper->mapped_data == nullptr)
+                // Packet size without the resource data.
+                upload_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(upload_cmd);
+                upload_cmd.meta_header.block_header.type = format::kMetaDataBlock;
+                upload_cmd.meta_header.meta_data_id      = format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_Vulkan,
+                                                                             format::MetaDataType::kInitImageCommand);
+                upload_cmd.thread_id                     = thread_data_->thread_id_;
+                upload_cmd.device_id                     = device_wrapper->handle_id;
+                upload_cmd.image_id                      = image_wrapper->handle_id;
+                upload_cmd.aspect                        = snapshot_entry.aspect;
+                upload_cmd.layout                        = image_wrapper->current_layout;
+
+                if (bytes != nullptr)
                 {
-                    device_table->UnmapMemory(device_wrapper->handle, memory_wrapper->handle);
+                    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, snapshot_entry.resource_size);
+
+                    size_t data_size = static_cast<size_t>(snapshot_entry.resource_size);
+
+                    // Store uncompressed data size in packet.
+                    upload_cmd.data_size   = data_size;
+                    upload_cmd.level_count = image_wrapper->mip_levels;
+
+                    if (compressor_ != nullptr)
+                    {
+                        size_t compressed_size =
+                            compressor_->Compress(data_size, bytes, &compressed_parameter_buffer_, 0);
+
+                        if ((compressed_size > 0) && (compressed_size < data_size))
+                        {
+                            upload_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
+
+                            bytes     = compressed_parameter_buffer_.data();
+                            data_size = compressed_size;
+                        }
+                    }
+
+                    // Calculate size of packet with compressed or uncompressed data size.
+                    assert(!snapshot_entry.level_sizes.empty() &&
+                           (snapshot_entry.level_sizes.size() == upload_cmd.level_count));
+                    size_t levels_size = snapshot_entry.level_sizes.size() * sizeof(snapshot_entry.level_sizes[0]);
+
+                    upload_cmd.meta_header.block_header.size += levels_size + data_size;
+
+                    const int64_t offset                             = asset_file_stream_->GetOffset();
+                    (*asset_file_offsets_)[image_wrapper->handle_id] = offset;
+                    asset_file_stream_->Write(&upload_cmd, sizeof(upload_cmd));
+                    asset_file_stream_->Write(snapshot_entry.level_sizes.data(), levels_size);
+                    asset_file_stream_->Write(bytes, data_size);
+
+                    if (output_stream_ != nullptr)
+                    {
+                        WriteExecuteFromFile(asset_file_name_, 1, offset);
+                    }
+
+                    if (!snapshot_entry.need_staging_copy && memory_wrapper->mapped_data == nullptr)
+                    {
+                        device_table->UnmapMemory(device_wrapper->handle, memory_wrapper->handle);
+                    }
+                }
+                else
+                {
+                    if (output_stream_ != nullptr)
+                    {
+                        // Write a packet without resource data; replay must still perform a layout transition at image
+                        // initialization.
+                        upload_cmd.data_size   = 0;
+                        upload_cmd.level_count = 0;
+
+                        output_stream_->Write(&upload_cmd, sizeof(upload_cmd));
+                        ++blocks_written_;
+                    }
                 }
             }
         }
@@ -2583,10 +2551,6 @@ void VulkanStateWriter::ProcessImageMemoryWithAssetFile(const vulkan_wrappers::D
             }
         }
     }
-
-    // batch process image-downloads requiring staging, use <128MB staging-mem
-    constexpr uint32_t staging_buffer_size = 128U << 20U;
-    resource_util.ReadImageResources(image_resources, write_init_image_cmd, staging_buffer_size);
 }
 
 void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_table,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -169,19 +169,19 @@ class VulkanStateWriter
     void WriteDeferredOperationJoinCommand(format::HandleId device_id, format::HandleId deferred_operation_id);
 
     void ProcessBufferMemory(const vulkan_wrappers::DeviceWrapper*  device_wrapper,
-                             const std::vector<BufferSnapshotInfo>& buffer_snapshot_infos,
+                             const std::vector<BufferSnapshotInfo>& buffer_snapshot_info,
                              graphics::VulkanResourcesUtil&         resource_util);
 
     void ProcessBufferMemoryWithAssetFile(const vulkan_wrappers::DeviceWrapper*  device_wrapper,
-                                          const std::vector<BufferSnapshotInfo>& buffer_snapshot_infos,
+                                          const std::vector<BufferSnapshotInfo>& buffer_snapshot_info,
                                           graphics::VulkanResourcesUtil&         resource_util);
 
     void ProcessImageMemory(const vulkan_wrappers::DeviceWrapper* device_wrapper,
-                            const std::vector<ImageSnapshotInfo>& image_snapshot_infos,
+                            const std::vector<ImageSnapshotInfo>& image_snapshot_info,
                             graphics::VulkanResourcesUtil&        resource_util);
 
     void ProcessImageMemoryWithAssetFile(const vulkan_wrappers::DeviceWrapper* device_wrapper,
-                                         const std::vector<ImageSnapshotInfo>& image_snapshot_infos,
+                                         const std::vector<ImageSnapshotInfo>& image_snapshot_info,
                                          graphics::VulkanResourcesUtil&        resource_util);
 
     void WriteBufferMemoryState(const VulkanStateTable& state_table,

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -21,17 +21,15 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include "vulkan_util.h"
+#include "vulkan_resources_util.h"
 #include "Vulkan-Utility-Libraries/vk_format_utils.h"
 #include "generated/generated_vulkan_enum_to_string.h"
 #include "util/logging.h"
 #include "vulkan/vulkan_core.h"
 
+#include <cinttypes>
 #include <cstdint>
-#include <cmath>
-#include <chrono>
-
-#include "vulkan_resources_util.h"
+#include <math.h>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
@@ -43,7 +41,7 @@ static constexpr bool IsMemoryCoherent(VkMemoryPropertyFlags property_flags)
 
 void GetFormatAspects(VkFormat format, std::vector<VkImageAspectFlagBits>* aspects, bool* combined_depth_stencil)
 {
-    GFXRECON_ASSERT(aspects != nullptr);
+    assert(aspects != nullptr);
 
     bool combined = false;
 
@@ -163,7 +161,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
+                assert(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
                 return VK_FORMAT_S8_UINT;
             }
         case VK_FORMAT_D24_UNORM_S8_UINT:
@@ -174,7 +172,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
+                assert(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
                 return VK_FORMAT_S8_UINT;
             }
         case VK_FORMAT_D32_SFLOAT_S8_UINT:
@@ -184,7 +182,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
+                assert(aspect == VK_IMAGE_ASPECT_STENCIL_BIT);
                 return VK_FORMAT_S8_UINT;
             }
         // Per-aspect/plane compatible formats as defined by the "Plane Format Compatibility Table" from the
@@ -203,7 +201,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
+                assert(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
                 return VK_FORMAT_R8G8_UNORM;
             }
         case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16:
@@ -220,7 +218,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
+                assert(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
                 return VK_FORMAT_R10X6G10X6_UNORM_2PACK16;
             }
         case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16:
@@ -237,7 +235,7 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
+                assert(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
                 return VK_FORMAT_R12X4G12X4_UNORM_2PACK16;
             }
         case VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM:
@@ -254,12 +252,12 @@ VkFormat GetImageAspectFormat(VkFormat format, VkImageAspectFlagBits aspect)
             }
             else
             {
-                GFXRECON_ASSERT(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
+                assert(aspect == VK_IMAGE_ASPECT_PLANE_1_BIT);
                 return VK_FORMAT_R16G16_UNORM;
             }
         default:
-            GFXRECON_ASSERT((aspect == VK_IMAGE_ASPECT_COLOR_BIT) || (aspect == VK_IMAGE_ASPECT_DEPTH_BIT) ||
-                            (aspect == VK_IMAGE_ASPECT_STENCIL_BIT));
+            assert((aspect == VK_IMAGE_ASPECT_COLOR_BIT) || (aspect == VK_IMAGE_ASPECT_DEPTH_BIT) ||
+                   (aspect == VK_IMAGE_ASPECT_STENCIL_BIT));
             return format;
     }
 }
@@ -272,7 +270,7 @@ bool FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properti
 {
     bool found = false;
 
-    GFXRECON_ASSERT(memory_properties.memoryTypeCount > 0);
+    assert(memory_properties.memoryTypeCount > 0);
 
     for (uint32_t i = 0; i < memory_properties.memoryTypeCount; ++i)
     {
@@ -775,42 +773,6 @@ bool NextRowTexelCoordinates(VkImageType       imageType,
     return result;
 }
 
-VulkanResourcesUtil::VulkanResourcesUtil(VkDevice                                device,
-                                         VkPhysicalDevice                        physical_device,
-                                         const encode::VulkanDeviceTable&        device_table,
-                                         const encode::VulkanInstanceTable&      instance_table,
-                                         const VkPhysicalDeviceMemoryProperties& memory_properties) :
-    device_(device),
-    device_table_(device_table), physical_device_(physical_device), instance_table_(instance_table),
-    memory_properties_(memory_properties)
-{
-    GFXRECON_ASSERT(device != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(memory_properties.memoryHeapCount <= VK_MAX_MEMORY_HEAPS);
-    GFXRECON_ASSERT(memory_properties.memoryTypeCount <= VK_MAX_MEMORY_TYPES);
-
-    set_debug_utils_object_name_fn_ = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(
-        device_table_.GetDeviceProcAddr(device_, "vkSetDebugUtilsObjectNameEXT"));
-}
-
-VulkanResourcesUtil::~VulkanResourcesUtil()
-{
-    DestroyStagingBuffer();
-
-    for (const auto& [queue_family_index, command_asset] : command_asset_map_)
-    {
-        if (command_asset.command_buffer != VK_NULL_HANDLE)
-        {
-            GFXRECON_ASSERT(command_asset.command_pool != VK_NULL_HANDLE);
-            device_table_.FreeCommandBuffers(device_, command_asset.command_pool, 1, &command_asset.command_buffer);
-        }
-
-        if (command_asset.command_pool != VK_NULL_HANDLE)
-        {
-            device_table_.DestroyCommandPool(device_, command_asset.command_pool, nullptr);
-        }
-    }
-}
-
 uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkImage                image,
                                                            VkFormat               format,
                                                            VkImageType            type,
@@ -823,7 +785,7 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkImage              
                                                            std::vector<uint64_t>* subresource_sizes,
                                                            bool                   all_layers_per_level)
 {
-    GFXRECON_ASSERT(mip_levels <= 1 + floor(log2(std::max(std::max(extent.width, extent.height), extent.depth))));
+    assert(mip_levels <= 1 + floor(log2(std::max(std::max(extent.width, extent.height), extent.depth))));
 
     if (subresource_sizes != nullptr)
     {
@@ -909,7 +871,7 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkImage              
 
 VkResult VulkanResourcesUtil::CreateStagingBuffer(VkDeviceSize size)
 {
-    GFXRECON_ASSERT(size > 0);
+    assert(size);
 
     if (staging_buffer_.buffer != VK_NULL_HANDLE)
     {
@@ -923,7 +885,7 @@ VkResult VulkanResourcesUtil::CreateStagingBuffer(VkDeviceSize size)
         }
     }
 
-    GFXRECON_ASSERT(staging_buffer_.buffer == VK_NULL_HANDLE && staging_buffer_.size == 0);
+    assert(staging_buffer_.buffer == VK_NULL_HANDLE && staging_buffer_.size == 0);
 
     VkBufferCreateInfo create_info    = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
     create_info.pNext                 = nullptr;
@@ -989,16 +951,6 @@ VkResult VulkanResourcesUtil::CreateStagingBuffer(VkDeviceSize size)
         {
             staging_buffer_.size       = size;
             staging_buffer_.mapped_ptr = nullptr;
-
-            if (set_debug_utils_object_name_fn_ != nullptr)
-            {
-                VkDebugUtilsObjectNameInfoEXT object_name_info = {};
-                object_name_info.sType                         = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
-                object_name_info.objectType                    = VK_OBJECT_TYPE_BUFFER;
-                object_name_info.objectHandle                  = VK_HANDLE_TO_UINT64(staging_buffer_.buffer);
-                object_name_info.pObjectName                   = "VulkanResourcesUtil internal staging-buffer";
-                set_debug_utils_object_name_fn_(device_, &object_name_info);
-            }
         }
     }
     else
@@ -1011,9 +963,9 @@ VkResult VulkanResourcesUtil::CreateStagingBuffer(VkDeviceSize size)
 
 VkResult VulkanResourcesUtil::MapStagingBuffer()
 {
-    GFXRECON_ASSERT(staging_buffer_.buffer != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(staging_buffer_.memory != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(staging_buffer_.size);
+    assert(staging_buffer_.buffer != VK_NULL_HANDLE);
+    assert(staging_buffer_.memory != VK_NULL_HANDLE);
+    assert(staging_buffer_.size);
 
     VkResult result = VK_SUCCESS;
 
@@ -1035,9 +987,9 @@ void VulkanResourcesUtil::UnmapStagingBuffer()
 {
     if (staging_buffer_.mapped_ptr != nullptr)
     {
-        GFXRECON_ASSERT(staging_buffer_.buffer != VK_NULL_HANDLE);
-        GFXRECON_ASSERT(staging_buffer_.memory != VK_NULL_HANDLE);
-        GFXRECON_ASSERT(staging_buffer_.size);
+        assert(staging_buffer_.buffer != VK_NULL_HANDLE);
+        assert(staging_buffer_.memory != VK_NULL_HANDLE);
+        assert(staging_buffer_.size);
 
         device_table_.UnmapMemory(device_, staging_buffer_.memory);
         staging_buffer_.mapped_ptr = nullptr;
@@ -1046,13 +998,13 @@ void VulkanResourcesUtil::UnmapStagingBuffer()
 
 void VulkanResourcesUtil::InvalidateStagingBuffer()
 {
-    GFXRECON_ASSERT(staging_buffer_.buffer != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(staging_buffer_.memory != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(staging_buffer_.size);
+    assert(staging_buffer_.buffer != VK_NULL_HANDLE);
+    assert(staging_buffer_.memory != VK_NULL_HANDLE);
+    assert(staging_buffer_.size);
 
     if (!IsMemoryCoherent(staging_buffer_.memory_property_flags))
     {
-        GFXRECON_ASSERT(staging_buffer_.mapped_ptr != nullptr);
+        assert(staging_buffer_.mapped_ptr != nullptr);
 
         const VkMappedMemoryRange range{
             VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, nullptr, staging_buffer_.memory, 0, staging_buffer_.size
@@ -1082,97 +1034,163 @@ void VulkanResourcesUtil::DestroyStagingBuffer()
     staging_buffer_.size                  = 0;
 }
 
-VkCommandBuffer VulkanResourcesUtil::CreateCommandBufferAndBegin(uint32_t queue_family_index)
+void VulkanResourcesUtil::InvalidateMappedMemoryRange(VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size)
 {
-    auto& command_asset = command_asset_map_[queue_family_index];
+    VkMappedMemoryRange invalidate_range = { VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE };
+    invalidate_range.pNext               = nullptr;
+    invalidate_range.memory              = memory;
+    invalidate_range.offset              = offset;
+    invalidate_range.size                = size;
 
-    if (command_asset.command_pool == VK_NULL_HANDLE)
+    device_table_.InvalidateMappedMemoryRanges(device_, 1, &invalidate_range);
+}
+
+VkResult VulkanResourcesUtil::CreateCommandPool(uint32_t queue_family_index)
+{
+    VkResult result = VK_SUCCESS;
+
+    if (queue_family_index != queue_family_index_ && command_pool_ != VK_NULL_HANDLE)
+    {
+        DestroyCommandPool();
+    }
+
+    if (command_pool_ == VK_NULL_HANDLE)
     {
         VkCommandPoolCreateInfo create_info = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
         create_info.pNext                   = nullptr;
         create_info.flags                   = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
         create_info.queueFamilyIndex        = queue_family_index;
 
-        VkResult result = device_table_.CreateCommandPool(device_, &create_info, nullptr, &command_asset.command_pool);
+        result = device_table_.CreateCommandPool(device_, &create_info, nullptr, &command_pool_);
 
-        if (result != VK_SUCCESS)
+        if (result == VK_SUCCESS)
+        {
+            queue_family_index_ = queue_family_index;
+        }
+        else
         {
             GFXRECON_LOG_ERROR("Failed to create a command pool for resource memory snapshot");
-            return VK_NULL_HANDLE;
         }
     }
 
-    if (command_asset.command_buffer == VK_NULL_HANDLE)
+    return result;
+}
+
+void VulkanResourcesUtil::DestroyCommandPool()
+{
+    if (command_pool_ != VK_NULL_HANDLE)
     {
-        GFXRECON_ASSERT(command_asset.command_pool != VK_NULL_HANDLE);
+        device_table_.DestroyCommandPool(device_, command_pool_, nullptr);
+        command_pool_ = VK_NULL_HANDLE;
+    }
+}
+
+VkResult VulkanResourcesUtil::CreateCommandBuffer(uint32_t queue_family_index)
+{
+    if (queue_family_index != queue_family_index_ && command_buffer_ != VK_NULL_HANDLE)
+    {
+        DestroyCommandBuffer();
+    }
+
+    VkResult result = VK_SUCCESS;
+
+    if (command_buffer_ == VK_NULL_HANDLE)
+    {
+        result = CreateCommandPool(queue_family_index);
+        if (result != VK_SUCCESS)
+        {
+            return result;
+        }
+
+        assert(command_pool_ != VK_NULL_HANDLE);
 
         VkCommandBufferAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
         alloc_info.pNext                       = nullptr;
-        alloc_info.commandPool                 = command_asset.command_pool;
+        alloc_info.commandPool                 = command_pool_;
         alloc_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
         alloc_info.commandBufferCount          = 1;
 
-        VkResult result = device_table_.AllocateCommandBuffers(device_, &alloc_info, &command_asset.command_buffer);
+        result = device_table_.AllocateCommandBuffers(device_, &alloc_info, &command_buffer_);
 
-        if (result != VK_SUCCESS)
+        if (result == VK_SUCCESS)
+        {
+            // Because this command buffer was not allocated through the loader, it must be assigned a dispatch
+            // table.
+            *reinterpret_cast<void**>(command_buffer_) = *reinterpret_cast<void**>(device_);
+        }
+        else
         {
             GFXRECON_LOG_ERROR("Failed to create a command buffer for resource memory snapshot");
-            return VK_NULL_HANDLE;
-        }
-
-        // Because this command buffer was not allocated through the loader, it must be assigned a dispatch table.
-        *reinterpret_cast<void**>(command_asset.command_buffer) = *reinterpret_cast<void**>(device_);
-
-        if (set_debug_utils_object_name_fn_ != nullptr)
-        {
-            VkDebugUtilsObjectNameInfoEXT object_name_info = {};
-            object_name_info.sType                         = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
-            object_name_info.objectType                    = VK_OBJECT_TYPE_COMMAND_BUFFER;
-
-            // NOTE: VK_HANDLE_TO_UINT64 fails here for 32bit (while it does work for VkBuffer), open for suggestions
-            object_name_info.objectHandle = (uint64_t)command_asset.command_buffer;
-            object_name_info.pObjectName  = "VulkanResourcesUtil internal command-buffer";
-            set_debug_utils_object_name_fn_(device_, &object_name_info);
         }
     }
 
-    // begin + return handle
-    BeginCommandBuffer(command_asset.command_buffer);
-    return command_asset.command_buffer;
+    if (result == VK_SUCCESS)
+    {
+        result = BeginCommandBuffer();
+    }
+
+    return result;
 }
 
-void VulkanResourcesUtil::ResetCommandBuffer(VkCommandBuffer command_buffer)
+void VulkanResourcesUtil::ResetCommandBuffer()
 {
-    GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
-    device_table_.ResetCommandBuffer(command_buffer, VkCommandBufferResetFlags(0));
+    assert(command_buffer_ != VK_NULL_HANDLE);
+
+    device_table_.ResetCommandBuffer(command_buffer_, VkCommandBufferResetFlags(0));
 }
 
-VkResult VulkanResourcesUtil::BeginCommandBuffer(VkCommandBuffer command_buffer)
+VkResult VulkanResourcesUtil::BeginCommandBuffer()
 {
-    GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
+    assert(command_buffer_ != VK_NULL_HANDLE);
+
     VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
     begin_info.pNext                    = nullptr;
     begin_info.flags                    = 0;
     begin_info.pInheritanceInfo         = nullptr;
 
-    VkResult result = device_table_.BeginCommandBuffer(command_buffer, &begin_info);
+    VkResult result = device_table_.BeginCommandBuffer(command_buffer_, &begin_info);
 
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("Failed to begin a command buffer for resource memory snapshot");
     }
+
     return result;
 }
 
-void VulkanResourcesUtil::TransitionImageToTransferOptimal(VkCommandBuffer    command_buffer,
-                                                           VkImage            image,
+VkResult VulkanResourcesUtil::EndCommandBuffer()
+{
+    assert(command_buffer_ != VK_NULL_HANDLE);
+
+    VkResult result = device_table_.EndCommandBuffer(command_buffer_);
+
+    if (result != VK_SUCCESS)
+    {
+        GFXRECON_LOG_ERROR("Failed to end a command buffer for resource memory snapshot");
+    }
+
+    return result;
+}
+
+void VulkanResourcesUtil::DestroyCommandBuffer()
+{
+    if (command_buffer_ != VK_NULL_HANDLE)
+    {
+        assert(command_pool_ != VK_NULL_HANDLE);
+
+        device_table_.FreeCommandBuffers(device_, command_pool_, 1, &command_buffer_);
+        command_buffer_ = VK_NULL_HANDLE;
+    }
+}
+
+void VulkanResourcesUtil::TransitionImageToTransferOptimal(VkImage            image,
                                                            VkImageLayout      current_layout,
                                                            VkImageLayout      destination_layout,
                                                            VkImageAspectFlags aspect,
                                                            uint32_t           queue_family_index)
 {
-    GFXRECON_ASSERT(image != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
+    assert(image != VK_NULL_HANDLE);
+    assert(command_buffer_ != VK_NULL_HANDLE);
 
     VkImageMemoryBarrier memory_barrier;
     memory_barrier.sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -1190,7 +1208,7 @@ void VulkanResourcesUtil::TransitionImageToTransferOptimal(VkCommandBuffer    co
     memory_barrier.subresourceRange.baseArrayLayer = 0;
     memory_barrier.subresourceRange.layerCount     = VK_REMAINING_ARRAY_LAYERS;
 
-    device_table_.CmdPipelineBarrier(command_buffer,
+    device_table_.CmdPipelineBarrier(command_buffer_,
                                      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                                      VK_PIPELINE_STAGE_TRANSFER_BIT,
                                      0,
@@ -1202,15 +1220,14 @@ void VulkanResourcesUtil::TransitionImageToTransferOptimal(VkCommandBuffer    co
                                      &memory_barrier);
 }
 
-void VulkanResourcesUtil::TransitionImageFromTransferOptimal(VkCommandBuffer    command_buffer,
-                                                             VkImage            image,
+void VulkanResourcesUtil::TransitionImageFromTransferOptimal(VkImage            image,
                                                              VkImageLayout      old_layout,
                                                              VkImageLayout      new_layout,
                                                              VkImageAspectFlags aspect,
                                                              uint32_t           queue_family_index)
 {
-    GFXRECON_ASSERT(image != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
+    assert(image != VK_NULL_HANDLE);
+    assert(command_buffer_ != VK_NULL_HANDLE);
 
     VkImageMemoryBarrier memory_barrier;
     memory_barrier.sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -1229,7 +1246,7 @@ void VulkanResourcesUtil::TransitionImageFromTransferOptimal(VkCommandBuffer    
     memory_barrier.oldLayout     = old_layout;
     memory_barrier.newLayout     = new_layout;
 
-    device_table_.CmdPipelineBarrier(command_buffer,
+    device_table_.CmdPipelineBarrier(command_buffer_,
                                      VK_PIPELINE_STAGE_TRANSFER_BIT,
                                      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                                      0,
@@ -1241,10 +1258,8 @@ void VulkanResourcesUtil::TransitionImageFromTransferOptimal(VkCommandBuffer    
                                      &memory_barrier);
 }
 
-void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_buffer,
-                                          VkImage                      image,
+void VulkanResourcesUtil::CopyImageBuffer(VkImage                      image,
                                           VkBuffer                     buffer,
-                                          uint32_t                     buffer_offset,
                                           const VkExtent3D&            extent,
                                           uint32_t                     mip_levels,
                                           uint32_t                     array_layers,
@@ -1253,18 +1268,18 @@ void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_b
                                           bool                         all_layers_per_level,
                                           CopyBufferImageDirection     copy_direction)
 {
-    GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
+    assert(command_buffer_ != VK_NULL_HANDLE);
 
     const uint32_t n_subresources = all_layers_per_level ? mip_levels : mip_levels * array_layers;
 
-    GFXRECON_ASSERT(sizes.size() == n_subresources);
+    assert(sizes.size() == n_subresources);
 
     std::vector<VkBufferImageCopy> copy_regions;
 
     VkBufferImageCopy copy_region;
     copy_region.bufferRowLength             = 0; // Request tightly packed data.
     copy_region.bufferImageHeight           = 0; // Request tightly packed data.
-    copy_region.bufferOffset                = buffer_offset;
+    copy_region.bufferOffset                = 0;
     copy_region.imageOffset.x               = 0;
     copy_region.imageOffset.y               = 0;
     copy_region.imageOffset.z               = 0;
@@ -1293,11 +1308,11 @@ void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_b
             }
         }
     }
-    GFXRECON_ASSERT(sr == n_subresources);
+    assert(sr == n_subresources);
 
     if (copy_direction == kImageToBuffer)
     {
-        device_table_.CmdCopyImageToBuffer(command_buffer,
+        device_table_.CmdCopyImageToBuffer(command_buffer_,
                                            image,
                                            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                            buffer,
@@ -1306,9 +1321,9 @@ void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_b
     }
     else
     {
-        GFXRECON_ASSERT(copy_direction == kBufferToImage);
+        assert(copy_direction == kBufferToImage);
 
-        device_table_.CmdCopyBufferToImage(command_buffer,
+        device_table_.CmdCopyBufferToImage(command_buffer_,
                                            buffer,
                                            image,
                                            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -1317,22 +1332,20 @@ void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_b
     }
 }
 
-void VulkanResourcesUtil::CopyBuffer(VkCommandBuffer command_buffer,
-                                     VkBuffer        source_buffer,
-                                     VkBuffer        destination_buffer,
-                                     uint64_t        size,
-                                     uint64_t        src_offset,
-                                     uint64_t        dst_offset)
+void VulkanResourcesUtil::CopyBuffer(VkBuffer source_buffer,
+                                     VkBuffer destination_buffer,
+                                     uint64_t size,
+                                     uint64_t src_offset)
 {
-    GFXRECON_ASSERT(source_buffer != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
+    assert(source_buffer != VK_NULL_HANDLE);
+    assert(command_buffer_ != VK_NULL_HANDLE);
 
     VkBufferCopy copy_region;
     copy_region.srcOffset = src_offset;
-    copy_region.dstOffset = dst_offset;
+    copy_region.dstOffset = 0;
     copy_region.size      = size;
 
-    device_table_.CmdCopyBuffer(command_buffer, source_buffer, destination_buffer, 1, &copy_region);
+    device_table_.CmdCopyBuffer(command_buffer_, source_buffer, destination_buffer, 1, &copy_region);
 }
 
 VkQueue VulkanResourcesUtil::GetQueue(uint32_t queue_family_index, uint32_t queue_index)
@@ -1353,12 +1366,12 @@ VkQueue VulkanResourcesUtil::GetQueue(uint32_t queue_family_index, uint32_t queu
     return queue;
 }
 
-VkResult VulkanResourcesUtil::SubmitCommandBuffer(VkCommandBuffer command_buffer, VkQueue queue)
+VkResult VulkanResourcesUtil::SubmitCommandBuffer(VkQueue queue)
 {
-    GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(queue != VK_NULL_HANDLE);
+    assert(command_buffer_ != VK_NULL_HANDLE);
+    assert(queue != VK_NULL_HANDLE);
 
-    device_table_.EndCommandBuffer(command_buffer);
+    device_table_.EndCommandBuffer(command_buffer_);
 
     VkSubmitInfo submit_info         = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
     submit_info.pNext                = nullptr;
@@ -1366,7 +1379,7 @@ VkResult VulkanResourcesUtil::SubmitCommandBuffer(VkCommandBuffer command_buffer
     submit_info.pWaitSemaphores      = nullptr;
     submit_info.pWaitDstStageMask    = nullptr;
     submit_info.commandBufferCount   = 1;
-    submit_info.pCommandBuffers      = &command_buffer;
+    submit_info.pCommandBuffers      = &command_buffer_;
     submit_info.signalSemaphoreCount = 0;
     submit_info.pSignalSemaphores    = nullptr;
 
@@ -1393,22 +1406,23 @@ VkResult VulkanResourcesUtil::SubmitCommandBuffer(VkCommandBuffer command_buffer
         return result;
     }
 
-    ResetCommandBuffer(command_buffer);
+    ResetCommandBuffer();
 
     return result;
 }
 
-VkResult VulkanResourcesUtil::ResolveImage(VkCommandBuffer   command_buffer,
-                                           VkImage           image,
+VkResult VulkanResourcesUtil::ResolveImage(VkImage           image,
                                            VkFormat          format,
                                            VkImageType       type,
                                            const VkExtent3D& extent,
                                            uint32_t          array_layers,
                                            VkImageLayout     current_layout,
+                                           VkQueue           queue,
+                                           uint32_t          queue_family_index,
                                            VkImage*          resolved_image,
                                            VkDeviceMemory*   resolved_image_memory)
 {
-    GFXRECON_ASSERT((image != VK_NULL_HANDLE) && (resolved_image != nullptr) && (resolved_image_memory != nullptr));
+    assert((image != VK_NULL_HANDLE) && (resolved_image != nullptr) && (resolved_image_memory != nullptr));
 
     VkFormatProperties format_properties{};
     instance_table_.GetPhysicalDeviceFormatProperties(physical_device_, format, &format_properties);
@@ -1437,521 +1451,502 @@ VkResult VulkanResourcesUtil::ResolveImage(VkCommandBuffer   command_buffer,
     create_info.initialLayout         = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkResult result = device_table_.CreateImage(device_, &create_info, nullptr, resolved_image);
-    if (result != VK_SUCCESS)
-    {
-        GFXRECON_LOG_ERROR("Failed to create temporary image for multisample resolve.");
-        return result;
-    }
-
-    uint32_t             memory_type_index = std::numeric_limits<uint32_t>::max();
-    VkMemoryRequirements memory_requirements;
-
-    device_table_.GetImageMemoryRequirements(device_, *resolved_image, &memory_requirements);
-
-    bool found = FindMemoryTypeIndex(memory_properties_,
-                                     memory_requirements.memoryTypeBits,
-                                     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                     &memory_type_index,
-                                     nullptr);
-
-    if (!found)
-    {
-        GFXRECON_LOG_ERROR(
-            "Failed to find a device local memory type for multisample resolve temporary image creation");
-        result = VK_ERROR_INITIALIZATION_FAILED;
-        device_table_.DestroyImage(device_, *resolved_image, nullptr);
-        *resolved_image = VK_NULL_HANDLE;
-        return result;
-    }
-
-    VkMemoryAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
-    alloc_info.pNext                = nullptr;
-    alloc_info.allocationSize       = memory_requirements.size;
-    alloc_info.memoryTypeIndex      = memory_type_index;
-
-    result = device_table_.AllocateMemory(device_, &alloc_info, nullptr, resolved_image_memory);
     if (result == VK_SUCCESS)
     {
-        device_table_.BindImageMemory(device_, *resolved_image, *resolved_image_memory, 0);
+        uint32_t             memory_type_index = std::numeric_limits<uint32_t>::max();
+        VkMemoryRequirements memory_requirements;
 
-        if (command_buffer != VK_NULL_HANDLE)
+        device_table_.GetImageMemoryRequirements(device_, *resolved_image, &memory_requirements);
+
+        bool found = FindMemoryTypeIndex(memory_properties_,
+                                         memory_requirements.memoryTypeBits,
+                                         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                                         &memory_type_index,
+                                         nullptr);
+
+        if (found)
         {
-            VkImageAspectFlags aspect_mask = GetFormatAspectMask(format);
+            VkMemoryAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
+            alloc_info.pNext                = nullptr;
+            alloc_info.allocationSize       = memory_requirements.size;
+            alloc_info.memoryTypeIndex      = memory_type_index;
 
-            uint32_t             num_barriers = 1;
-            VkImageMemoryBarrier memory_barriers[2];
-
-            // Destination image
-            memory_barriers[0].sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-            memory_barriers[0].pNext                           = nullptr;
-            memory_barriers[0].srcAccessMask                   = 0;
-            memory_barriers[0].dstAccessMask                   = VK_ACCESS_TRANSFER_WRITE_BIT;
-            memory_barriers[0].oldLayout                       = VK_IMAGE_LAYOUT_UNDEFINED;
-            memory_barriers[0].newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            memory_barriers[0].srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
-            memory_barriers[0].dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
-            memory_barriers[0].image                           = *resolved_image;
-            memory_barriers[0].subresourceRange.aspectMask     = aspect_mask;
-            memory_barriers[0].subresourceRange.baseMipLevel   = 0;
-            memory_barriers[0].subresourceRange.levelCount     = 1;
-            memory_barriers[0].subresourceRange.baseArrayLayer = 0;
-            memory_barriers[0].subresourceRange.layerCount     = array_layers;
-
-            // Multi-sample source image
-            if (current_layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
+            result = device_table_.AllocateMemory(device_, &alloc_info, nullptr, resolved_image_memory);
+            if (result == VK_SUCCESS)
             {
-                num_barriers = 2;
+                device_table_.BindImageMemory(device_, *resolved_image, *resolved_image_memory, 0);
 
-                memory_barriers[1].sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-                memory_barriers[1].pNext                           = nullptr;
-                memory_barriers[1].srcAccessMask                   = VK_ACCESS_MEMORY_WRITE_BIT;
-                memory_barriers[1].dstAccessMask                   = VK_ACCESS_TRANSFER_READ_BIT;
-                memory_barriers[1].oldLayout                       = current_layout;
-                memory_barriers[1].newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-                memory_barriers[1].srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
-                memory_barriers[1].dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
-                memory_barriers[1].image                           = image;
-                memory_barriers[1].subresourceRange.aspectMask     = aspect_mask;
-                memory_barriers[1].subresourceRange.baseMipLevel   = 0;
-                memory_barriers[1].subresourceRange.levelCount     = 1;
-                memory_barriers[1].subresourceRange.baseArrayLayer = 0;
-                memory_barriers[1].subresourceRange.layerCount     = array_layers;
+                result = CreateCommandPool(queue_family_index);
+                if (result != VK_SUCCESS)
+                {
+                    return result;
+                }
+
+                result = CreateCommandBuffer(queue_family_index);
+                if (result != VK_SUCCESS)
+                {
+                    return result;
+                }
+
+                if (result == VK_SUCCESS)
+                {
+                    VkImageAspectFlags aspect_mask = GetFormatAspectMask(format);
+
+                    uint32_t             num_barriers = 1;
+                    VkImageMemoryBarrier memory_barriers[2];
+
+                    // Destination image
+                    memory_barriers[0].sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                    memory_barriers[0].pNext                           = nullptr;
+                    memory_barriers[0].srcAccessMask                   = 0;
+                    memory_barriers[0].dstAccessMask                   = VK_ACCESS_TRANSFER_WRITE_BIT;
+                    memory_barriers[0].oldLayout                       = VK_IMAGE_LAYOUT_UNDEFINED;
+                    memory_barriers[0].newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                    memory_barriers[0].srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                    memory_barriers[0].dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                    memory_barriers[0].image                           = *resolved_image;
+                    memory_barriers[0].subresourceRange.aspectMask     = aspect_mask;
+                    memory_barriers[0].subresourceRange.baseMipLevel   = 0;
+                    memory_barriers[0].subresourceRange.levelCount     = 1;
+                    memory_barriers[0].subresourceRange.baseArrayLayer = 0;
+                    memory_barriers[0].subresourceRange.layerCount     = array_layers;
+
+                    // Multi-sample source image
+                    if (current_layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
+                    {
+                        num_barriers = 2;
+
+                        memory_barriers[1].sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                        memory_barriers[1].pNext                           = nullptr;
+                        memory_barriers[1].srcAccessMask                   = VK_ACCESS_MEMORY_WRITE_BIT;
+                        memory_barriers[1].dstAccessMask                   = VK_ACCESS_TRANSFER_READ_BIT;
+                        memory_barriers[1].oldLayout                       = current_layout;
+                        memory_barriers[1].newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                        memory_barriers[1].srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                        memory_barriers[1].dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                        memory_barriers[1].image                           = image;
+                        memory_barriers[1].subresourceRange.aspectMask     = aspect_mask;
+                        memory_barriers[1].subresourceRange.baseMipLevel   = 0;
+                        memory_barriers[1].subresourceRange.levelCount     = 1;
+                        memory_barriers[1].subresourceRange.baseArrayLayer = 0;
+                        memory_barriers[1].subresourceRange.layerCount     = array_layers;
+                    }
+
+                    device_table_.CmdPipelineBarrier(command_buffer_,
+                                                     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                                     VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                                     0,
+                                                     0,
+                                                     nullptr,
+                                                     0,
+                                                     nullptr,
+                                                     num_barriers,
+                                                     memory_barriers);
+
+                    VkImageResolve region;
+                    region.srcSubresource.aspectMask     = aspect_mask;
+                    region.srcSubresource.mipLevel       = 0;
+                    region.srcSubresource.baseArrayLayer = 0;
+                    region.srcSubresource.layerCount     = array_layers;
+                    region.srcOffset.x                   = 0;
+                    region.srcOffset.y                   = 0;
+                    region.srcOffset.z                   = 0;
+                    region.dstSubresource.aspectMask     = aspect_mask;
+                    region.dstSubresource.mipLevel       = 0;
+                    region.dstSubresource.baseArrayLayer = 0;
+                    region.dstSubresource.layerCount     = array_layers;
+                    region.dstOffset.x                   = 0;
+                    region.dstOffset.y                   = 0;
+                    region.dstOffset.z                   = 0;
+                    region.extent.width                  = extent.width;
+                    region.extent.height                 = extent.height;
+                    region.extent.depth                  = extent.depth;
+
+                    device_table_.CmdResolveImage(command_buffer_,
+                                                  image,
+                                                  VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                                  *resolved_image,
+                                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                                  1,
+                                                  &region);
+
+                    // Prepare the resolved image for the next staging copy.
+                    memory_barriers[0].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                    memory_barriers[0].dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                    memory_barriers[0].oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                    memory_barriers[0].newLayout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+
+                    if (num_barriers == 2)
+                    {
+                        memory_barriers[1].srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                        memory_barriers[1].dstAccessMask = 0;
+                        memory_barriers[1].oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                        memory_barriers[1].newLayout     = current_layout;
+                    }
+
+                    device_table_.CmdPipelineBarrier(command_buffer_,
+                                                     VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                                     VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                                     0,
+                                                     0,
+                                                     nullptr,
+                                                     0,
+                                                     nullptr,
+                                                     num_barriers,
+                                                     memory_barriers);
+
+                    result = SubmitCommandBuffer(queue);
+
+                    if (result != VK_SUCCESS)
+                    {
+                        GFXRECON_LOG_ERROR("Failed to resolve multisample image");
+                        device_table_.DestroyImage(device_, *resolved_image, nullptr);
+                        device_table_.FreeMemory(device_, *resolved_image_memory, nullptr);
+
+                        *resolved_image        = VK_NULL_HANDLE;
+                        *resolved_image_memory = VK_NULL_HANDLE;
+                    }
+                }
             }
-
-            device_table_.CmdPipelineBarrier(command_buffer,
-                                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                             0,
-                                             0,
-                                             nullptr,
-                                             0,
-                                             nullptr,
-                                             num_barriers,
-                                             memory_barriers);
-
-            VkImageResolve region;
-            region.srcSubresource.aspectMask     = aspect_mask;
-            region.srcSubresource.mipLevel       = 0;
-            region.srcSubresource.baseArrayLayer = 0;
-            region.srcSubresource.layerCount     = array_layers;
-            region.srcOffset.x                   = 0;
-            region.srcOffset.y                   = 0;
-            region.srcOffset.z                   = 0;
-            region.dstSubresource.aspectMask     = aspect_mask;
-            region.dstSubresource.mipLevel       = 0;
-            region.dstSubresource.baseArrayLayer = 0;
-            region.dstSubresource.layerCount     = array_layers;
-            region.dstOffset.x                   = 0;
-            region.dstOffset.y                   = 0;
-            region.dstOffset.z                   = 0;
-            region.extent.width                  = extent.width;
-            region.extent.height                 = extent.height;
-            region.extent.depth                  = extent.depth;
-
-            device_table_.CmdResolveImage(command_buffer,
-                                          image,
-                                          VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                          *resolved_image,
-                                          VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                          1,
-                                          &region);
-
-            // Prepare the resolved image for the next staging copy.
-            memory_barriers[0].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            memory_barriers[0].dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-            memory_barriers[0].oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            memory_barriers[0].newLayout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-
-            if (num_barriers == 2)
+            else
             {
-                memory_barriers[1].srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-                memory_barriers[1].dstAccessMask = 0;
-                memory_barriers[1].oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-                memory_barriers[1].newLayout     = current_layout;
+                GFXRECON_LOG_ERROR("Failed to allocate temporary image memory for multisample resolve");
+                device_table_.DestroyImage(device_, *resolved_image, nullptr);
+                *resolved_image = VK_NULL_HANDLE;
             }
-
-            device_table_.CmdPipelineBarrier(command_buffer,
-                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                             0,
-                                             0,
-                                             nullptr,
-                                             0,
-                                             nullptr,
-                                             num_barriers,
-                                             memory_barriers);
+        }
+        else
+        {
+            GFXRECON_LOG_ERROR(
+                "Failed to find a device local memory type for multisample resolve temporary image creation");
+            result = VK_ERROR_INITIALIZATION_FAILED;
+            device_table_.DestroyImage(device_, *resolved_image, nullptr);
+            *resolved_image = VK_NULL_HANDLE;
         }
     }
     else
     {
-        GFXRECON_LOG_ERROR("Failed to allocate temporary image memory for multisample resolve");
-        device_table_.DestroyImage(device_, *resolved_image, nullptr);
-        *resolved_image = VK_NULL_HANDLE;
+        GFXRECON_LOG_ERROR("Failed to create temporary image for multisample resolve.");
     }
+
     return result;
 }
 
-VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource>&   image_resources,
-                                                 const ReadImageResourcesCallbackFn& call_back,
-                                                 size_t                              staging_buffer_size)
+VkResult VulkanResourcesUtil::ReadFromImageResourceStaging(VkImage                image,
+                                                           VkFormat               format,
+                                                           VkImageType            type,
+                                                           const VkExtent3D&      extent,
+                                                           uint32_t               mip_levels,
+                                                           uint32_t               array_layers,
+                                                           VkImageTiling          tiling,
+                                                           VkSampleCountFlags     samples,
+                                                           VkImageLayout          layout,
+                                                           uint32_t               queue_family_index,
+                                                           bool                   external_format,
+                                                           VkDeviceSize           size,
+                                                           VkImageAspectFlagBits  aspect,
+                                                           std::vector<uint8_t>&  data,
+                                                           std::vector<uint64_t>& subresource_offsets,
+                                                           std::vector<uint64_t>& subresource_sizes,
+                                                           bool&                  scaling_supported,
+                                                           bool                   all_layers_per_level,
+                                                           float                  scale,
+                                                           VkFormat               dst_format)
 {
-    if (image_resources.empty())
+    VkResult           result           = VK_SUCCESS;
+    VkImage            resolve_image    = VK_NULL_HANDLE;
+    VkDeviceMemory     resolve_memory   = VK_NULL_HANDLE;
+    VkImage            scaled_image     = VK_NULL_HANDLE;
+    VkDeviceMemory     scaled_image_mem = VK_NULL_HANDLE;
+    VkQueue            queue;
+    uint64_t           resource_size;
+    VkImageAspectFlags transition_aspect;
+    VkImage            copy_image;
+
+    // No format conversion
+    if (dst_format == VK_FORMAT_UNDEFINED)
     {
-        return VK_SUCCESS;
-    }
-    // aggregate to store temporary data during batch-processing
-    struct image_resource_tmp_data_t
-    {
-        uint64_t                  resource_size       = 0;
-        VkDeviceSize              staging_offset      = 0;
-        VkImage                   resolve_image       = VK_NULL_HANDLE;
-        VkDeviceMemory            resolve_memory      = VK_NULL_HANDLE;
-        VkImage                   scaled_image        = VK_NULL_HANDLE;
-        VkDeviceMemory            scaled_image_memory = VK_NULL_HANDLE;
-        bool                      use_blit            = false;
-        bool                      scaling_supported   = false;
-        VkExtent3D                scaled_extent       = {};
-        VkImageAspectFlags        transition_aspect   = VK_IMAGE_ASPECT_NONE;
-        std::vector<VkDeviceSize> level_sizes;
-
-        VkDevice                         device       = VK_NULL_HANDLE;
-        const encode::VulkanDeviceTable* device_table = nullptr;
-
-        image_resource_tmp_data_t& operator=(image_resource_tmp_data_t other)
-        {
-            std::swap(resource_size, other.resource_size);
-            std::swap(staging_offset, other.staging_offset);
-            std::swap(resolve_image, other.resolve_image);
-            std::swap(resolve_memory, other.resolve_memory);
-            std::swap(scaled_image, other.scaled_image);
-            std::swap(scaled_image_memory, other.scaled_image_memory);
-            std::swap(use_blit, other.use_blit);
-            std::swap(scaling_supported, other.scaling_supported);
-            std::swap(scaled_extent, other.scaled_extent);
-            std::swap(transition_aspect, other.transition_aspect);
-            std::swap(level_sizes, other.level_sizes);
-            std::swap(device, other.device);
-            std::swap(device_table, other.device_table);
-            return *this;
-        }
-
-        ~image_resource_tmp_data_t()
-        {
-            if (device_table != nullptr && device != VK_NULL_HANDLE)
-            {
-                if (resolve_image != VK_NULL_HANDLE)
-                {
-                    device_table->DestroyImage(device, resolve_image, nullptr);
-                    device_table->FreeMemory(device, resolve_memory, nullptr);
-                }
-
-                if (scaled_image != VK_NULL_HANDLE)
-                {
-                    device_table->DestroyImage(device, scaled_image, nullptr);
-                    device_table->FreeMemory(device, scaled_image_memory, nullptr);
-                }
-            }
-        }
-    };
-    std::vector<image_resource_tmp_data_t> tmp_data(image_resources.size());
-    uint32_t                               current_batch_size = 0;
-
-    // start with entire range
-    std::vector<std::pair<uint32_t, uint32_t>> batch_ranges = { { 0, static_cast<uint32_t>(image_resources.size()) } };
-
-    // iterate inputs, determine sizes, split into batches
-    for (uint32_t i = 0; i < image_resources.size(); ++i)
-    {
-        const auto& img = image_resources[i];
-
-        // allow temporary data to cleanup after itself
-        tmp_data[i].device       = device_;
-        tmp_data[i].device_table = &device_table_;
-
-        VkFormat dst_format = img.dst_format == VK_FORMAT_UNDEFINED ? img.dst_format : img.format;
-
-        GFXRECON_ASSERT(img.level_count <=
-                        1 + floor(log2(std::max(std::max(img.extent.width, img.extent.height), img.extent.depth))));
-        GFXRECON_ASSERT((img.aspect == VK_IMAGE_ASPECT_COLOR_BIT) || (img.aspect == VK_IMAGE_ASPECT_DEPTH_BIT) ||
-                        (img.aspect == VK_IMAGE_ASPECT_STENCIL_BIT));
-
-        bool blit_supported = IsBlitSupported(img.format, img.tiling, dst_format);
-        tmp_data[i].scaling_supported =
-            IsScalingSupported(img.format, img.tiling, dst_format, img.type, img.extent, img.scale);
-
-        tmp_data[i].use_blit =
-            (img.format != dst_format && blit_supported) || (img.scale != 1.0f && tmp_data[i].scaling_supported);
-
-        tmp_data[i].scaled_extent = {
-            static_cast<uint32_t>(std::max(static_cast<float>(img.extent.width) * img.scale, 1.0f)),
-            static_cast<uint32_t>(std::max(static_cast<float>(img.extent.height) * img.scale, 1.0f)),
-            static_cast<uint32_t>(std::max(static_cast<float>(img.extent.depth) * img.scale, 1.0f))
-        };
-
-        uint64_t resource_size = img.resource_size;
-
-        if (img.external_format)
-        {
-            resource_size = img.size;
-            tmp_data[i].level_sizes.push_back(resource_size);
-        }
-        else if (resource_size == 0 || img.level_sizes == nullptr)
-        {
-            resource_size = GetImageResourceSizesOptimal(img.image,
-                                                         tmp_data[i].use_blit ? dst_format : img.format,
-                                                         img.type,
-                                                         tmp_data[i].use_blit ? tmp_data[i].scaled_extent : img.extent,
-                                                         img.level_count,
-                                                         img.layer_count,
-                                                         img.tiling,
-                                                         img.aspect,
-                                                         nullptr,
-                                                         &tmp_data[i].level_sizes,
-                                                         img.all_layers_per_level);
-        }
-
-        if (resource_size > staging_buffer_size)
-        {
-            // we need a bigger boat
-            staging_buffer_size = resource_size;
-        }
-
-        if (current_batch_size + resource_size > staging_buffer_size)
-        {
-            // end current batch, start next
-            auto& current_batch  = batch_ranges.back();
-            current_batch.second = i;
-
-            auto& next_batch   = batch_ranges.emplace_back(i, static_cast<uint32_t>(image_resources.size()));
-            current_batch_size = 0;
-        }
-
-        tmp_data[i].resource_size  = resource_size;
-        tmp_data[i].staging_offset = current_batch_size;
-        current_batch_size += resource_size;
-    } // image_resources, 1st batch-splitting pass
-
-    VkResult result = CreateStagingBuffer(staging_buffer_size);
-    if (result != VK_SUCCESS)
-    {
-        GFXRECON_LOG_ERROR(
-            "%s: could not create a staging-buffer of size: %d kB", __func__, staging_buffer_size >> 10U);
-        return result;
+        dst_format = format;
     }
 
-    // accumulate timing data
-    uint32_t gpu_micros = 0, cpu_micros = 0;
+    assert(mip_levels <= 1 + floor(log2(std::max(std::max(extent.width, extent.height), extent.depth))));
+    assert((aspect == VK_IMAGE_ASPECT_COLOR_BIT) || (aspect == VK_IMAGE_ASPECT_DEPTH_BIT) ||
+           (aspect == VK_IMAGE_ASPECT_STENCIL_BIT));
 
-    for (const auto& [start_idx, end_idx] : batch_ranges)
+    const bool is_blit_supported = IsBlitSupported(format, tiling, dst_format);
+    if (scale > 1.0f)
     {
-        auto                                          start_time = std::chrono::high_resolution_clock::now();
-        std::unordered_map<uint32_t, VkCommandBuffer> command_buffer_map;
+        scaling_supported = IsScalingSupported(format, tiling, dst_format, type, extent, scale);
+    }
+    else
+    {
+        scaling_supported = (scale == 1.0f ? true : is_blit_supported);
+    }
 
-        // iterate over current batch
-        for (uint32_t i = start_idx; i < end_idx; ++i)
-        {
-            const auto& img = image_resources[i];
+    const bool use_blit = (format != dst_format && is_blit_supported) || (scale != 1.0f && scaling_supported);
 
-            VkCommandBuffer command_buffer = VK_NULL_HANDLE;
-            auto            cmd_buf_it     = command_buffer_map.find(img.queue_family_index);
-            if (cmd_buf_it == command_buffer_map.end())
-            {
-                command_buffer                             = CreateCommandBufferAndBegin(img.queue_family_index);
-                command_buffer_map[img.queue_family_index] = command_buffer;
-            }
-            else
-            {
-                command_buffer = cmd_buf_it->second;
-            }
+    const VkExtent3D scaled_extent = { static_cast<uint32_t>(std::max(static_cast<float>(extent.width) * scale, 1.0f)),
+                                       static_cast<uint32_t>(std::max(static_cast<float>(extent.height) * scale, 1.0f)),
+                                       static_cast<uint32_t>(
+                                           std::max(static_cast<float>(extent.depth) * scale, 1.0f)) };
 
-            VkImage copy_image = tmp_data[i].resolve_image != VK_NULL_HANDLE ? tmp_data[i].resolve_image : img.image;
+    subresource_offsets.clear();
+    subresource_sizes.clear();
 
-            if (img.sample_count != VK_SAMPLE_COUNT_1_BIT)
-            {
-                result = ResolveImage(command_buffer,
-                                      img.image,
-                                      img.format,
-                                      img.type,
-                                      img.extent,
-                                      img.layer_count,
-                                      img.layout,
-                                      &tmp_data[i].resolve_image,
-                                      &tmp_data[i].resolve_memory);
-                if (result != VK_SUCCESS)
-                {
-                    GFXRECON_ASSERT(false);
-                    return result;
-                }
-            }
+    if (external_format)
+    {
+        resource_size = size;
+        subresource_sizes.push_back(resource_size);
+    }
+    else
+    {
+        resource_size = GetImageResourceSizesOptimal(image,
+                                                     use_blit ? dst_format : format,
+                                                     type,
+                                                     use_blit ? scaled_extent : extent,
+                                                     mip_levels,
+                                                     array_layers,
+                                                     tiling,
+                                                     aspect,
+                                                     &subresource_offsets,
+                                                     &subresource_sizes,
+                                                     all_layers_per_level);
+    }
 
-            tmp_data[i].transition_aspect = img.aspect;
-            if ((img.aspect == VK_IMAGE_ASPECT_DEPTH_BIT) || (img.aspect == VK_IMAGE_ASPECT_STENCIL_BIT))
-            {
-                // Depth and stencil aspects need to be transitioned together, so get full aspect
-                // mask for image.
-                tmp_data[i].transition_aspect = GetFormatAspectMask(img.format);
-            }
+    queue = GetQueue(queue_family_index, 0);
+    if (queue == VK_NULL_HANDLE)
+    {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
 
-            if (img.sample_count == VK_SAMPLE_COUNT_1_BIT && img.layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
-            {
-                TransitionImageToTransferOptimal(command_buffer,
-                                                 img.image,
-                                                 img.layout,
-                                                 VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                                 tmp_data[i].transition_aspect,
-                                                 img.queue_family_index);
-            }
-
-            VkFormat dst_format = img.dst_format == VK_FORMAT_UNDEFINED ? img.dst_format : img.format;
-
-            // Blit image to change dimensions or convert format
-            if (tmp_data[i].use_blit)
-            {
-                VkImage blit_src = tmp_data[i].resolve_image ? tmp_data[i].resolve_image : img.image;
-                result           = BlitImage(command_buffer,
-                                   blit_src,
-                                   img.format,
-                                   dst_format,
-                                   img.type,
-                                   img.tiling,
-                                   img.extent,
-                                   tmp_data[i].scaled_extent,
-                                   img.level_count,
-                                   img.layer_count,
-                                   img.aspect,
-                                   img.queue_family_index,
-                                   img.scale,
-                                   tmp_data[i].scaled_image,
-                                   tmp_data[i].scaled_image_memory);
-
-                copy_image = tmp_data[i].scaled_image != VK_NULL_HANDLE ? tmp_data[i].scaled_image : copy_image;
-
-                if (result != VK_SUCCESS)
-                {
-                    return result;
-                }
-            }
-
-            if (!img.external_format)
-            {
-                // Copy image to staging buffer
-                CopyImageBuffer(command_buffer,
-                                copy_image,
-                                staging_buffer_.buffer,
-                                tmp_data[i].staging_offset,
-                                tmp_data[i].scaled_extent,
-                                img.level_count,
-                                img.layer_count,
-                                img.aspect,
-                                img.level_sizes != nullptr ? *img.level_sizes : tmp_data[i].level_sizes,
-                                img.all_layers_per_level,
-                                kImageToBuffer);
-            }
-
-            // Cache flushing barrier. Make results visible to host
-            VkBufferMemoryBarrier buffer_barrier;
-            buffer_barrier.sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
-            buffer_barrier.pNext               = nullptr;
-            buffer_barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
-            buffer_barrier.dstAccessMask       = VK_ACCESS_HOST_READ_BIT;
-            buffer_barrier.srcQueueFamilyIndex = img.queue_family_index;
-            buffer_barrier.dstQueueFamilyIndex = img.queue_family_index;
-            buffer_barrier.buffer              = staging_buffer_.buffer;
-            buffer_barrier.offset              = 0;
-            buffer_barrier.size                = VK_WHOLE_SIZE;
-
-            device_table_.CmdPipelineBarrier(command_buffer,
-                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                             VK_PIPELINE_STAGE_HOST_BIT,
-                                             0,
-                                             0,
-                                             nullptr,
-                                             1,
-                                             &buffer_barrier,
-                                             0,
-                                             nullptr);
-
-            if ((img.sample_count == VK_SAMPLE_COUNT_1_BIT) && (img.layout != VK_IMAGE_LAYOUT_UNDEFINED) &&
-                (img.layout != VK_IMAGE_LAYOUT_PREINITIALIZED) && (img.layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL))
-            {
-                TransitionImageFromTransferOptimal(command_buffer,
-                                                   img.image,
-                                                   VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                                   img.layout,
-                                                   tmp_data[i].transition_aspect,
-                                                   img.queue_family_index);
-            }
-        } // current batch, record commands
-
-        // submit recorded command-buffer(s)
-        for (const auto& [queue_family_index, command_buffer] : command_buffer_map)
-        {
-            VkQueue queue = GetQueue(queue_family_index, 0);
-            if (queue == VK_NULL_HANDLE)
-            {
-                return VK_ERROR_INITIALIZATION_FAILED;
-            }
-            SubmitCommandBuffer(command_buffer, queue);
-        }
-
-        result = MapStagingBuffer();
+    if (samples != VK_SAMPLE_COUNT_1_BIT)
+    {
+        result = ResolveImage(image,
+                              format,
+                              type,
+                              extent,
+                              array_layers,
+                              layout,
+                              queue,
+                              queue_family_index,
+                              &resolve_image,
+                              &resolve_memory);
         if (result != VK_SUCCESS)
         {
             return result;
         }
+    }
 
-        // guarantees that all device writes are now visible to host
-        InvalidateStagingBuffer();
+    result = CreateStagingBuffer(resource_size);
+    if (result != VK_SUCCESS)
+    {
+        return result;
+    }
 
-        gpu_micros += std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() -
-                                                                            start_time)
-                          .count();
+    result = CreateCommandPool(queue_family_index);
+    if (result != VK_SUCCESS)
+    {
+        return result;
+    }
 
-        // consume staging-buffer, cleanup temporary resources
-        for (uint32_t i = start_idx; i < end_idx; ++i)
+    result = CreateCommandBuffer(queue_family_index);
+    if (result != VK_SUCCESS)
+    {
+        return result;
+    }
+
+    transition_aspect = aspect;
+    if ((transition_aspect == VK_IMAGE_ASPECT_DEPTH_BIT) || (transition_aspect == VK_IMAGE_ASPECT_STENCIL_BIT))
+    {
+        // Depth and stencil aspects need to be transitioned together, so get full aspect
+        // mask for image.
+        transition_aspect = GetFormatAspectMask(format);
+    }
+
+    copy_image = image;
+    if (samples != VK_SAMPLE_COUNT_1_BIT)
+    {
+        copy_image = resolve_image;
+    }
+    else if (layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
+    {
+        TransitionImageToTransferOptimal(
+            image, layout, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, transition_aspect, queue_family_index);
+    }
+
+    // Blit image to change dimensions or convert format
+    if (use_blit)
+    {
+        result = BlitImage(copy_image,
+                           format,
+                           dst_format,
+                           type,
+                           tiling,
+                           extent,
+                           scaled_extent,
+                           mip_levels,
+                           array_layers,
+                           aspect,
+                           queue_family_index,
+                           scale,
+                           scaled_image,
+                           scaled_image_mem);
+
+        if (result != VK_SUCCESS)
         {
-            const auto& img = image_resources[i];
-            auto* out_ptr   = reinterpret_cast<const uint8_t*>(staging_buffer_.mapped_ptr) + tmp_data[i].staging_offset;
-            if (call_back)
-            {
-                call_back(img, out_ptr, tmp_data[i].resource_size);
-            }
+            return result;
+        }
+    }
+    else
+    {
+        scaled_image = copy_image;
+    }
 
-            // free potential temporary resources
-            tmp_data[i] = {};
-        } // current batch, consume staging-buffer
+    assert(scaled_image != VK_NULL_HANDLE);
 
-        UnmapStagingBuffer();
+    if (external_format)
+    {
+        // Todo
+    }
+    else
+    {
+        // Copy image to staging buffer
+        CopyImageBuffer(scaled_image,
+                        staging_buffer_.buffer,
+                        use_blit ? scaled_extent : extent,
+                        mip_levels,
+                        array_layers,
+                        aspect,
+                        subresource_sizes,
+                        all_layers_per_level,
+                        kImageToBuffer);
+    }
 
-        auto batch_micros = std::chrono::duration_cast<std::chrono::microseconds>(
-                                std::chrono::high_resolution_clock::now() - start_time)
-                                .count();
-        cpu_micros += batch_micros - gpu_micros;
-    } // batch_ranges
-    GFXRECON_LOG_DEBUG("gpu: %d ms - cpu: %d ms", gpu_micros / 1000, cpu_micros / 1000);
-    return VK_SUCCESS;
+    // Cache flushing barrier. Make results visible to host
+    VkBufferMemoryBarrier buffer_barrier;
+    buffer_barrier.sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+    buffer_barrier.pNext               = nullptr;
+    buffer_barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+    buffer_barrier.dstAccessMask       = VK_ACCESS_HOST_READ_BIT;
+    buffer_barrier.srcQueueFamilyIndex = queue_family_index_;
+    buffer_barrier.dstQueueFamilyIndex = queue_family_index_;
+    buffer_barrier.buffer              = staging_buffer_.buffer;
+    buffer_barrier.offset              = 0;
+    buffer_barrier.size                = VK_WHOLE_SIZE;
+
+    device_table_.CmdPipelineBarrier(command_buffer_,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_HOST_BIT,
+                                     0,
+                                     0,
+                                     nullptr,
+                                     1,
+                                     &buffer_barrier,
+                                     0,
+                                     nullptr);
+
+    if ((samples == VK_SAMPLE_COUNT_1_BIT) && (layout != VK_IMAGE_LAYOUT_UNDEFINED) &&
+        (layout != VK_IMAGE_LAYOUT_PREINITIALIZED) && (layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL))
+    {
+        TransitionImageFromTransferOptimal(
+            image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, layout, transition_aspect, queue_family_index);
+    }
+
+    result = SubmitCommandBuffer(queue);
+
+    result = MapStagingBuffer();
+    if (result != VK_SUCCESS)
+    {
+        return result;
+    }
+
+    data.resize(static_cast<size_t>(resource_size));
+
+    InvalidateStagingBuffer();
+
+    // Copy staging buffer to host memory
+    util::platform::MemoryCopy(data.data(), resource_size, staging_buffer_.mapped_ptr, resource_size);
+
+    UnmapStagingBuffer();
+
+    // Release temporary resources
+    if (samples != VK_SAMPLE_COUNT_1_BIT)
+    {
+        device_table_.DestroyImage(device_, resolve_image, nullptr);
+        device_table_.FreeMemory(device_, resolve_memory, nullptr);
+    }
+
+    if (use_blit)
+    {
+        device_table_.DestroyImage(device_, scaled_image, nullptr);
+        device_table_.FreeMemory(device_, scaled_image_mem, nullptr);
+    }
+
+    return result;
 }
 
-VkResult VulkanResourcesUtil::ReadImageResource(const VulkanResourcesUtil::ImageResource& image_resource,
-                                                std::vector<uint8_t>&                     out_data)
+void VulkanResourcesUtil::ReadFromImageResourceLinear(VkImage                image,
+                                                      VkFormat               format,
+                                                      VkImageType            type,
+                                                      const VkExtent3D&      extent,
+                                                      uint32_t               mip_levels,
+                                                      uint32_t               array_layers,
+                                                      VkImageAspectFlagBits  aspect,
+                                                      const void*            mapped_image_ptr,
+                                                      std::vector<uint8_t>&  data,
+                                                      std::vector<uint64_t>& subresource_offsets,
+                                                      std::vector<uint64_t>& subresource_sizes)
 {
-    return ReadImageResources(
-        { image_resource },
-        [&out_data](const ImageResource& img, const void* data, size_t num_bytes) {
-            const auto* ptr = reinterpret_cast<const uint8_t*>(data);
-            out_data.clear();
-            out_data.insert(out_data.end(), ptr, ptr + num_bytes);
-        },
-        0);
+    GFXRECON_ASSERT(mip_levels <= 1 + floor(log2(std::max(std::max(extent.width, extent.height), extent.depth))));
+    GFXRECON_ASSERT(mapped_image_ptr);
+
+    subresource_offsets.clear();
+    subresource_sizes.clear();
+
+    const double texel_size = vkuFormatTexelSizeWithAspect(format, aspect);
+    GFXRECON_ASSERT(texel_size == std::floor(texel_size));
+
+    uint64_t offset = 0;
+    for (uint32_t m = 0; m < mip_levels; ++m)
+    {
+        for (uint32_t l = 0; l < array_layers; ++l)
+        {
+            VkSubresourceLayout layout;
+            VkImageSubresource  subresource;
+            subresource.aspectMask = aspect;
+            subresource.mipLevel   = m;
+            subresource.arrayLayer = l;
+
+            device_table_.GetImageSubresourceLayout(device_, image, &subresource, &layout);
+
+            const uint8_t* image_u8_ptr = static_cast<const uint8_t*>(mapped_image_ptr) + layout.offset;
+            uint8_t*       data_u8      = static_cast<uint8_t*>(data.data());
+
+            const uint32_t mip_width  = std::max(1u, (extent.width >> m));
+            const uint32_t mip_height = std::max(1u, (extent.height >> m));
+            const uint64_t stride     = mip_width * static_cast<uint64_t>(texel_size);
+
+            for (uint32_t y = 0; y < mip_height; ++y)
+            {
+                util::platform::MemoryCopy(data_u8, stride, image_u8_ptr, stride);
+                data_u8 += stride;
+                image_u8_ptr += layout.rowPitch;
+            }
+
+            subresource_offsets.push_back(offset);
+            subresource_sizes.push_back(stride * mip_height);
+            offset += stride * mip_height;
+        }
+    }
 }
 
 VkResult VulkanResourcesUtil::ReadFromBufferResource(
     VkBuffer buffer, uint64_t size, uint64_t offset, uint32_t queue_family_index, std::vector<uint8_t>& data)
 {
-    GFXRECON_ASSERT(buffer != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(size);
+    assert(buffer != VK_NULL_HANDLE);
+    assert(size);
 
-    VkQueue queue = GetQueue(queue_family_index, 0);
+    const VkQueue queue = GetQueue(queue_family_index, 0);
     if (queue == VK_NULL_HANDLE)
     {
         return VK_ERROR_INITIALIZATION_FAILED;
@@ -1963,16 +1958,21 @@ VkResult VulkanResourcesUtil::ReadFromBufferResource(
         return result;
     }
 
-    VkCommandBuffer command_buffer = CreateCommandBufferAndBegin(queue_family_index);
-    GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
-    if (command_buffer == VK_NULL_HANDLE)
+    result = CreateCommandPool(queue_family_index);
+    if (result != VK_SUCCESS)
     {
-        return VK_ERROR_UNKNOWN;
+        return result;
     }
 
-    CopyBuffer(command_buffer, buffer, staging_buffer_.buffer, size, offset, 0);
+    result = CreateCommandBuffer(queue_family_index);
+    if (result != VK_SUCCESS)
+    {
+        return result;
+    }
 
-    result = SubmitCommandBuffer(command_buffer, queue);
+    CopyBuffer(buffer, staging_buffer_.buffer, size, offset);
+
+    result = SubmitCommandBuffer(queue);
     if (result != VK_SUCCESS)
     {
         return result;
@@ -1992,136 +1992,106 @@ VkResult VulkanResourcesUtil::ReadFromBufferResource(
     return result;
 }
 
-void VulkanResourcesUtil::ReadBufferResources(const std::vector<BufferResource>& buffer_resources,
-                                              const VulkanResourcesUtil::ReadBufferResourcesCallbackFn& callback,
-                                              size_t staging_buffer_size)
+VkResult VulkanResourcesUtil::WriteToImageResourceStaging(VkImage                      image,
+                                                          VkFormat                     format,
+                                                          VkImageType                  type,
+                                                          const VkExtent3D&            extent,
+                                                          uint32_t                     mip_levels,
+                                                          uint32_t                     array_layers,
+                                                          VkImageAspectFlagBits        aspect,
+                                                          VkImageLayout                layout,
+                                                          uint32_t                     queue_family_index,
+                                                          const void*                  data,
+                                                          const std::vector<uint64_t>& subresource_offsets,
+                                                          const std::vector<uint64_t>& subresource_sizes)
 {
-    if (buffer_resources.empty())
+    assert(mip_levels <= 1 + floor(log2(std::max(std::max(extent.width, extent.height), extent.depth))));
+
+    const VkQueue queue = GetQueue(queue_family_index, 0);
+    if (queue == VK_NULL_HANDLE)
     {
-        return;
+        return VK_ERROR_INITIALIZATION_FAILED;
     }
-    std::vector<VkDeviceSize> staging_offsets(buffer_resources.size());
 
-    uint32_t current_batch_size = 0;
-
-    // start with entire range
-    std::vector<std::pair<uint32_t, uint32_t>> batch_ranges = { { 0, static_cast<uint32_t>(buffer_resources.size()) } };
-
-    for (uint32_t i = 0; i < buffer_resources.size(); ++i)
+    VkResult result;
+    uint64_t resource_size = 0;
+    for (const auto size : subresource_sizes)
     {
-        const auto& buffer_resource = buffer_resources[i];
+        resource_size += size;
+    }
 
-        if (buffer_resource.size > staging_buffer_size)
-        {
-            // we need a bigger boat
-            staging_buffer_size = buffer_resource.size;
-        }
-
-        if (current_batch_size + buffer_resource.size > staging_buffer_size)
-        {
-            // end current batch, start next
-            auto& current_batch  = batch_ranges.back();
-            current_batch.second = i;
-
-            batch_ranges.emplace_back(i, static_cast<uint32_t>(buffer_resources.size()));
-            current_batch_size = 0;
-        }
-
-        staging_offsets[i] = current_batch_size;
-        current_batch_size += buffer_resource.size;
-    } // buffer_resources, split into batches
-
-    VkResult result = CreateStagingBuffer(staging_buffer_size);
+    result = CreateStagingBuffer(resource_size);
     if (result != VK_SUCCESS)
     {
-        GFXRECON_LOG_ERROR(
-            "%s: could not create a staging-buffer of size: %d kB", __func__, staging_buffer_size >> 10U);
-        return;
+        return result;
     }
 
-    for (const auto& [start_idx, end_idx] : batch_ranges)
+    result = MapStagingBuffer();
+    if (result != VK_SUCCESS)
     {
-        auto                                          start_time = std::chrono::high_resolution_clock::now();
-        std::unordered_map<uint32_t, VkCommandBuffer> command_buffer_map;
-
-        // iterate over current batch
-        for (uint32_t i = start_idx; i < end_idx; ++i)
-        {
-            const auto& buf = buffer_resources[i];
-
-            VkCommandBuffer command_buffer = VK_NULL_HANDLE;
-            auto            cmd_buf_it     = command_buffer_map.find(buf.queue_family_index);
-            if (cmd_buf_it == command_buffer_map.end())
-            {
-                command_buffer                             = CreateCommandBufferAndBegin(buf.queue_family_index);
-                command_buffer_map[buf.queue_family_index] = command_buffer;
-            }
-            else
-            {
-                command_buffer = cmd_buf_it->second;
-            }
-
-            CopyBuffer(command_buffer, buf.buffer, staging_buffer_.buffer, buf.size, buf.offset, staging_offsets[i]);
-        }
-
-        // submit recorded command-buffer(s)
-        for (const auto& [queue_family_index, command_buffer] : command_buffer_map)
-        {
-            // Cache flushing barrier. Make results visible to host
-            VkBufferMemoryBarrier buffer_barrier;
-            buffer_barrier.sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
-            buffer_barrier.pNext               = nullptr;
-            buffer_barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
-            buffer_barrier.dstAccessMask       = VK_ACCESS_HOST_READ_BIT;
-            buffer_barrier.srcQueueFamilyIndex = queue_family_index;
-            buffer_barrier.dstQueueFamilyIndex = queue_family_index;
-            buffer_barrier.buffer              = staging_buffer_.buffer;
-            buffer_barrier.offset              = 0;
-            buffer_barrier.size                = VK_WHOLE_SIZE;
-
-            device_table_.CmdPipelineBarrier(command_buffer,
-                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                             VK_PIPELINE_STAGE_HOST_BIT,
-                                             0,
-                                             0,
-                                             nullptr,
-                                             1,
-                                             &buffer_barrier,
-                                             0,
-                                             nullptr);
-
-            VkQueue queue = GetQueue(queue_family_index, 0);
-            if (queue == VK_NULL_HANDLE)
-            {
-                GFXRECON_ASSERT(false);
-                return;
-            }
-            SubmitCommandBuffer(command_buffer, queue);
-        }
-
-        result = MapStagingBuffer();
-        if (result != VK_SUCCESS)
-        {
-            GFXRECON_LOG_ERROR("%s: could not map staging-buffer", __func__);
-            return;
-        }
-
-        // guarantees that all device writes are now visible to host
-        InvalidateStagingBuffer();
-
-        // consume staging-buffer
-        for (uint32_t i = start_idx; i < end_idx; ++i)
-        {
-            const auto& buf     = buffer_resources[i];
-            auto*       out_ptr = reinterpret_cast<const uint8_t*>(staging_buffer_.mapped_ptr) + staging_offsets[i];
-            if (callback)
-            {
-                callback(buf, out_ptr);
-            }
-        } // current batch, consume staging-buffer
-
-        GFXRECON_LOG_DEBUG("%s: batch done: %d - %d (%d)", __func__, start_idx, end_idx, buffer_resources.size());
+        return result;
     }
+
+    uint8_t*       stg_u8_ptr  = static_cast<uint8_t*>(staging_buffer_.mapped_ptr);
+    const uint8_t* data_u8_ptr = static_cast<const uint8_t*>(data);
+    uint32_t       sr          = 0;
+    for (uint32_t m = 0; m < mip_levels; ++m)
+    {
+        for (uint32_t l = 0; l < array_layers; ++l)
+        {
+            util::platform::MemoryCopy(stg_u8_ptr, subresource_sizes[sr], data_u8_ptr, subresource_sizes[sr]);
+            stg_u8_ptr += subresource_sizes[sr];
+            data_u8_ptr += subresource_sizes[sr];
+            ++sr;
+        }
+    }
+    assert(sr == subresource_sizes.size());
+
+    result = CreateCommandPool(queue_family_index);
+    if (result != VK_SUCCESS)
+    {
+        return result;
+    }
+
+    result = CreateCommandBuffer(queue_family_index);
+    if (result != VK_SUCCESS)
+    {
+        return result;
+    }
+
+    VkImageAspectFlags transition_aspect = aspect;
+    if ((transition_aspect == VK_IMAGE_ASPECT_DEPTH_BIT) || (transition_aspect == VK_IMAGE_ASPECT_STENCIL_BIT))
+    {
+        // Depth and stencil aspects need to be transitioned together, so get full aspect
+        // mask for image.
+        transition_aspect = GetFormatAspectMask(format);
+    }
+
+    if (layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
+    {
+        TransitionImageToTransferOptimal(
+            image, layout, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, transition_aspect, queue_family_index);
+    }
+
+    CopyImageBuffer(image,
+                    staging_buffer_.buffer,
+                    extent,
+                    mip_levels,
+                    array_layers,
+                    aspect,
+                    subresource_sizes,
+                    false,
+                    kBufferToImage);
+
+    if (layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
+    {
+        TransitionImageFromTransferOptimal(
+            image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, layout, transition_aspect, queue_family_index);
+    }
+
+    result = SubmitCommandBuffer(queue);
+
+    return result;
 }
 
 bool VulkanResourcesUtil::IsBlitSupported(VkFormat       src_format,
@@ -2207,11 +2177,10 @@ bool VulkanResourcesUtil::IsScalingSupported(VkFormat          src_format,
         }
     }
 
-    return scale == 1.0f || is_blit_supported;
+    return is_blit_supported;
 }
 
-VkResult VulkanResourcesUtil::BlitImage(VkCommandBuffer       command_buffer,
-                                        VkImage               image,
+VkResult VulkanResourcesUtil::BlitImage(VkImage               image,
                                         VkFormat              format,
                                         VkFormat              dst_format,
                                         VkImageType           type,
@@ -2324,7 +2293,7 @@ VkResult VulkanResourcesUtil::BlitImage(VkCommandBuffer       command_buffer,
     img_barrier.image               = scaled_image;
     img_barrier.subresourceRange    = { aspectMask, 0, mip_levels, 0, array_layers };
 
-    device_table_.CmdPipelineBarrier(command_buffer,
+    device_table_.CmdPipelineBarrier(command_buffer_,
                                      VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
                                      VK_PIPELINE_STAGE_TRANSFER_BIT,
                                      0,
@@ -2344,7 +2313,7 @@ VkResult VulkanResourcesUtil::BlitImage(VkCommandBuffer       command_buffer,
     blit_region.dstOffsets[0].y = 0;
     blit_region.dstOffsets[0].z = 0;
 
-    GFXRECON_ASSERT(mip_levels);
+    assert(mip_levels);
     // assert(dst_img_mip_levels);
     std::vector<VkImageBlit> blit_regions(mip_levels);
     for (uint32_t i = 0; i < mip_levels; ++i)
@@ -2362,7 +2331,7 @@ VkResult VulkanResourcesUtil::BlitImage(VkCommandBuffer       command_buffer,
         blit_regions[i] = blit_region;
     }
 
-    device_table_.CmdBlitImage(command_buffer,
+    device_table_.CmdBlitImage(command_buffer_,
                                image,
                                VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                scaled_image,
@@ -2378,7 +2347,7 @@ VkResult VulkanResourcesUtil::BlitImage(VkCommandBuffer       command_buffer,
     img_barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     img_barrier.newLayout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
 
-    device_table_.CmdPipelineBarrier(command_buffer,
+    device_table_.CmdPipelineBarrier(command_buffer_,
                                      VK_PIPELINE_STAGE_TRANSFER_BIT,
                                      VK_PIPELINE_STAGE_TRANSFER_BIT,
                                      0,

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -31,7 +31,6 @@
 #include "vulkan/vulkan_core.h"
 
 #include <vector>
-#include <unordered_map>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
@@ -51,9 +50,23 @@ class VulkanResourcesUtil
                         VkPhysicalDevice                        physical_device,
                         const encode::VulkanDeviceTable&        device_table,
                         const encode::VulkanInstanceTable&      instance_table,
-                        const VkPhysicalDeviceMemoryProperties& memory_properties);
+                        const VkPhysicalDeviceMemoryProperties& memory_properties) :
+        device_(device),
+        device_table_(device_table), physical_device_(physical_device), instance_table_(instance_table),
+        memory_properties_(memory_properties), queue_family_index_(UINT32_MAX), command_pool_(VK_NULL_HANDLE),
+        command_buffer_(VK_NULL_HANDLE)
+    {
+        assert(device != VK_NULL_HANDLE);
+        assert(memory_properties.memoryHeapCount <= VK_MAX_MEMORY_HEAPS);
+        assert(memory_properties.memoryTypeCount <= VK_MAX_MEMORY_TYPES);
+    }
 
-    ~VulkanResourcesUtil();
+    ~VulkanResourcesUtil()
+    {
+        DestroyStagingBuffer();
+        DestroyCommandBuffer();
+        DestroyCommandPool();
+    }
 
     // This function creates a staging buffer that will be used by the ReadFromImageResourceStaging() and
     // ReadFromBufferResource() functions. It is not necessary to do so but can be useful when dumping multiple
@@ -82,88 +95,65 @@ class VulkanResourcesUtil
                                           std::vector<uint64_t>* subresource_sizes    = nullptr,
                                           bool                   all_layers_per_level = false);
 
-    //! aggregate type to group information about an image-resource
-    struct ImageResource
-    {
-        format::HandleId   handle_id          = format::kNullHandleId;
-        VkImage            image              = VK_NULL_HANDLE;
-        VkFormat           format             = VK_FORMAT_UNDEFINED;
-        VkImageType        type               = VK_IMAGE_TYPE_2D;
-        VkExtent3D         extent             = {};
-        uint32_t           level_count        = 0;
-        uint32_t           layer_count        = 0;
-        VkImageTiling      tiling             = VK_IMAGE_TILING_MAX_ENUM;
-        VkSampleCountFlags sample_count       = 0;
-        VkImageLayout      layout             = VK_IMAGE_LAYOUT_UNDEFINED;
-        uint32_t           queue_family_index = 0;
-        bool               external_format    = false;
-        VkDeviceSize       size               = 0;
+    // Use this function to dump an image sub resources into data vector.
+    // This function is intented to be used when accessing the image content directly is not possible
+    // and a staging buffer is required.
+    // subresource_offsets and subresource_sizes will be populated in the same manner as with
+    // GetImageResourceSizesOptimal()
+    VkResult ReadFromImageResourceStaging(VkImage                image,
+                                          VkFormat               format,
+                                          VkImageType            type,
+                                          const VkExtent3D&      extent,
+                                          uint32_t               mip_levels,
+                                          uint32_t               array_layers,
+                                          VkImageTiling          tiling,
+                                          VkSampleCountFlags     samples,
+                                          VkImageLayout          layout,
+                                          uint32_t               queue_family_index,
+                                          bool                   external_format,
+                                          VkDeviceSize           size,
+                                          VkImageAspectFlagBits  aspect,
+                                          std::vector<uint8_t>&  data,
+                                          std::vector<uint64_t>& subresource_offsets,
+                                          std::vector<uint64_t>& subresource_sizes,
+                                          bool&                  scaling_supported,
+                                          bool                   all_layers_per_level = false,
+                                          float                  scale                = 1.0f,
+                                          VkFormat               dst_format           = VK_FORMAT_UNDEFINED);
 
-        //! optionally provide resource_size
-        VkDeviceSize resource_size = 0;
+    // Use this function to dump an image sub resources into data vector.
+    // This function is intented to be used when the image content can be accessed directly and expects to received a
+    // pointer to the mapped memory.
+    // subresource_offsets and subresource_sizes will be populated in the same manner as
+    // with GetImageResourceSizesLinear()
+    void ReadFromImageResourceLinear(VkImage                image,
+                                     VkFormat               format,
+                                     VkImageType            type,
+                                     const VkExtent3D&      extent,
+                                     uint32_t               mip_levels,
+                                     uint32_t               array_layers,
+                                     VkImageAspectFlagBits  aspect,
+                                     const void*            mapped_image_ptr,
+                                     std::vector<uint8_t>&  data,
+                                     std::vector<uint64_t>& subresource_offsets,
+                                     std::vector<uint64_t>& subresource_sizes);
 
-        //! optionally provide sizes of sub-resources (mipmap-levels)
-        const std::vector<VkDeviceSize>* level_sizes = nullptr;
-
-        VkImageAspectFlagBits aspect               = VK_IMAGE_ASPECT_NONE;
-        bool                  all_layers_per_level = false;
-        float                 scale                = 1.0f;
-        VkFormat              dst_format           = VK_FORMAT_UNDEFINED;
-    };
-
-    //! signature for a callback-function, providing an ImageResource and a corresponding data-pointer
-    using ReadImageResourcesCallbackFn =
-        std::function<void(const ImageResource& img_resource, const void* data, size_t num_bytes)>;
-
-    /**
-     * @brief   ReadImageResources processes an array of ImageResources in batches,
-     *          downloads data from GPU-memory using a staging-buffer and provides that data via callback-function.
-     *
-     * @param   image_resources     an array of ImageResource-structs
-     * @param   call_back           a callback-function, consuming data from staging-buffer
-     * @param   staging_buffer_size target size for the staging-buffer in bytes. we might allocate a larger buffer,
-     *                              depending on largest resource-size
-     */
-    VkResult ReadImageResources(const std::vector<ImageResource>&   image_resources,
-                                const ReadImageResourcesCallbackFn& call_back,
-                                size_t                              staging_buffer_size);
-
-    /**
-     * @brief   ReadImageResource downloads image-data from GPU-memory using a staging-buffer
-     *
-     * @param   image_resource  an ImageResource struct
-     * @param   out_data        an output array
-     */
-    VkResult ReadImageResource(const ImageResource& image_resource, std::vector<uint8_t>& out_data);
+    VkResult WriteToImageResourceStaging(VkImage                      image,
+                                         VkFormat                     format,
+                                         VkImageType                  type,
+                                         const VkExtent3D&            extent,
+                                         uint32_t                     mip_levels,
+                                         uint32_t                     array_layers,
+                                         VkImageAspectFlagBits        aspect,
+                                         VkImageLayout                layout,
+                                         uint32_t                     queue_family_index,
+                                         const void*                  data,
+                                         const std::vector<uint64_t>& subresource_offsets,
+                                         const std::vector<uint64_t>& subresource_sizes);
 
     // Use this function to dump the content of a buffer resource into the data vector.
     VkResult ReadFromBufferResource(
         VkBuffer buffer, uint64_t size, uint64_t offset, uint32_t queue_family_index, std::vector<uint8_t>& data);
-
-    struct BufferResource
-    {
-        format::HandleId handle_id          = format::kNullHandleId;
-        VkBuffer         buffer             = VK_NULL_HANDLE;
-        uint64_t         size               = 0;
-        uint64_t         offset             = 0;
-        uint32_t         queue_family_index = 0;
-    };
-
-    //! signature for a callback-function, providing a BufferResource and a corresponding data-pointer
-    using ReadBufferResourcesCallbackFn = std::function<void(const BufferResource& buffer_resource, const void* data)>;
-
-    /**
-     * @brief   ReadBufferResources processes an array of BufferResources in batches,
-     *          downloads data from GPU-memory using a staging-buffer and provides that data via callback-function.
-     *
-     * @param   buffer_resources    an array of BufferResource-structs
-     * @param   callback            a callback-function, consuming data from staging-buffer
-     * @param   staging_buffer_size target size for the staging-buffer in bytes. we might allocate a larger buffer,
-     *                                   depending on largest resource-size
-     */
-    void ReadBufferResources(const std::vector<BufferResource>&   buffer_resources,
-                             const ReadBufferResourcesCallbackFn& callback,
-                             size_t                               staging_buffer_size);
 
     bool IsBlitSupported(VkFormat       src_format,
                          VkImageTiling  src_image_tiling,
@@ -178,11 +168,19 @@ class VulkanResourcesUtil
                             float             scale) const;
 
   private:
-    VkCommandBuffer CreateCommandBufferAndBegin(uint32_t queue_family_index);
+    VkResult CreateCommandPool(uint32_t queue_family_index);
 
-    void ResetCommandBuffer(VkCommandBuffer command_buffer);
+    void DestroyCommandPool();
 
-    VkResult BeginCommandBuffer(VkCommandBuffer command_buffer);
+    VkResult CreateCommandBuffer(uint32_t queue_family_index);
+
+    void ResetCommandBuffer();
+
+    VkResult BeginCommandBuffer();
+
+    VkResult EndCommandBuffer();
+
+    void DestroyCommandBuffer();
 
     VkResult MapStagingBuffer();
 
@@ -192,24 +190,20 @@ class VulkanResourcesUtil
 
     void DestroyStagingBuffer();
 
-    void TransitionImageToTransferOptimal(VkCommandBuffer    command_buffer,
-                                          VkImage            image,
+    void TransitionImageToTransferOptimal(VkImage            image,
                                           VkImageLayout      current_layout,
                                           VkImageLayout      destination_layout,
                                           VkImageAspectFlags aspect,
                                           uint32_t           queue_family_index);
 
-    void TransitionImageFromTransferOptimal(VkCommandBuffer    command_buffer,
-                                            VkImage            image,
+    void TransitionImageFromTransferOptimal(VkImage            image,
                                             VkImageLayout      old_layout,
                                             VkImageLayout      new_layout,
                                             VkImageAspectFlags aspect,
                                             uint32_t           queue_family_index);
 
-    void CopyImageBuffer(VkCommandBuffer              command_buffer,
-                         VkImage                      image,
+    void CopyImageBuffer(VkImage                      image,
                          VkBuffer                     buffer,
-                         uint32_t                     buffer_offset,
                          const VkExtent3D&            extent,
                          uint32_t                     mip_levels,
                          uint32_t                     array_layers,
@@ -218,29 +212,26 @@ class VulkanResourcesUtil
                          bool                         all_layers_per_level,
                          CopyBufferImageDirection     copy_direction);
 
-    void CopyBuffer(VkCommandBuffer command_buffer,
-                    VkBuffer        source_buffer,
-                    VkBuffer        destination_buffer,
-                    uint64_t        size,
-                    uint64_t        src_offset,
-                    uint64_t        dst_offset);
+    void CopyBuffer(VkBuffer source_buffer, VkBuffer destination_buffer, uint64_t size, uint64_t offset);
 
-    VkResult ResolveImage(VkCommandBuffer   command_buffer,
-                          VkImage           image,
+    VkResult ResolveImage(VkImage           image,
                           VkFormat          format,
                           VkImageType       type,
                           const VkExtent3D& extent,
                           uint32_t          array_layers,
                           VkImageLayout     current_layout,
+                          VkQueue           queue,
+                          uint32_t          queue_family_index,
                           VkImage*          resolve_image,
                           VkDeviceMemory*   resolve_memory);
 
     VkQueue GetQueue(uint32_t queue_family_index, uint32_t queue_index);
 
-    VkResult SubmitCommandBuffer(VkCommandBuffer command_buffer, VkQueue queue);
+    VkResult SubmitCommandBuffer(VkQueue queue);
 
-    VkResult BlitImage(VkCommandBuffer       command_buffer,
-                       VkImage               image,
+    void InvalidateMappedMemoryRange(VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size);
+
+    VkResult BlitImage(VkImage               image,
                        VkFormat              format,
                        VkFormat              dst_format,
                        VkImageType           type,
@@ -271,18 +262,10 @@ class VulkanResourcesUtil
     VkPhysicalDevice                        physical_device_;
     const encode::VulkanInstanceTable&      instance_table_;
     const VkPhysicalDeviceMemoryProperties& memory_properties_;
-
-    struct command_assets_t
-    {
-        VkCommandPool   command_pool   = VK_NULL_HANDLE;
-        VkCommandBuffer command_buffer = VK_NULL_HANDLE;
-    };
-
-    // map queue-family index -> command-pool/buffer
-    std::unordered_map<uint32_t, command_assets_t> command_asset_map_;
-    StagingBufferContext                           staging_buffer_;
-
-    PFN_vkSetDebugUtilsObjectNameEXT set_debug_utils_object_name_fn_ = nullptr;
+    uint32_t                                queue_family_index_;
+    VkCommandPool                           command_pool_;
+    VkCommandBuffer                         command_buffer_;
+    StagingBufferContext                    staging_buffer_;
 };
 
 void GetFormatAspects(VkFormat                            format,

--- a/framework/util/compressor.h
+++ b/framework/util/compressor.h
@@ -36,20 +36,20 @@ GFXRECON_BEGIN_NAMESPACE(util)
 class Compressor
 {
   public:
-    Compressor() = default;
+    Compressor() {}
 
-    virtual ~Compressor() = default;
+    virtual ~Compressor() {}
 
     // If needed, compressed_data will be resized to fit the compressed data + compressed_data_offset.
-    virtual size_t Compress(size_t                uncompressed_size,
+    virtual size_t Compress(const size_t          uncompressed_size,
                             const uint8_t*        uncompressed_data,
                             std::vector<uint8_t>* compressed_data,
-                            size_t                compressed_data_offset) const = 0;
+                            size_t                compressed_data_offset) = 0;
 
-    virtual size_t Decompress(size_t                      compressed_size,
+    virtual size_t Decompress(const size_t                compressed_size,
                               const std::vector<uint8_t>& compressed_data,
-                              size_t                      expected_uncompressed_size,
-                              std::vector<uint8_t>*       uncompressed_data) const = 0;
+                              const size_t                expected_uncompressed_size,
+                              std::vector<uint8_t>*       uncompressed_data) = 0;
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/lz4_compressor.cpp
+++ b/framework/util/lz4_compressor.cpp
@@ -35,7 +35,7 @@ GFXRECON_BEGIN_NAMESPACE(util)
 size_t Lz4Compressor::Compress(const size_t          uncompressed_size,
                                const uint8_t*        uncompressed_data,
                                std::vector<uint8_t>* compressed_data,
-                               size_t                compressed_data_offset) const
+                               size_t                compressed_data_offset)
 {
     size_t data_size = 0;
 
@@ -69,7 +69,7 @@ size_t Lz4Compressor::Compress(const size_t          uncompressed_size,
 size_t Lz4Compressor::Decompress(const size_t                compressed_size,
                                  const std::vector<uint8_t>& compressed_data,
                                  const size_t                expected_uncompressed_size,
-                                 std::vector<uint8_t>*       uncompressed_data) const
+                                 std::vector<uint8_t>*       uncompressed_data)
 {
     size_t data_size = 0;
 

--- a/framework/util/lz4_compressor.h
+++ b/framework/util/lz4_compressor.h
@@ -32,19 +32,19 @@ GFXRECON_BEGIN_NAMESPACE(util)
 class Lz4Compressor : public Compressor
 {
   public:
-    Lz4Compressor() = default;
+    Lz4Compressor() {}
 
-    ~Lz4Compressor() override = default;
+    virtual ~Lz4Compressor() override {}
 
-    size_t Compress(size_t                uncompressed_size,
-                    const uint8_t*        uncompressed_data,
-                    std::vector<uint8_t>* compressed_data,
-                    size_t                compressed_data_offset) const override;
+    virtual size_t Compress(const size_t          uncompressed_size,
+                            const uint8_t*        uncompressed_data,
+                            std::vector<uint8_t>* compressed_data,
+                            size_t                compressed_data_offset) override;
 
-    size_t Decompress(size_t                      compressed_size,
-                      const std::vector<uint8_t>& compressed_data,
-                      size_t                      expected_uncompressed_size,
-                      std::vector<uint8_t>*       uncompressed_data) const override;
+    virtual size_t Decompress(const size_t                compressed_size,
+                              const std::vector<uint8_t>& compressed_data,
+                              const size_t                expected_uncompressed_size,
+                              std::vector<uint8_t>*       uncompressed_data) override;
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/zlib_compressor.cpp
+++ b/framework/util/zlib_compressor.cpp
@@ -33,7 +33,7 @@ GFXRECON_BEGIN_NAMESPACE(util)
 size_t ZlibCompressor::Compress(const size_t          uncompressed_size,
                                 const uint8_t*        uncompressed_data,
                                 std::vector<uint8_t>* compressed_data,
-                                size_t                compressed_data_offset) const
+                                size_t                compressed_data_offset)
 {
     size_t copy_size = 0;
 
@@ -74,7 +74,7 @@ size_t ZlibCompressor::Compress(const size_t          uncompressed_size,
 size_t ZlibCompressor::Decompress(const size_t                compressed_size,
                                   const std::vector<uint8_t>& compressed_data,
                                   const size_t                expected_uncompressed_size,
-                                  std::vector<uint8_t>*       uncompressed_data) const
+                                  std::vector<uint8_t>*       uncompressed_data)
 {
     size_t copy_size = 0;
 

--- a/framework/util/zlib_compressor.h
+++ b/framework/util/zlib_compressor.h
@@ -32,19 +32,19 @@ GFXRECON_BEGIN_NAMESPACE(util)
 class ZlibCompressor : public Compressor
 {
   public:
-    ZlibCompressor() = default;
+    ZlibCompressor() {}
 
-    ~ZlibCompressor() override = default;
+    virtual ~ZlibCompressor() override {}
 
-    size_t Compress(size_t                uncompressed_size,
-                    const uint8_t*        uncompressed_data,
-                    std::vector<uint8_t>* compressed_data,
-                    size_t                compressed_data_offset) const override;
+    virtual size_t Compress(const size_t          uncompressed_size,
+                            const uint8_t*        uncompressed_data,
+                            std::vector<uint8_t>* compressed_data,
+                            size_t                compressed_data_offset) override;
 
-    size_t Decompress(size_t                      compressed_size,
-                      const std::vector<uint8_t>& compressed_data,
-                      size_t                      expected_uncompressed_size,
-                      std::vector<uint8_t>*       uncompressed_data) const override;
+    virtual size_t Decompress(const size_t                compressed_size,
+                              const std::vector<uint8_t>& compressed_data,
+                              const size_t                expected_uncompressed_size,
+                              std::vector<uint8_t>*       uncompressed_data) override;
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/zstd_compressor.cpp
+++ b/framework/util/zstd_compressor.cpp
@@ -36,7 +36,7 @@ GFXRECON_BEGIN_NAMESPACE(util)
 size_t ZstdCompressor::Compress(const size_t          uncompressed_size,
                                 const uint8_t*        uncompressed_data,
                                 std::vector<uint8_t>* compressed_data,
-                                size_t                compressed_data_offset) const
+                                size_t                compressed_data_offset)
 {
     size_t data_size = 0;
 
@@ -74,7 +74,7 @@ size_t ZstdCompressor::Compress(const size_t          uncompressed_size,
 size_t ZstdCompressor::Decompress(const size_t                compressed_size,
                                   const std::vector<uint8_t>& compressed_data,
                                   const size_t                expected_uncompressed_size,
-                                  std::vector<uint8_t>*       uncompressed_data) const
+                                  std::vector<uint8_t>*       uncompressed_data)
 {
     size_t data_size = 0;
 

--- a/framework/util/zstd_compressor.h
+++ b/framework/util/zstd_compressor.h
@@ -31,19 +31,19 @@ GFXRECON_BEGIN_NAMESPACE(util)
 class ZstdCompressor : public Compressor
 {
   public:
-    ZstdCompressor() = default;
+    ZstdCompressor() {}
 
-    ~ZstdCompressor() override = default;
+    virtual ~ZstdCompressor() override {}
 
-    size_t Compress(size_t                uncompressed_size,
-                    const uint8_t*        uncompressed_data,
-                    std::vector<uint8_t>* compressed_data,
-                    size_t                compressed_data_offset) const override;
+    virtual size_t Compress(const size_t          uncompressed_size,
+                            const uint8_t*        uncompressed_data,
+                            std::vector<uint8_t>* compressed_data,
+                            size_t                compressed_data_offset) override;
 
-    size_t Decompress(size_t                      compressed_size,
-                      const std::vector<uint8_t>& compressed_data,
-                      size_t                      expected_uncompressed_size,
-                      std::vector<uint8_t>*       uncompressed_data) const override;
+    virtual size_t Decompress(const size_t                compressed_size,
+                              const std::vector<uint8_t>& compressed_data,
+                              const size_t                expected_uncompressed_size,
+                              std::vector<uint8_t>*       uncompressed_data) override;
 };
 
 GFXRECON_END_NAMESPACE(util)


### PR DESCRIPTION
Reverts LunarG/gfxreconstruct#2089

We discovered incorrect results from screenshots from replaying trimmed captures in a recent Release build extended testing run.  Running trimmed capture of some tests in Debug build indicates an assertion which would not have fired in Release.