### PR TITLE
Fix handling of portability extensions

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -169,6 +169,7 @@ struct VulkanReplayDeviceInfo
     std::optional<VkPhysicalDeviceMemoryProperties> memory_properties;
 
     // extensions
+    std::optional<VkPhysicalDeviceDriverProperties>                   driver_properties;
     std::optional<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>    raytracing_properties;
     std::optional<VkPhysicalDeviceAccelerationStructurePropertiesKHR> acceleration_structure_properties;
 };

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2697,7 +2697,8 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
     std::vector<VkExtensionProperties> available_extensions;
     if (feature_util::GetInstanceExtensions(instance_extension_proc, &available_extensions) == VK_SUCCESS)
     {
-        // Always enable portability enumeration if available
+        // Always enable portability enumeration if on Mac
+        #ifdef __APPLE__
         modified_create_info.flags &= ~VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
         for (const VkExtensionProperties& extension : available_extensions)
         {
@@ -2707,6 +2708,7 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
                 modified_create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
             }
         }
+        #endif
 
         // All VK_KHR_get_physical_device_properties2 functionalities are included in Vulkan 1.1,
         // otherwise always enable it if available.

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2879,8 +2879,9 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
     if (result != VK_SUCCESS)
     {
         // Assume we weren't able to create instance because of VK_KHR_portability_enumeration
-        GFXRECON_LOG_WARNING("Unable to create instance due to VK_KHR_portability_enumeration. Attempting creation "
-                             "without that extension...");
+        GFXRECON_LOG_WARNING(
+            "Assuming unable to create instance due to VK_KHR_portability_enumeration. Attempting creation "
+            "without that extension...");
         create_state.modified_create_info.flags &= ~VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
 
         std::vector<const char*>& modified_extensions = create_state.modified_extensions;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2876,7 +2876,7 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
     VkResult result =
         create_instance_proc_(&create_state.modified_create_info, GetAllocationCallbacks(pAllocator), replay_instance);
 
-    if (result != VK_SUCCESS)
+    if (result == VK_ERROR_EXTENSION_NOT_PRESENT)
     {
         // Assume we weren't able to create instance because of VK_KHR_portability_enumeration
         GFXRECON_LOG_WARNING(

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3002,10 +3002,21 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
         replay_next          = replay_next->pNext;
     }
 
+    // Filter out portability subset if not on MoltenVK
+    bool on_moltenvk = false;
+    if (physical_device_info->replay_device_info->driver_properties)
+    {
+        on_moltenvk = physical_device_info->replay_device_info->driver_properties->driverID == VK_DRIVER_ID_MOLTENVK;
+    }
+
     // Copy requested extensions to modified_extensions
     for (uint32_t i = 0; i < replay_create_info->enabledExtensionCount; ++i)
     {
-        modified_extensions.push_back(replay_create_info->ppEnabledExtensionNames[i]);
+        const char* name = replay_create_info->ppEnabledExtensionNames[i];
+        if (!on_moltenvk || util::platform::StringCompare(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME, name) != 0)
+        {
+            modified_extensions.push_back(name);
+        }
     }
 
     // Enable extensions used for loading resources during initial state setup for trimmed files.

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -345,13 +345,18 @@ void VulkanDeviceUtil::GetReplayDeviceProperties(const VulkanInstanceUtilInfo&  
     if (instance_info.api_version >= VK_MAKE_VERSION(1, 1, 0))
     {
         // pNext-chaining
-        VkPhysicalDeviceRayTracingPipelinePropertiesKHR raytracing_properties;
+        VkPhysicalDeviceDriverProperties driver_properties = {};
+        driver_properties.sType                            = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
+
+        VkPhysicalDeviceRayTracingPipelinePropertiesKHR raytracing_properties = {};
         raytracing_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
-        raytracing_properties.pNext = nullptr;
+
+        raytracing_properties.pNext = &driver_properties;
         device_properties2.pNext    = &raytracing_properties;
 
         instance_table->GetPhysicalDeviceProperties2(physical_device, &device_properties2);
         replay_device_info->raytracing_properties = raytracing_properties;
+        replay_device_info->driver_properties     = driver_properties;
     }
     else
     {


### PR DESCRIPTION
Resolves #2132 

This PR implements two changes to `replay`:

-  If the replay device's `VkPhysicalDeviceDriverProperties::driverID` is _not_ MoltenVK, we omit the `VK_KHR_portability_subset` extension
-   If `vkCreateInstance` fails with `VK_ERROR_EXTENSION_NOT_PRESENT`, we remove the `VK_KHR_portability_enumeration` extension and try again. This is important because some tools, like RenderDoc, do not support even the enumeration extension.