### PR TITLE
Fix resource memory binding failure

### DIFF
--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -837,7 +837,7 @@ VkResult VulkanRebindAllocator::AllocateAHBMemory(MemoryAllocInfo* memory_alloc_
     VkMemoryAllocateInfo allocate_info{};
     allocate_info.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
     allocate_info.pNext           = &dedicatedAllocateInfo;
-    allocate_info.allocationSize  = memory_alloc_info->allocation_size;
+    allocate_info.allocationSize  = memoryRequirements.size;
     allocate_info.memoryTypeIndex = replay_memory_properties_.memoryTypeCount;
     for (uint32_t i = 0; i < replay_memory_properties_.memoryTypeCount; ++i)
     {

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -837,7 +837,7 @@ VkResult VulkanRebindAllocator::AllocateAHBMemory(MemoryAllocInfo* memory_alloc_
     VkMemoryAllocateInfo allocate_info{};
     allocate_info.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
     allocate_info.pNext           = &dedicatedAllocateInfo;
-    allocate_info.allocationSize  = memoryRequirements.size;
+    allocate_info.allocationSize  = std::max<VkDeviceSize>(memory_alloc_info->allocation_size, memoryRequirements.size);
     allocate_info.memoryTypeIndex = replay_memory_properties_.memoryTypeCount;
     for (uint32_t i = 0; i < replay_memory_properties_.memoryTypeCount; ++i)
     {


### PR DESCRIPTION
In rebind allocator, the allocation size has some issue and vkAllocateMemory returns VK_ERROR_INVALID_EXTERNAL_HANDLE
This will cause resource memory binding to fail

Change-Id: I635c5c708ef32ce70db2fa20ccce80f288652c15