### PR TITLE
codegen: Refactor check_write/make multi-api safe

### DIFF
--- a/framework/generated/khronos_generators/khronos_api_call_encoders_generator.py
+++ b/framework/generated/khronos_generators/khronos_api_call_encoders_generator.py
@@ -28,6 +28,11 @@ class KhronosApiCallEncodersGenerator():
     """KhronosApiCallEncodersGenerator
     Common functions for Api Call Encoding generation
     """
+    def __init__(self, check_write=None):
+        if check_write:
+            self.CHECK_WRITE = check_write
+        else:
+            self.CHECK_WRITE = []
 
     def need_feature_generation(self):
         """Indicates that the current feature has C++ code to generate."""

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -90,8 +90,6 @@ class VulkanApiCallEncodersBodyGenerator(VulkanBaseGenerator, KhronosApiCallEnco
     # Functions that can activate trimming from a post call command.
     POSTCALL_TRIM_TRIGGERS = ['vkQueueSubmit', 'vkQueueSubmit2', 'vkQueueSubmit2KHR', 'vkQueuePresentKHR', 'vkFrameBoundaryANDROID']
 
-    CHECK_WRITE = ['vkWaitForPresentKHR']
-
     def __init__(
         self, err_file=sys.stderr, warn_file=sys.stderr, diag_file=sys.stdout
     ):
@@ -101,6 +99,8 @@ class VulkanApiCallEncodersBodyGenerator(VulkanBaseGenerator, KhronosApiCallEnco
             warn_file=warn_file,
             diag_file=diag_file
         )
+        KhronosApiCallEncodersGenerator.__init__(self, check_write=['vkWaitForPresentKHR'])
+
 
     def beginFile(self, gen_opts):
         """Method override."""


### PR DESCRIPTION
Derived classes shouldn't be required to define variable needed by functional mixins, but instead they should be passed, or defined (at least as empty) in a base class.

No change to generated code.