### PR TITLE
Fix crashes when using --dump-resources

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -2589,7 +2589,7 @@ void DrawCallsDumpingContext::BindVertexBuffers2(uint64_t                       
         const uint32_t binding = static_cast<uint32_t>(first_binding + i);
         bound_vertex_buffers_.bound_vertex_buffer_per_binding[binding].buffer_info = buffer_infos[i];
         bound_vertex_buffers_.bound_vertex_buffer_per_binding[binding].offset      = pOffsets[i];
-        bound_vertex_buffers_.bound_vertex_buffer_per_binding[binding].stride      = pStrides[i];
+        bound_vertex_buffers_.bound_vertex_buffer_per_binding[binding].stride = pStrides != nullptr ? pStrides[i] : 0;
         if (pSizes != nullptr)
         {
             bound_vertex_buffers_.bound_vertex_buffer_per_binding[binding].size = buffer_size;

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -75,12 +75,11 @@ class DrawCallsDumpingContext
 
     VkResult CloneRenderPass(const VulkanRenderPassInfo* original_render_pass, const VulkanFramebufferInfo* fb_info);
 
-    VkResult BeginRenderPass(const VulkanRenderPassInfo*  render_pass_info,
-                             uint32_t                     clear_value_count,
-                             const VkClearValue*          p_clear_values,
-                             const VulkanFramebufferInfo* framebuffer_info,
-                             const VkRect2D&              render_area,
-                             VkSubpassContents            contents);
+    VkResult BeginRenderPass(const VulkanRenderPassInfo*                         render_pass_info,
+                             const VulkanFramebufferInfo*                        framebuffer_info,
+                             const VkRenderPassBeginInfo*                        renderpass_begin_info,
+                             VkSubpassContents                                   contents,
+                             const std::optional<std::vector<format::HandleId>>& override_attachment_image_views);
 
     void NextSubpass(VkSubpassContents contents);
 

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -73,7 +73,9 @@ class DrawCallsDumpingContext
                                 const graphics::VulkanInstanceTable* inst_table,
                                 const VkCommandBufferBeginInfo*      begin_info);
 
-    VkResult CloneRenderPass(const VulkanRenderPassInfo* original_render_pass, const VulkanFramebufferInfo* fb_info);
+    VkResult CloneRenderPass(const VulkanRenderPassInfo*                         original_render_pass,
+                             const VulkanFramebufferInfo*                        fb_info,
+                             const std::optional<std::vector<format::HandleId>>& override_attachment_image_views);
 
     VkResult BeginRenderPass(const VulkanRenderPassInfo*                         render_pass_info,
                              const VulkanFramebufferInfo*                        framebuffer_info,


### PR DESCRIPTION
Fix different crashes:

- implement missing support for `VK_KHR_imageless_framebuffer` in dump-resources 
- handle (legit) nullptrs (from spec: `pStrides is NULL or a pointer to an array of buffer strides`)