### PR TITLE
Add `--screenshot-interval` option

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -706,6 +706,7 @@ usage: gfxrecon.py replay [-h] [--push-file LOCAL_FILE] [--version]
                           [--paused] [--screenshot-all] [--screenshots RANGES]
                           [--screenshot-format FORMAT] [--screenshot-dir DIR]
                           [--screenshot-prefix PREFIX] [--screenshot-scale SCALE]
+                          [--screenshot-interval INTERVAL]
                           [--screenshot-size WIDTHxHEIGHT] [--sfa] [--opcd]
                           [--surface-index N] [--sync] [--remove-unsupported]
                           [--mfr START-END] [--replace-shaders <dir>]
@@ -780,6 +781,12 @@ optional arguments:
               numbering is 1-based (i.e. the first frame is frame
               1). Example: 200,301-305 will generate six screenshots
               (forwarded to replay tool)
+  --screenshot-interval INTERVAL
+              Specifies the number of frames between two screenshots
+              twithin a screenshot range.
+              Example: If screenshot range is 10-15 and interval is 2,
+              screenshot will be generated for frames 10, 12 and 14.
+              Default is 1.
   --screenshot-format FORMAT
               Image file format to use for screenshot generation.
               Available formats are:

--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -202,6 +202,7 @@ Usage:
                         [--screenshots <N1(-N2),...>] [--screenshot-format <format>]
                         [--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]
                         [--screenshot-scale SCALE] [--screenshot-size WIDTHxHEIGHT]
+                        [--screenshot-interval <N>]
                         [--sfa | --skip-failed-allocations] [--replace-shaders <dir>]
                         [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
                         [--use-cached-psos] [--surface-index <N>]
@@ -246,6 +247,12 @@ Optional arguments:
                         ascending order and cannot overlap.  Note that frame
                         numbering is 1-based (i.e. the first frame is frame 1).
                         Example: 200,301-305 will generate six screenshots.
+  --screenshot-interval <N>
+                        Specifies the number of frames between two screenshots
+                        twithin a screenshot range.
+                        Example: If screenshot range is 10-15 and interval is 2,
+                        screenshot will be generated for frames 10, 12 and 14.
+                        Default is 1.
   --screenshot-format <format>
                         Image file format to use for screenshot generation.
                         Available formats are:

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -551,6 +551,7 @@ gfxrecon-replay         [-h | --help] [--version] [--cpu-mask <binary-mask>] [--
                         [--screenshots <N1(-N2),...>] [--screenshot-format <format>]
                         [--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]
                         [--screenshot-scale SCALE] [--screenshot-size WIDTHxHEIGHT]
+                        [--screenshot-interval <N>]
                         [--sfa | --skip-failed-allocations] [--replace-shaders <dir>]
                         [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
                         [--surface-index <N>] [--remove-unsupported] [--validate]
@@ -625,6 +626,12 @@ Optional arguments:
                         ascending order and cannot overlap.  Note that frame
                         numbering is 1-based (i.e. the first frame is frame 1).
                         Example: 200,301-305 will generate six screenshots.
+  --screenshot-interval <N>
+                        Specifies the number of frames between two screenshots
+                        twithin a screenshot range.
+                        Example: If screenshot range is 10-15 and interval is 2,
+                        screenshot will be generated for frames 10, 12 and 14.
+                        Default is 1.
   --screenshot-format <format>
                         Image file format to use for screenshot generation.
                         Available formats are:

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -100,6 +100,7 @@ def CreateReplayParser():
     parser.add_argument('--cpu-mask', metavar='binary_mask', help='Set of CPU cores used by the replayer. `binary-mask` is a succession of "0" and "1" that specifies used/unused cores read from left to right. For example "10010" activates the first and fourth cores and deactivate all other cores. If the option is not set, all cores can be used. If the option is set only for some cores, the other cores are not used. (forwarded to replay tool)')
     parser.add_argument('--screenshot-all', action='store_true', default=False, help='Generate screenshots for all frames.  When this option is specified, --screenshots is ignored (forwarded to replay tool)')
     parser.add_argument('--screenshots', metavar='RANGES', help='Generate screenshots for the specified frames.  Target frames are specified as a comma separated list of frame ranges.  A frame range can be specified as a single value, to specify a single frame, or as two hyphenated values, to specify the first and last frames to process.  Frame ranges should be specified in ascending order and cannot overlap.  Note that frame numbering is 1-based (i.e. the first frame is frame 1).  Example: 200,301-305 will generate six screenshots (forwarded to replay tool)')
+    parser.add_argument('--screenshot-interval', metavar='INTERVAL', help='Specifies the number of frames between two screenshots within a screenshot range. Example: If screenshot range is 10-15 and interval is 2, screenshot will be generated for frames 10, 12 and 14. Default is 1. (forwarded to replay tool)')
     parser.add_argument('--screenshot-format', metavar='FORMAT', choices=['bmp', 'png'], help='Image file format to use for screenshot generation.  Available formats are: bmp, png (forwarded to replay tool)')
     parser.add_argument('--screenshot-dir', metavar='DIR', help='Directory to write screenshots. Default is "/sdcard" (forwarded to replay tool)')
     parser.add_argument('--screenshot-prefix', metavar='PREFIX', help='Prefix to apply to the screenshot file name.  Default is "screenshot" (forwarded to replay tool)')
@@ -181,6 +182,10 @@ def MakeExtrasString(args):
     elif args.screenshots:
         arg_list.append('--screenshots')
         arg_list.append('{}'.format(args.screenshots))
+    
+    if args.screenshot_interval:
+        arg_list.append('--screenshot-interval')
+        arg_list.append('{}'.format(args.screenshot_interval))
 
     if args.screenshot_format:
         arg_list.append('--screenshot-format')

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -3448,8 +3448,8 @@ void Dx12ReplayConsumerBase::InitializeScreenshotHandler()
     {
         screenshot_file_prefix_ = util::filepath::Join(options_.screenshot_dir, screenshot_file_prefix_);
     }
-    screenshot_handler_ =
-        std::make_unique<ScreenshotHandlerBase>(options_.screenshot_format, options_.screenshot_ranges);
+    screenshot_handler_ = std::make_unique<ScreenshotHandlerBase>(
+        options_.screenshot_format, options_.screenshot_ranges, options_.screenshot_interval);
 }
 
 void Dx12ReplayConsumerBase::Process_ID3D12Device_CheckFeatureSupport(format::HandleId object_id,

--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -73,6 +73,7 @@ struct ReplayOptions
     bool                         remove_unsupported_features{ false };
     util::ScreenshotFormat       screenshot_format{ util::ScreenshotFormat::kBmp };
     std::vector<ScreenshotRange> screenshot_ranges;
+    uint32_t                     screenshot_interval{ 1 };
     std::string                  screenshot_dir;
     std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
     uint32_t                     screenshot_width, screenshot_height;

--- a/framework/decode/screenshot_handler.h
+++ b/framework/decode/screenshot_handler.h
@@ -44,12 +44,16 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class ScreenshotHandler : public ScreenshotHandlerBase
 {
   public:
-    ScreenshotHandler(util::ScreenshotFormat screenshot_format, const std::vector<ScreenshotRange>& screenshot_ranges) :
-        ScreenshotHandlerBase(screenshot_format, screenshot_ranges)
+    ScreenshotHandler(util::ScreenshotFormat              screenshot_format,
+                      const std::vector<ScreenshotRange>& screenshot_ranges,
+                      uint32_t                            screenshot_interval) :
+        ScreenshotHandlerBase(screenshot_format, screenshot_ranges, screenshot_interval)
     {}
 
-    ScreenshotHandler(util::ScreenshotFormat screenshot_format, std::vector<ScreenshotRange>&& screenshot_ranges) :
-        ScreenshotHandlerBase(screenshot_format, screenshot_ranges)
+    ScreenshotHandler(util::ScreenshotFormat         screenshot_format,
+                      std::vector<ScreenshotRange>&& screenshot_ranges,
+                      uint32_t                       screenshot_interval) :
+        ScreenshotHandlerBase(screenshot_format, screenshot_ranges, screenshot_interval)
     {}
 
     void WriteImage(const std::string&                      filename_prefix,

--- a/framework/decode/screenshot_handler_base.cpp
+++ b/framework/decode/screenshot_handler_base.cpp
@@ -32,15 +32,19 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 ScreenshotHandlerBase::ScreenshotHandlerBase(util::ScreenshotFormat              screenshot_format,
-                                             const std::vector<ScreenshotRange>& screenshot_ranges) :
+                                             const std::vector<ScreenshotRange>& screenshot_ranges,
+                                             uint32_t                            screenshot_interval) :
     current_frame_number_(1),
-    screenshot_format_(screenshot_format), screenshot_ranges_(screenshot_ranges), current_range_index_(0)
+    screenshot_format_(screenshot_format), screenshot_ranges_(screenshot_ranges),
+    screenshot_interval_(screenshot_interval), current_range_index_(0)
 {}
 
 ScreenshotHandlerBase::ScreenshotHandlerBase(util::ScreenshotFormat         screenshot_format,
-                                             std::vector<ScreenshotRange>&& screenshot_ranges) :
+                                             std::vector<ScreenshotRange>&& screenshot_ranges,
+                                             uint32_t                       screenshot_interval) :
     current_frame_number_(1),
-    screenshot_format_(screenshot_format), screenshot_ranges_(std::move(screenshot_ranges)), current_range_index_(0)
+    screenshot_format_(screenshot_format), screenshot_ranges_(std::move(screenshot_ranges)),
+    screenshot_interval_(screenshot_interval), current_range_index_(0)
 {}
 
 void ScreenshotHandlerBase::EndFrame()
@@ -62,7 +66,8 @@ bool ScreenshotHandlerBase::IsScreenshotFrame() const
     if (current_range_index_ < screenshot_ranges_.size())
     {
         const auto& current_range = screenshot_ranges_[current_range_index_];
-        if ((current_range.first <= current_frame_number_) && (current_range.last >= current_frame_number_))
+        if ((current_range.first <= current_frame_number_) && (current_range.last >= current_frame_number_) &&
+            ((current_frame_number_ - current_range.first) % screenshot_interval_ == 0))
         {
             return true;
         }

--- a/framework/decode/screenshot_handler_base.h
+++ b/framework/decode/screenshot_handler_base.h
@@ -39,9 +39,12 @@ class ScreenshotHandlerBase
 {
   public:
     ScreenshotHandlerBase(util::ScreenshotFormat              screenshot_format,
-                          const std::vector<ScreenshotRange>& screenshot_ranges);
+                          const std::vector<ScreenshotRange>& screenshot_ranges,
+                          uint32_t                            screenshot_interval);
 
-    ScreenshotHandlerBase(util::ScreenshotFormat screenshot_format, std::vector<ScreenshotRange>&& screenshot_ranges);
+    ScreenshotHandlerBase(util::ScreenshotFormat         screenshot_format,
+                          std::vector<ScreenshotRange>&& screenshot_ranges,
+                          uint32_t                       screenshot_interval);
 
     uint32_t GetCurrentFrame() const { return current_frame_number_; }
 
@@ -53,6 +56,7 @@ class ScreenshotHandlerBase
     uint32_t                     current_frame_number_;
     util::ScreenshotFormat       screenshot_format_;
     std::vector<ScreenshotRange> screenshot_ranges_;
+    uint32_t                     screenshot_interval_;
     size_t                       current_range_index_;
 };
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2396,7 +2396,8 @@ void VulkanReplayConsumerBase::InitializeScreenshotHandler()
         screenshot_file_prefix_ = util::filepath::Join(options_.screenshot_dir, screenshot_file_prefix_);
     }
 
-    screenshot_handler_ = std::make_unique<ScreenshotHandler>(options_.screenshot_format, options_.screenshot_ranges);
+    screenshot_handler_ = std::make_unique<ScreenshotHandler>(
+        options_.screenshot_format, options_.screenshot_ranges, options_.screenshot_interval);
 }
 
 void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* meta_info) const

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -212,7 +212,7 @@ void CommonCaptureManager::DestroyInstance(ApiCaptureManager* api_capture_manage
     }
 }
 
-std::vector<uint32_t> CalcScreenshotIndices(std::vector<util::UintRange> ranges)
+std::vector<uint32_t> CalcScreenshotIndices(std::vector<util::UintRange> ranges, uint32_t interval)
 {
     // Take a range of frames and convert it to a flat list of indices
     std::vector<uint32_t> indices;
@@ -223,7 +223,7 @@ std::vector<uint32_t> CalcScreenshotIndices(std::vector<util::UintRange> ranges)
 
         uint32_t diff = range.last - range.first + 1;
 
-        for (uint32_t j = 0; j < diff; ++j)
+        for (uint32_t j = 0; j < diff; j += interval)
         {
             uint32_t screenshot_index = range.first + j;
 
@@ -261,20 +261,20 @@ bool CommonCaptureManager::Initialize(format::ApiFamilyId                   api_
 {
     bool success = true;
 
-    base_filename_                   = base_filename;
-    file_options_                    = trace_settings.capture_file_options;
-    timestamp_filename_              = trace_settings.time_stamp_file;
-    memory_tracking_mode_            = trace_settings.memory_tracking_mode;
-    force_file_flush_                = trace_settings.force_flush;
-    debug_layer_                     = trace_settings.debug_layer;
-    debug_device_lost_               = trace_settings.debug_device_lost;
-    screenshots_enabled_             = !trace_settings.screenshot_ranges.empty();
-    screenshot_format_               = trace_settings.screenshot_format;
-    screenshot_indices_              = CalcScreenshotIndices(trace_settings.screenshot_ranges);
-    screenshot_prefix_               = PrepScreenshotPrefix(trace_settings.screenshot_dir);
-    disable_dxr_                     = trace_settings.disable_dxr;
-    accel_struct_padding_            = trace_settings.accel_struct_padding;
-    iunknown_wrapping_               = trace_settings.iunknown_wrapping;
+    base_filename_        = base_filename;
+    file_options_         = trace_settings.capture_file_options;
+    timestamp_filename_   = trace_settings.time_stamp_file;
+    memory_tracking_mode_ = trace_settings.memory_tracking_mode;
+    force_file_flush_     = trace_settings.force_flush;
+    debug_layer_          = trace_settings.debug_layer;
+    debug_device_lost_    = trace_settings.debug_device_lost;
+    screenshots_enabled_  = !trace_settings.screenshot_ranges.empty();
+    screenshot_format_    = trace_settings.screenshot_format;
+    screenshot_indices_   = CalcScreenshotIndices(trace_settings.screenshot_ranges, trace_settings.screenshot_interval);
+    screenshot_prefix_    = PrepScreenshotPrefix(trace_settings.screenshot_dir);
+    disable_dxr_          = trace_settings.disable_dxr;
+    accel_struct_padding_ = trace_settings.accel_struct_padding;
+    iunknown_wrapping_    = trace_settings.iunknown_wrapping;
     force_command_serialization_     = trace_settings.force_command_serialization;
     queue_zero_only_                 = trace_settings.queue_zero_only;
     allow_pipeline_compile_required_ = trace_settings.allow_pipeline_compile_required;
@@ -1630,7 +1630,8 @@ CaptureFileOutputStream::CaptureFileOutputStream(CommonCaptureManager* capture_m
                                                  const std::string&    filename,
                                                  size_t                buffer_size,
                                                  bool                  append) :
-    FileOutputStream(filename, buffer_size, append), capture_manager_(capture_manager)
+    FileOutputStream(filename, buffer_size, append),
+    capture_manager_(capture_manager)
 {}
 
 bool CaptureFileOutputStream::Write(const void* data, size_t len)

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -81,6 +81,8 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 #define SCREENSHOT_FORMAT_UPPER                              "SCREENSHOT_FORMAT"
 #define SCREENSHOT_FRAMES_LOWER                              "screenshot_frames"
 #define SCREENSHOT_FRAMES_UPPER                              "SCREENSHOT_FRAMES"
+#define SCREENSHOT_INTERVAL_LOWER                            "screenshot_interval"
+#define SCREENSHOT_INTERVAL_UPPER                            "SCREENSHOT_INTERVAL"
 #define CAPTURE_FRAMES_LOWER                                 "capture_frames"
 #define CAPTURE_FRAMES_UPPER                                 "CAPTURE_FRAMES"
 #define CAPTURE_DRAW_CALLS_LOWER                             "capture_draw_calls"
@@ -184,6 +186,7 @@ const char kMemoryTrackingModeEnvVar[]                       = GFXRECON_OPTION_S
 const char kScreenshotDirEnvVar[]                            = GFXRECON_OPTION_STR(SCREENSHOT_DIR);
 const char kScreenshotFormatEnvVar[]                         = GFXRECON_OPTION_STR(SCREENSHOT_FORMAT);
 const char kScreenshotFramesEnvVar[]                         = GFXRECON_OPTION_STR(SCREENSHOT_FRAMES);
+const char kScreenshotIntervalEnvVar[]                       = GFXRECON_OPTION_STR(SCREENSHOT_INTERVAL);
 const char kCaptureFramesEnvVar[]                            = GFXRECON_OPTION_STR(CAPTURE_FRAMES);
 const char kCaptureDrawCallsEnvVar[]                         = GFXRECON_OPTION_STR(CAPTURE_DRAW_CALLS);
 const char kQuitAfterFramesEnvVar[]                          = GFXRECON_OPTION_STR(QUIT_AFTER_CAPTURE_FRAMES);
@@ -242,6 +245,7 @@ const std::string kOptionKeyMemoryTrackingMode                       = std::stri
 const std::string kOptionKeyScreenshotDir                            = std::string(kSettingsFilter) + std::string(SCREENSHOT_DIR_LOWER);
 const std::string kOptionKeyScreenshotFormat                         = std::string(kSettingsFilter) + std::string(SCREENSHOT_FORMAT_LOWER);
 const std::string kOptionKeyScreenshotFrames                         = std::string(kSettingsFilter) + std::string(SCREENSHOT_FRAMES_LOWER);
+const std::string kOptionKeyScreenshotInterval                       = std::string(kSettingsFilter) + std::string(SCREENSHOT_INTERVAL_LOWER);
 const std::string kOptionKeyCaptureFrames                            = std::string(kSettingsFilter) + std::string(CAPTURE_FRAMES_LOWER);
 const std::string kOptionKeyCaptureDrawCalls                         = std::string(kSettingsFilter) + std::string(CAPTURE_DRAW_CALLS_LOWER);
 const std::string kOptionKeyQuitAfterCaptureFrames                   = std::string(kSettingsFilter) + std::string(QUIT_AFTER_CAPTURE_FRAMES_LOWER);
@@ -423,6 +427,7 @@ void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
     LoadSingleOptionEnvVar(options, kScreenshotDirEnvVar, kOptionKeyScreenshotDir);
     LoadSingleOptionEnvVar(options, kScreenshotFormatEnvVar, kOptionKeyScreenshotFormat);
     LoadSingleOptionEnvVar(options, kScreenshotFramesEnvVar, kOptionKeyScreenshotFrames);
+    LoadSingleOptionEnvVar(options, kScreenshotIntervalEnvVar, kOptionKeyScreenshotInterval);
 
     // DirectX environment variables
     LoadSingleOptionEnvVar(options, kDisableDxrEnvVar, kOptionDisableDxr);
@@ -620,6 +625,14 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
     ParseUintRangeList(FindOption(options, kOptionKeyScreenshotFrames),
                        &settings->trace_settings_.screenshot_ranges,
                        "screenshot frames");
+    settings->trace_settings_.screenshot_interval = ParseIntegerString(
+        FindOption(options, kOptionKeyScreenshotInterval), settings->trace_settings_.screenshot_interval);
+    if (settings->trace_settings_.screenshot_interval == 0)
+    {
+        GFXRECON_LOG_WARNING(
+            "A screenshot interval of 0 has been specified, which is invalid. An interval of 1 will be used.");
+        settings->trace_settings_.screenshot_interval = 1;
+    }
     settings->trace_settings_.screenshot_format = ParseScreenshotFormatString(
         FindOption(options, kOptionKeyScreenshotFormat), settings->trace_settings_.screenshot_format);
 

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -106,6 +106,7 @@ class CaptureSettings
         MemoryTrackingMode           memory_tracking_mode{ kPageGuard };
         std::string                  screenshot_dir;
         std::vector<util::UintRange> screenshot_ranges;
+        uint32_t                     screenshot_interval{ 1 };
         util::ScreenshotFormat       screenshot_format;
         TrimBoundary                 trim_boundary{ TrimBoundary::kUnknown };
         std::vector<util::UintRange> trim_ranges;

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -40,7 +40,7 @@ const char kOptions[] =
     "--add-new-pipeline-caches,--screenshot-ignore-FrameBoundaryANDROID";
 const char kArguments[] =
     "--log-level,--log-file,--cpu-mask,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
-    "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
+    "--replace-shaders,--screenshots,--screenshot-interval,--denied-messages,--allowed-messages,--screenshot-format,--"
     "screenshot-dir,--screenshot-prefix,--screenshot-size,--screenshot-scale,--mfr|--measurement-frame-range,--fw|--"
     "force-windowed,--fwo|--force-windowed-origin,--batching-memory-usage,--measurement-file,--swapchain,--sgfs|--skip-"
     "get-fence-status,--sgfr|--"
@@ -67,7 +67,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshots <N1(-N2),...>] [--screenshot-format <format>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-size <width>x<height>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-scale <scale>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-scale <scale>] [--screenshot-interval <N>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sfa | --skip-failed-allocations] [--replace-shaders <dir>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data] [--wsi <platform>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-cached-psos] [--surface-index <N>]");
@@ -137,6 +137,12 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tascending order and cannot overlap.  Note that frame");
     GFXRECON_WRITE_CONSOLE("          \t\tnumbering is 1-based (i.e. the first frame is frame 1).");
     GFXRECON_WRITE_CONSOLE("          \t\tExample: 200,301-305 will generate six screenshots.");
+    GFXRECON_WRITE_CONSOLE("  --screenshot-interval <N>");
+    GFXRECON_WRITE_CONSOLE("          \t\tSpecifies the number of frames between two screenshots");
+    GFXRECON_WRITE_CONSOLE("          \t\twithin a screenshot range.");
+    GFXRECON_WRITE_CONSOLE("          \t\tExample: If screenshot range is 10-15 and interval is 2,");
+    GFXRECON_WRITE_CONSOLE("          \t\tscreenshot will be generated for frames 10, 12 and 14.");
+    GFXRECON_WRITE_CONSOLE("          \t\tDefault is 1.");
     GFXRECON_WRITE_CONSOLE("  --screenshot-format <format>");
     GFXRECON_WRITE_CONSOLE("          \t\tImage file format to use for screenshot generation.");
     GFXRECON_WRITE_CONSOLE("          \t\tAvailable formats are:");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -92,6 +92,7 @@ const char kAllowedMessages[]                    = "--allowed-messages";
 const char kShaderReplaceArgument[]              = "--replace-shaders";
 const char kScreenshotAllOption[]                = "--screenshot-all";
 const char kScreenshotRangeArgument[]            = "--screenshots";
+const char kScreenshotIntervalArgument[]         = "--screenshot-interval";
 const char kScreenshotFormatArgument[]           = "--screenshot-format";
 const char kScreenshotDirArgument[]              = "--screenshot-dir";
 const char kScreenshotFilePrefixArgument[]       = "--screenshot-prefix";
@@ -1074,7 +1075,15 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     replay_options.create_resource_allocator =
         GetCreateResourceAllocatorFunc(arg_parser, filename, replay_options, tracked_object_info_table);
 
-    replay_options.screenshot_ranges      = GetScreenshotRanges(arg_parser);
+    replay_options.screenshot_ranges = GetScreenshotRanges(arg_parser);
+    if (arg_parser.IsArgumentSet(kScreenshotIntervalArgument))
+    {
+        replay_options.screenshot_interval = std::stoi(arg_parser.GetArgumentValue(kScreenshotIntervalArgument));
+        if (replay_options.screenshot_interval == 0)
+        {
+            throw std::runtime_error("A screenshot interval of 0 is invalid. Closing the program.");
+        }
+    }
     replay_options.screenshot_format      = GetScreenshotFormat(arg_parser);
     replay_options.screenshot_dir         = GetScreenshotDir(arg_parser);
     replay_options.screenshot_file_prefix = arg_parser.GetArgumentValue(kScreenshotFilePrefixArgument);
@@ -1263,7 +1272,15 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
         }
     }
 
-    replay_options.screenshot_ranges      = GetScreenshotRanges(arg_parser);
+    replay_options.screenshot_ranges = GetScreenshotRanges(arg_parser);
+    if (arg_parser.IsArgumentSet(kScreenshotIntervalArgument))
+    {
+        replay_options.screenshot_interval = std::stoi(arg_parser.GetArgumentValue(kScreenshotIntervalArgument));
+        if (replay_options.screenshot_interval == 0)
+        {
+            throw std::runtime_error("A screenshot interval of 0 is invalid. Closing the program.");
+        }
+    }
     replay_options.screenshot_format      = GetScreenshotFormat(arg_parser);
     replay_options.screenshot_dir         = GetScreenshotDir(arg_parser);
     replay_options.screenshot_file_prefix = arg_parser.GetArgumentValue(kScreenshotFilePrefixArgument);


### PR DESCRIPTION
In some case people want to be able to take a screenshot "every N frame" over long frame ranges or over the entire capture.

For now the only way to do this was either to take all screenshots and discard unused ones afterwards - which increase significantly the run time - or to write a very long list manually or assisted with a script, which is not very user-friendly.

This commit implements this with an option `--screenshot-interval N` where a screenshot is taken every `N` frame within screenshot ranges.

The default behavior stays the same if `--screenshot-interval` is `1`, which is the default value.

Example: If the screenshot ranges are `10-15,20-30` and the screenshot interval is `3`, then screenshots will be taken at frames 10, 13, 20, 23, 26 and 29.