### PR TITLE
Fix dump-resource crash wrt. missing depth

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -2323,13 +2323,14 @@ VkResult DrawCallsDumpingContext::BeginRenderPass(
             GFXRECON_LOG_WARNING("unhandled missing depth-attachment in %s", __func__);
         }
     }
-    GFXRECON_ASSERT(depth_img_view_info != nullptr);
 
-    depth_img_info = object_info_table_.GetVkImageInfo(depth_img_view_info->image_id);
-    GFXRECON_ASSERT(depth_img_info != nullptr);
+    if (depth_img_view_info != nullptr)
+    {
+        depth_img_info = object_info_table_.GetVkImageInfo(depth_img_view_info->image_id);
+        GFXRECON_ASSERT(depth_img_info != nullptr);
+    }
 
     SetRenderTargets(color_att_imgs, depth_img_info, true);
-
     SetRenderArea(renderpass_begin_info->renderArea);
 
     VkResult res = CloneRenderPass(render_pass_info, framebuffer_info, override_attachment_image_views);


### PR DESCRIPTION
the root-cause 'could' be related to `VK_EXT_multisampled_render_to_single_sampled` being used.

as first step, just try not to crash:
- Change a check/assert to an if-condition, avoid nullptr dereference