### PR TITLE
Add '--log-timestamps' option

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -702,7 +702,7 @@ The `gfxrecon.py replay` command has the following usage:
 
 ```text
 usage: gfxrecon.py replay [-h] [-p LOCAL_FILE] [--version] [--log-level LEVEL]
-                          [--log-file DEVICE_FILE]
+                          [--log-timestamps] [--log-file DEVICE_FILE]
                           [--debug-messenger-level LEVEL] [--pause-frame N]
                           [--paused] [--cpu-mask binary_mask]
                           [--screenshot-all] [--screenshots RANGES]
@@ -757,6 +757,7 @@ options:
   --log-level LEVEL     Specify highest level message to log. Options are:
                         debug, info, warning, error, and fatal. Default is
                         info. (forwarded to replay tool)
+  --log-timestamps      Output a timestamp in front of each log message.
   --log-file DEVICE_FILE
                         Write log messages to a file at the specified path
                         instead of logcat (forwarded to replay tool)

--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -228,6 +228,7 @@ Optional arguments:
   --version             Print version information and exit.
   --log-level <level>   Specify highest level message to log. Options are:
                         debug, info, warning, error, and fatal. Default is info.
+  --log-timestamps      Output a timestamp in front of each log message.
   --log-file <file>     Write log messages to a file at the specified path.
                         Default is: Empty string (file logging disabled).
   --log-debugview       Log messages with OutputDebugStringA.

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -477,6 +477,7 @@ usage: gfxrecon-capture-vulkan.py [-h]
                                   [--compression-type {LZ4,ZLIB,ZSTD,NONE}]
                                   [--file-flush]
                                   [--log-level {debug,info,warn,error,fatal}]
+                                  [--log-timestamps]
                                   [--log-file <file>]
                                   [--memory-tracking-mode {page_guard,assisted,unassisted}]
                                   <program> [<programArgs>]
@@ -507,6 +508,7 @@ optional arguments:
                         capture file
   --log-level {debug,info,warn,error,fatal}
                         Specify highest level message to log, default is info
+  --log-timestamps      Output a timestamp in front of each log message.
   --log-file <logFile>  Write log messages to a file at the specified path.
                         Default is: Empty string (file logging disabled)
   --memory-tracking-mode {page_guard,assisted,unassisted}
@@ -592,6 +594,7 @@ Optional arguments:
   --version             Print version information and exit.
   --log-level <level>   Specify highest level message to log. Options are:
                         debug, info, warning, error, and fatal. Default is info.
+  --log-timestamps      Output a timestamp in front of each log message.
   --log-file <file>     Write log messages to a file at the specified path.
                         Default is: Empty string (file logging disabled).
   --log-debugview       Log messages with OutputDebugStringA. Windows only.

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -94,6 +94,7 @@ def CreateReplayParser():
     parser.add_argument('-p', '--push-file', metavar='LOCAL_FILE', help='Local file to push to the location on device specified by <file>')
     parser.add_argument('--version', action='store_true', default=False, help='Print version information and exit (forwarded to replay tool)')
     parser.add_argument('--log-level', metavar='LEVEL', help='Specify highest level message to log. Options are: debug, info, warning, error, and fatal. Default is info. (forwarded to replay tool)')
+    parser.add_argument('--log-timestamps', action='store_true', help='Output a timestamp in front of each log message. (forwarded to replay tool)')
     parser.add_argument('--log-file', metavar='DEVICE_FILE', help='Write log messages to a file at the specified path instead of logcat (forwarded to replay tool)')
     parser.add_argument('--debug-messenger-level', metavar='LEVEL', help='Specify highest debug messenger severity level. Options are: debug, info, warning, and error. Default is warning. (forwarded to replay tool)')
     parser.add_argument('--pause-frame', metavar='N', help='Pause after replaying frame number N (forwarded to replay tool)')
@@ -163,6 +164,9 @@ def MakeExtrasString(args):
     if args.log_level:
         arg_list.append('--log-level')
         arg_list.append('{}'.format(args.log_level))
+
+    if args.log_timestamps:
+        arg_list.append('--log-timestamps')
 
     if args.log_file:
         arg_list.append('--log-file')

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -69,6 +69,8 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 #define LOG_FILE_KEEP_OPEN_UPPER                             "LOG_FILE_KEEP_OPEN"
 #define LOG_LEVEL_LOWER                                      "log_level"
 #define LOG_LEVEL_UPPER                                      "LOG_LEVEL"
+#define LOG_TIMESTAMPS_LOWER                                 "log_timestamps"
+#define LOG_TIMESTAMPS_UPPER                                 "LOG_TIMESTAMPS"
 #define LOG_OUTPUT_TO_CONSOLE_LOWER                          "log_output_to_console"
 #define LOG_OUTPUT_TO_CONSOLE_UPPER                          "LOG_OUTPUT_TO_CONSOLE"
 #define LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER                  "log_output_to_os_debug_string"
@@ -182,6 +184,7 @@ const char kLogFileCreateNewEnvVar[]                         = GFXRECON_OPTION_S
 const char kLogFileFlushAfterWriteEnvVar[]                   = GFXRECON_OPTION_STR(LOG_FILE_FLUSH_AFTER_WRITE);
 const char kLogFileKeepFileOpenEnvVar[]                      = GFXRECON_OPTION_STR(LOG_FILE_KEEP_OPEN);
 const char kLogLevelEnvVar[]                                 = GFXRECON_OPTION_STR(LOG_LEVEL);
+const char kLogTimestampsEnvVar[]                            = GFXRECON_OPTION_STR(LOG_TIMESTAMPS);
 const char kLogOutputToConsoleEnvVar[]                       = GFXRECON_OPTION_STR(LOG_OUTPUT_TO_CONSOLE);
 const char kLogOutputToOsDebugStringEnvVar[]                 = GFXRECON_OPTION_STR(LOG_OUTPUT_TO_OS_DEBUG_STRING);
 const char kMemoryTrackingModeEnvVar[]                       = GFXRECON_OPTION_STR(MEMORY_TRACKING_MODE);
@@ -242,6 +245,7 @@ const std::string kOptionKeyLogFileCreateNew                         = std::stri
 const std::string kOptionKeyLogFileFlushAfterWrite                   = std::string(kSettingsFilter) + std::string(LOG_FILE_FLUSH_AFTER_WRITE_LOWER);
 const std::string kOptionKeyLogFileKeepOpen                          = std::string(kSettingsFilter) + std::string(LOG_FILE_KEEP_OPEN_LOWER);
 const std::string kOptionKeyLogLevel                                 = std::string(kSettingsFilter) + std::string(LOG_LEVEL_LOWER);
+const std::string kOptionKeyLogTimestamps                            = std::string(kSettingsFilter) + std::string(LOG_TIMESTAMPS_LOWER);
 const std::string kOptionKeyLogOutputToConsole                       = std::string(kSettingsFilter) + std::string(LOG_OUTPUT_TO_CONSOLE_LOWER);
 const std::string kOptionKeyLogOutputToOsDebugString                 = std::string(kSettingsFilter) + std::string(LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER);
 const std::string kOptionKeyMemoryTrackingMode                       = std::string(kSettingsFilter) + std::string(MEMORY_TRACKING_MODE_LOWER);
@@ -396,6 +400,7 @@ void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
     LoadSingleOptionEnvVar(options, kLogFileFlushAfterWriteEnvVar, kOptionKeyLogFileFlushAfterWrite);
     LoadSingleOptionEnvVar(options, kLogFileKeepFileOpenEnvVar, kOptionKeyLogFileKeepOpen);
     LoadSingleOptionEnvVar(options, kLogLevelEnvVar, kOptionKeyLogLevel);
+    LoadSingleOptionEnvVar(options, kLogTimestampsEnvVar, kOptionKeyLogTimestamps);
     LoadSingleOptionEnvVar(options, kLogOutputToConsoleEnvVar, kOptionKeyLogOutputToConsole);
     LoadSingleOptionEnvVar(options, kLogOutputToOsDebugStringEnvVar, kOptionKeyLogOutputToOsDebugString);
 
@@ -710,6 +715,8 @@ void CaptureSettings::ProcessLogOptions(OptionsMap* options, CaptureSettings* se
         FindOption(options, kOptionKeyLogOutputToOsDebugString), settings->log_settings_.output_to_os_debug_string);
     settings->log_settings_.min_severity =
         ParseLogLevelString(FindOption(options, kOptionKeyLogLevel), settings->log_settings_.min_severity);
+    settings->log_settings_.output_timestamps =
+        ParseBoolString(FindOption(options, kOptionKeyLogTimestamps), settings->log_settings_.output_timestamps);
 }
 
 std::string CaptureSettings::FindOption(OptionsMap* options, const std::string& key, const std::string& default_value)

--- a/framework/util/logging.cpp
+++ b/framework/util/logging.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "util/logging.h"
+#include "util/date_time.h"
 
 #include <cstdarg>
 #include <string>
@@ -67,6 +68,7 @@ void Log::Init(Severity    min_severity,
                bool        flush_after_write,
                bool        break_on_error,
                bool        output_detailed_log_info,
+               bool        output_timestamps,
                bool        write_to_console,
                bool        errors_to_stderr,
                bool        output_to_os_debug_string,
@@ -98,6 +100,7 @@ void Log::Init(Severity    min_severity,
     settings_.flush_after_write         = flush_after_write;
     settings_.break_on_error            = break_on_error;
     settings_.output_detailed_log_info  = output_detailed_log_info;
+    settings_.output_timestamps         = output_timestamps;
     settings_.write_to_console          = write_to_console;
     settings_.output_errors_to_stderr   = errors_to_stderr;
     settings_.output_to_os_debug_string = output_to_os_debug_string;
@@ -163,6 +166,12 @@ void Log::LogMessage(
         // Only add a string prefix if this isn't a string that always outputs.
         prefix += "[";
         prefix += process_tag;
+        if (settings_.output_timestamps)
+        {
+            prefix += "]";
+            prefix += "[";
+            prefix += std::to_string(util::datetime::GetBootTime());
+        }
         prefix += "] ";
         prefix += SeverityToString(severity);
         if (settings_.output_detailed_log_info)

--- a/framework/util/logging.h
+++ b/framework/util/logging.h
@@ -50,6 +50,7 @@ class Log
         // General settings
         Severity    min_severity{ kInfoSeverity };     // Any severity >= to this value will print
         bool        output_detailed_log_info{ false }; // Output detailed log messages
+        bool        output_timestamps{ false };        // Output a timestamp in front of each log message
         bool        flush_after_write{ false };        // Flush the file/console after every log write
         bool        use_indent{ false };               // Write out messages using indenting
         uint32_t    indent{ 0 };                       // Number of indents to shift this message
@@ -76,6 +77,7 @@ class Log
                      bool        flush_after_write         = false,
                      bool        break_on_error            = false,
                      bool        output_detailed_log_info  = false,
+                     bool        output_timestamps         = false,
                      bool        write_to_console          = true,
                      bool        errors_to_stderr          = true,
                      bool        output_to_os_debug_string = false,

--- a/tools/capture-vulkan/gfxrecon-capture-vulkan.py
+++ b/tools/capture-vulkan/gfxrecon-capture-vulkan.py
@@ -58,6 +58,7 @@ def usage_message():
         '                                 [--compression-type {LZ4,ZLIB,ZSTD,NONE}]',
         '                                 [--file-flush]',
         '                                 [--log-level {debug,info,warn,error,fatal}]',
+        '                                 [--log-timestamps]',
         '                                 [--log-file <file>]',
         '                                 [--memory-tracking-mode {page_guard,assisted,unassisted}]',
         '                                 [--capture-layer <capture_layer_path>',
@@ -152,6 +153,9 @@ def create_argument_parser():
     parser.add_argument(
         '--log-level', dest='log_level', choices=LOG_LEVEL_CHOICES,
         help='Specify highest level message to log, default is info')
+    parser.add_argument(
+        '--log-timestamps', dest='log_timestamps', action='store_const', const='true',
+        help='Output a timestamp in front of each log message.')
     parser.add_argument(
         '--log-file', dest='log_file', metavar='<log_file>',
         help='Write log messages to a file at the specified path. Default is: Empty string (file logging disabled)')

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -38,7 +38,7 @@ const char kOptions[] =
     "--dump-resources-dump-all-image-subresources,--dump-resources-dump-raw-images,--dump-resources-dump-"
     "separate-alpha,--dump-resources-modifiable-state-only,--pbi-all,--preload-measurement-range,"
     "--add-new-pipeline-caches,--screenshot-ignore-FrameBoundaryANDROID,--dump-resources-dump-unused-vertex-bindings,--"
-    "deduplicate-device";
+    "deduplicate-device,--log-timestamps";
 const char kArguments[] =
     "--log-level,--log-file,--cpu-mask,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--screenshot-interval,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -118,6 +118,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --version\t\tPrint version information and exit.");
     GFXRECON_WRITE_CONSOLE("  --log-level <level>\tSpecify highest level message to log. Options are:");
     GFXRECON_WRITE_CONSOLE("          \t\tdebug, info, warning, error, and fatal. Default is info.");
+    GFXRECON_WRITE_CONSOLE("  --log-timestamps\tOutput a timestamp in front of each log message.");
     GFXRECON_WRITE_CONSOLE("  --log-file <file>\tWrite log messages to a file at the specified path.")
     GFXRECON_WRITE_CONSOLE("          \t\tDefault is: Empty string (file logging disabled).");
 #if defined(WIN32)

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -71,6 +71,7 @@ const char kHelpShortOption[]                    = "-h";
 const char kHelpLongOption[]                     = "--help";
 const char kVersionOption[]                      = "--version";
 const char kLogLevelArgument[]                   = "--log-level";
+const char kLogTimestampsOption[]                = "--log-timestamps";
 const char kDebugMessageSeverityArgument[]       = "--debug-messenger-level";
 const char kLogFileArgument[]                    = "--log-file";
 const char kLogDebugView[]                       = "--log-debugview";
@@ -535,6 +536,7 @@ static void GetLogSettings(const gfxrecon::util::ArgumentParser& arg_parser,
 
     // Update settings
     log_settings.min_severity              = log_level;
+    log_settings.output_timestamps         = arg_parser.IsOptionSet(kLogTimestampsOption);
     log_settings.file_name                 = arg_parser.GetArgumentValue(kLogFileArgument);
     log_settings.output_to_os_debug_string = arg_parser.IsOptionSet(kLogDebugView);
 }


### PR DESCRIPTION
When running GFXReconstruct in automation, it can be useful to have timestamps in front of each message for debug purpose.
This commit add the boot time in front of each logged message on desktop platforms (linux/windows) if log-level is debug.

Here's an example of logs with this commit:
```
GFXReconstruct Version 1.0.5-jenkins-c790995d (7d059ae*) Release
Vulkan Header Version 1.4.304
[gfxrecon][681347.146449] DEBUG - Failed to connect to an X server
[gfxrecon][681347.221838] DEBUG - Skip vkGetPhysicalDeviceSurfaceSupportKHR for offscreen.
[gfxrecon][681347.462342] DEBUG - Skip vkGetPhysicalDeviceSurfaceCapabilitiesKHR for offscreen.
[gfxrecon][681347.462359] DEBUG - Skip vkGetPhysicalDeviceSurfaceFormatsKHR for offscreen.
[gfxrecon][681347.462378] DEBUG - Skip vkGetPhysicalDeviceSurfaceFormatsKHR for offscreen.
[gfxrecon][681347.462382] DEBUG - Skip vkGetPhysicalDeviceSurfacePresentModesKHR for offscreen.
[gfxrecon][681347.462385] DEBUG - Skip vkGetPhysicalDeviceSurfacePresentModesKHR for offscreen.
[gfxrecon][681347.462521] DEBUG - Skipping window resize for VkSurface object (ID = 2) without an associated window
[gfxrecon][681348.469331] DEBUG - Frame 1 memory (mb): 716.02 max RSS, 716.02 current RSS, 3542.41 available
[gfxrecon][681348.474590] DEBUG - Frame 2 memory (mb): 716.14 max RSS, 716.14 current RSS, 3542.41 available
[gfxrecon][681348.479575] DEBUG - Frame 3 memory (mb): 716.14 max RSS, 716.14 current RSS, 3542.41 available
[gfxrecon][681348.485825] DEBUG - Frame 4 memory (mb): 716.14 max RSS, 716.14 current RSS, 3542.41 available
[gfxrecon][681348.494195] DEBUG - Frame 5 memory (mb): 716.27 max RSS, 716.27 current RSS, 3542.41 available
[gfxrecon][681348.502483] DEBUG - Frame 6 memory (mb): 716.27 max RSS, 716.27 current RSS, 3542.41 available
[gfxrecon][681348.511178] DEBUG - Frame 7 memory (mb): 716.27 max RSS, 716.27 current RSS, 3542.41 available
[gfxrecon][681348.519809] DEBUG - Frame 8 memory (mb): 716.27 max RSS, 716.27 current RSS, 3542.41 available
[gfxrecon][681348.525914] DEBUG - Frame 9 memory (mb): 716.89 max RSS, 716.89 current RSS, 3541.91 available
[gfxrecon][681348.560585] INFO - WriteBmpImage(): Writing file "/tmp/gfxrt/device/UM6XJJ-2/QSNO25/X67K2W/LJMHNI/screenshot_frame_10.bmp"
[gfxrecon][681348.578069] DEBUG - Frame 10 memory (mb): 727.02 max RSS, 727.02 current RSS, 3521.73 available
Load time: 0.000000 seconds (frame 1)
Total time: 1.432489 seconds
Measured FPS: 250.194088 fps, 0.003997 seconds, 1 frame, 1 loop, framerange [9-10)```
```