### PR TITLE
Handle xrEnumerateDisplayRefreshRatesFB incomplete

### DIFF
--- a/framework/decode/openxr_replay_consumer_base.cpp
+++ b/framework/decode/openxr_replay_consumer_base.cpp
@@ -1026,10 +1026,11 @@ void OpenXrReplayConsumerBase::Process_xrEnumerateDisplayRefreshRatesFB(
             }
 
             // Allocate the blend mode array and get all the values
-            std::vector<float> display_refresh_rates;
-            display_refresh_rates.resize(replay_count);
-            replay_result = pfn_enum_dis_refresh_rates_fb(
-                in_session, replay_count, out_displayRefreshRateCountOutput, display_refresh_rates.data());
+            std::vector<float> display_refresh_rates(replay_count);
+            replay_result = pfn_enum_dis_refresh_rates_fb(in_session,
+                                                          display_refresh_rates.size(),
+                                                          out_displayRefreshRateCountOutput,
+                                                          display_refresh_rates.data());
 
             // We are comparing against success, but the original replay may have had an incomplete
             CheckResult("xrEnumerateEnvironmentBlendModes", XR_SUCCESS, replay_result, call_info);

--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -198,6 +198,13 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
                                              PointerDecoder<uint32_t>*               environmentBlendModeCountOutput,
                                              PointerDecoder<XrEnvironmentBlendMode>* environmentBlendModes) override;
 
+    void Process_xrEnumerateDisplayRefreshRatesFB(const ApiCallInfo&        call_info,
+                                                  XrResult                  returnValue,
+                                                  format::HandleId          session,
+                                                  uint32_t                  displayRefreshRateCapacityInput,
+                                                  PointerDecoder<uint32_t>* displayRefreshRateCountOutput,
+                                                  PointerDecoder<float>*    displayRefreshRates) override;
+
     void UpdateState_xrGetVulkanGraphicsDeviceKHR(const ApiCallInfo&                      call_info,
                                                   XrResult                                returnValue,
                                                   format::HandleId                        instance,

--- a/framework/generated/generated_openxr_replay_consumer.cpp
+++ b/framework/generated/generated_openxr_replay_consumer.cpp
@@ -1978,23 +1978,6 @@ void OpenXrReplayConsumer::Process_xrGetSerializedSceneFragmentDataMSFT(
     CustomProcess<format::ApiCallId::ApiCall_xrGetSerializedSceneFragmentDataMSFT>::UpdateState(this, call_info, returnValue, scene, getInfo, countInput, readOutput, buffer, replay_result);
 }
 
-void OpenXrReplayConsumer::Process_xrEnumerateDisplayRefreshRatesFB(
-    const ApiCallInfo&                          call_info,
-    XrResult                                    returnValue,
-    format::HandleId                            session,
-    uint32_t                                    displayRefreshRateCapacityInput,
-    PointerDecoder<uint32_t>*                   displayRefreshRateCountOutput,
-    PointerDecoder<float>*                      displayRefreshRates)
-{
-    XrSession in_session = MapHandle<OpenXrSessionInfo>(session, &CommonObjectInfoTable::GetXrSessionInfo);
-    uint32_t* out_displayRefreshRateCountOutput = displayRefreshRateCountOutput->IsNull() ? nullptr : displayRefreshRateCountOutput->AllocateOutputData(1, static_cast<uint32_t>(0));
-    float* out_displayRefreshRates = displayRefreshRates->IsNull() ? nullptr : displayRefreshRates->AllocateOutputData(displayRefreshRateCapacityInput);
-
-    XrResult replay_result = GetInstanceTable(in_session)->EnumerateDisplayRefreshRatesFB(in_session, displayRefreshRateCapacityInput, out_displayRefreshRateCountOutput, out_displayRefreshRates);
-    CheckResult("xrEnumerateDisplayRefreshRatesFB", returnValue, replay_result, call_info);
-    CustomProcess<format::ApiCallId::ApiCall_xrEnumerateDisplayRefreshRatesFB>::UpdateState(this, call_info, returnValue, session, displayRefreshRateCapacityInput, displayRefreshRateCountOutput, displayRefreshRates, replay_result);
-}
-
 void OpenXrReplayConsumer::Process_xrGetDisplayRefreshRateFB(
     const ApiCallInfo&                          call_info,
     XrResult                                    returnValue,

--- a/framework/generated/generated_openxr_replay_consumer.h
+++ b/framework/generated/generated_openxr_replay_consumer.h
@@ -835,14 +835,6 @@ class OpenXrReplayConsumer : public OpenXrReplayConsumerBase
         PointerDecoder<uint32_t>*                   readOutput,
         PointerDecoder<uint8_t>*                    buffer) override;
 
-    virtual void Process_xrEnumerateDisplayRefreshRatesFB(
-        const ApiCallInfo&                          call_info,
-        XrResult                                    returnValue,
-        format::HandleId                            session,
-        uint32_t                                    displayRefreshRateCapacityInput,
-        PointerDecoder<uint32_t>*                   displayRefreshRateCountOutput,
-        PointerDecoder<float>*                      displayRefreshRates) override;
-
     virtual void Process_xrGetDisplayRefreshRateFB(
         const ApiCallInfo&                          call_info,
         XrResult                                    returnValue,

--- a/framework/generated/khronos_generators/openxr_generators/gencode.py
+++ b/framework/generated/khronos_generators/openxr_generators/gencode.py
@@ -697,6 +697,7 @@ def make_gen_opts(args):
                 'xrCreateApiLayerInstance',
                 'xrCreateDebugUtilsMessengerEXT',
                 'xrEnumerateEnvironmentBlendModes',
+                'xrEnumerateDisplayRefreshRatesFB'
             ]
         )
     ]

--- a/framework/generated/khronos_generators/openxr_generators/openxr_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_replay_consumer_body_generator.py
@@ -113,6 +113,7 @@ class OpenXrReplayConsumerBodyGenerator(
             'xrCreateVulkanDeviceKHR',
             'xrCreateDebugUtilsMessengerEXT',
             'xrEnumerateEnvironmentBlendModes',
+            'xrEnumerateDisplayRefreshRatesFB'
         ]
 
         # These structures require a customized manager when they are an output struct


### PR DESCRIPTION
Handle a different amount of display rates returned in the replay from the capture for the xrEnumerateDisplayRefreshRatesFB command.