### PR TITLE
util: Move android utils and native_app_glue

### DIFF
--- a/android/framework/application-multi-win/CMakeLists.txt
+++ b/android/framework/application-multi-win/CMakeLists.txt
@@ -25,13 +25,13 @@ endif()
 
 target_include_directories(gfxrecon_application_multiwin
                            PUBLIC
-                               ${GFXRECON_SOURCE_DIR}/framework
-                               ${ANDROID_NDK}/sources/android/native_app_glue)
+                               ${GFXRECON_SOURCE_DIR}/framework)
 
 target_link_libraries(gfxrecon_application_multiwin
                       gfxrecon_decode
                       gfxrecon_graphics
                       gfxrecon_format
                       gfxrecon_util
+                      native_app_glue
                       vulkan_registry
                       platform_specific)

--- a/android/framework/application/CMakeLists.txt
+++ b/android/framework/application/CMakeLists.txt
@@ -20,13 +20,13 @@ endif()
 
 target_include_directories(gfxrecon_application
                            PUBLIC
-                               ${GFXRECON_SOURCE_DIR}/framework
-                               ${ANDROID_NDK}/sources/android/native_app_glue)
+                               ${GFXRECON_SOURCE_DIR}/framework)
 
 target_link_libraries(gfxrecon_application
                       gfxrecon_decode
                       gfxrecon_graphics
                       gfxrecon_format
                       gfxrecon_util
+                      native_app_glue
                       vulkan_registry
                       platform_specific)

--- a/android/framework/cmake-config/PlatformConfig.cmake
+++ b/android/framework/cmake-config/PlatformConfig.cmake
@@ -86,3 +86,7 @@ set(SPIRV_REFLECT_STATIC_LIB ON CACHE INTERNAL "create spirv-reflect-static libr
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW CACHE INTERNAL "set a cmake policy for spirv_reflect" FORCE)
 add_subdirectory("${GFXRECON_SOURCE_DIR}/external/SPIRV-Reflect" EXCLUDE_FROM_ALL "${CMAKE_BINARY_DIR}/external/SPIRV-Reflect")
 include_directories("${GFXRECON_SOURCE_DIR}/external/SPIRV-Reflect")
+
+# Export ANativeActivity_onCreate(),
+# Refer to: https://github.com/android-ndk/ndk/issues/381.
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")

--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -194,7 +194,6 @@ endif()
 target_include_directories(gfxrecon_decode
                            PUBLIC
                                ${CMAKE_BINARY_DIR}
-                               ${ANDROID_NDK}/sources/android/native_app_glue
                                ${GFXRECON_SOURCE_DIR}/framework
                                ${GFXRECON_SOURCE_DIR}/external/precompiled/android/include)
 

--- a/android/framework/util/CMakeLists.txt
+++ b/android/framework/util/CMakeLists.txt
@@ -1,7 +1,19 @@
+
+add_library(native_app_glue STATIC
+            ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
+
+target_include_directories(native_app_glue
+                           PUBLIC
+                               ${ANDROID_NDK}/sources/android/native_app_glue)
+
 add_library(gfxrecon_util STATIC "")
 
 target_sources(gfxrecon_util
                PRIVATE
+                   ${GFXRECON_SOURCE_DIR}/framework/util/android/activity.h
+                   ${GFXRECON_SOURCE_DIR}/framework/util/android/activity.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/util/android/intent.h
+                   ${GFXRECON_SOURCE_DIR}/framework/util/android/intent.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/alignment_utils.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/argument_parser.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/argument_parser.cpp
@@ -70,6 +82,7 @@ target_compile_definitions(gfxrecon_util
 
 target_include_directories(gfxrecon_util
                            PUBLIC
+                               ${ANDROID_NDK}/sources/android/native_app_glue
                                ${GFXRECON_SOURCE_DIR}/external/precompiled/android/include
                                ${GFXRECON_SOURCE_DIR}/external/stb
                                ${GFXRECON_SOURCE_DIR}/framework)
@@ -80,11 +93,13 @@ if (OPENXR_SUPPORT_ENABLED)
 endif()
 
 target_link_libraries(gfxrecon_util
-                          platform_specific
-                          vulkan_registry
-                          spirv_registry
-                          spirv-reflect-static
-                          nlohmann_json::nlohmann_json
-                          ${GFXRECON_SOURCE_DIR}/external/precompiled/android/lib/${ANDROID_ABI}/liblz4_static.a
-                          ${GFXRECON_SOURCE_DIR}/external/precompiled/android/lib/${ANDROID_ABI}/libzstd.a
-                          z)
+                      platform_specific
+                      vulkan_registry
+                      spirv_registry
+                      spirv-reflect-static
+                      nlohmann_json::nlohmann_json
+                      android
+                      log
+                      ${GFXRECON_SOURCE_DIR}/external/precompiled/android/lib/${ANDROID_ABI}/liblz4_static.a
+                      ${GFXRECON_SOURCE_DIR}/external/precompiled/android/lib/${ANDROID_ABI}/libzstd.a
+                      z)

--- a/android/test/test_apps/common/CMakeLists.txt
+++ b/android/test/test_apps/common/CMakeLists.txt
@@ -1,7 +1,20 @@
 find_package(SDL3)
 
 add_library(gfxrecon-testapp-base STATIC ${GFXRECON_SOURCE_DIR}/test/test_apps/common/test_app_base.cpp)
-target_include_directories(gfxrecon-testapp-base PRIVATE ${GFXRECON_SOURCE_DIR}/external)
-target_include_directories(gfxrecon-testapp-base PUBLIC ${GFXRECON_SOURCE_DIR}/test/test_apps/common ${GFXRECON_SOURCE_DIR}/test/icd ${ANDROID_NDK}/sources/android/native_app_glue)
-target_link_libraries(gfxrecon-testapp-base SDL3::SDL3-static vulkan_registry native_app_glue)
+target_include_directories(gfxrecon-testapp-base
+                           PRIVATE
+                               ${GFXRECON_SOURCE_DIR}/external)
+target_include_directories(gfxrecon-testapp-base
+                           PUBLIC
+                               ${GFXRECON_SOURCE_DIR}/test/test_apps/common
+                               ${GFXRECON_SOURCE_DIR}/test/icd)
+
+set(FRAMEWORK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../framework)
+add_subdirectory(${FRAMEWORK_DIR}/util ${CMAKE_SOURCE_DIR}/../framework/util/build/layer/${ANDROID_ABI})
+
+target_link_libraries(gfxrecon-testapp-base
+                      gfxrecon_util
+                      native_app_glue
+                      SDL3::SDL3-static
+                      vulkan_registry)
 

--- a/android/test/test_apps/triangle/CMakeLists.txt
+++ b/android/test/test_apps/triangle/CMakeLists.txt
@@ -14,14 +14,7 @@ set(CMAKE_MODULE_PATH "${GFXRECON_SOURCE_DIR}/cmake" "${GFXRECON_SOURCE_DIR}/ext
 
 project(gfxrecon-testapp-triangle)
 
-add_library(native_app_glue STATIC
-        ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
-
 add_subdirectory(../common ${CMAKE_SOURCE_DIR}/../common/build/testapps/triangle/${ANDROID_ABI})
-
-# Export ANativeActivity_onCreate(),
-# Refer to: https://github.com/android-ndk/ndk/issues/381.
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
 
 include(../../../framework/cmake-config/PlatformConfig.cmake)
 
@@ -31,13 +24,9 @@ add_library(gfxrecon-testapp-triangle
 
 target_include_directories(gfxrecon-testapp-triangle
                            PUBLIC
-                               ${ANDROID_NDK}/sources/android/native_app_glue
                                ${GFXRECON_SOURCE_DIR}/external/precompiled/android/include
                                ${CMAKE_BINARY_DIR})
 
 target_link_libraries(
         gfxrecon-testapp-triangle
-        gfxrecon-testapp-base
-        native_app_glue
-        android
-        log)
+        gfxrecon-testapp-base)

--- a/android/tools/multi-win-replay/CMakeLists.txt
+++ b/android/tools/multi-win-replay/CMakeLists.txt
@@ -12,13 +12,6 @@ get_filename_component(GFXRECON_SOURCE_DIR ../../.. ABSOLUTE)
 set(nlohmann_json_DIR "${GFXRECON_SOURCE_DIR}/external/nlohmann-json/share/cmake/nlohmann_json")
 find_package(nlohmann_json REQUIRED CONFIG PATHS "${nlohmann_json_DIR}" NO_DEFAULT_PATH)
 
-add_library(native_app_glue STATIC
-        ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
-
-# Export ANativeActivity_onCreate(),
-# Refer to: https://github.com/android-ndk/ndk/issues/381.
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
-
 include(../../framework/cmake-config/PlatformConfig.cmake)
 add_subdirectory(../../framework/util ${PROJECT_SOURCE_DIR}/../../framework/util/build/tools/replay/${ANDROID_ABI})
 add_subdirectory(../../framework/graphics ${PROJECT_SOURCE_DIR}/../../framework/graphics/build/tools/replay/${ANDROID_ABI})
@@ -37,7 +30,6 @@ add_library(gfxrecon-replay
 
 target_include_directories(gfxrecon-replay
                            PUBLIC
-                               ${ANDROID_NDK}/sources/android/native_app_glue
                                ${GFXRECON_SOURCE_DIR}/external/precompiled/android/include
                                ${CMAKE_BINARY_DIR})
 
@@ -47,10 +39,6 @@ target_link_libraries(
         gfxrecon_decode
         gfxrecon_graphics
         gfxrecon_format
-        gfxrecon_util
-        platform_specific
-        native_app_glue
-        android
-        log)
+        platform_specific)
 
 message(STATUS "CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}")

--- a/android/tools/quest_replay/CMakeLists.txt
+++ b/android/tools/quest_replay/CMakeLists.txt
@@ -21,13 +21,6 @@ else()
     message(FATAL_ERROR "Failed to find OpenXR headers for support.  Continuing with it disabled!")
 endif()
 
-add_library(native_app_glue STATIC
-        ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
-
-# Export ANativeActivity_onCreate(),
-# Refer to: https://github.com/android-ndk/ndk/issues/381.
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
-
 add_subdirectory(../../framework/util ${PROJECT_SOURCE_DIR}/../../framework/util/build/tools/quest_replay/${ANDROID_ABI})
 add_subdirectory(../../framework/graphics ${PROJECT_SOURCE_DIR}/../../framework/graphics/build/tools/quest_replay/${ANDROID_ABI})
 add_subdirectory(../../framework/format ${PROJECT_SOURCE_DIR}/../../framework/format/build/tools/quest_replay/${ANDROID_ABI})
@@ -45,7 +38,6 @@ add_library(gfxrecon-quest-replay
 
 target_include_directories(gfxrecon-quest-replay
                            PUBLIC
-                               ${ANDROID_NDK}/sources/android/native_app_glue
                                ${GFXRECON_SOURCE_DIR}/external/precompiled/android/include
                                ${CMAKE_BINARY_DIR})
 
@@ -59,11 +51,7 @@ target_link_libraries(
         gfxrecon_decode
         gfxrecon_graphics
         gfxrecon_format
-        gfxrecon_util
         platform_specific
-        native_app_glue
-        android
-        log
         OpenXR::openxr_loader)
 
 endif()

--- a/android/tools/replay/CMakeLists.txt
+++ b/android/tools/replay/CMakeLists.txt
@@ -12,13 +12,6 @@ get_filename_component(GFXRECON_SOURCE_DIR ../../.. ABSOLUTE)
 set(nlohmann_json_DIR "${GFXRECON_SOURCE_DIR}/external/nlohmann-json/share/cmake/nlohmann_json")
 find_package(nlohmann_json REQUIRED CONFIG PATHS "${nlohmann_json_DIR}" NO_DEFAULT_PATH)
 
-add_library(native_app_glue STATIC
-        ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
-
-# Export ANativeActivity_onCreate(),
-# Refer to: https://github.com/android-ndk/ndk/issues/381.
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
-
 include(../../framework/cmake-config/PlatformConfig.cmake)
 add_subdirectory(../../framework/util ${PROJECT_SOURCE_DIR}/../../framework/util/build/tools/replay/${ANDROID_ABI})
 add_subdirectory(../../framework/graphics ${PROJECT_SOURCE_DIR}/../../framework/graphics/build/tools/replay/${ANDROID_ABI})
@@ -37,7 +30,6 @@ add_library(gfxrecon-replay
 
 target_include_directories(gfxrecon-replay
                            PUBLIC
-                               ${ANDROID_NDK}/sources/android/native_app_glue
                                ${GFXRECON_SOURCE_DIR}/external/precompiled/android/include
                                ${CMAKE_BINARY_DIR})
 
@@ -47,8 +39,4 @@ target_link_libraries(
         gfxrecon_decode
         gfxrecon_graphics
         gfxrecon_format
-        gfxrecon_util
-        platform_specific
-        native_app_glue
-        android
-        log)
+        platform_specific)

--- a/framework/util/android/activity.cpp
+++ b/framework/util/android/activity.cpp
@@ -1,0 +1,53 @@
+/*
+** Copyright (c) 2025 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "util/android/activity.h"
+
+#include <android_native_app_glue.h>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+void DestroyActivity(struct android_app* app)
+{
+    ANativeActivity_finish(app->activity);
+
+    // Wait for APP_CMD_DESTROY
+    while (app->destroyRequested == 0)
+    {
+        struct android_poll_source* source = nullptr;
+        int                         events = 0;
+        int                         result = ALooper_pollAll(-1, nullptr, &events, reinterpret_cast<void**>(&source));
+
+        if ((result >= 0) && (source))
+        {
+            source->process(app, source);
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/android/activity.h
+++ b/framework/util/android/activity.h
@@ -1,0 +1,38 @@
+/*
+** Copyright (c) 2025 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_UTIL_ANDROID_ACTIVITY_H
+#define GFXRECON_UTIL_ANDROID_ACTIVITY_H
+
+#include "util/defines.h"
+
+struct android_app;
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+void DestroyActivity(struct android_app* app);
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_ANDROID_ACTIVITY_H

--- a/framework/util/android/intent.cpp
+++ b/framework/util/android/intent.cpp
@@ -1,0 +1,81 @@
+/*
+** Copyright (c) 2025 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "util/android/intent.h"
+
+#include <android_native_app_glue.h>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+std::string GetIntentExtra(struct android_app* app, const char* key)
+{
+    std::string value;
+    JavaVM*     jni_vm       = nullptr;
+    jobject     jni_activity = nullptr;
+    JNIEnv*     env          = nullptr;
+
+    if ((app != nullptr) && (app->activity != nullptr))
+    {
+        jni_vm       = app->activity->vm;
+        jni_activity = app->activity->clazz;
+    }
+
+    if ((jni_vm != nullptr) && (jni_activity != 0) && (jni_vm->AttachCurrentThread(&env, nullptr) == JNI_OK))
+    {
+        jclass    activity_class = env->GetObjectClass(jni_activity);
+        jmethodID get_intent     = env->GetMethodID(activity_class, "getIntent", "()Landroid/content/Intent;");
+        jobject   intent         = env->CallObjectMethod(jni_activity, get_intent);
+
+        if (intent)
+        {
+            jclass    intent_class = env->GetObjectClass(intent);
+            jmethodID get_string_extra =
+                env->GetMethodID(intent_class, "getStringExtra", "(Ljava/lang/String;)Ljava/lang/String;");
+
+            jvalue extra_key;
+            extra_key.l = env->NewStringUTF(key);
+
+            jstring extra = static_cast<jstring>(env->CallObjectMethodA(intent, get_string_extra, &extra_key));
+
+            if (extra)
+            {
+                const char* utf_chars = env->GetStringUTFChars(extra, nullptr);
+
+                value = utf_chars;
+
+                env->ReleaseStringUTFChars(extra, utf_chars);
+                env->DeleteLocalRef(extra);
+            }
+
+            env->DeleteLocalRef(extra_key.l);
+            env->DeleteLocalRef(intent);
+        }
+
+        jni_vm->DetachCurrentThread();
+    }
+
+    return value;
+}
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/android/intent.h
+++ b/framework/util/android/intent.h
@@ -1,0 +1,41 @@
+/*
+** Copyright (c) 2025 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_UTIL_ANDROID_INTENT_H
+#define GFXRECON_UTIL_ANDROID_INTENT_H
+
+#include <string>
+
+#include "util/defines.h"
+
+struct android_app;
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+// Retrieve the program argument string from the intent extras
+std::string GetIntentExtra(struct android_app* app, const char* key);
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_ANDROID_INTENT_H

--- a/test/test_apps/external-memory-fd/export/CMakeLists.txt
+++ b/test/test_apps/external-memory-fd/export/CMakeLists.txt
@@ -40,7 +40,6 @@ target_link_libraries(gfxrecon-testapp-external-memory-fd-export
         gfxrecon_decode
         gfxrecon_graphics
         gfxrecon_format
-        gfxrecon_util
         gfxrecon-testapp-base
         platform_specific)
 

--- a/test/test_apps/external-memory-fd/import/CMakeLists.txt
+++ b/test/test_apps/external-memory-fd/import/CMakeLists.txt
@@ -40,7 +40,6 @@ target_link_libraries(gfxrecon-testapp-external-memory-fd-import
         gfxrecon_decode
         gfxrecon_graphics
         gfxrecon_format
-        gfxrecon_util
         platform_specific
         gfxrecon-testapp-base)
 

--- a/tools/optimize/CMakeLists.txt
+++ b/tools/optimize/CMakeLists.txt
@@ -62,7 +62,6 @@ target_link_libraries(gfxrecon-optimize
                           gfxrecon_decode
                           gfxrecon_graphics
                           gfxrecon_format
-                          gfxrecon_util
                           platform_specific
                           $<$<BOOL:${D3D12_SUPPORT}>:d3d12.lib>
                           $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -46,7 +46,6 @@ target_link_libraries(gfxrecon-replay
                           gfxrecon_decode
                           gfxrecon_graphics
                           gfxrecon_format
-                          gfxrecon_util
                           platform_specific
                           $<$<BOOL:${D3D12_SUPPORT}>:d3d12.lib>
                           $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>


### PR DESCRIPTION
Move GetIntentExtra, DestroyActivity and the native_app_glue library to
gfxrecon_util. This simplifies dependencies and exposes Android util
functions to the test targets.