### PR TITLE
Add timestamp in logs when `--log-level` is `debug` or less

### DIFF
--- a/framework/util/logging.cpp
+++ b/framework/util/logging.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "util/logging.h"
+#include "util/date_time.h"
 
 #include <cstdarg>
 #include <string>
@@ -163,6 +164,12 @@ void Log::LogMessage(
         // Only add a string prefix if this isn't a string that always outputs.
         prefix += "[";
         prefix += process_tag;
+        if (settings_.min_severity <= kDebugSeverity)
+        {
+            prefix += "]";
+            prefix += "[";
+            prefix += std::to_string(util::datetime::GetBootTime());
+        }
         prefix += "] ";
         prefix += SeverityToString(severity);
         if (settings_.output_detailed_log_info)


### PR DESCRIPTION
When running GFXReconstruct in automation, it can be useful to have timestamps in front of each message for debug purpose.
This commit add the boot time in front of each logged message on desktop platforms (linux/windows) if log-level is debug.

Here's an example of logs with this commit:
```gfxrecon-replay version info:
GFXReconstruct Version 1.0.5-jenkins-c790995d (7d059ae*) Release
Vulkan Header Version 1.4.304
[gfxrecon][681347.146449] DEBUG - Failed to connect to an X server
[gfxrecon][681347.221838] DEBUG - Skip vkGetPhysicalDeviceSurfaceSupportKHR for offscreen.
[gfxrecon][681347.462342] DEBUG - Skip vkGetPhysicalDeviceSurfaceCapabilitiesKHR for offscreen.
[gfxrecon][681347.462359] DEBUG - Skip vkGetPhysicalDeviceSurfaceFormatsKHR for offscreen.
[gfxrecon][681347.462378] DEBUG - Skip vkGetPhysicalDeviceSurfaceFormatsKHR for offscreen.
[gfxrecon][681347.462382] DEBUG - Skip vkGetPhysicalDeviceSurfacePresentModesKHR for offscreen.
[gfxrecon][681347.462385] DEBUG - Skip vkGetPhysicalDeviceSurfacePresentModesKHR for offscreen.
[gfxrecon][681347.462521] DEBUG - Skipping window resize for VkSurface object (ID = 2) without an associated window
[gfxrecon][681348.469331] DEBUG - Frame 1 memory (mb): 716.02 max RSS, 716.02 current RSS, 3542.41 available
[gfxrecon][681348.474590] DEBUG - Frame 2 memory (mb): 716.14 max RSS, 716.14 current RSS, 3542.41 available
[gfxrecon][681348.479575] DEBUG - Frame 3 memory (mb): 716.14 max RSS, 716.14 current RSS, 3542.41 available
[gfxrecon][681348.485825] DEBUG - Frame 4 memory (mb): 716.14 max RSS, 716.14 current RSS, 3542.41 available
[gfxrecon][681348.494195] DEBUG - Frame 5 memory (mb): 716.27 max RSS, 716.27 current RSS, 3542.41 available
[gfxrecon][681348.502483] DEBUG - Frame 6 memory (mb): 716.27 max RSS, 716.27 current RSS, 3542.41 available
[gfxrecon][681348.511178] DEBUG - Frame 7 memory (mb): 716.27 max RSS, 716.27 current RSS, 3542.41 available
[gfxrecon][681348.519809] DEBUG - Frame 8 memory (mb): 716.27 max RSS, 716.27 current RSS, 3542.41 available
[gfxrecon][681348.525914] DEBUG - Frame 9 memory (mb): 716.89 max RSS, 716.89 current RSS, 3541.91 available
[gfxrecon][681348.560585] INFO - WriteBmpImage(): Writing file "/tmp/gfxrt/device/UM6XJJ-2/QSNO25/X67K2W/LJMHNI/screenshot_frame_10.bmp"
[gfxrecon][681348.578069] DEBUG - Frame 10 memory (mb): 727.02 max RSS, 727.02 current RSS, 3521.73 available
Load time: 0.000000 seconds (frame 1)
Total time: 1.432489 seconds
Measured FPS: 250.194088 fps, 0.003997 seconds, 1 frame, 1 loop, framerange [9-10)```