### PR TITLE
Move VulkanDispatchTable to gfxrecon::graphics

### DIFF
--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -65,7 +65,6 @@ target_sources(gfxrecon_encode
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_api_call_encoders.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_command_buffer_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_command_buffer_util.cpp
-                   ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_dispatch_table.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_pnext_struct_encoder.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_encoders.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_encoders.cpp

--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(gfxrecon_graphics
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_deep_copy.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_get_pnext.h
+                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_dispatch_table.h
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_extract_handles.h

--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -123,10 +123,10 @@ VkExtent2D AndroidWindow::GetSize() const
     return { width_, height_ };
 }
 
-VkResult AndroidWindow::CreateSurface(const encode::VulkanInstanceTable* table,
-                                      VkInstance                         instance,
-                                      VkFlags                            flags,
-                                      VkSurfaceKHR*                      pSurface)
+VkResult AndroidWindow::CreateSurface(const graphics::VulkanInstanceTable* table,
+                                      VkInstance                           instance,
+                                      VkFlags                              flags,
+                                      VkSurfaceKHR*                        pSurface)
 {
     if (table != nullptr)
     {
@@ -140,7 +140,9 @@ VkResult AndroidWindow::CreateSurface(const encode::VulkanInstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void AndroidWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void AndroidWindow::DestroySurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkSurfaceKHR                         surface)
 {
     if (table != nullptr)
     {
@@ -194,9 +196,9 @@ void AndroidWindowFactory::Destroy(decode::Window* window)
 #endif
 }
 
-VkBool32 AndroidWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                                    VkPhysicalDevice                   physical_device,
-                                                                    uint32_t queue_family_index)
+VkBool32 AndroidWindowFactory::GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                                    VkPhysicalDevice physical_device,
+                                                                    uint32_t         queue_family_index)
 {
     GFXRECON_UNREFERENCED_PARAMETER(table);
     GFXRECON_UNREFERENCED_PARAMETER(physical_device);

--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -75,13 +75,13 @@ class AndroidWindow : public decode::Window
 
     virtual VkExtent2D GetSize() const override;
 
-    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
-                                   VkInstance                         instance,
-                                   VkFlags                            flags,
-                                   VkSurfaceKHR*                      pSurface) override;
+    virtual VkResult CreateSurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkFlags                              flags,
+                                   VkSurfaceKHR*                        pSurface) override;
 
     virtual void
-    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     AndroidContext* android_context_;
@@ -108,8 +108,8 @@ class AndroidWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                          VkPhysicalDevice                   physical_device,
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                     physical_device,
                                                           uint32_t queue_family_index) override;
 
   private:

--- a/framework/application/display_window.cpp
+++ b/framework/application/display_window.cpp
@@ -35,9 +35,9 @@ DisplayWindow::DisplayWindow(DisplayContext* display_context) : display_context_
     assert(display_context_ != nullptr);
 }
 
-VkResult DisplayWindow::SelectPhysicalDevice(const encode::VulkanInstanceTable* table,
-                                             VkInstance                         instance,
-                                             VkPhysicalDevice*                  physical_device) const
+VkResult DisplayWindow::SelectPhysicalDevice(const graphics::VulkanInstanceTable* table,
+                                             VkInstance                           instance,
+                                             VkPhysicalDevice*                    physical_device) const
 {
     assert(table);
     uint32_t physical_device_count = 0;
@@ -74,9 +74,9 @@ VkResult DisplayWindow::SelectPhysicalDevice(const encode::VulkanInstanceTable* 
     return VK_SUCCESS;
 }
 
-VkResult DisplayWindow::SelectDisplay(const encode::VulkanInstanceTable* table,
-                                      VkPhysicalDevice                   physical_device,
-                                      VkDisplayKHR*                      display) const
+VkResult DisplayWindow::SelectDisplay(const graphics::VulkanInstanceTable* table,
+                                      VkPhysicalDevice                     physical_device,
+                                      VkDisplayKHR*                        display) const
 {
     assert(table);
     uint32_t num_displays;
@@ -102,10 +102,10 @@ VkResult DisplayWindow::SelectDisplay(const encode::VulkanInstanceTable* table,
     return VK_SUCCESS;
 }
 
-VkResult DisplayWindow::SelectMode(const encode::VulkanInstanceTable* table,
-                                   VkPhysicalDevice                   physical_device,
-                                   VkDisplayKHR                       display,
-                                   VkDisplayModePropertiesKHR*        mode_props) const
+VkResult DisplayWindow::SelectMode(const graphics::VulkanInstanceTable* table,
+                                   VkPhysicalDevice                     physical_device,
+                                   VkDisplayKHR                         display,
+                                   VkDisplayModePropertiesKHR*          mode_props) const
 {
     assert(table);
     uint32_t num_modes;
@@ -129,11 +129,11 @@ VkResult DisplayWindow::SelectMode(const encode::VulkanInstanceTable* table,
     return VK_SUCCESS;
 }
 
-VkResult DisplayWindow::SelectPlane(const encode::VulkanInstanceTable* table,
-                                    VkPhysicalDevice                   physical_device,
-                                    VkDisplayKHR                       display,
-                                    uint32_t*                          plane_index,
-                                    VkDisplayPlanePropertiesKHR*       plane_props) const
+VkResult DisplayWindow::SelectPlane(const graphics::VulkanInstanceTable* table,
+                                    VkPhysicalDevice                     physical_device,
+                                    VkDisplayKHR                         display,
+                                    uint32_t*                            plane_index,
+                                    VkDisplayPlanePropertiesKHR*         plane_props) const
 {
     assert(table);
     uint32_t num_planes;
@@ -211,10 +211,10 @@ VkExtent2D DisplayWindow::GetSize() const
     return { width_, height_ };
 }
 
-VkResult DisplayWindow::CreateSurface(const encode::VulkanInstanceTable* table,
-                                      VkInstance                         instance,
-                                      VkFlags                            flags,
-                                      VkSurfaceKHR*                      pSurface)
+VkResult DisplayWindow::CreateSurface(const graphics::VulkanInstanceTable* table,
+                                      VkInstance                           instance,
+                                      VkFlags                              flags,
+                                      VkSurfaceKHR*                        pSurface)
 {
     VkResult error = VK_ERROR_INITIALIZATION_FAILED;
     if (table)
@@ -279,7 +279,9 @@ VkResult DisplayWindow::CreateSurface(const encode::VulkanInstanceTable* table,
     return error;
 }
 
-void DisplayWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void DisplayWindow::DestroySurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkSurfaceKHR                         surface)
 {
     if (table)
     {
@@ -313,9 +315,9 @@ void DisplayWindowFactory::Destroy(decode::Window* window)
     GFXRECON_UNREFERENCED_PARAMETER(window);
 }
 
-VkBool32 DisplayWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                                    VkPhysicalDevice                   physical_device,
-                                                                    uint32_t queue_family_index)
+VkBool32 DisplayWindowFactory::GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                                    VkPhysicalDevice physical_device,
+                                                                    uint32_t         queue_family_index)
 {
     GFXRECON_UNREFERENCED_PARAMETER(table);
     GFXRECON_UNREFERENCED_PARAMETER(physical_device);

--- a/framework/application/display_window.h
+++ b/framework/application/display_window.h
@@ -69,30 +69,30 @@ class DisplayWindow : public decode::Window
 
     virtual VkExtent2D GetSize() const override;
 
-    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
-                                   VkInstance                         instance,
-                                   VkFlags                            flags,
-                                   VkSurfaceKHR*                      pSurface) override;
+    virtual VkResult CreateSurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkFlags                              flags,
+                                   VkSurfaceKHR*                        pSurface) override;
 
     virtual void
-    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
-    VkResult SelectPhysicalDevice(const encode::VulkanInstanceTable* table,
-                                  VkInstance                         instance,
-                                  VkPhysicalDevice*                  physical_device) const;
-    VkResult SelectDisplay(const encode::VulkanInstanceTable* table,
-                           VkPhysicalDevice                   physical_device,
-                           VkDisplayKHR*                      display) const;
-    VkResult SelectMode(const encode::VulkanInstanceTable* table,
-                        VkPhysicalDevice                   physical_device,
-                        VkDisplayKHR                       display,
-                        VkDisplayModePropertiesKHR*        mode_props) const;
-    VkResult SelectPlane(const encode::VulkanInstanceTable* table,
-                         VkPhysicalDevice                   physical_device,
-                         VkDisplayKHR                       display,
-                         uint32_t*                          plane_index,
-                         VkDisplayPlanePropertiesKHR*       plane_props) const;
+    VkResult SelectPhysicalDevice(const graphics::VulkanInstanceTable* table,
+                                  VkInstance                           instance,
+                                  VkPhysicalDevice*                    physical_device) const;
+    VkResult SelectDisplay(const graphics::VulkanInstanceTable* table,
+                           VkPhysicalDevice                     physical_device,
+                           VkDisplayKHR*                        display) const;
+    VkResult SelectMode(const graphics::VulkanInstanceTable* table,
+                        VkPhysicalDevice                     physical_device,
+                        VkDisplayKHR                         display,
+                        VkDisplayModePropertiesKHR*          mode_props) const;
+    VkResult SelectPlane(const graphics::VulkanInstanceTable* table,
+                         VkPhysicalDevice                     physical_device,
+                         VkDisplayKHR                         display,
+                         uint32_t*                            plane_index,
+                         VkDisplayPlanePropertiesKHR*         plane_props) const;
 
   private:
     DisplayContext* display_context_;
@@ -118,8 +118,8 @@ class DisplayWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                          VkPhysicalDevice                   physical_device,
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                     physical_device,
                                                           uint32_t queue_family_index) override;
 
   private:

--- a/framework/application/headless_window.cpp
+++ b/framework/application/headless_window.cpp
@@ -108,10 +108,10 @@ VkExtent2D HeadlessWindow::GetSize() const
     return { width_, height_ };
 }
 
-VkResult HeadlessWindow::CreateSurface(const encode::VulkanInstanceTable* table,
-                                       VkInstance                         instance,
-                                       VkFlags                            flags,
-                                       VkSurfaceKHR*                      pSurface)
+VkResult HeadlessWindow::CreateSurface(const graphics::VulkanInstanceTable* table,
+                                       VkInstance                           instance,
+                                       VkFlags                              flags,
+                                       VkSurfaceKHR*                        pSurface)
 {
     GFXRECON_UNREFERENCED_PARAMETER(flags);
 
@@ -125,7 +125,9 @@ VkResult HeadlessWindow::CreateSurface(const encode::VulkanInstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void HeadlessWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void HeadlessWindow::DestroySurface(const graphics::VulkanInstanceTable* table,
+                                    VkInstance                           instance,
+                                    VkSurfaceKHR                         surface)
 {
     if (table != nullptr)
     {
@@ -158,9 +160,9 @@ void HeadlessWindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 HeadlessWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                                     VkPhysicalDevice                   physical_device,
-                                                                     uint32_t queue_family_index)
+VkBool32 HeadlessWindowFactory::GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                                     VkPhysicalDevice physical_device,
+                                                                     uint32_t         queue_family_index)
 {
     GFXRECON_UNREFERENCED_PARAMETER(table);
     GFXRECON_UNREFERENCED_PARAMETER(physical_device);

--- a/framework/application/headless_window.h
+++ b/framework/application/headless_window.h
@@ -67,13 +67,13 @@ class HeadlessWindow : public decode::Window
 
     virtual VkExtent2D GetSize() const override;
 
-    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
-                                   VkInstance                         instance,
-                                   VkFlags                            flags,
-                                   VkSurfaceKHR*                      pSurface) override;
+    virtual VkResult CreateSurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkFlags                              flags,
+                                   VkSurfaceKHR*                        pSurface) override;
 
     virtual void
-    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     HeadlessContext* headless_context_;
@@ -97,8 +97,8 @@ class HeadlessWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                          VkPhysicalDevice                   physical_device,
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                     physical_device,
                                                           uint32_t queue_family_index) override;
 
   private:

--- a/framework/application/metal_window.h
+++ b/framework/application/metal_window.h
@@ -68,12 +68,12 @@ class MetalWindow : public decode::Window
 
     VkExtent2D GetSize() const override;
 
-    VkResult CreateSurface(const encode::VulkanInstanceTable* table,
-                           VkInstance                         instance,
-                           VkFlags                            flags,
-                           VkSurfaceKHR*                      pSurface) override;
+    VkResult CreateSurface(const graphics::VulkanInstanceTable* table,
+                           VkInstance                           instance,
+                           VkFlags                              flags,
+                           VkSurfaceKHR*                        pSurface) override;
 
-    void DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    void DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     GFXReconWindowDelegate* window_delegate_;
@@ -99,9 +99,9 @@ class MetalWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                  VkPhysicalDevice                   physical_device,
-                                                  uint32_t                           queue_family_index) override;
+    VkBool32 GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                  VkPhysicalDevice                     physical_device,
+                                                  uint32_t                             queue_family_index) override;
 
   private:
     MetalContext* metal_context_;

--- a/framework/application/metal_window.mm
+++ b/framework/application/metal_window.mm
@@ -268,10 +268,10 @@ VkExtent2D MetalWindow::GetSize() const
     return { width_, height_ };
 }
 
-VkResult MetalWindow::CreateSurface(const encode::VulkanInstanceTable* table,
-                                    VkInstance                         instance,
-                                    VkFlags                            flags,
-                                    VkSurfaceKHR*                      pSurface)
+VkResult MetalWindow::CreateSurface(const graphics::VulkanInstanceTable* table,
+                                    VkInstance                           instance,
+                                    VkFlags                              flags,
+                                    VkSurfaceKHR*                        pSurface)
 {
     if (table)
     {
@@ -284,7 +284,7 @@ VkResult MetalWindow::CreateSurface(const encode::VulkanInstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void MetalWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void MetalWindow::DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table)
         table->DestroySurfaceKHR(instance, surface, nullptr);
@@ -314,9 +314,9 @@ void MetalWindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 MetalWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                                  VkPhysicalDevice                   physical_device,
-                                                                  uint32_t                           queue_family_index)
+VkBool32 MetalWindowFactory::GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                                  VkPhysicalDevice                     physical_device,
+                                                                  uint32_t queue_family_index)
 {
     return true;
 }

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -259,10 +259,10 @@ VkExtent2D WaylandWindow::GetSize() const
     return { width_, height_ };
 }
 
-VkResult WaylandWindow::CreateSurface(const encode::VulkanInstanceTable* table,
-                                      VkInstance                         instance,
-                                      VkFlags                            flags,
-                                      VkSurfaceKHR*                      pSurface)
+VkResult WaylandWindow::CreateSurface(const graphics::VulkanInstanceTable* table,
+                                      VkInstance                           instance,
+                                      VkFlags                              flags,
+                                      VkSurfaceKHR*                        pSurface)
 {
     if (table != nullptr)
     {
@@ -276,7 +276,9 @@ VkResult WaylandWindow::CreateSurface(const encode::VulkanInstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void WaylandWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void WaylandWindow::DestroySurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkSurfaceKHR                         surface)
 {
     if (table != nullptr)
     {
@@ -382,9 +384,9 @@ void WaylandWindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 WaylandWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                                    VkPhysicalDevice                   physical_device,
-                                                                    uint32_t queue_family_index)
+VkBool32 WaylandWindowFactory::GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                                    VkPhysicalDevice physical_device,
+                                                                    uint32_t         queue_family_index)
 {
     assert(wayland_context_->GetDisplay() != nullptr);
     return table->GetPhysicalDeviceWaylandPresentationSupportKHR(

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -75,13 +75,13 @@ class WaylandWindow : public decode::Window
 
     virtual VkExtent2D GetSize() const override;
 
-    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
-                                   VkInstance                         instance,
-                                   VkFlags                            flags,
-                                   VkSurfaceKHR*                      pSurface) override;
+    virtual VkResult CreateSurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkFlags                              flags,
+                                   VkSurfaceKHR*                        pSurface) override;
 
     virtual void
-    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     static void HandleSurfaceEnter(void* data, struct wl_surface* surface, struct wl_output* output);
@@ -132,8 +132,8 @@ class WaylandWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                          VkPhysicalDevice                   physical_device,
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                     physical_device,
                                                           uint32_t queue_family_index) override;
 
   private:

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -291,10 +291,10 @@ VkExtent2D Win32Window::GetSize() const
     return { width_, height_ };
 }
 
-VkResult Win32Window::CreateSurface(const encode::VulkanInstanceTable* table,
-                                    VkInstance                         instance,
-                                    VkFlags                            flags,
-                                    VkSurfaceKHR*                      pSurface)
+VkResult Win32Window::CreateSurface(const graphics::VulkanInstanceTable* table,
+                                    VkInstance                           instance,
+                                    VkFlags                              flags,
+                                    VkSurfaceKHR*                        pSurface)
 {
     if (table != nullptr)
     {
@@ -308,7 +308,7 @@ VkResult Win32Window::CreateSurface(const encode::VulkanInstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void Win32Window::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void Win32Window::DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table != nullptr)
     {
@@ -341,9 +341,9 @@ void Win32WindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 Win32WindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                                  VkPhysicalDevice                   physical_device,
-                                                                  uint32_t                           queue_family_index)
+VkBool32 Win32WindowFactory::GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                                  VkPhysicalDevice                     physical_device,
+                                                                  uint32_t queue_family_index)
 {
     return table->GetPhysicalDeviceWin32PresentationSupportKHR(physical_device, queue_family_index);
 }

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -70,13 +70,13 @@ class Win32Window : public decode::Window
 
     virtual VkExtent2D GetSize() const override;
 
-    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
-                                   VkInstance                         instance,
-                                   VkFlags                            flags,
-                                   VkSurfaceKHR*                      pSurface) override;
+    virtual VkResult CreateSurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkFlags                              flags,
+                                   VkSurfaceKHR*                        pSurface) override;
 
     virtual void
-    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     HWND          hwnd_;
@@ -105,8 +105,8 @@ class Win32WindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                          VkPhysicalDevice                   physical_device,
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                     physical_device,
                                                           uint32_t queue_family_index) override;
 
   private:

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -414,10 +414,10 @@ VkExtent2D XcbWindow::GetSize() const
     return { width_, height_ };
 }
 
-VkResult XcbWindow::CreateSurface(const encode::VulkanInstanceTable* table,
-                                  VkInstance                         instance,
-                                  VkFlags                            flags,
-                                  VkSurfaceKHR*                      pSurface)
+VkResult XcbWindow::CreateSurface(const graphics::VulkanInstanceTable* table,
+                                  VkInstance                           instance,
+                                  VkFlags                              flags,
+                                  VkSurfaceKHR*                        pSurface)
 {
     if (table != nullptr)
     {
@@ -431,7 +431,7 @@ VkResult XcbWindow::CreateSurface(const encode::VulkanInstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void XcbWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void XcbWindow::DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table != nullptr)
     {
@@ -546,9 +546,9 @@ void XcbWindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 XcbWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                                VkPhysicalDevice                   physical_device,
-                                                                uint32_t                           queue_family_index)
+VkBool32 XcbWindowFactory::GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                                VkPhysicalDevice                     physical_device,
+                                                                uint32_t                             queue_family_index)
 {
     xcb_connection_t* connection = xcb_context_->GetConnection();
     xcb_screen_t*     screen     = xcb_context_->GetScreen();

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -88,13 +88,13 @@ class XcbWindow : public decode::Window
 
     virtual VkExtent2D GetSize() const override;
 
-    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
-                                   VkInstance                         instance,
-                                   VkFlags                            flags,
-                                   VkSurfaceKHR*                      pSurface) override;
+    virtual VkResult CreateSurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkFlags                              flags,
+                                   VkSurfaceKHR*                        pSurface) override;
 
     virtual void
-    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     void SetFullscreen(bool fullscreen);
@@ -150,8 +150,8 @@ class XcbWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                          VkPhysicalDevice                   physical_device,
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                     physical_device,
                                                           uint32_t queue_family_index) override;
 
   private:

--- a/framework/application/xlib_window.cpp
+++ b/framework/application/xlib_window.cpp
@@ -305,10 +305,10 @@ VkExtent2D XlibWindow::GetSize() const
     return { width_, height_ };
 }
 
-VkResult XlibWindow::CreateSurface(const encode::VulkanInstanceTable* table,
-                                   VkInstance                         instance,
-                                   VkFlags                            flags,
-                                   VkSurfaceKHR*                      pSurface)
+VkResult XlibWindow::CreateSurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkFlags                              flags,
+                                   VkSurfaceKHR*                        pSurface)
 {
     if (table != nullptr)
     {
@@ -321,7 +321,7 @@ VkResult XlibWindow::CreateSurface(const encode::VulkanInstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void XlibWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void XlibWindow::DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table != nullptr)
     {
@@ -354,9 +354,9 @@ void XlibWindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 XlibWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                                 VkPhysicalDevice                   physical_device,
-                                                                 uint32_t                           queue_family_index)
+VkBool32 XlibWindowFactory::GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                                 VkPhysicalDevice                     physical_device,
+                                                                 uint32_t queue_family_index)
 {
     const auto display = xlib_context_->OpenDisplay();
     const auto xlib    = xlib_context_->GetXlibFunctionTable();

--- a/framework/application/xlib_window.h
+++ b/framework/application/xlib_window.h
@@ -66,13 +66,13 @@ class XlibWindow : public decode::Window
 
     virtual VkExtent2D GetSize() const override;
 
-    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
-                                   VkInstance                         instance,
-                                   VkFlags                            flags,
-                                   VkSurfaceKHR*                      pSurface) override;
+    virtual VkResult CreateSurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkFlags                              flags,
+                                   VkSurfaceKHR*                        pSurface) override;
 
     virtual void
-    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     void SetFullscreen(bool fullscreen);
@@ -105,8 +105,8 @@ class XlibWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                          VkPhysicalDevice                   physical_device,
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                     physical_device,
                                                           uint32_t queue_family_index) override;
 
   private:

--- a/framework/decode/decoder_util.h
+++ b/framework/decode/decoder_util.h
@@ -49,10 +49,10 @@ bool IsComplete(std::vector<T>& consumers, uint64_t block_index)
     return consumers.empty();
 }
 
-static VkQueue GetDeviceQueue(const encode::VulkanDeviceTable* device_table,
-                              const VulkanDeviceInfo*          device_info,
-                              uint32_t                         queue_family_index,
-                              uint32_t                         queue_index)
+static VkQueue GetDeviceQueue(const graphics::VulkanDeviceTable* device_table,
+                              const VulkanDeviceInfo*            device_info,
+                              uint32_t                           queue_family_index,
+                              uint32_t                           queue_index)
 {
     VkQueue queue = VK_NULL_HANDLE;
 

--- a/framework/decode/openxr_replay_session_state.h
+++ b/framework/decode/openxr_replay_session_state.h
@@ -62,12 +62,12 @@ struct VulkanSwapchainInfo
 struct VulkanGraphicsBinding : public XrGraphicsBindingVulkanKHR
 {
     VulkanGraphicsBinding(VulkanReplayConsumerBase& vulkan_consumer, const Decoded_XrGraphicsBindingVulkanKHR& xr);
-    VulkanReplayConsumerBase*          vulkan_consumer = nullptr;
-    const encode::VulkanInstanceTable* instance_table{ nullptr };
-    const encode::VulkanDeviceTable*   device_table{ nullptr };
-    format::HandleId                   instance_id{ format::kNullHandleId };
-    format::HandleId                   device_id{ format::kNullHandleId };
-    VkQueue                            queue = VK_NULL_HANDLE;
+    VulkanReplayConsumerBase*            vulkan_consumer = nullptr;
+    const graphics::VulkanInstanceTable* instance_table{ nullptr };
+    const graphics::VulkanDeviceTable*   device_table{ nullptr };
+    format::HandleId                     instance_id{ format::kNullHandleId };
+    format::HandleId                     device_id{ format::kNullHandleId };
+    VkQueue                              queue = VK_NULL_HANDLE;
 
     XrResult ResetCommandBuffer(VulkanSwapchainInfo::ProxyImage& proxy) const;
 };

--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -68,7 +68,7 @@ inline void WriteImageFile(const std::string&     filename,
 
 void ScreenshotHandler::WriteImage(const std::string&                      filename_prefix,
                                    const VulkanDeviceInfo*                 device_info,
-                                   const encode::VulkanDeviceTable*        device_table,
+                                   const graphics::VulkanDeviceTable*      device_table,
                                    const VkPhysicalDeviceMemoryProperties& memory_properties,
                                    VulkanResourceAllocator*                allocator,
                                    VkImage                                 image,
@@ -432,7 +432,7 @@ void ScreenshotHandler::WriteImage(const std::string&                      filen
     }
 }
 
-void ScreenshotHandler::DestroyDeviceResources(VkDevice device, const encode::VulkanDeviceTable* device_table)
+void ScreenshotHandler::DestroyDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table)
 {
     auto entry = copy_resources_.find(device);
     if (entry != copy_resources_.end())
@@ -498,11 +498,11 @@ VkFormat ScreenshotHandler::GetConversionFormat(VkFormat image_format) const
     return IsSrgbFormat(image_format) ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8A8_UNORM;
 }
 
-VkDeviceSize ScreenshotHandler::GetCopyBufferSize(VkDevice                         device,
-                                                  const encode::VulkanDeviceTable* device_table,
-                                                  VkFormat                         format,
-                                                  uint32_t                         width,
-                                                  uint32_t                         height) const
+VkDeviceSize ScreenshotHandler::GetCopyBufferSize(VkDevice                           device,
+                                                  const graphics::VulkanDeviceTable* device_table,
+                                                  VkFormat                           format,
+                                                  uint32_t                           width,
+                                                  uint32_t                           height) const
 {
     VkImageCreateInfo create_info     = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
     create_info.pNext                 = nullptr;
@@ -538,7 +538,7 @@ VkDeviceSize ScreenshotHandler::GetCopyBufferSize(VkDevice                      
 }
 
 VkResult ScreenshotHandler::CreateCopyResource(VkDevice                                device,
-                                               const encode::VulkanDeviceTable*        device_table,
+                                               const graphics::VulkanDeviceTable*      device_table,
                                                const VkPhysicalDeviceMemoryProperties& memory_properties,
                                                VkDeviceSize                            buffer_size,
                                                VkFormat                                image_format,

--- a/framework/decode/screenshot_handler.h
+++ b/framework/decode/screenshot_handler.h
@@ -54,7 +54,7 @@ class ScreenshotHandler : public ScreenshotHandlerBase
 
     void WriteImage(const std::string&                      filename_prefix,
                     const VulkanDeviceInfo*                 device_info,
-                    const encode::VulkanDeviceTable*        device_table,
+                    const graphics::VulkanDeviceTable*      device_table,
                     const VkPhysicalDeviceMemoryProperties& memory_properties,
                     VulkanResourceAllocator*                allocator,
                     VkImage                                 image,
@@ -65,7 +65,7 @@ class ScreenshotHandler : public ScreenshotHandlerBase
                     uint32_t                                copy_height,
                     VkImageLayout                           image_layout);
 
-    void DestroyDeviceResources(VkDevice device, const encode::VulkanDeviceTable* device_table);
+    void DestroyDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table);
 
   private:
     struct CopyResource
@@ -94,14 +94,14 @@ class ScreenshotHandler : public ScreenshotHandlerBase
 
     VkFormat GetConversionFormat(VkFormat image_format) const;
 
-    VkDeviceSize GetCopyBufferSize(VkDevice                         device,
-                                   const encode::VulkanDeviceTable* device_table,
-                                   VkFormat                         format,
-                                   uint32_t                         width,
-                                   uint32_t                         height) const;
+    VkDeviceSize GetCopyBufferSize(VkDevice                           device,
+                                   const graphics::VulkanDeviceTable* device_table,
+                                   VkFormat                           format,
+                                   uint32_t                           width,
+                                   uint32_t                           height) const;
 
     VkResult CreateCopyResource(VkDevice                                device,
-                                const encode::VulkanDeviceTable*        device_table,
+                                const graphics::VulkanDeviceTable*      device_table,
                                 const VkPhysicalDeviceMemoryProperties& memory_properties,
                                 VkDeviceSize                            buffer_size,
                                 VkFormat                                image_format,

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -50,17 +50,17 @@ struct MarkInjectedCommandsHelper
 //! RAII helper submit a command-buffer to a queue and synchronize via fence
 struct QueueSubmitHelper
 {
-    const encode::VulkanDeviceTable* device_table   = nullptr;
+    const graphics::VulkanDeviceTable* device_table   = nullptr;
     VkDevice                         device         = VK_NULL_HANDLE;
     VkCommandBuffer                  command_buffer = VK_NULL_HANDLE;
     VkFence                          fence          = VK_NULL_HANDLE;
     VkQueue                          queue          = VK_NULL_HANDLE;
 
-    QueueSubmitHelper(const encode::VulkanDeviceTable* device_table_,
-                      VkDevice                         device_,
-                      VkCommandBuffer                  command_buffer_,
-                      VkQueue                          queue_,
-                      VkFence                          fence_) :
+    QueueSubmitHelper(const graphics::VulkanDeviceTable* device_table_,
+                      VkDevice                           device_,
+                      VkCommandBuffer                    command_buffer_,
+                      VkQueue                            queue_,
+                      VkFence                            fence_) :
         device_table(device_table_),
         device(device_), command_buffer(command_buffer_), fence(fence_), queue(queue_)
     {
@@ -172,10 +172,11 @@ decode::VulkanAddressReplacer::acceleration_structure_asset_t::~acceleration_str
 }
 
 VulkanAddressReplacer::VulkanAddressReplacer(const VulkanDeviceInfo*              device_info,
-                                             const encode::VulkanDeviceTable*     device_table,
-                                             const encode::VulkanInstanceTable*   instance_table,
+                                             const graphics::VulkanDeviceTable*   device_table,
+                                             const graphics::VulkanInstanceTable* instance_table,
                                              const decode::CommonObjectInfoTable& object_table) :
-    device_table_(device_table), object_table_(&object_table)
+    device_table_(device_table),
+    object_table_(&object_table)
 {
     GFXRECON_ASSERT(device_info != nullptr && device_table != nullptr && instance_table != nullptr);
     physical_device_info_ = object_table.GetVkPhysicalDeviceInfo(device_info->parent_id);

--- a/framework/decode/vulkan_address_replacer.h
+++ b/framework/decode/vulkan_address_replacer.h
@@ -44,8 +44,8 @@ class VulkanAddressReplacer
     VulkanAddressReplacer() = default;
 
     VulkanAddressReplacer(const VulkanDeviceInfo*              device_info,
-                          const encode::VulkanDeviceTable*     device_table,
-                          const encode::VulkanInstanceTable*   instance_table,
+                          const graphics::VulkanDeviceTable*   device_table,
+                          const graphics::VulkanInstanceTable* instance_table,
                           const decode::CommonObjectInfoTable& object_table);
 
     //! prevent copying
@@ -372,7 +372,7 @@ class VulkanAddressReplacer
 
     bool swap_acceleration_structure_handle(VkAccelerationStructureKHR& handle);
 
-    const encode::VulkanDeviceTable*                               device_table_      = nullptr;
+    const graphics::VulkanDeviceTable*                             device_table_      = nullptr;
     const decode::CommonObjectInfoTable*                           object_table_      = nullptr;
     VkPhysicalDeviceMemoryProperties                               memory_properties_ = {};
     std::optional<VkPhysicalDeviceRayTracingPipelinePropertiesKHR> capture_ray_properties_{}, replay_ray_properties_{};

--- a/framework/decode/vulkan_captured_swapchain.cpp
+++ b/framework/decode/vulkan_captured_swapchain.cpp
@@ -34,7 +34,7 @@ VkResult VulkanCapturedSwapchain::CreateSwapchainKHR(VkResult                   
                                                      const VkSwapchainCreateInfoKHR*       create_info,
                                                      const VkAllocationCallbacks*          allocator,
                                                      HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                                     const encode::VulkanDeviceTable*      device_table)
+                                                     const graphics::VulkanDeviceTable*    device_table)
 {
     VkDevice device = VK_NULL_HANDLE;
 

--- a/framework/decode/vulkan_captured_swapchain.h
+++ b/framework/decode/vulkan_captured_swapchain.h
@@ -39,7 +39,7 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const encode::VulkanDeviceTable*      device_table) override;
+                                        const graphics::VulkanDeviceTable*    device_table) override;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
                                      const VulkanDeviceInfo*       device_info,

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -158,12 +158,12 @@ void ClearObjects(CommonObjectInfoTable* table,
     }
 }
 
-void FreeAllLiveObjects(CommonObjectInfoTable*                                         table,
-                        bool                                                           remove_entries,
-                        bool                                                           report_leaks,
-                        std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
-                        std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table,
-                        VulkanSwapchain*                                               swapchain)
+void FreeAllLiveObjects(CommonObjectInfoTable*                                           table,
+                        bool                                                             remove_entries,
+                        bool                                                             report_leaks,
+                        std::function<const graphics::VulkanInstanceTable*(const void*)> get_instance_table,
+                        std::function<const graphics::VulkanDeviceTable*(const void*)>   get_device_table,
+                        VulkanSwapchain*                                                 swapchain)
 {
     FreeChildObjects<VulkanDeviceInfo, VulkanEventInfo>(
         table,
@@ -720,11 +720,11 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
     }
 }
 
-void FreeAllLiveInstances(CommonObjectInfoTable*                                         table,
-                          bool                                                           remove_entries,
-                          bool                                                           report_leaks,
-                          std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
-                          std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table)
+void FreeAllLiveInstances(CommonObjectInfoTable*                                           table,
+                          bool                                                             remove_entries,
+                          bool                                                             report_leaks,
+                          std::function<const graphics::VulkanInstanceTable*(const void*)> get_instance_table,
+                          std::function<const graphics::VulkanDeviceTable*(const void*)>   get_device_table)
 {
     FreeParentObjects<VulkanInstanceInfo>(table,
                                           remove_entries,

--- a/framework/decode/vulkan_object_cleanup_util.h
+++ b/framework/decode/vulkan_object_cleanup_util.h
@@ -34,18 +34,18 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 GFXRECON_BEGIN_NAMESPACE(object_cleanup)
 
-void FreeAllLiveObjects(CommonObjectInfoTable*                                         table,
-                        bool                                                           remove_entries,
-                        bool                                                           report_leaks,
-                        std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
-                        std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table,
-                        VulkanSwapchain*                                               swapchain);
+void FreeAllLiveObjects(CommonObjectInfoTable*                                           table,
+                        bool                                                             remove_entries,
+                        bool                                                             report_leaks,
+                        std::function<const graphics::VulkanInstanceTable*(const void*)> get_instance_table,
+                        std::function<const graphics::VulkanDeviceTable*(const void*)>   get_device_table,
+                        VulkanSwapchain*                                                 swapchain);
 
-void FreeAllLiveInstances(CommonObjectInfoTable*                                         table,
-                          bool                                                           remove_entries,
-                          bool                                                           report_leaks,
-                          std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
-                          std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table);
+void FreeAllLiveInstances(CommonObjectInfoTable*                                           table,
+                          bool                                                             remove_entries,
+                          bool                                                             report_leaks,
+                          std::function<const graphics::VulkanInstanceTable*(const void*)> get_instance_table,
+                          std::function<const graphics::VulkanDeviceTable*(const void*)>   get_device_table);
 
 GFXRECON_END_NAMESPACE(object_cleanup)
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -27,18 +27,18 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                            original_result,
-                                                 VulkanInstanceInfo*                 instance_info,
-                                                 const std::string&                  wsi_extension,
-                                                 VkFlags                             flags,
-                                                 HandlePointerDecoder<VkSurfaceKHR>* surface,
-                                                 const encode::VulkanInstanceTable*  instance_table,
-                                                 application::Application*           application,
-                                                 const int32_t                       xpos,
-                                                 const int32_t                       ypos,
-                                                 const uint32_t                      width,
-                                                 const uint32_t                      height,
-                                                 bool                                force_windowed)
+VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                             original_result,
+                                                 VulkanInstanceInfo*                  instance_info,
+                                                 const std::string&                   wsi_extension,
+                                                 VkFlags                              flags,
+                                                 HandlePointerDecoder<VkSurfaceKHR>*  surface,
+                                                 const graphics::VulkanInstanceTable* instance_table,
+                                                 application::Application*            application,
+                                                 const int32_t                        xpos,
+                                                 const int32_t                        ypos,
+                                                 const uint32_t                       width,
+                                                 const uint32_t                       height,
+                                                 bool                                 force_windowed)
 {
     GFXRECON_ASSERT(surface);
 
@@ -85,7 +85,7 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
                                                       const VkSwapchainCreateInfoKHR*       create_info,
                                                       const VkAllocationCallbacks*          allocator,
                                                       HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                                      const encode::VulkanDeviceTable*      device_table)
+                                                      const graphics::VulkanDeviceTable*    device_table)
 {
     GFXRECON_ASSERT(device_info);
     device_table_ = device_table;

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -35,18 +35,18 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
   public:
     virtual ~VulkanOffscreenSwapchain() override {}
 
-    virtual VkResult CreateSurface(VkResult                            original_result,
-                                   VulkanInstanceInfo*                 instance_info,
-                                   const std::string&                  wsi_extension,
-                                   VkFlags                             flags,
-                                   HandlePointerDecoder<VkSurfaceKHR>* surface,
-                                   const encode::VulkanInstanceTable*  instance_table,
-                                   application::Application*           application,
-                                   const int32_t                       xpos,
-                                   const int32_t                       ypos,
-                                   const uint32_t                      width,
-                                   const uint32_t                      height,
-                                   bool                                force_windowed = false) override;
+    virtual VkResult CreateSurface(VkResult                             original_result,
+                                   VulkanInstanceInfo*                  instance_info,
+                                   const std::string&                   wsi_extension,
+                                   VkFlags                              flags,
+                                   HandlePointerDecoder<VkSurfaceKHR>*  surface,
+                                   const graphics::VulkanInstanceTable* instance_table,
+                                   application::Application*            application,
+                                   const int32_t                        xpos,
+                                   const int32_t                        ypos,
+                                   const uint32_t                       width,
+                                   const uint32_t                       height,
+                                   bool                                 force_windowed = false) override;
 
     virtual void DestroySurface(PFN_vkDestroySurfaceKHR      func,
                                 const VulkanInstanceInfo*    instance_info,
@@ -59,7 +59,7 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const encode::VulkanDeviceTable*      device_table) override;
+                                        const graphics::VulkanDeviceTable*    device_table) override;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
                                      const VulkanDeviceInfo*       device_info,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1280,43 +1280,43 @@ void VulkanReplayConsumerBase::InitializeLoader()
 
 void VulkanReplayConsumerBase::AddInstanceTable(VkInstance instance)
 {
-    encode::VulkanDispatchKey dispatch_key = encode::GetVulkanDispatchKey(instance);
+    graphics::VulkanDispatchKey dispatch_key = graphics::GetVulkanDispatchKey(instance);
 
     get_device_proc_addrs_[dispatch_key] =
         reinterpret_cast<PFN_vkGetDeviceProcAddr>(get_instance_proc_addr_(instance, "vkGetDeviceProcAddr"));
     create_device_procs_[dispatch_key] =
         reinterpret_cast<PFN_vkCreateDevice>(get_instance_proc_addr_(instance, "vkCreateDevice"));
 
-    encode::VulkanInstanceTable& table = instance_tables_[dispatch_key];
-    encode::LoadVulkanInstanceTable(get_instance_proc_addr_, instance, &table);
+    graphics::VulkanInstanceTable& table = instance_tables_[dispatch_key];
+    graphics::LoadVulkanInstanceTable(get_instance_proc_addr_, instance, &table);
 }
 
 void VulkanReplayConsumerBase::AddDeviceTable(VkDevice device, PFN_vkGetDeviceProcAddr gpa)
 {
-    encode::VulkanDeviceTable& table = device_tables_[encode::GetVulkanDispatchKey(device)];
-    encode::LoadVulkanDeviceTable(gpa, device, &table);
+    graphics::VulkanDeviceTable& table = device_tables_[graphics::GetVulkanDispatchKey(device)];
+    graphics::LoadVulkanDeviceTable(gpa, device, &table);
 }
 
 PFN_vkGetDeviceProcAddr VulkanReplayConsumerBase::GetDeviceAddrProc(VkPhysicalDevice physical_device)
 {
-    return get_device_proc_addrs_[encode::GetVulkanDispatchKey(physical_device)];
+    return get_device_proc_addrs_[graphics::GetVulkanDispatchKey(physical_device)];
 }
 
 PFN_vkCreateDevice VulkanReplayConsumerBase::GetCreateDeviceProc(VkPhysicalDevice physical_device)
 {
-    return create_device_procs_[encode::GetVulkanDispatchKey(physical_device)];
+    return create_device_procs_[graphics::GetVulkanDispatchKey(physical_device)];
 }
 
-const encode::VulkanInstanceTable* VulkanReplayConsumerBase::GetInstanceTable(const void* handle) const
+const graphics::VulkanInstanceTable* VulkanReplayConsumerBase::GetInstanceTable(const void* handle) const
 {
-    auto table = instance_tables_.find(encode::GetVulkanDispatchKey(handle));
+    auto table = instance_tables_.find(graphics::GetVulkanDispatchKey(handle));
     assert(table != instance_tables_.end());
     return (table != instance_tables_.end()) ? &table->second : nullptr;
 }
 
-const encode::VulkanDeviceTable* VulkanReplayConsumerBase::GetDeviceTable(const void* handle) const
+const graphics::VulkanDeviceTable* VulkanReplayConsumerBase::GetDeviceTable(const void* handle) const
 {
-    auto table = device_tables_.find(encode::GetVulkanDispatchKey(handle));
+    auto table = device_tables_.find(graphics::GetVulkanDispatchKey(handle));
     assert(table != device_tables_.end());
     return (table != device_tables_.end()) ? &table->second : nullptr;
 }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -239,9 +239,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         return MapHandle<VulkanDeviceInfo>(capture_id, &CommonObjectInfoTable::GetVkDeviceInfo);
     }
 
-    const encode::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
+    const graphics::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
 
-    const encode::VulkanDeviceTable* GetDeviceTable(const void* handle) const;
+    const graphics::VulkanDeviceTable* GetDeviceTable(const void* handle) const;
     void AddImageHandle(format::HandleId parent_id, format::HandleId id, VkImage handle, VulkanImageInfo&& initial_info)
     {
         AddHandle<VulkanImageInfo>(
@@ -1692,10 +1692,10 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     util::platform::LibraryHandle                                              loader_handle_;
     PFN_vkGetInstanceProcAddr                                                  get_instance_proc_addr_;
     PFN_vkCreateInstance                                                       create_instance_proc_;
-    std::unordered_map<encode::VulkanDispatchKey, PFN_vkGetDeviceProcAddr>     get_device_proc_addrs_;
-    std::unordered_map<encode::VulkanDispatchKey, PFN_vkCreateDevice>          create_device_procs_;
-    std::unordered_map<encode::VulkanDispatchKey, encode::VulkanInstanceTable> instance_tables_;
-    std::unordered_map<encode::VulkanDispatchKey, encode::VulkanDeviceTable>   device_tables_;
+    std::unordered_map<graphics::VulkanDispatchKey, PFN_vkGetDeviceProcAddr>       get_device_proc_addrs_;
+    std::unordered_map<graphics::VulkanDispatchKey, PFN_vkCreateDevice>            create_device_procs_;
+    std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanInstanceTable> instance_tables_;
+    std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanDeviceTable>   device_tables_;
     std::function<void(const char*)>                                           fatal_error_handler_;
     std::shared_ptr<application::Application>                                  application_;
     CommonObjectInfoTable*                                                     object_info_table_;

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -260,8 +260,8 @@ VulkanReplayDumpResourcesBase::FindDispatchRaysCommandBufferContext(VkCommandBuf
 
 VkResult VulkanReplayDumpResourcesBase::CloneCommandBuffer(uint64_t                 bcb_index,
                                                            VulkanCommandBufferInfo* original_command_buffer_info,
-                                                           const encode::VulkanDeviceTable*   device_table,
-                                                           const encode::VulkanInstanceTable* inst_table)
+                                                           const graphics::VulkanDeviceTable*   device_table,
+                                                           const graphics::VulkanInstanceTable* inst_table)
 
 {
     assert(device_table);
@@ -1767,11 +1767,11 @@ bool VulkanReplayDumpResourcesBase::MustDumpTraceRays(VkCommandBuffer original_c
     }
 }
 
-VkResult VulkanReplayDumpResourcesBase::QueueSubmit(const std::vector<VkSubmitInfo>& submit_infos,
-                                                    const encode::VulkanDeviceTable& device_table,
-                                                    VkQueue                          queue,
-                                                    VkFence                          fence,
-                                                    uint64_t                         index)
+VkResult VulkanReplayDumpResourcesBase::QueueSubmit(const std::vector<VkSubmitInfo>&   submit_infos,
+                                                    const graphics::VulkanDeviceTable& device_table,
+                                                    VkQueue                            queue,
+                                                    VkFence                            fence,
+                                                    uint64_t                           index)
 {
     bool     pre_submit = false;
     bool     submitted  = false;

--- a/framework/decode/vulkan_replay_dump_resources.h
+++ b/framework/decode/vulkan_replay_dump_resources.h
@@ -53,10 +53,10 @@ class VulkanReplayDumpResourcesBase
 
     ~VulkanReplayDumpResourcesBase();
 
-    VkResult CloneCommandBuffer(uint64_t                           bcb_index,
-                                VulkanCommandBufferInfo*           original_command_buffer_info,
-                                const encode::VulkanDeviceTable*   device_table,
-                                const encode::VulkanInstanceTable* inst_table);
+    VkResult CloneCommandBuffer(uint64_t                             bcb_index,
+                                VulkanCommandBufferInfo*             original_command_buffer_info,
+                                const graphics::VulkanDeviceTable*   device_table,
+                                const graphics::VulkanInstanceTable* inst_table);
 
     void OverrideCmdDraw(const ApiCallInfo& call_info,
                          PFN_vkCmdDraw      func,
@@ -282,11 +282,11 @@ class VulkanReplayDumpResourcesBase
     void
     OverrideEndCommandBuffer(const ApiCallInfo& call_info, PFN_vkEndCommandBuffer func, VkCommandBuffer commandBuffer);
 
-    VkResult QueueSubmit(const std::vector<VkSubmitInfo>& modified_submit_infos,
-                         const encode::VulkanDeviceTable& device_table,
-                         VkQueue                          queue,
-                         VkFence                          fence,
-                         uint64_t                         index);
+    VkResult QueueSubmit(const std::vector<VkSubmitInfo>&   modified_submit_infos,
+                         const graphics::VulkanDeviceTable& device_table,
+                         VkQueue                            queue,
+                         VkFence                            fence,
+                         uint64_t                           index);
 
     bool MustDumpQueueSubmitIndex(uint64_t index) const;
 

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -132,7 +132,7 @@ uint32_t GetMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_prope
 }
 
 VkResult CloneImage(CommonObjectInfoTable&                  object_info_table,
-                    const encode::VulkanDeviceTable*        device_table,
+                    const graphics::VulkanDeviceTable*      device_table,
                     const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
                     const VulkanImageInfo*                  image_info,
                     VkImage*                                new_image,
@@ -203,7 +203,7 @@ VkResult CloneImage(CommonObjectInfoTable&                  object_info_table,
 }
 
 VkResult CloneBuffer(CommonObjectInfoTable&                  object_info_table,
-                     const encode::VulkanDeviceTable*        device_table,
+                     const graphics::VulkanDeviceTable*      device_table,
                      const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
                      const VulkanBufferInfo*                 buffer_info,
                      VkBuffer*                               new_buffer,
@@ -431,19 +431,19 @@ MinMaxVertexIndex FindMinMaxVertexIndices(const std::vector<uint8_t>& index_data
     }
 }
 
-VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
-                         const VulkanDeviceInfo*            device_info,
-                         const encode::VulkanDeviceTable*   device_table,
-                         const encode::VulkanInstanceTable* instance_table,
-                         CommonObjectInfoTable&             object_info_table,
-                         const std::vector<std::string>&    filenames,
-                         float                              scale,
-                         std::vector<bool>&                 scaling_supported,
-                         util::ScreenshotFormat             image_file_format,
-                         bool                               dump_all_subresources,
-                         bool                               dump_image_raw,
-                         bool                               dump_separate_alpha,
-                         VkImageLayout                      layout)
+VkResult DumpImageToFile(const VulkanImageInfo*               image_info,
+                         const VulkanDeviceInfo*              device_info,
+                         const graphics::VulkanDeviceTable*   device_table,
+                         const graphics::VulkanInstanceTable* instance_table,
+                         CommonObjectInfoTable&               object_info_table,
+                         const std::vector<std::string>&      filenames,
+                         float                                scale,
+                         std::vector<bool>&                   scaling_supported,
+                         util::ScreenshotFormat               image_file_format,
+                         bool                                 dump_all_subresources,
+                         bool                                 dump_image_raw,
+                         bool                                 dump_separate_alpha,
+                         VkImageLayout                        layout)
 {
     assert(image_info != nullptr);
     assert(device_info != nullptr);
@@ -693,7 +693,7 @@ std::string IndexTypeToStr(VkIndexType type)
 }
 
 VkResult CreateVkBuffer(VkDeviceSize                            size,
-                        const encode::VulkanDeviceTable*        device_table,
+                        const graphics::VulkanDeviceTable*      device_table,
                         VkDevice                                parent_device,
                         VkBaseInStructure*                      pNext,
                         const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
@@ -775,15 +775,15 @@ void GetFormatAspects(VkFormat format, std::vector<VkImageAspectFlagBits>& aspec
     }
 }
 
-DumpedImageFormat GetDumpedImageFormat(const VulkanDeviceInfo*            device_info,
-                                       const encode::VulkanDeviceTable*   device_table,
-                                       const encode::VulkanInstanceTable* instance_table,
-                                       VulkanObjectInfoTable&             object_info_table,
-                                       VkFormat                           src_format,
-                                       VkImageTiling                      src_image_tiling,
-                                       VkImageType                        type,
-                                       util::ScreenshotFormat             image_file_format,
-                                       bool                               dump_raw)
+DumpedImageFormat GetDumpedImageFormat(const VulkanDeviceInfo*              device_info,
+                                       const graphics::VulkanDeviceTable*   device_table,
+                                       const graphics::VulkanInstanceTable* instance_table,
+                                       VulkanObjectInfoTable&               object_info_table,
+                                       VkFormat                             src_format,
+                                       VkImageTiling                        src_image_tiling,
+                                       VkImageType                          type,
+                                       util::ScreenshotFormat               image_file_format,
+                                       bool                                 dump_raw)
 {
     const VulkanPhysicalDeviceInfo* phys_dev_info = object_info_table.GetVkPhysicalDeviceInfo(device_info->parent_id);
     assert(phys_dev_info);

--- a/framework/decode/vulkan_replay_dump_resources_common.h
+++ b/framework/decode/vulkan_replay_dump_resources_common.h
@@ -61,15 +61,15 @@ struct MinMaxVertexIndex
     uint32_t max = 0;
 };
 
-DumpedImageFormat GetDumpedImageFormat(const VulkanDeviceInfo*            device_info,
-                                       const encode::VulkanDeviceTable*   device_table,
-                                       const encode::VulkanInstanceTable* instance_table,
-                                       VulkanObjectInfoTable&             object_info_table,
-                                       VkFormat                           src_format,
-                                       VkImageTiling                      src_image_tiling,
-                                       VkImageType                        type,
-                                       util::ScreenshotFormat             image_file_format,
-                                       bool                               dump_raw = false);
+DumpedImageFormat GetDumpedImageFormat(const VulkanDeviceInfo*              device_info,
+                                       const graphics::VulkanDeviceTable*   device_table,
+                                       const graphics::VulkanInstanceTable* instance_table,
+                                       VulkanObjectInfoTable&               object_info_table,
+                                       VkFormat                             src_format,
+                                       VkImageTiling                        src_image_tiling,
+                                       VkImageType                          type,
+                                       util::ScreenshotFormat               image_file_format,
+                                       bool                                 dump_raw = false);
 
 const char* ImageFileExtension(DumpedImageFormat image_format);
 
@@ -78,14 +78,14 @@ uint32_t GetMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_prope
                             VkMemoryPropertyFlags                   property_flags);
 
 VkResult CloneImage(CommonObjectInfoTable&                  object_info_table,
-                    const encode::VulkanDeviceTable*        device_table,
+                    const graphics::VulkanDeviceTable*      device_table,
                     const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
                     const VulkanImageInfo*                  image_info,
                     VkImage*                                new_image,
                     VkDeviceMemory*                         new_image_memory);
 
 VkResult CloneBuffer(CommonObjectInfoTable&                  object_info_table,
-                     const encode::VulkanDeviceTable*        device_table,
+                     const graphics::VulkanDeviceTable*      device_table,
                      const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,
                      const VulkanBufferInfo*                 buffer_info,
                      VkBuffer*                               new_buffer,
@@ -100,19 +100,19 @@ MinMaxVertexIndex FindMinMaxVertexIndices(const std::vector<uint8_t>& index_data
                                           int32_t                     vertex_offset,
                                           VkIndexType                 type);
 
-VkResult DumpImageToFile(const VulkanImageInfo*             image_info,
-                         const VulkanDeviceInfo*            device_info,
-                         const encode::VulkanDeviceTable*   device_table,
-                         const encode::VulkanInstanceTable* instance_table,
-                         CommonObjectInfoTable&             object_info_table,
-                         const std::vector<std::string>&    filenames,
-                         float                              scale,
-                         std::vector<bool>&                 scaling_supported,
-                         util::ScreenshotFormat             image_file_format,
-                         bool                               dump_all_subresources = false,
-                         bool                               dump_image_raw        = false,
-                         bool                               dump_separate_alpha   = false,
-                         VkImageLayout                      layout                = VK_IMAGE_LAYOUT_MAX_ENUM);
+VkResult DumpImageToFile(const VulkanImageInfo*               image_info,
+                         const VulkanDeviceInfo*              device_info,
+                         const graphics::VulkanDeviceTable*   device_table,
+                         const graphics::VulkanInstanceTable* instance_table,
+                         CommonObjectInfoTable&               object_info_table,
+                         const std::vector<std::string>&      filenames,
+                         float                                scale,
+                         std::vector<bool>&                   scaling_supported,
+                         util::ScreenshotFormat               image_file_format,
+                         bool                                 dump_all_subresources = false,
+                         bool                                 dump_image_raw        = false,
+                         bool                                 dump_separate_alpha   = false,
+                         VkImageLayout                        layout                = VK_IMAGE_LAYOUT_MAX_ENUM);
 
 std::string ShaderStageToStr(VkShaderStageFlagBits shader_stage);
 
@@ -123,7 +123,7 @@ std::string FormatToStr(VkFormat format);
 std::string IndexTypeToStr(VkIndexType type);
 
 VkResult CreateVkBuffer(VkDeviceSize                            size,
-                        const encode::VulkanDeviceTable*        device_table,
+                        const graphics::VulkanDeviceTable*      device_table,
                         VkDevice                                parent_device,
                         VkBaseInStructure*                      pNext,
                         const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props,

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -105,9 +105,9 @@ void DispatchTraceRaysDumpingContext::Release()
     trace_rays_params.clear();
 }
 
-VkResult DispatchTraceRaysDumpingContext::CloneCommandBuffer(VulkanCommandBufferInfo*           orig_cmd_buf_info,
-                                                             const encode::VulkanDeviceTable*   dev_table,
-                                                             const encode::VulkanInstanceTable* inst_table)
+VkResult DispatchTraceRaysDumpingContext::CloneCommandBuffer(VulkanCommandBufferInfo*             orig_cmd_buf_info,
+                                                             const graphics::VulkanDeviceTable*   dev_table,
+                                                             const graphics::VulkanInstanceTable* inst_table)
 {
     assert(orig_cmd_buf_info);
     assert(dev_table);

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
@@ -54,9 +54,9 @@ class DispatchTraceRaysDumpingContext
 
     ~DispatchTraceRaysDumpingContext();
 
-    VkResult CloneCommandBuffer(VulkanCommandBufferInfo*           orig_cmd_buf_info,
-                                const encode::VulkanDeviceTable*   dev_table,
-                                const encode::VulkanInstanceTable* inst_table);
+    VkResult CloneCommandBuffer(VulkanCommandBufferInfo*             orig_cmd_buf_info,
+                                const graphics::VulkanDeviceTable*   dev_table,
+                                const graphics::VulkanInstanceTable* inst_table);
 
     VkCommandBuffer GetDispatchRaysCommandBuffer() const { return DR_command_buffer; }
 
@@ -442,9 +442,9 @@ class DispatchTraceRaysDumpingContext
     // One entry for each trace rays command
     std::unordered_map<uint64_t, TraceRaysParameters> trace_rays_params;
 
-    const encode::VulkanDeviceTable*        device_table;
+    const graphics::VulkanDeviceTable*      device_table;
     VkDevice                                parent_device;
-    const encode::VulkanInstanceTable*      instance_table;
+    const graphics::VulkanInstanceTable*    instance_table;
     CommonObjectInfoTable&                  object_info_table;
     const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props;
     size_t                                  current_dispatch_index;

--- a/framework/decode/vulkan_replay_dump_resources_delegate.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.cpp
@@ -30,8 +30,8 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-bool DefaultVulkanDumpResourcesDelegate::IsImageDumpable(const encode::VulkanInstanceTable* instance_table,
-                                                         const VulkanImageInfo*             image_info)
+bool DefaultVulkanDumpResourcesDelegate::IsImageDumpable(const graphics::VulkanInstanceTable* instance_table,
+                                                         const VulkanImageInfo*               image_info)
 {
     GFXRECON_ASSERT(instance_table != nullptr);
     GFXRECON_ASSERT(image_info != nullptr);
@@ -60,8 +60,8 @@ bool DefaultVulkanDumpResourcesDelegate::IsImageDumpable(const encode::VulkanIns
     return true;
 }
 
-void DefaultVulkanDumpResourcesDelegate::DumpDrawCallInfo(const VulkanDumpDrawCallInfo&      draw_call_info,
-                                                          const encode::VulkanInstanceTable* instance_table)
+void DefaultVulkanDumpResourcesDelegate::DumpDrawCallInfo(const VulkanDumpDrawCallInfo&        draw_call_info,
+                                                          const graphics::VulkanInstanceTable* instance_table)
 {
     switch (draw_call_info.type)
     {
@@ -410,8 +410,9 @@ DefaultVulkanDumpResourcesDelegate::GenerateBufferDescriptorFilename(const Vulka
 {
     std::stringstream filename;
 
-    filename << capture_filename_ << "_" << "buffer_" << resource_info.buffer_info->capture_id << "_qs_"
-             << resource_info.qs_index << "_bcb_" << resource_info.bcb_index << "_rp_" << resource_info.rp << ".bin";
+    filename << capture_filename_ << "_"
+             << "buffer_" << resource_info.buffer_info->capture_id << "_qs_" << resource_info.qs_index << "_bcb_"
+             << resource_info.bcb_index << "_rp_" << resource_info.rp << ".bin";
 
     std::filesystem::path filedirname(options_.dump_resources_output_dir);
     std::filesystem::path filebasename(filename.str());
@@ -431,9 +432,9 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateInlineUniformBufferDescr
     const VulkanDumpResourceInfo& resource_info) const
 {
     std::stringstream filename;
-    filename << capture_filename_ << "_" << "inlineUniformBlock_set_" << resource_info.set << "_binding_"
-             << resource_info.binding << "_qs_" << resource_info.qs_index << "_bcb_" << resource_info.bcb_index
-             << ".bin";
+    filename << capture_filename_ << "_"
+             << "inlineUniformBlock_set_" << resource_info.set << "_binding_" << resource_info.binding << "_qs_"
+             << resource_info.qs_index << "_bcb_" << resource_info.bcb_index << ".bin";
 
     std::filesystem::path filedirname(options_.dump_resources_output_dir);
     std::filesystem::path filebasename(filename.str());
@@ -452,9 +453,10 @@ std::string
 DefaultVulkanDumpResourcesDelegate::GenerateVertexBufferFilename(const VulkanDumpResourceInfo& resource_info) const
 {
     std::stringstream filename;
-    filename << capture_filename_ << "_" << "vertexBuffers_" << "qs_" << resource_info.qs_index << "_bcb_"
-             << resource_info.bcb_index << "_dc_" << resource_info.cmd_index << "_binding_" << resource_info.binding
-             << ".bin";
+    filename << capture_filename_ << "_"
+             << "vertexBuffers_"
+             << "qs_" << resource_info.qs_index << "_bcb_" << resource_info.bcb_index << "_dc_"
+             << resource_info.cmd_index << "_binding_" << resource_info.binding << ".bin";
 
     std::filesystem::path filedirname(options_.dump_resources_output_dir);
     std::filesystem::path filebasename(filename.str());
@@ -475,7 +477,8 @@ DefaultVulkanDumpResourcesDelegate::GenerateIndexBufferFilename(const VulkanDump
     std::stringstream filename;
     filename << capture_filename_ << "_";
     std::string index_type_name = IndexTypeToStr(resource_info.index_type);
-    filename << "indexBuffer_" << "qs_" << resource_info.qs_index << "_bcb_" << resource_info.bcb_index << "_dc_"
+    filename << "indexBuffer_"
+             << "qs_" << resource_info.qs_index << "_bcb_" << resource_info.bcb_index << "_dc_"
              << resource_info.cmd_index << index_type_name << ".bin";
 
     std::filesystem::path filedirname(options_.dump_resources_output_dir);
@@ -484,7 +487,7 @@ DefaultVulkanDumpResourcesDelegate::GenerateIndexBufferFilename(const VulkanDump
 }
 
 void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
-    const VulkanDumpDrawCallInfo& draw_call_info, const encode::VulkanInstanceTable* instance_table)
+    const VulkanDumpDrawCallInfo& draw_call_info, const graphics::VulkanInstanceTable* instance_table)
 {
     if (options_.dump_resources_json_per_command)
     {
@@ -1131,8 +1134,9 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysImageFi
     if (resource_info.before_cmd)
     {
         filename << (resource_info.is_dispatch ? "dispatch_" : "traceRays_") << resource_info.cmd_index << "_qs_"
-                 << resource_info.qs_index << "_bcb_" << resource_info.bcb_index << "_before_" << "set_"
-                 << resource_info.set << "_binding_" << resource_info.binding << "_index_" << resource_info.array_index;
+                 << resource_info.qs_index << "_bcb_" << resource_info.bcb_index << "_before_"
+                 << "set_" << resource_info.set << "_binding_" << resource_info.binding << "_index_"
+                 << resource_info.array_index;
         if (output_image_format != KFormatRaw)
         {
             filename << "_" << util::ToString<VkFormat>(image_info->format).c_str();
@@ -1182,9 +1186,9 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysBufferF
     if (resource_info.before_cmd)
     {
         filename << (resource_info.is_dispatch ? "dispatch_" : "traceRays_") << resource_info.cmd_index << "_qs_"
-                 << resource_info.qs_index << "_bcb_" << resource_info.bcb_index << "_before_" << "set_"
-                 << resource_info.set << "_binding_" << resource_info.binding << "_index_" << resource_info.array_index
-                 << "_buffer.bin";
+                 << resource_info.qs_index << "_bcb_" << resource_info.bcb_index << "_before_"
+                 << "set_" << resource_info.set << "_binding_" << resource_info.binding << "_index_"
+                 << resource_info.array_index << "_buffer.bin";
     }
     else
     {
@@ -1359,7 +1363,7 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysInlineU
 }
 
 void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDispatchInfo(
-    const VulkanDumpDrawCallInfo& draw_call_info, const encode::VulkanInstanceTable* instance_table)
+    const VulkanDumpDrawCallInfo& draw_call_info, const graphics::VulkanInstanceTable* instance_table)
 {
     if (draw_call_info.disp_param == nullptr)
     {
@@ -1835,7 +1839,7 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDispatchInfo(
 }
 
 void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonTraceRaysIndex(
-    const VulkanDumpDrawCallInfo& draw_call_info, const encode::VulkanInstanceTable* instance_table)
+    const VulkanDumpDrawCallInfo& draw_call_info, const graphics::VulkanInstanceTable* instance_table)
 {
     if (draw_call_info.tr_param == nullptr)
     {

--- a/framework/decode/vulkan_replay_dump_resources_delegate.h
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.h
@@ -34,11 +34,11 @@ struct VulkanDumpDrawCallInfo
 {
     DumpResourceType type{ DumpResourceType::kUnknown };
 
-    const encode::VulkanInstanceTable* instance_table;
-    const encode::VulkanDeviceTable*   device_table;
-    CommonObjectInfoTable*             object_info_table;
-    const VulkanDeviceInfo*            device_info;
-    const VulkanCommandBufferInfo*     original_command_buffer_info;
+    const graphics::VulkanInstanceTable* instance_table;
+    const graphics::VulkanDeviceTable*   device_table;
+    CommonObjectInfoTable*               object_info_table;
+    const VulkanDeviceInfo*              device_info;
+    const VulkanCommandBufferInfo*       original_command_buffer_info;
 
     uint64_t cmd_index; // dc_index, disp_index, tr_index
     uint64_t qs_index;  // queue submit
@@ -58,11 +58,11 @@ struct VulkanDumpResourceInfo
 {
     DumpResourceType type{ DumpResourceType::kUnknown };
 
-    const encode::VulkanInstanceTable* instance_table;
-    const encode::VulkanDeviceTable*   device_table;
-    CommonObjectInfoTable*             object_info_table;
-    const VulkanDeviceInfo*            device_info;
-    const VulkanCommandBufferInfo*     original_command_buffer_info;
+    const graphics::VulkanInstanceTable* instance_table;
+    const graphics::VulkanDeviceTable*   device_table;
+    CommonObjectInfoTable*               object_info_table;
+    const VulkanDeviceInfo*              device_info;
+    const VulkanCommandBufferInfo*       original_command_buffer_info;
 
     uint64_t cmd_index; // dc_index, disp_index, tr_index
     uint64_t qs_index;  // queue submit
@@ -107,13 +107,13 @@ class VulkanDumpResourcesDelegate
     VulkanDumpResourcesDelegate(const VulkanReplayOptions& options, const std::string capture_filename) {}
     virtual ~VulkanDumpResourcesDelegate() {}
 
-    virtual bool     Open()                                                              = 0;
-    virtual void     DumpDrawCallInfo(const VulkanDumpDrawCallInfo&      draw_call_info,
-                                      const encode::VulkanInstanceTable* instance_table) = 0;
-    virtual void     DumpStart()                                                         = 0;
-    virtual VkResult DumpResource(const VulkanDumpResourceInfo& resource_info)           = 0;
-    virtual void     DumpEnd()                                                           = 0;
-    virtual void     Close()                                                             = 0;
+    virtual bool     Open()                                                                = 0;
+    virtual void     DumpDrawCallInfo(const VulkanDumpDrawCallInfo&        draw_call_info,
+                                      const graphics::VulkanInstanceTable* instance_table) = 0;
+    virtual void     DumpStart()                                                           = 0;
+    virtual VkResult DumpResource(const VulkanDumpResourceInfo& resource_info)             = 0;
+    virtual void     DumpEnd()                                                             = 0;
+    virtual void     Close()                                                               = 0;
 };
 
 class DefaultVulkanDumpResourcesDelegate : public VulkanDumpResourcesDelegate
@@ -133,8 +133,8 @@ class DefaultVulkanDumpResourcesDelegate : public VulkanDumpResourcesDelegate
         return dump_json_.Open(options_.capture_filename, options_.dump_resources_output_dir);
     }
 
-    virtual void DumpDrawCallInfo(const VulkanDumpDrawCallInfo&      draw_call_info,
-                                  const encode::VulkanInstanceTable* instance_table) override;
+    virtual void DumpDrawCallInfo(const VulkanDumpDrawCallInfo&        draw_call_info,
+                                  const graphics::VulkanInstanceTable* instance_table) override;
 
     virtual void DumpStart() override { dump_json_.BlockStart(); }
 
@@ -176,8 +176,8 @@ class DefaultVulkanDumpResourcesDelegate : public VulkanDumpResourcesDelegate
 
     std::string GenerateIndexBufferFilename(const VulkanDumpResourceInfo& resource_info) const;
 
-    void GenerateOutputJsonDrawCallInfo(const VulkanDumpDrawCallInfo&      draw_call_info,
-                                        const encode::VulkanInstanceTable* instance_table);
+    void GenerateOutputJsonDrawCallInfo(const VulkanDumpDrawCallInfo&        draw_call_info,
+                                        const graphics::VulkanInstanceTable* instance_table);
 
     // DispatchTraceRaysDumpingContext
     VkResult DumpeDispatchTraceRaysImage(const VulkanDumpResourceInfo& resource_info);
@@ -207,13 +207,13 @@ class DefaultVulkanDumpResourcesDelegate : public VulkanDumpResourcesDelegate
     std::string
     GenerateDispatchTraceRaysInlineUniformBufferDescriptorFilename(const VulkanDumpResourceInfo& resource_info) const;
 
-    void GenerateOutputJsonDispatchInfo(const VulkanDumpDrawCallInfo&      draw_call_info,
-                                        const encode::VulkanInstanceTable* instance_table);
+    void GenerateOutputJsonDispatchInfo(const VulkanDumpDrawCallInfo&        draw_call_info,
+                                        const graphics::VulkanInstanceTable* instance_table);
 
-    void GenerateOutputJsonTraceRaysIndex(const VulkanDumpDrawCallInfo&      draw_call_info,
-                                          const encode::VulkanInstanceTable* instance_table);
+    void GenerateOutputJsonTraceRaysIndex(const VulkanDumpDrawCallInfo&        draw_call_info,
+                                          const graphics::VulkanInstanceTable* instance_table);
 
-    bool IsImageDumpable(const encode::VulkanInstanceTable* instance_table, const VulkanImageInfo* image_info);
+    bool IsImageDumpable(const graphics::VulkanInstanceTable* instance_table, const VulkanImageInfo* image_info);
 
     // Keep track of images for which scalling failed so we can
     // note them in the output json

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -1876,9 +1876,9 @@ VkResult DrawCallsDumpingContext::DumpVertexIndexBuffers(uint64_t qs_index, uint
     return VK_SUCCESS;
 }
 
-VkResult DrawCallsDumpingContext::CloneCommandBuffer(VulkanCommandBufferInfo*           orig_cmd_buf_info,
-                                                     const encode::VulkanDeviceTable*   dev_table,
-                                                     const encode::VulkanInstanceTable* inst_table)
+VkResult DrawCallsDumpingContext::CloneCommandBuffer(VulkanCommandBufferInfo*             orig_cmd_buf_info,
+                                                     const graphics::VulkanDeviceTable*   dev_table,
+                                                     const graphics::VulkanInstanceTable* inst_table)
 {
     assert(orig_cmd_buf_info);
     assert(dev_table);

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -65,9 +65,9 @@ class DrawCallsDumpingContext
 
     void BindPipeline(VkPipelineBindPoint bind_point, const VulkanPipelineInfo* pipeline);
 
-    VkResult CloneCommandBuffer(VulkanCommandBufferInfo*           orig_cmd_buf_info,
-                                const encode::VulkanDeviceTable*   dev_table,
-                                const encode::VulkanInstanceTable* inst_table);
+    VkResult CloneCommandBuffer(VulkanCommandBufferInfo*             orig_cmd_buf_info,
+                                const graphics::VulkanDeviceTable*   dev_table,
+                                const graphics::VulkanInstanceTable* inst_table);
 
     VkResult CloneRenderPass(const VulkanRenderPassInfo* original_render_pass, const VulkanFramebufferInfo* fb_info);
 
@@ -680,8 +680,8 @@ class DrawCallsDumpingContext
     VkFence         aux_fence;
     bool            must_backup_resources;
 
-    const encode::VulkanDeviceTable*        device_table;
-    const encode::VulkanInstanceTable*      instance_table;
+    const graphics::VulkanDeviceTable*      device_table;
+    const graphics::VulkanInstanceTable*    instance_table;
     CommonObjectInfoTable&                  object_info_table;
     const VkPhysicalDeviceMemoryProperties* replay_device_phys_mem_props;
 };

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -71,7 +71,7 @@ VulkanResourceInitializer::VulkanResourceInitializer(const VulkanDeviceInfo*    
                                                      const VkPhysicalDeviceMemoryProperties& memory_properties,
                                                      bool                                    have_shader_stencil_write,
                                                      VulkanResourceAllocator*                resource_allocator,
-                                                     const encode::VulkanDeviceTable*        device_table) :
+                                                     const graphics::VulkanDeviceTable*      device_table) :
     device_(device_info->handle),
     staging_memory_(VK_NULL_HANDLE), staging_memory_data_(0), staging_buffer_(VK_NULL_HANDLE), staging_buffer_data_(0),
     staging_buffer_mapped_ptr_(nullptr), staging_buffer_offset_(0), draw_sampler_(VK_NULL_HANDLE),

--- a/framework/decode/vulkan_resource_initializer.h
+++ b/framework/decode/vulkan_resource_initializer.h
@@ -45,7 +45,7 @@ class VulkanResourceInitializer
                               const VkPhysicalDeviceMemoryProperties& memory_properties,
                               bool                                    have_shader_stencil_write,
                               VulkanResourceAllocator*                resource_allocator,
-                              const encode::VulkanDeviceTable*        device_table);
+                              const graphics::VulkanDeviceTable*      device_table);
 
     ~VulkanResourceInitializer();
 
@@ -197,7 +197,7 @@ class VulkanResourceInitializer
     VkPhysicalDeviceMemoryProperties      memory_properties_;
     bool                                  have_shader_stencil_write_;
     VulkanResourceAllocator*              resource_allocator_;
-    const encode::VulkanDeviceTable*      device_table_;
+    const graphics::VulkanDeviceTable*    device_table_;
     const VulkanDeviceInfo*               device_info_;
 
     // Copies of the copy information passed into the InitializeBuffer and InitializeImage respectively.

--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -85,43 +85,43 @@ void VulkanResourceTrackingConsumer::InitializeLoader()
 
 void VulkanResourceTrackingConsumer::AddInstanceTable(VkInstance instance)
 {
-    encode::VulkanDispatchKey dispatch_key = encode::GetVulkanDispatchKey(instance);
+    graphics::VulkanDispatchKey dispatch_key = graphics::GetVulkanDispatchKey(instance);
 
     get_device_proc_addrs_[dispatch_key] =
         reinterpret_cast<PFN_vkGetDeviceProcAddr>(get_instance_proc_addr_(instance, "vkGetDeviceProcAddr"));
     create_device_procs_[dispatch_key] =
         reinterpret_cast<PFN_vkCreateDevice>(get_instance_proc_addr_(instance, "vkCreateDevice"));
 
-    encode::VulkanInstanceTable& table = instance_tables_[dispatch_key];
-    encode::LoadVulkanInstanceTable(get_instance_proc_addr_, instance, &table);
+    graphics::VulkanInstanceTable& table = instance_tables_[dispatch_key];
+    graphics::LoadVulkanInstanceTable(get_instance_proc_addr_, instance, &table);
 }
 
 void VulkanResourceTrackingConsumer::AddDeviceTable(VkDevice device, PFN_vkGetDeviceProcAddr gpa)
 {
-    encode::VulkanDeviceTable& table = device_tables_[encode::GetVulkanDispatchKey(device)];
-    encode::LoadVulkanDeviceTable(gpa, device, &table);
+    graphics::VulkanDeviceTable& table = device_tables_[graphics::GetVulkanDispatchKey(device)];
+    graphics::LoadVulkanDeviceTable(gpa, device, &table);
 }
 
 PFN_vkGetDeviceProcAddr VulkanResourceTrackingConsumer::GetDeviceAddrProc(VkPhysicalDevice physical_device)
 {
-    return get_device_proc_addrs_[encode::GetVulkanDispatchKey(physical_device)];
+    return get_device_proc_addrs_[graphics::GetVulkanDispatchKey(physical_device)];
 }
 
 PFN_vkCreateDevice VulkanResourceTrackingConsumer::GetCreateDeviceProc(VkPhysicalDevice physical_device)
 {
-    return create_device_procs_[encode::GetVulkanDispatchKey(physical_device)];
+    return create_device_procs_[graphics::GetVulkanDispatchKey(physical_device)];
 }
 
-const encode::VulkanInstanceTable* VulkanResourceTrackingConsumer::GetInstanceTable(const void* handle) const
+const graphics::VulkanInstanceTable* VulkanResourceTrackingConsumer::GetInstanceTable(const void* handle) const
 {
-    auto table = instance_tables_.find(encode::GetVulkanDispatchKey(handle));
+    auto table = instance_tables_.find(graphics::GetVulkanDispatchKey(handle));
     assert(table != instance_tables_.end());
     return (table != instance_tables_.end()) ? &table->second : nullptr;
 }
 
-const encode::VulkanDeviceTable* VulkanResourceTrackingConsumer::GetDeviceTable(const void* handle) const
+const graphics::VulkanDeviceTable* VulkanResourceTrackingConsumer::GetDeviceTable(const void* handle) const
 {
-    auto table = device_tables_.find(encode::GetVulkanDispatchKey(handle));
+    auto table = device_tables_.find(graphics::GetVulkanDispatchKey(handle));
     assert(table != device_tables_.end());
     return (table != device_tables_.end()) ? &table->second : nullptr;
 }

--- a/framework/decode/vulkan_resource_tracking_consumer.h
+++ b/framework/decode/vulkan_resource_tracking_consumer.h
@@ -58,9 +58,9 @@ class VulkanResourceTrackingConsumer : public VulkanConsumer
 
     PFN_vkCreateDevice GetCreateDeviceProc(VkPhysicalDevice physical_device);
 
-    const encode::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
+    const graphics::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
 
-    const encode::VulkanDeviceTable* GetDeviceTable(const void* handle) const;
+    const graphics::VulkanDeviceTable* GetDeviceTable(const void* handle) const;
 
     virtual void Process_vkCreateInstance(const ApiCallInfo&                                   call_info,
                                           VkResult                                             returnValue,
@@ -215,10 +215,10 @@ class VulkanResourceTrackingConsumer : public VulkanConsumer
     util::platform::LibraryHandle loader_handle_;
 
     // map to function pointers to API calls
-    std::unordered_map<encode::VulkanDispatchKey, PFN_vkGetDeviceProcAddr>     get_device_proc_addrs_;
-    std::unordered_map<encode::VulkanDispatchKey, PFN_vkCreateDevice>          create_device_procs_;
-    std::unordered_map<encode::VulkanDispatchKey, encode::VulkanInstanceTable> instance_tables_;
-    std::unordered_map<encode::VulkanDispatchKey, encode::VulkanDeviceTable>   device_tables_;
+    std::unordered_map<graphics::VulkanDispatchKey, PFN_vkGetDeviceProcAddr>       get_device_proc_addrs_;
+    std::unordered_map<graphics::VulkanDispatchKey, PFN_vkCreateDevice>            create_device_procs_;
+    std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanInstanceTable> instance_tables_;
+    std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanDeviceTable>   device_tables_;
     // funtion pointers to the API calls that will be made during the first pass of replay
     PFN_vkCreateInstance      create_instance_function_;
     PFN_vkGetInstanceProcAddr get_instance_proc_addr_;

--- a/framework/decode/vulkan_swapchain.cpp
+++ b/framework/decode/vulkan_swapchain.cpp
@@ -46,18 +46,18 @@ void VulkanSwapchain::Clean()
     }
 }
 
-VkResult VulkanSwapchain::CreateSurface(VkResult                            original_result,
-                                        VulkanInstanceInfo*                 instance_info,
-                                        const std::string&                  wsi_extension,
-                                        VkFlags                             flags,
-                                        HandlePointerDecoder<VkSurfaceKHR>* surface,
-                                        const encode::VulkanInstanceTable*  instance_table,
-                                        application::Application*           application,
-                                        const int32_t                       xpos,
-                                        const int32_t                       ypos,
-                                        const uint32_t                      width,
-                                        const uint32_t                      height,
-                                        bool                                force_windowed)
+VkResult VulkanSwapchain::CreateSurface(VkResult                             original_result,
+                                        VulkanInstanceInfo*                  instance_info,
+                                        const std::string&                   wsi_extension,
+                                        VkFlags                              flags,
+                                        HandlePointerDecoder<VkSurfaceKHR>*  surface,
+                                        const graphics::VulkanInstanceTable* instance_table,
+                                        application::Application*            application,
+                                        const int32_t                        xpos,
+                                        const int32_t                        ypos,
+                                        const uint32_t                       width,
+                                        const uint32_t                       height,
+                                        bool                                 force_windowed)
 {
     assert(instance_info != nullptr);
 

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -62,18 +62,18 @@ class VulkanSwapchain
 
     void SetOptions(const VulkanSwapchainOptions& options) { swapchain_options_ = options; }
 
-    virtual VkResult CreateSurface(VkResult                            original_result,
-                                   VulkanInstanceInfo*                 instance_info,
-                                   const std::string&                  wsi_extension,
-                                   VkFlags                             flags,
-                                   HandlePointerDecoder<VkSurfaceKHR>* surface,
-                                   const encode::VulkanInstanceTable*  instance_table,
-                                   application::Application*           application,
-                                   const int32_t                       xpos,
-                                   const int32_t                       ypos,
-                                   const uint32_t                      width,
-                                   const uint32_t                      height,
-                                   bool                                force_windowed = false);
+    virtual VkResult CreateSurface(VkResult                             original_result,
+                                   VulkanInstanceInfo*                  instance_info,
+                                   const std::string&                   wsi_extension,
+                                   VkFlags                              flags,
+                                   HandlePointerDecoder<VkSurfaceKHR>*  surface,
+                                   const graphics::VulkanInstanceTable* instance_table,
+                                   application::Application*            application,
+                                   const int32_t                        xpos,
+                                   const int32_t                        ypos,
+                                   const uint32_t                       width,
+                                   const uint32_t                       height,
+                                   bool                                 force_windowed = false);
 
     virtual void DestroySurface(PFN_vkDestroySurfaceKHR      func,
                                 const VulkanInstanceInfo*    instance_info,
@@ -86,7 +86,7 @@ class VulkanSwapchain
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const encode::VulkanDeviceTable*      device_table) = 0;
+                                        const graphics::VulkanDeviceTable*    device_table) = 0;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
                                      const VulkanDeviceInfo*       device_info,
@@ -176,8 +176,8 @@ class VulkanSwapchain
   protected:
     typedef std::unordered_set<Window*> ActiveWindows;
 
-    const encode::VulkanInstanceTable* instance_table_{ nullptr };
-    const encode::VulkanDeviceTable*   device_table_{ nullptr };
+    const graphics::VulkanInstanceTable* instance_table_{ nullptr };
+    const graphics::VulkanDeviceTable*   device_table_{ nullptr };
 
     application::Application* application_{ nullptr };
     ActiveWindows             active_windows_;

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -49,7 +49,7 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainKHR(VkResult                    
                                                     const VkSwapchainCreateInfoKHR*       create_info,
                                                     const VkAllocationCallbacks*          allocator,
                                                     HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                                    const encode::VulkanDeviceTable*      device_table)
+                                                    const graphics::VulkanDeviceTable*    device_table)
 {
     VkDevice                 device = VK_NULL_HANDLE;
     VkSurfaceCapabilitiesKHR surfCapabilities{};

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -39,7 +39,7 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const encode::VulkanDeviceTable*      device_table) override;
+                                        const graphics::VulkanDeviceTable*    device_table) override;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
                                      const VulkanDeviceInfo*       device_info,

--- a/framework/decode/window.h
+++ b/framework/decode/window.h
@@ -85,13 +85,13 @@ class Window
 
     virtual VkExtent2D GetSize() const = 0;
 
-    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
-                                   VkInstance                         instance,
-                                   VkFlags                            flags,
-                                   VkSurfaceKHR*                      pSurface) = 0;
+    virtual VkResult CreateSurface(const graphics::VulkanInstanceTable* table,
+                                   VkInstance                           instance,
+                                   VkFlags                              flags,
+                                   VkSurfaceKHR*                        pSurface) = 0;
 
     virtual void
-    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) = 0;
+    DestroySurface(const graphics::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) = 0;
 };
 
 class WindowFactory
@@ -108,9 +108,9 @@ class WindowFactory
 
     virtual void Destroy(Window* window) = 0;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
-                                                          VkPhysicalDevice                   physical_device,
-                                                          uint32_t                           queue_family_index) = 0;
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const graphics::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                     physical_device,
+                                                          uint32_t                             queue_family_index) = 0;
 
     std::unordered_map<Window*, int32_t> created_window_;
 };

--- a/framework/encode/vulkan_capture_common.cpp
+++ b/framework/encode/vulkan_capture_common.cpp
@@ -237,13 +237,13 @@ void CommonProcessHardwareBuffer(format::ThreadId                      thread_id
     else
     {
         // The AHB is not CPU-readable, copy the data into a host visible buffer on the GPU
-        format::HandleId           device_id               = device_wrapper->handle_id;
-        VkDevice                   device                  = device_wrapper->handle;
-        auto                       physical_device_wrapper = device_wrapper->physical_device;
-        auto                       physical_device         = physical_device_wrapper->handle;
-        const VulkanInstanceTable* instance_table          = vulkan_wrappers::GetInstanceTable(physical_device);
-        auto                       device_table            = vulkan_wrappers::GetDeviceTable(device);
-        auto                       memory_properties       = &physical_device_wrapper->memory_properties;
+        format::HandleId                     device_id               = device_wrapper->handle_id;
+        VkDevice                             device                  = device_wrapper->handle;
+        auto                                 physical_device_wrapper = device_wrapper->physical_device;
+        auto                                 physical_device         = physical_device_wrapper->handle;
+        const graphics::VulkanInstanceTable* instance_table    = vulkan_wrappers::GetInstanceTable(physical_device);
+        auto                                 device_table      = vulkan_wrappers::GetDeviceTable(device);
+        auto                                 memory_properties = &physical_device_wrapper->memory_properties;
 
         uint32_t device_queue_index = -1;
         uint32_t queue_family_index = -1;

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -62,7 +62,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
 VulkanCaptureManager* VulkanCaptureManager::singleton_ = nullptr;
-VulkanLayerTable      VulkanCaptureManager::vulkan_layer_table_;
+graphics::VulkanLayerTable VulkanCaptureManager::vulkan_layer_table_;
 
 bool VulkanCaptureManager::CreateInstance()
 {
@@ -164,7 +164,7 @@ void VulkanCaptureManager::InitVkInstance(VkInstance* instance, PFN_vkGetInstanc
         GetUniqueId);
 
     auto wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::InstanceWrapper>(*instance);
-    LoadVulkanInstanceTable(gpa, wrapper->handle, &wrapper->layer_table);
+    graphics::LoadVulkanInstanceTable(gpa, wrapper->handle, &wrapper->layer_table);
 }
 
 void VulkanCaptureManager::InitVkDevice(VkDevice* device, PFN_vkGetDeviceProcAddr gpa)
@@ -177,7 +177,7 @@ void VulkanCaptureManager::InitVkDevice(VkDevice* device, PFN_vkGetDeviceProcAdd
         VK_NULL_HANDLE, vulkan_wrappers::NoParentWrapper::kHandleValue, device, GetUniqueId);
 
     auto wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(*device);
-    LoadVulkanDeviceTable(gpa, wrapper->handle, &wrapper->layer_table);
+    graphics::LoadVulkanDeviceTable(gpa, wrapper->handle, &wrapper->layer_table);
 }
 
 void VulkanCaptureManager::WriteResizeWindowCmd2(format::HandleId              surface_id,
@@ -635,7 +635,7 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
 
     assert(pCreateInfo_unwrapped != nullptr);
 
-    const VulkanInstanceTable* instance_table = vulkan_wrappers::GetInstanceTable(physicalDevice);
+    const graphics::VulkanInstanceTable* instance_table = vulkan_wrappers::GetInstanceTable(physicalDevice);
     auto physical_device_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
 
     graphics::VulkanDeviceUtil                device_util;
@@ -910,7 +910,7 @@ VulkanCaptureManager::OverrideCreateAccelerationStructureKHR(VkDevice           
 {
     auto                     device_wrapper   = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
     VkDevice                 device_unwrapped = device_wrapper->handle;
-    const VulkanDeviceTable* device_table     = vulkan_wrappers::GetDeviceTable(device);
+    const graphics::VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(device);
 
     std::unique_ptr<uint8_t[]>            struct_memory;
     VkAccelerationStructureCreateInfoKHR* modified_create_info =
@@ -970,7 +970,7 @@ void VulkanCaptureManager::OverrideCmdBuildAccelerationStructuresKHR(
     {
         state_tracker_->TrackAccelerationStructureBuildCommand(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
     }
-    const VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(commandBuffer);
+    const graphics::VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(commandBuffer);
     device_table->CmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
 }
 
@@ -981,7 +981,7 @@ void VulkanCaptureManager::OverrideCmdCopyAccelerationStructureKHR(VkCommandBuff
     {
         state_tracker_->TrackAccelerationStructureCopyCommand(command_buffer, pInfo);
     }
-    const VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(command_buffer);
+    const graphics::VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(command_buffer);
     device_table->CmdCopyAccelerationStructureKHR(command_buffer, pInfo);
 }
 
@@ -999,7 +999,7 @@ void VulkanCaptureManager::OverrideCmdWriteAccelerationStructuresPropertiesKHR(
             commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
     }
 
-    const VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(commandBuffer);
+    const graphics::VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(commandBuffer);
     device_table->CmdWriteAccelerationStructuresPropertiesKHR(
         commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
 }
@@ -1277,7 +1277,7 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                                                            VkPipeline*                              pPipelines)
 {
     auto                     device_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
-    const VulkanDeviceTable* device_table   = vulkan_wrappers::GetDeviceTable(device);
+    const graphics::VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(device);
     auto                     deferred_operation_wrapper =
         vulkan_wrappers::GetWrapper<vulkan_wrappers::DeferredOperationKHRWrapper>(deferredOperation);
 
@@ -1467,7 +1467,7 @@ void VulkanCaptureManager::DeferredOperationPostProcess(VkDevice               d
     auto                              deferred_operation_wrapper =
         vulkan_wrappers::GetWrapper<vulkan_wrappers::DeferredOperationKHRWrapper>(deferredOperation);
     auto                     device_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
-    const VulkanDeviceTable* device_table   = vulkan_wrappers::GetDeviceTable(device);
+    const graphics::VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(device);
 
     GFXRECON_ASSERT(device_table != nullptr);
 
@@ -1742,7 +1742,8 @@ void VulkanCaptureManager::ProcessEnumeratePhysicalDevices(VkResult          res
 
             if (physical_device != VK_NULL_HANDLE)
             {
-                const VulkanInstanceTable* instance_table = vulkan_wrappers::GetInstanceTable(physical_device);
+                const graphics::VulkanInstanceTable* instance_table =
+                    vulkan_wrappers::GetInstanceTable(physical_device);
                 assert(instance_table != nullptr);
 
                 auto physical_device_wrapper =

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -81,7 +81,7 @@ class VulkanCaptureManager : public ApiCaptureManager
     // the appropriate resource cleanup.
     static void CheckVkCreateInstanceStatus(VkResult result);
 
-    static const VulkanLayerTable* GetLayerTable() { return &vulkan_layer_table_; }
+    static const graphics::VulkanLayerTable* GetLayerTable() { return &vulkan_layer_table_; }
 
     void InitVkInstance(VkInstance* instance, PFN_vkGetInstanceProcAddr gpa);
 
@@ -1653,7 +1653,7 @@ class VulkanCaptureManager : public ApiCaptureManager
     void QueueSubmitWriteFillMemoryCmd();
 
     static VulkanCaptureManager*                    singleton_;
-    static VulkanLayerTable                         vulkan_layer_table_;
+    static graphics::VulkanLayerTable               vulkan_layer_table_;
     std::set<vulkan_wrappers::DeviceMemoryWrapper*> mapped_memory_; // Track mapped memory for unassisted tracking mode.
     std::unique_ptr<VulkanStateTracker>             state_tracker_;
     HardwareBufferMap                               hardware_buffers_;

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -126,14 +126,14 @@ uint64_t GetWrappedId(uint64_t, VkObjectType object_type);
 
 uint64_t GetWrappedId(uint64_t object, VkDebugReportObjectTypeEXT object_type);
 
-inline const VulkanInstanceTable* GetInstanceTable(VkInstance handle)
+inline const graphics::VulkanInstanceTable* GetInstanceTable(VkInstance handle)
 {
     assert(handle != VK_NULL_HANDLE);
     auto wrapper = GetWrapper<InstanceWrapper>(handle);
     return &wrapper->layer_table;
 }
 
-inline const VulkanInstanceTable* GetInstanceTable(VkPhysicalDevice handle)
+inline const graphics::VulkanInstanceTable* GetInstanceTable(VkPhysicalDevice handle)
 {
     assert(handle != VK_NULL_HANDLE);
     auto wrapper = GetWrapper<PhysicalDeviceWrapper>(handle);
@@ -141,14 +141,14 @@ inline const VulkanInstanceTable* GetInstanceTable(VkPhysicalDevice handle)
     return wrapper->layer_table_ref;
 }
 
-inline const VulkanDeviceTable* GetDeviceTable(VkDevice handle)
+inline const graphics::VulkanDeviceTable* GetDeviceTable(VkDevice handle)
 {
     assert(handle != VK_NULL_HANDLE);
     auto wrapper = GetWrapper<DeviceWrapper>(handle);
     return &wrapper->layer_table;
 }
 
-inline const VulkanDeviceTable* GetDeviceTable(VkQueue handle)
+inline const graphics::VulkanDeviceTable* GetDeviceTable(VkQueue handle)
 {
     assert(handle != VK_NULL_HANDLE);
     auto wrapper = GetWrapper<QueueWrapper>(handle);
@@ -156,7 +156,7 @@ inline const VulkanDeviceTable* GetDeviceTable(VkQueue handle)
     return wrapper->layer_table_ref;
 }
 
-inline const VulkanDeviceTable* GetDeviceTable(VkCommandBuffer handle)
+inline const graphics::VulkanDeviceTable* GetDeviceTable(VkCommandBuffer handle)
 {
     assert(handle != VK_NULL_HANDLE);
     auto wrapper = GetWrapper<CommandBufferWrapper>(handle);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -128,7 +128,7 @@ struct DisplayKHRWrapper : public HandleWrapper<VkDisplayKHR>
 // handle wrapper, which will filter duplicate handle retrievals and ensure that the wrapper is destroyed.
 struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 {
-    VulkanInstanceTable*             layer_table_ref{ nullptr };
+    graphics::VulkanInstanceTable*   layer_table_ref{ nullptr };
     std::vector<DisplayKHRWrapper*>  child_displays;
     graphics::VulkanInstanceUtilInfo instance_info{};
 
@@ -150,7 +150,7 @@ struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 
 struct InstanceWrapper : public HandleWrapper<VkInstance>
 {
-    VulkanInstanceTable                 layer_table;
+    graphics::VulkanInstanceTable       layer_table;
     std::vector<PhysicalDeviceWrapper*> child_physical_devices;
     bool                                have_device_properties{ false };
     uint32_t                            api_version{ VK_MAKE_VERSION(1, 0, 0) };
@@ -158,12 +158,12 @@ struct InstanceWrapper : public HandleWrapper<VkInstance>
 
 struct QueueWrapper : public HandleWrapper<VkQueue>
 {
-    VulkanDeviceTable* layer_table_ref{ nullptr };
+    graphics::VulkanDeviceTable* layer_table_ref{ nullptr };
 };
 
 struct DeviceWrapper : public HandleWrapper<VkDevice>
 {
-    VulkanDeviceTable          layer_table;
+    graphics::VulkanDeviceTable layer_table;
     PhysicalDeviceWrapper*     physical_device{ nullptr };
     std::vector<QueueWrapper*> child_queues;
 
@@ -394,7 +394,7 @@ struct AccelerationStructureKHRWrapper;
 struct CommandPoolWrapper;
 struct CommandBufferWrapper : public HandleWrapper<VkCommandBuffer>
 {
-    VulkanDeviceTable* layer_table_ref{ nullptr };
+    graphics::VulkanDeviceTable* layer_table_ref{ nullptr };
 
     // Members for general wrapper support.
     // Pool from which command buffer was allocated. The command buffer must be removed from the pool's allocation list

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -611,7 +611,7 @@ void VulkanStateTracker::TrackImageMemoryBinding(
     // AHB image memory requirements can only be queried after the memory is bound
     if (wrapper->external_format || wrapper->external_memory_android)
     {
-        const VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(device);
+        const graphics::VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(device);
         VkMemoryRequirements     image_mem_reqs;
         device_table->GetImageMemoryRequirements(device, image, &image_mem_reqs);
         wrapper->size = image_mem_reqs.size;
@@ -2456,7 +2456,7 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
                 // If PageGuardManager is not used or if it couldn't find the memory id it means that
                 // we need to map the memory.
                 VkDevice                 device        = dev_mem_wrapper->parent_device->handle;
-                const VulkanDeviceTable* device_table  = vulkan_wrappers::GetDeviceTable(device);
+                const graphics::VulkanDeviceTable* device_table  = vulkan_wrappers::GetDeviceTable(device);
                 const VkDeviceSize       map_size      = sizeof(VkAccelerationStructureInstanceKHR) * blas_count;
                 void*                    mapped_memory = nullptr;
                 const VkResult           result =
@@ -2492,7 +2492,7 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
                 if (needs_unmapping)
                 {
                     VkDevice                 device       = dev_mem_wrapper->parent_device->handle;
-                    const VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(device);
+                    const graphics::VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(device);
                     device_table->UnmapMemory(device, dev_mem_wrapper->handle);
                 }
             }

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -663,7 +663,7 @@ inline void InitializeState<VkDevice, vulkan_wrappers::ImageWrapper, VkImageCrea
     }
     else
     {
-        const VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(parent_handle);
+        const graphics::VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(parent_handle);
         VkMemoryRequirements     image_mem_reqs;
         assert(wrapper->handle != VK_NULL_HANDLE);
         device_table->GetImageMemoryRequirements(parent_handle, wrapper->handle, &image_mem_reqs);

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2023,7 +2023,7 @@ void VulkanStateWriter::ProcessBufferMemory(const vulkan_wrappers::DeviceWrapper
 {
     assert(device_wrapper != nullptr);
 
-    const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
+    const graphics::VulkanDeviceTable* device_table = &device_wrapper->layer_table;
 
     for (const auto& snapshot_entry : buffer_snapshot_info)
     {
@@ -2132,7 +2132,7 @@ void VulkanStateWriter::ProcessBufferMemoryWithAssetFile(const vulkan_wrappers::
     assert(device_wrapper != nullptr);
     assert(asset_file_stream_ != nullptr);
 
-    const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
+    const graphics::VulkanDeviceTable* device_table = &device_wrapper->layer_table;
 
     for (const auto& snapshot_entry : buffer_snapshot_info)
     {
@@ -2263,7 +2263,7 @@ void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper*
 {
     assert(device_wrapper != nullptr);
 
-    const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
+    const graphics::VulkanDeviceTable* device_table = &device_wrapper->layer_table;
 
     for (const auto& snapshot_entry : image_snapshot_info)
     {
@@ -2374,7 +2374,7 @@ void VulkanStateWriter::ProcessImageMemoryWithAssetFile(const vulkan_wrappers::D
     assert(device_wrapper != nullptr);
     assert(asset_file_stream_ != nullptr);
 
-    const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
+    const graphics::VulkanDeviceTable* device_table = &device_wrapper->layer_table;
 
     for (const auto& snapshot_entry : image_snapshot_info)
     {
@@ -2577,7 +2577,7 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
             {
                 // Write memory requirements query before bind command.
                 VkMemoryRequirements     memory_requirements;
-                const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
+                const graphics::VulkanDeviceTable* device_table = &device_wrapper->layer_table;
                 assert(device_table != nullptr);
 
                 device_table->GetBufferMemoryRequirements(
@@ -2670,7 +2670,7 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
             if (write_memory_state)
             {
                 VkMemoryRequirements     memory_requirements;
-                const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
+                const graphics::VulkanDeviceTable* device_table = &device_wrapper->layer_table;
                 assert(device_table != nullptr);
 
                 device_table->GetImageMemoryRequirements(device_wrapper->handle, wrapper->handle, &memory_requirements);
@@ -2825,7 +2825,7 @@ void VulkanStateWriter::WriteImageSubresourceLayouts(const vulkan_wrappers::Imag
     assert((image_wrapper != nullptr) && (aspect_flags != 0));
 
     const vulkan_wrappers::DeviceWrapper* device_wrapper = image_wrapper->bind_device;
-    const VulkanDeviceTable*              device_table   = &device_wrapper->layer_table;
+    const graphics::VulkanDeviceTable*    device_table   = &device_wrapper->layer_table;
 
     assert((device_wrapper != nullptr) && (device_table != nullptr));
 
@@ -3064,7 +3064,7 @@ void VulkanStateWriter::WritePhysicalDevicePropertiesMetaData(
     const vulkan_wrappers::PhysicalDeviceWrapper* physical_device_wrapper)
 {
     // Write the meta-data commands to set physical device properties.
-    const VulkanInstanceTable* instance_table = physical_device_wrapper->layer_table_ref;
+    const graphics::VulkanInstanceTable* instance_table = physical_device_wrapper->layer_table_ref;
     assert(instance_table != nullptr);
 
     format::HandleId           physical_device_id     = physical_device_wrapper->handle_id;

--- a/framework/generated/generated_vulkan_dispatch_table.h
+++ b/framework/generated/generated_vulkan_dispatch_table.h
@@ -55,7 +55,7 @@
 #endif
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
-GFXRECON_BEGIN_NAMESPACE(encode)
+GFXRECON_BEGIN_NAMESPACE(graphics)
 
 typedef const void* VulkanDispatchKey;
 
@@ -2138,7 +2138,7 @@ static void LoadVulkanDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, 
     LoadVulkanFunction(gpa, device, "vkCmdDrawMeshTasksIndirectCountEXT", &table->CmdDrawMeshTasksIndirectCountEXT);
 }
 
-GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
 #endif // GFXRECON_GENERATED_VULKAN_DISPATCH_TABLE_H

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_dispatch_table_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_dispatch_table_generator.py
@@ -71,7 +71,7 @@ class VulkanDispatchTableGeneratorOptions(VulkanBaseGeneratorOptions):
             ''
         ))
 
-        self.begin_end_file_data.namespaces.extend(('gfxrecon', 'encode'))
+        self.begin_end_file_data.namespaces.extend(('gfxrecon', 'graphics'))
 
 class VulkanDispatchTableGenerator(VulkanBaseGenerator, KhronosDispatchTableGenerator):
     """VulkanDispatchTableGenerator - subclass of VulkanBaseGenerator.

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(gfxrecon_graphics
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy_stype.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_extract_handles.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_extract_handles.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_dispatch_table.h
               )
 
 if (${GFXRECON_AGS_SUPPORT_FINAL})

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -52,10 +52,10 @@ uint32_t GetMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_prope
 // Requires Vulkan version >= 1.1 or VK_KHR_get_physical_device_properties2
 // feature_struct sType must be set, pNext must be nullptr
 template <typename T>
-static void GetPhysicalDeviceFeatures(const VulkanInstanceUtilInfo&      instance_info,
-                                      const encode::VulkanInstanceTable* instance_table,
-                                      const VkPhysicalDevice             physical_device,
-                                      T&                                 feature_struct)
+static void GetPhysicalDeviceFeatures(const VulkanInstanceUtilInfo& instance_info,
+                                      const VulkanInstanceTable*    instance_table,
+                                      const VkPhysicalDevice        physical_device,
+                                      T&                            feature_struct)
 {
     assert((feature_struct.sType != 0) && (feature_struct.pNext == nullptr));
     feature_struct.pNext = nullptr;
@@ -75,10 +75,10 @@ static void GetPhysicalDeviceFeatures(const VulkanInstanceUtilInfo&      instanc
 // Requires Vulkan version >= 1.1 or VK_KHR_get_physical_device_properties2
 // properties_struct sType must be set, pNext must be nullptr
 template <typename T>
-static void GetPhysicalDeviceProperties(const VulkanInstanceUtilInfo&      instance_info,
-                                        const encode::VulkanInstanceTable* instance_table,
-                                        const VkPhysicalDevice             physical_device,
-                                        T&                                 properties_struct)
+static void GetPhysicalDeviceProperties(const VulkanInstanceUtilInfo& instance_info,
+                                        const VulkanInstanceTable*    instance_table,
+                                        const VkPhysicalDevice        physical_device,
+                                        T&                            properties_struct)
 {
     assert((properties_struct.sType != 0) && (properties_struct.pNext == nullptr));
     properties_struct.pNext = nullptr;
@@ -95,10 +95,10 @@ static void GetPhysicalDeviceProperties(const VulkanInstanceUtilInfo&      insta
 }
 
 template <typename T>
-VkBool32 VulkanDeviceUtil::EnableRequiredBufferDeviceAddressFeatures(const VulkanInstanceUtilInfo&      instance_info,
-                                                                     const encode::VulkanInstanceTable* instance_table,
-                                                                     const VkPhysicalDevice             physical_device,
-                                                                     T*                                 feature_struct)
+VkBool32 VulkanDeviceUtil::EnableRequiredBufferDeviceAddressFeatures(const VulkanInstanceUtilInfo& instance_info,
+                                                                     const VulkanInstanceTable*    instance_table,
+                                                                     const VkPhysicalDevice        physical_device,
+                                                                     T*                            feature_struct)
 {
     // Type must be feature struct type that contains bufferDeviceAddress and bufferDeviceAddressCaptureReplay
     static_assert(std::is_same<T, VkPhysicalDeviceVulkan12Features>::value ||
@@ -136,10 +136,10 @@ VkBool32 VulkanDeviceUtil::EnableRequiredBufferDeviceAddressFeatures(const Vulka
 }
 
 template <typename T>
-VkBool32 VulkanDeviceUtil::EnableSamplerYcbcrConversionFeatures(const VulkanInstanceUtilInfo&      instance_info,
-                                                                const encode::VulkanInstanceTable* instance_table,
-                                                                const VkPhysicalDevice             physical_device,
-                                                                T*                                 feature_struct)
+VkBool32 VulkanDeviceUtil::EnableSamplerYcbcrConversionFeatures(const VulkanInstanceUtilInfo& instance_info,
+                                                                const VulkanInstanceTable*    instance_table,
+                                                                const VkPhysicalDevice        physical_device,
+                                                                T*                            feature_struct)
 {
     // Type must be feature struct type that contains samplerYcbcrConversion
     static_assert(std::is_same<T, VkPhysicalDeviceVulkan11Features>::value ||
@@ -166,10 +166,10 @@ VkBool32 VulkanDeviceUtil::EnableSamplerYcbcrConversionFeatures(const VulkanInst
 }
 
 VulkanDevicePropertyFeatureInfo
-VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(const VulkanInstanceUtilInfo&      instance_info,
-                                                       const encode::VulkanInstanceTable* instance_table,
-                                                       const VkPhysicalDevice             physical_device,
-                                                       const VkDeviceCreateInfo*          create_info)
+VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(const VulkanInstanceUtilInfo& instance_info,
+                                                       const VulkanInstanceTable*    instance_table,
+                                                       const VkPhysicalDevice        physical_device,
+                                                       const VkDeviceCreateInfo*     create_info)
 {
     VulkanDevicePropertyFeatureInfo result;
     GFXRECON_ASSERT(create_info != nullptr);
@@ -331,10 +331,10 @@ void VulkanDeviceUtil::RestoreModifiedPhysicalDeviceFeatures()
     }
 }
 
-void VulkanDeviceUtil::GetReplayDeviceProperties(const VulkanInstanceUtilInfo&      instance_info,
-                                                 const encode::VulkanInstanceTable* instance_table,
-                                                 VkPhysicalDevice                   physical_device,
-                                                 decode::VulkanReplayDeviceInfo*    replay_device_info)
+void VulkanDeviceUtil::GetReplayDeviceProperties(const VulkanInstanceUtilInfo&   instance_info,
+                                                 const VulkanInstanceTable*      instance_table,
+                                                 VkPhysicalDevice                physical_device,
+                                                 decode::VulkanReplayDeviceInfo* replay_device_info)
 {
     GFXRECON_ASSERT(instance_table != nullptr);
     GFXRECON_ASSERT(replay_device_info != nullptr);

--- a/framework/graphics/vulkan_device_util.h
+++ b/framework/graphics/vulkan_device_util.h
@@ -68,33 +68,32 @@ class VulkanDeviceUtil
     // Incoming create_info data will be modified. Use RestoreModifiedPhysicalDeviceFeatures
     // to revert incoming data to original values (e.g., prior to writing to the capture file).
     // feature_* property_* members store the state of the features/properties after this call.
-    VulkanDevicePropertyFeatureInfo
-    EnableRequiredPhysicalDeviceFeatures(const VulkanInstanceUtilInfo&      instance_info,
-                                         const encode::VulkanInstanceTable* instance_table,
-                                         const VkPhysicalDevice             physical_device,
-                                         const VkDeviceCreateInfo*          create_info);
+    VulkanDevicePropertyFeatureInfo EnableRequiredPhysicalDeviceFeatures(const VulkanInstanceUtilInfo& instance_info,
+                                                                         const VulkanInstanceTable*    instance_table,
+                                                                         const VkPhysicalDevice        physical_device,
+                                                                         const VkDeviceCreateInfo*     create_info);
 
     // Restore any incoming values that were modified in EnableRequiredPhysicalDeviceFeatures
     void RestoreModifiedPhysicalDeviceFeatures();
 
     // Populates various property-structs in the provided replay_device_info
-    static void GetReplayDeviceProperties(const VulkanInstanceUtilInfo&      instance_info,
-                                          const encode::VulkanInstanceTable* instance_table,
-                                          VkPhysicalDevice                   physical_device,
-                                          decode::VulkanReplayDeviceInfo*    replay_device_info);
+    static void GetReplayDeviceProperties(const VulkanInstanceUtilInfo&   instance_info,
+                                          const VulkanInstanceTable*      instance_table,
+                                          VkPhysicalDevice                physical_device,
+                                          decode::VulkanReplayDeviceInfo* replay_device_info);
 
   private:
     template <typename T>
-    VkBool32 EnableRequiredBufferDeviceAddressFeatures(const VulkanInstanceUtilInfo&      instance_info,
-                                                       const encode::VulkanInstanceTable* instance_table,
-                                                       const VkPhysicalDevice             physical_device,
-                                                       T*                                 feature_struct);
+    VkBool32 EnableRequiredBufferDeviceAddressFeatures(const VulkanInstanceUtilInfo& instance_info,
+                                                       const VulkanInstanceTable*    instance_table,
+                                                       const VkPhysicalDevice        physical_device,
+                                                       T*                            feature_struct);
 
     template <typename T>
-    VkBool32 EnableSamplerYcbcrConversionFeatures(const VulkanInstanceUtilInfo&      instance_info,
-                                                  const encode::VulkanInstanceTable* instance_table,
-                                                  const VkPhysicalDevice             physical_device,
-                                                  T*                                 feature_struct);
+    VkBool32 EnableSamplerYcbcrConversionFeatures(const VulkanInstanceUtilInfo&        instance_info,
+                                                  const graphics::VulkanInstanceTable* instance_table,
+                                                  const VkPhysicalDevice               physical_device,
+                                                  T*                                   feature_struct);
 
   private:
     // VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressCaptureReplay

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -48,8 +48,8 @@ class VulkanResourcesUtil
 
     VulkanResourcesUtil(VkDevice                                device,
                         VkPhysicalDevice                        physical_device,
-                        const encode::VulkanDeviceTable&        device_table,
-                        const encode::VulkanInstanceTable&      instance_table,
+                        const VulkanDeviceTable&                device_table,
+                        const VulkanInstanceTable&              instance_table,
                         const VkPhysicalDeviceMemoryProperties& memory_properties) :
         device_(device),
         device_table_(device_table), physical_device_(physical_device), instance_table_(instance_table),
@@ -258,9 +258,9 @@ class VulkanResourcesUtil
     };
 
     VkDevice                                device_;
-    const encode::VulkanDeviceTable&        device_table_;
+    const VulkanDeviceTable&                device_table_;
     VkPhysicalDevice                        physical_device_;
-    const encode::VulkanInstanceTable&      instance_table_;
+    const VulkanInstanceTable&              instance_table_;
     const VkPhysicalDeviceMemoryProperties& memory_properties_;
     uint32_t                                queue_family_index_;
     VkCommandPool                           command_pool_;

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -148,13 +148,13 @@ static void AddInstanceHandle(VkInstance instance)
 {
     // Store the instance for use with vkCreateDevice.
     std::lock_guard<std::mutex> lock(vulkan_instance_handles_lock);
-    vulkan_instance_handles[encode::GetVulkanDispatchKey(instance)] = instance;
+    vulkan_instance_handles[graphics::GetVulkanDispatchKey(instance)] = instance;
 }
 
 static VkInstance GetInstanceHandle(const void* handle)
 {
     std::lock_guard<std::mutex> lock(vulkan_instance_handles_lock);
-    auto                        entry = vulkan_instance_handles.find(encode::GetVulkanDispatchKey(handle));
+    auto                        entry = vulkan_instance_handles.find(graphics::GetVulkanDispatchKey(handle));
     return (entry != vulkan_instance_handles.end()) ? entry->second : VK_NULL_HANDLE;
 }
 


### PR DESCRIPTION
VulkanDispatchTable is used by both encode and decode so this PR moves it to a common depedency.