### PR TITLE
Resolve issues around DebugUtilsCallback()

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -121,6 +121,8 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeve
     if (pCallbackData->pMessageIdName != nullptr)
         message_id_name = pCallbackData->pMessageIdName;
 
+    GFXRECON_LOG_INFO("WE ARE IN THE DEBUG CALLBACK UNCONDITIONAL SECTION");
+
     if ((pCallbackData != nullptr) && (pCallbackData->pMessage != nullptr))
     {
         if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
@@ -140,8 +142,6 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeve
             GFXRECON_LOG_DEBUG("DEBUG MESSENGER: %s: %s", message_id_name, pCallbackData->pMessage);
         }
     }
-
-    abort();
 
     return VK_FALSE;
 }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2729,7 +2729,7 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
     {
         modified_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 
-        create_state.messenger_create_info = { VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT };
+        create_state.messenger_create_info             = { VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT };
         create_state.messenger_create_info.pNext       = modified_create_info.pNext;
         create_state.messenger_create_info.flags       = 0;
         create_state.messenger_create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_FLAG_BITS_MAX_ENUM_EXT;
@@ -2743,9 +2743,8 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
     }
     else
     {
-        GFXRECON_LOG_WARNING(
-            "Failed to create debug utils callback. "
-            "VK_EXT_debug_utils extension is not available for the replay instance.");
+        GFXRECON_LOG_WARNING("Failed to create debug utils callback. "
+                             "VK_EXT_debug_utils extension is not available for the replay instance.");
     }
 
     // Enable validation layer and create a debug messenger if the enable_validation_layer replay option is set.
@@ -2857,12 +2856,9 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
         if (create_state.messenger_create_info.pfnUserCallback != nullptr)
         {
             VkDebugUtilsMessengerEXT where_should_this_go;
-            GetInstanceTable(*replay_instance)->CreateDebugUtilsMessengerEXT(
-                *replay_instance,
-                &create_state.messenger_create_info,
-                nullptr,
-                &where_should_this_go
-            );
+            GetInstanceTable(*replay_instance)
+                ->CreateDebugUtilsMessengerEXT(
+                    *replay_instance, &create_state.messenger_create_info, nullptr, &where_should_this_go);
         }
     }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -141,6 +141,8 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeve
         }
     }
 
+    abort();
+
     return VK_FALSE;
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -116,24 +116,28 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeve
 {
     GFXRECON_UNREFERENCED_PARAMETER(pUserData);
 
-    if ((pCallbackData != nullptr) && (pCallbackData->pMessageIdName != nullptr) &&
-        (pCallbackData->pMessage != nullptr))
+    // Allow pCallbackData->pMessageIdName to be nullptr by defining a default string for message id name
+    const char* message_id_name = "(nullptr)";
+    if (pCallbackData->pMessageIdName != nullptr)
+        message_id_name = pCallbackData->pMessageIdName;
+
+    if ((pCallbackData != nullptr) && (pCallbackData->pMessage != nullptr))
     {
         if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
         {
-            GFXRECON_LOG_ERROR("DEBUG MESSENGER: %s: %s", pCallbackData->pMessageIdName, pCallbackData->pMessage);
+            GFXRECON_LOG_ERROR("DEBUG MESSENGER: %s: %s", message_id_name, pCallbackData->pMessage);
         }
         else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
         {
-            GFXRECON_LOG_WARNING("DEBUG MESSENGER: %s: %s", pCallbackData->pMessageIdName, pCallbackData->pMessage);
+            GFXRECON_LOG_WARNING("DEBUG MESSENGER: %s: %s", message_id_name, pCallbackData->pMessage);
         }
         else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT)
         {
-            GFXRECON_LOG_INFO("DEBUG MESSENGER: %s: %s", pCallbackData->pMessageIdName, pCallbackData->pMessage);
+            GFXRECON_LOG_INFO("DEBUG MESSENGER: %s: %s", message_id_name, pCallbackData->pMessage);
         }
         else
         {
-            GFXRECON_LOG_DEBUG("DEBUG MESSENGER: %s: %s", pCallbackData->pMessageIdName, pCallbackData->pMessage);
+            GFXRECON_LOG_DEBUG("DEBUG MESSENGER: %s: %s", message_id_name, pCallbackData->pMessage);
         }
     }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2733,7 +2733,7 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
         create_state.messenger_create_info.pNext       = modified_create_info.pNext;
         create_state.messenger_create_info.flags       = 0;
         create_state.messenger_create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_FLAG_BITS_MAX_ENUM_EXT;
-        create_state.messenger_create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_FLAG_BITS_MAX_ENUM_EXT;
+        create_state.messenger_create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
         create_state.messenger_create_info.pfnUserCallback = DebugUtilsCallback;
         create_state.messenger_create_info.pUserData       = nullptr;
 
@@ -2858,7 +2858,7 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
             VkDebugUtilsMessengerEXT where_should_this_go;
             GetInstanceTable(*replay_instance)
                 ->CreateDebugUtilsMessengerEXT(
-                    *replay_instance, &create_state.messenger_create_info, nullptr, &where_should_this_go);
+                    *replay_instance, &create_state.messenger_create_info, GetAllocationCallbacks(pAllocator), &where_should_this_go);
         }
     }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -121,8 +121,6 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeve
     if (pCallbackData->pMessageIdName != nullptr)
         message_id_name = pCallbackData->pMessageIdName;
 
-    GFXRECON_LOG_INFO("messageSeverity == %i", messageSeverity);
-
     if ((pCallbackData != nullptr) && (pCallbackData->pMessage != nullptr))
     {
         if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2748,6 +2748,10 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
                 message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
                 break;
             }
+            default:
+            {
+                GFXRECON_LOG_WARNING("Invalid severity value found when querying logger.")
+            }
         }
 
         create_state.messenger_create_info             = { VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT };

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -118,8 +118,10 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeve
 
     // Allow pCallbackData->pMessageIdName to be nullptr by defining a default string for message id name
     const char* message_id_name = "(nullptr)";
-    if (pCallbackData->pMessageIdName != nullptr)
+    if ((pCallbackData != nullptr) && (pCallbackData->pMessageIdName != nullptr))
+    {
         message_id_name = pCallbackData->pMessageIdName;
+    }
 
     if ((pCallbackData != nullptr) && (pCallbackData->pMessage != nullptr))
     {
@@ -2872,7 +2874,7 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
                 ->CreateDebugUtilsMessengerEXT(*replay_instance,
                                                &create_state.messenger_create_info,
                                                GetAllocationCallbacks(pAllocator),
-                                               &debug_messenger);
+                                               &debug_messenger_);
         }
     }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -121,6 +121,8 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeve
     if (pCallbackData->pMessageIdName != nullptr)
         message_id_name = pCallbackData->pMessageIdName;
 
+    GFXRECON_LOG_INFO("messageSeverity == %i", messageSeverity);
+
     if ((pCallbackData != nullptr) && (pCallbackData->pMessage != nullptr))
     {
         if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
@@ -2732,31 +2734,6 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
     {
         modified_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 
-        // Select debug message severity based on requested logging level
-        VkDebugUtilsMessageSeverityFlagBitsEXT message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-        switch (util::Log::GetSeverity())
-        {
-            case util::Log::Severity::kDebugSeverity:
-            {
-                message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
-                break;
-            }
-            case util::Log::Severity::kInfoSeverity:
-            {
-                message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
-                break;
-            }
-            case util::Log::Severity::kWarningSeverity:
-            {
-                message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
-                break;
-            }
-            default:
-            {
-                GFXRECON_LOG_WARNING("Invalid severity value found when querying logger.")
-            }
-        }
-
         // Set pfnUserCallback for all debug messengers down the pNext chain
         VkDebugUtilsMessengerCreateInfoEXT* pnext_callback_info =
             graphics::vulkan_struct_get_pnext<VkDebugUtilsMessengerCreateInfoEXT>(&modified_create_info);
@@ -2771,7 +2748,7 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
         create_state.messenger_create_info.pNext       = modified_create_info.pNext;
         create_state.messenger_create_info.flags       = 0;
         create_state.messenger_create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_FLAG_BITS_MAX_ENUM_EXT;
-        create_state.messenger_create_info.messageSeverity = message_severity;
+        create_state.messenger_create_info.messageSeverity = options_.debug_message_severity;
         create_state.messenger_create_info.pfnUserCallback = DebugUtilsCallback;
         create_state.messenger_create_info.pUserData       = nullptr;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1715,7 +1715,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     util::ThreadPool main_thread_queue_;
     util::ThreadPool background_queue_;
 
-    VkDebugUtilsMessengerEXT debug_messenger;
+    VkDebugUtilsMessengerEXT debug_messenger_;
 
     //! async_tracked_handle_asset_t groups assets used by tracked async-dependencies
     struct async_tracked_handle_asset_t

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1715,6 +1715,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     util::ThreadPool main_thread_queue_;
     util::ThreadPool background_queue_;
 
+    VkDebugUtilsMessengerEXT debug_messenger;
+
     //! async_tracked_handle_asset_t groups assets used by tracked async-dependencies
     struct async_tracked_handle_asset_t
     {

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -71,6 +71,7 @@ struct VulkanReplayOptions : public ReplayOptions
     SkipGetFenceStatus           skip_get_fence_status{ SkipGetFenceStatus::NoSkip };
     std::vector<util::UintRange> skip_get_fence_ranges;
     bool                         wait_before_present{ false };
+    VkDebugUtilsMessageSeverityFlagBitsEXT debug_message_severity{ VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT };
 
     // Dumping resources related configurable replay options
     std::vector<uint64_t>                           BeginCommandBuffer_Indices;

--- a/framework/util/logging.h
+++ b/framework/util/logging.h
@@ -181,6 +181,8 @@ class Log
         return parse_success;
     }
 
+    static Severity GetSeverity() { return settings_.min_severity; }
+
   private:
     static std::string ConvertFormatVaListToString(const std::string& format_string, va_list& var_args);
 

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -124,7 +124,7 @@ static void PrintUsage(const char* exe_name)
 #endif
     GFXRECON_WRITE_CONSOLE(
         "  --debug-messenger-level <level>\tSpecify highest debug messenger severity level. Options are:")
-    GFXRECON_WRITE_CONSOLE("          \t\tdebug, info, warning, and error. Default is info.");
+    GFXRECON_WRITE_CONSOLE("          \t\tdebug, info, warning, and error. Default is warning.");
     GFXRECON_WRITE_CONSOLE("  --pause-frame <N>\tPause after replaying frame number N.");
     GFXRECON_WRITE_CONSOLE("  --paused\t\tPause after replaying the first frame (same");
     GFXRECON_WRITE_CONSOLE("          \t\tas --pause-frame 1).");

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -96,6 +96,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-json-output-per-command]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-dump-immutable-resources]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-dump-all-image-subresources]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--debug-messenger-level <level>]");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-modifiable-state-only]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--fwo <x,y> | --force-windowed-origin <x,y>]");
@@ -121,6 +122,9 @@ static void PrintUsage(const char* exe_name)
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("  --log-debugview\tLog messages with OutputDebugStringA.");
 #endif
+    GFXRECON_WRITE_CONSOLE(
+        "  --debug-messenger-level <level>\tSpecify highest debug messenger severity level. Options are:")
+    GFXRECON_WRITE_CONSOLE("          \t\tdebug, info, warning, and error. Default is info.");
     GFXRECON_WRITE_CONSOLE("  --pause-frame <N>\tPause after replaying frame number N.");
     GFXRECON_WRITE_CONSOLE("  --paused\t\tPause after replaying the first frame (same");
     GFXRECON_WRITE_CONSOLE("          \t\tas --pause-frame 1).");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -71,6 +71,7 @@ const char kHelpShortOption[]                    = "-h";
 const char kHelpLongOption[]                     = "--help";
 const char kVersionOption[]                      = "--version";
 const char kLogLevelArgument[]                   = "--log-level";
+const char kDebugMessageSeverityArgument[]       = "--debug-messenger-level";
 const char kLogFileArgument[]                    = "--log-file";
 const char kLogDebugView[]                       = "--log-debugview";
 const char kNoDebugPopup[]                       = "--no-debug-popup";
@@ -1072,6 +1073,32 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
         arg_parser.IsOptionSet(kVirtualSwapchainSkipBlitShortOption))
     {
         replay_options.virtual_swapchain_skip_blit = true;
+    }
+
+    const std::string debug_severity_string = arg_parser.GetArgumentValue(kDebugMessageSeverityArgument);
+    if (!debug_severity_string.empty())
+    {
+        if (gfxrecon::util::platform::StringCompareNoCase("debug", debug_severity_string.c_str()))
+        {
+            replay_options.debug_message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
+        }
+        else if (gfxrecon::util::platform::StringCompareNoCase("info", debug_severity_string.c_str()))
+        {
+            replay_options.debug_message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+        }
+        else if (gfxrecon::util::platform::StringCompareNoCase("warning", debug_severity_string.c_str()))
+        {
+            replay_options.debug_message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+        }
+        else if (gfxrecon::util::platform::StringCompareNoCase("error", debug_severity_string.c_str()))
+        {
+            replay_options.debug_message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING("Ignoring unrecognized debug messenger severity option value \"%s\"",
+                                 debug_severity_string.c_str());
+        }
     }
 
     replay_options.replace_shader_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);


### PR DESCRIPTION
Resolves #2112 

`DebugUtilsCallback` will silently omit messages that don't set `pCallbackData->pMessageIdName`. This causes an issue with layers that don't set that field, such as RenderDoc

This PR makes the function print `(nullptr)` in place of `pCallbackData->pMessageIdName` when it is null.

Additionally, this PR unconditionally registers the debug callback so that messages from layers are displayed even when the captured app didn't set the debug callback, and sets the callback severity based on a new option `--debug-messenger-level`