### PR TITLE
Resolve image aspect in rebind allocator resource initialization

### DIFF
--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -321,6 +321,7 @@ VkResult VulkanRebindAllocator::CreateImage(const VkImageCreateInfo*     create_
             resource_alloc_info->usage       = create_info->usage;
             resource_alloc_info->tiling      = create_info->tiling;
             resource_alloc_info->height      = create_info->extent.height;
+            resource_alloc_info->format      = create_info->format;
             resource_alloc_info->object_type = ObjectType::image;
             (*allocator_data)                = reinterpret_cast<uintptr_t>(resource_alloc_info);
 
@@ -1677,11 +1678,32 @@ void VulkanRebindAllocator::WriteBoundResourceStaging(
                     "Ignoring potential mip maps/array layers in staging buffer to image copy: support "
                     "not yet implemented");
 
+                VkImageAspectFlags aspect{};
+                switch (resource_alloc_info->format)
+                {
+                    case VK_FORMAT_D16_UNORM:
+                    case VK_FORMAT_X8_D24_UNORM_PACK32:
+                    case VK_FORMAT_D32_SFLOAT:
+                        aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
+                        break;
+                    case VK_FORMAT_S8_UINT:
+                        aspect = VK_IMAGE_ASPECT_STENCIL_BIT;
+                        break;
+                    case VK_FORMAT_D16_UNORM_S8_UINT:
+                    case VK_FORMAT_D24_UNORM_S8_UINT:
+                    case VK_FORMAT_D32_SFLOAT_S8_UINT:
+                        aspect = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+                        break;
+                    default:
+                        aspect = VK_IMAGE_ASPECT_COLOR_BIT;
+                        break;
+                }
+
                 VkBufferImageCopy region{};
                 region.bufferOffset      = 0;
                 region.bufferRowLength   = 0;
                 region.bufferImageHeight = 0;
-                region.imageSubresource  = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
+                region.imageSubresource  = { aspect, 0, 0, 1 };
                 region.imageOffset       = { 0, 0, 0 };
                 region.imageExtent       = { 1, 1, 1 };
 

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -369,6 +369,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         VkImageTiling    tiling{};
         uint32_t         height{ 0 };
         bool             uses_extensions{ false };
+        VkFormat         format{ VK_FORMAT_UNDEFINED };
 
         std::string          debug_utils_name;
         std::vector<uint8_t> debug_utils_tag;


### PR DESCRIPTION
Currently the image aspect for copy operation is hardcoded as VK_IMAGE_ASPECT_COLOR_BIT. This can casue issues with processing depth and stencil data. This commit fixes the problem for single-planar formats by resolving aspect based on image format.