### PR TITLE
Add D3D12 replay support for shared resources

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -976,7 +976,7 @@ void* Dx12ReplayConsumerBase::PreProcessExternalObject(uint64_t          object_
 }
 
 void Dx12ReplayConsumerBase::PostProcessExternalObject(
-    HRESULT replay_result, void* object, uint64_t* object_id, format::ApiCallId call_id, const char* call_name)
+    HRESULT replay_result, void** object, uint64_t* object_id, format::ApiCallId call_id, const char* call_name)
 {
     GFXRECON_UNREFERENCED_PARAMETER(replay_result);
     GFXRECON_UNREFERENCED_PARAMETER(object_id);

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -967,6 +967,19 @@ void* Dx12ReplayConsumerBase::PreProcessExternalObject(uint64_t          object_
             // These are pointers to user data for callback functions. Return nullptr for the replay callbacks that
             // don't expect user data.
             break;
+        case format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandle:
+        {
+            auto entry = shared_handles_.find(object_id);
+            if (entry != shared_handles_.end())
+            {
+                object = entry->second;
+            }
+            else
+            {
+                GFXRECON_LOG_ERROR("%s: Unable to retrieve NTHandle.", call_name);
+            }
+            break;
+        }
         default:
             GFXRECON_LOG_WARNING("Skipping object handle mapping for unsupported external object type processed by %s",
                                  call_name);
@@ -988,7 +1001,14 @@ void Dx12ReplayConsumerBase::PostProcessExternalObject(
         case format::ApiCallId::ApiCall_IDXGIFactory_GetWindowAssociation:
         case format::ApiCallId::ApiCall_IDXGISwapChain1_GetHwnd:
             break;
-
+        case format::ApiCallId::ApiCall_IDXGIResource1_CreateSharedHandle:
+        case format::ApiCallId::ApiCall_ID3D12Device_CreateSharedHandle:
+        case format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandleByName:
+            if (SUCCEEDED(replay_result) && (object_id != nullptr) && (object != nullptr))
+            {
+                shared_handles_.insert(std::make_pair(*object_id, *reinterpret_cast<void**>(object)));
+            }
+            break;
         default:
             GFXRECON_LOG_WARNING("Skipping object handle mapping for unsupported external object type processed by %s",
                                  call_name);

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -4335,6 +4335,46 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateRootSignature(DxObjectInfo*       
     return replay_result;
 }
 
+HRESULT Dx12ReplayConsumerBase::OverrideOpenSharedHandle(DxObjectInfo*                device_object_info,
+                                                         HRESULT                      original_result,
+                                                         uint64_t                     NTHandle,
+                                                         Decoded_GUID                 riid,
+                                                         HandlePointerDecoder<void*>* ppvObj)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(original_result);
+
+    auto  device        = static_cast<ID3D12Device*>(device_object_info->object);
+    auto  in_NTHandle   = static_cast<HANDLE>(PreProcessExternalObject(
+        NTHandle, format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandle, "ID3D12Device_OpenSharedHandle"));
+    auto& riid_value    = *riid.decoded_value;
+    auto  out_p_ppvObj  = ppvObj->GetPointer();
+    auto  out_hp_ppvObj = ppvObj->GetHandlePointer();
+    auto  replay_result = device->OpenSharedHandle(in_NTHandle, riid_value, out_hp_ppvObj);
+
+    if (SUCCEEDED(replay_result) && !ppvObj->IsNull())
+    {
+        if (IsEqualIID(riid_value, __uuidof(ID3D12Resource)) || IsEqualIID(riid_value, __uuidof(ID3D12Resource1)) ||
+            IsEqualIID(riid_value, __uuidof(ID3D12Resource2)))
+        {
+            // For standard resource creation, the resource state would be initilized based on the InitialState
+            // parameter. For this case, we don't know what the initial state was so initilize to the common state.
+            InitialResourceExtraInfo(ppvObj, D3D12_RESOURCE_STATE_COMMON, false);
+        }
+        else if (IsEqualIID(riid_value, __uuidof(ID3D12Fence)) || IsEqualIID(riid_value, __uuidof(ID3D12Fence1)))
+        {
+            auto fence_info = std::make_unique<D3D12FenceInfo>();
+
+            // For ID3D12Device::CreateFence, this would be initialized with the InitialValue parameter. For this case,
+            // we don't know what the initial value was so initialize to zero.
+            fence_info->last_signaled_value = 0;
+
+            SetExtraInfo(ppvObj, std::move(fence_info));
+        }
+    }
+
+    return replay_result;
+}
+
 HRESULT
 Dx12ReplayConsumerBase::OverrideCreateStateObject(DxObjectInfo* device5_object_info,
                                                   HRESULT       original_result,

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -443,7 +443,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     void* PreProcessExternalObject(uint64_t object_id, format::ApiCallId call_id, const char* call_name);
 
     void PostProcessExternalObject(
-        HRESULT replay_result, void* object, uint64_t* object_id, format::ApiCallId call_id, const char* call_name);
+        HRESULT replay_result, void** object, uint64_t* object_id, format::ApiCallId call_id, const char* call_name);
 
     ULONG OverrideAddRef(DxObjectInfo* replay_object_info, ULONG original_result);
 

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -1272,6 +1272,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     std::unordered_map<uint64_t, void*>                   heap_allocations_;
     std::unordered_map<uint64_t, HANDLE>                  event_objects_;
     std::unordered_map<uint64_t, LUID>                    adapter_luid_map_;
+    std::unordered_map<uint64_t, void*>                   shared_handles_;
     std::function<void(const char*)>                      fatal_error_handler_;
     Dx12DescriptorMap                                     descriptor_map_;
     graphics::Dx12GpuVaMap                                gpu_va_map_;

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -960,6 +960,12 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                         Decoded_GUID                 riid,
                                         HandlePointerDecoder<void*>* root_signature_decoder);
 
+    HRESULT OverrideOpenSharedHandle(DxObjectInfo*                device_object_info,
+                                     HRESULT                      original_result,
+                                     uint64_t                     NTHandle,
+                                     Decoded_GUID                 riid,
+                                     HandlePointerDecoder<void*>* ppvObj);
+
     HRESULT OverrideCreateStateObject(DxObjectInfo*                                          device5_object_info,
                                       HRESULT                                                original_result,
                                       StructPointerDecoder<Decoded_D3D12_STATE_OBJECT_DESC>* desc_decoder,

--- a/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
@@ -442,7 +442,7 @@ class Dx12ReplayConsumerBodyGenerator(
 
                         arg_list.append('out_op_{}'.format(value.name))
                         post_extenal_object_list.append(
-                            'PostProcessExternalObject(replay_result, out_op_{0}, out_p_{0}, format::ApiCallId::ApiCall_{1}, "{1}");\n'
+                            'PostProcessExternalObject(replay_result, reinterpret_cast<void**>(out_op_{0}), out_p_{0}, format::ApiCallId::ApiCall_{1}, "{1}");\n'
                             .format(value.name, name)
                         )
 

--- a/framework/generated/dx12_generators/replay_overrides.json
+++ b/framework/generated/dx12_generators/replay_overrides.json
@@ -35,7 +35,8 @@
       "CreateComputePipelineState": "OverrideCreateComputePipelineState",
       "CreateCommandSignature": "OverrideCreateCommandSignature",
       "CreateCommandList": "OverrideCreateCommandList",
-      "CreateRootSignature": "OverrideCreateRootSignature"
+      "CreateRootSignature": "OverrideCreateRootSignature",
+      "OpenSharedHandle": "OverrideOpenSharedHandle"
     },
     "ID3D12Device1": {
       "CreatePipelineLibrary": "OverrideCreatePipelineLibrary"

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -5259,16 +5259,20 @@ void Dx12ReplayConsumer::Process_ID3D12Device_OpenSharedHandle(
             NTHandle,
             riid,
             ppvObj);
-        auto in_NTHandle = static_cast<HANDLE>(PreProcessExternalObject(NTHandle, format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandle, "ID3D12Device_OpenSharedHandle"));
-        if(!ppvObj->IsNull()) ppvObj->SetHandleLength(1);
-        auto out_p_ppvObj    = ppvObj->GetPointer();
-        auto out_hp_ppvObj   = ppvObj->GetHandlePointer();
-        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->OpenSharedHandle(in_NTHandle,
-                                                                                                      *riid.decoded_value,
-                                                                                                      out_hp_ppvObj);
+        DxObjectInfo object_info_ppvObj{};
+        if(!ppvObj->IsNull())
+        {
+            ppvObj->SetHandleLength(1);
+            ppvObj->SetConsumerData(0, &object_info_ppvObj);
+        }
+        auto replay_result = OverrideOpenSharedHandle(replay_object,
+                                                      return_value,
+                                                      NTHandle,
+                                                      riid,
+                                                      ppvObj);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvObj, out_hp_ppvObj, format::ApiCall_ID3D12Device_OpenSharedHandle);
+            AddObject(ppvObj->GetPointer(), ppvObj->GetHandlePointer(), std::move(object_info_ppvObj), format::ApiCall_ID3D12Device_OpenSharedHandle);
         }
         CheckReplayResult("ID3D12Device_OpenSharedHandle", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandle>::Dispatch(

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -5237,7 +5237,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateSharedHandle(
             Access,
             Name,
             pHandle);
-        PostProcessExternalObject(replay_result, out_op_pHandle, out_p_pHandle, format::ApiCallId::ApiCall_ID3D12Device_CreateSharedHandle, "ID3D12Device_CreateSharedHandle");
+        PostProcessExternalObject(replay_result, reinterpret_cast<void**>(out_op_pHandle), out_p_pHandle, format::ApiCallId::ApiCall_ID3D12Device_CreateSharedHandle, "ID3D12Device_CreateSharedHandle");
     }
 }
 
@@ -5320,7 +5320,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_OpenSharedHandleByName(
             Name,
             Access,
             pNTHandle);
-        PostProcessExternalObject(replay_result, out_op_pNTHandle, out_p_pNTHandle, format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandleByName, "ID3D12Device_OpenSharedHandleByName");
+        PostProcessExternalObject(replay_result, reinterpret_cast<void**>(out_op_pNTHandle), out_p_pNTHandle, format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandleByName, "ID3D12Device_OpenSharedHandleByName");
     }
 }
 
@@ -9553,7 +9553,7 @@ void Dx12ReplayConsumer::Process_ID3D12VirtualizationGuestDevice_ShareWithHost(
             replay_result,
             pObject,
             pHandle);
-        PostProcessExternalObject(replay_result, out_op_pHandle, out_p_pHandle, format::ApiCallId::ApiCall_ID3D12VirtualizationGuestDevice_ShareWithHost, "ID3D12VirtualizationGuestDevice_ShareWithHost");
+        PostProcessExternalObject(replay_result, reinterpret_cast<void**>(out_op_pHandle), out_p_pHandle, format::ApiCallId::ApiCall_ID3D12VirtualizationGuestDevice_ShareWithHost, "ID3D12VirtualizationGuestDevice_ShareWithHost");
     }
 }
 
@@ -13147,7 +13147,7 @@ void Dx12ReplayConsumer::Process_IDXGIResource_GetSharedHandle(
             return_value,
             replay_result,
             pSharedHandle);
-        PostProcessExternalObject(replay_result, out_op_pSharedHandle, out_p_pSharedHandle, format::ApiCallId::ApiCall_IDXGIResource_GetSharedHandle, "IDXGIResource_GetSharedHandle");
+        PostProcessExternalObject(replay_result, reinterpret_cast<void**>(out_op_pSharedHandle), out_p_pSharedHandle, format::ApiCallId::ApiCall_IDXGIResource_GetSharedHandle, "IDXGIResource_GetSharedHandle");
     }
 }
 
@@ -13409,7 +13409,7 @@ void Dx12ReplayConsumer::Process_IDXGISurface1_GetDC(
             replay_result,
             Discard,
             phdc);
-        PostProcessExternalObject(replay_result, out_op_phdc, out_p_phdc, format::ApiCallId::ApiCall_IDXGISurface1_GetDC, "IDXGISurface1_GetDC");
+        PostProcessExternalObject(replay_result, reinterpret_cast<void**>(out_op_phdc), out_p_phdc, format::ApiCallId::ApiCall_IDXGISurface1_GetDC, "IDXGISurface1_GetDC");
     }
 }
 
@@ -14341,7 +14341,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_GetWindowAssociation(
             return_value,
             replay_result,
             pWindowHandle);
-        PostProcessExternalObject(replay_result, out_op_pWindowHandle, out_p_pWindowHandle, format::ApiCallId::ApiCall_IDXGIFactory_GetWindowAssociation, "IDXGIFactory_GetWindowAssociation");
+        PostProcessExternalObject(replay_result, reinterpret_cast<void**>(out_op_pWindowHandle), out_p_pWindowHandle, format::ApiCallId::ApiCall_IDXGIFactory_GetWindowAssociation, "IDXGIFactory_GetWindowAssociation");
     }
 }
 
@@ -15200,7 +15200,7 @@ void Dx12ReplayConsumer::Process_IDXGIResource1_CreateSharedHandle(
             dwAccess,
             lpName,
             pHandle);
-        PostProcessExternalObject(replay_result, out_op_pHandle, out_p_pHandle, format::ApiCallId::ApiCall_IDXGIResource1_CreateSharedHandle, "IDXGIResource1_CreateSharedHandle");
+        PostProcessExternalObject(replay_result, reinterpret_cast<void**>(out_op_pHandle), out_p_pHandle, format::ApiCallId::ApiCall_IDXGIResource1_CreateSharedHandle, "IDXGIResource1_CreateSharedHandle");
     }
 }
 
@@ -15394,7 +15394,7 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetHwnd(
             return_value,
             replay_result,
             pHwnd);
-        PostProcessExternalObject(replay_result, out_op_pHwnd, out_p_pHwnd, format::ApiCallId::ApiCall_IDXGISwapChain1_GetHwnd, "IDXGISwapChain1_GetHwnd");
+        PostProcessExternalObject(replay_result, reinterpret_cast<void**>(out_op_pHwnd), out_p_pHwnd, format::ApiCallId::ApiCall_IDXGISwapChain1_GetHwnd, "IDXGISwapChain1_GetHwnd");
     }
 }
 


### PR DESCRIPTION
Add D3D12 replay mapping for NT handles returned by CreateSharedHandle/OpenSharedHandleByName, and received by OpenSharedHandle.