### PR TITLE
Marky fix disable openxr

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -392,6 +392,18 @@ codesign -dvvv libVkLayer_gfxreconstruct.dylib`
 Apple's developer information about code-signing can be found here:
 https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Introduction/Introduction.html
 
+### Disabling OpenXR Inclusing For Desktop Builds
+
+If there are any concerns about using the OpenXR content in the resulting components of GFXReconstruct,
+it may be disabled during CMake build target generation by setting the following CMake option:
+
+```bash
+-DOPENXR_SUPPORT_ENABLED=OFF
+```
+
+This causes the code generation to skip over any OpenXR specific files, and not define the
+environment variables used to enable OpenXR code in files that are included.
+
 ## Building for Android
 
 ### Android Development Requirements
@@ -441,6 +453,16 @@ On Linux:
 ```
 
 To perform a release build, replace the `assembleDebug` task name with `assembleRelease`.
+
+##### Disabling OpenXR support in Gradle
+
+It is also possible to disable OpenXR support in the GFXReconstruct layer when
+building Gradle.
+This can be done by defining the Gradle property `DisableOpenXR` to `true`.
+The Gradle property can be provided either in the command line of the
+build, or defined in the gradle.properties file.
+The later is most useful if the layer is included in a separate external application
+build.
 
 #### Building with Android Studio
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,10 +133,12 @@ if (GFXRECON_ENABLE_OPENXR)
 
     if ((NOT XR_VERSION_MAJOR STREQUAL "") AND (NOT XR_VERSION_MINOR STREQUAL ""))
         set(OPENXR_SUPPORT_ENABLED TRUE)
+        message(STATUS "OpenXR support enabled")
     else()
         message(FATAL_ERROR "Failed to find OpenXR headers for support!")
     endif()
-
+else()
+    message(STATUS "OpenXR support disabled!")
 endif()
 
 # Apply misc build directives to the given target

--- a/android/layer/CMakeLists.txt
+++ b/android/layer/CMakeLists.txt
@@ -26,6 +26,8 @@ if (GFXRECON_ENABLE_OPENXR)
     else()
 	    message(FATAL_ERROR "Failed to find OpenXR headers for support.  Continuing with it disabled!")
     endif()
+else()
+    message(STATUS "OpenXR support disabled!")
 endif()
 
 add_subdirectory(../framework/util ${PROJECT_SOURCE_DIR}/../framework/util/build/layer/${ANDROID_ABI})

--- a/android/layer/build.gradle
+++ b/android/layer/build.gradle
@@ -28,6 +28,7 @@ android {
                 arguments "-DANDROID_TOOLCHAIN=clang", "-DANDROID_STL=c++_static"
                 if (project.hasProperty("DisableOpenXR")) {
                     logger.info('GFXReconstruct layer built with NO OpenXr Support! [DisableOpenXR found]')
+                    arguments.add("-DGFXRECON_ENABLE_OPENXR=OFF")
                 }
                 else {
                     logger.info('GFXReconstruct layer built with OpenXr Support.')

--- a/android/test/test_apps/triangle/build.gradle
+++ b/android/test/test_apps/triangle/build.gradle
@@ -50,6 +50,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.0'
 }

--- a/android/tools/quest_replay/CMakeLists.txt
+++ b/android/tools/quest_replay/CMakeLists.txt
@@ -65,5 +65,6 @@ target_link_libraries(
         android
         log
         OpenXR::openxr_loader)
-
+else()
+    message(WARNING "OpenXR support disabled!")
 endif()


### PR DESCRIPTION
Two commits:

```
openxr: Add ability to disable OpenXR in gradle

Add the ability to disable OpenXR when building the GFXR layer
in Gradle.
Also add some better error messages.
```

```
Fix android test build with Gradle

The build failed for me because some components were built with
AndroidX packages and others were not.
```
