### PR TITLE
Use a single log for writing time information

### DIFF
--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -240,10 +240,7 @@ uint64_t VulkanStateWriter::WriteState(const VulkanStateTable& state_table, uint
 
     auto done = std::chrono::high_resolution_clock::now();
     uint32_t time = std::chrono::duration_cast<std::chrono::milliseconds>(done - started).count();
-    GFXRECON_LOG_INFO("--------------------------------------")
-    GFXRECON_LOG_INFO("%s()", __func__)
-    GFXRECON_LOG_INFO("  saved in %u ms", time);
-    GFXRECON_LOG_INFO("--------------------------------------")
+    GFXRECON_LOG_INFO("%s() saved in %u ms", __func__, time);
 
     return blocks_written_;
     // clang-format on
@@ -2977,10 +2974,7 @@ void VulkanStateWriter::WriteResourceMemoryState(const VulkanStateTable& state_t
     auto     done = std::chrono::high_resolution_clock::now();
     uint32_t time = std::chrono::duration_cast<std::chrono::milliseconds>(done - started).count();
 
-    GFXRECON_LOG_INFO("--------------------------------------")
-    GFXRECON_LOG_INFO("%s()", __func__)
-    GFXRECON_LOG_INFO("  saved in %u ms", time);
-    GFXRECON_LOG_INFO("--------------------------------------")
+    GFXRECON_LOG_INFO("%s()  saved in %u ms", __func__, time)
 }
 
 void VulkanStateWriter::WriteMappedMemoryState(const VulkanStateTable& state_table)


### PR DESCRIPTION
On Android, each log maps to a separate call to androids log system, hence when looking at the timestamps of the 4 log calls we can measure how long the first 3 log statements did need. For a specific case I did see 26 us and 31 us seconds. This is not that much, but it is also very simple to improve. Hence combining the 4 log statements. Dropping the line separation (at least on Android, there is no guarantee that it is not mixed with other content, especially as there is a 31 us time period this can happen. By only issuing a single log statement, the same information can be logged with 57 us less time.

Here the log statements I did see:
1.209 678 593 I gfxrecon com.khronos.vulkan_samples --------------------------------------
1.209 704 140 I gfxrecon com.khronos.vulkan_samples WriteResourceMemoryState()
1.209 707 617 I gfxrecon com.khronos.vulkan_samples saved in 1115 ms
1.209 710 742 I gfxrecon com.khronos.vulkan_samples --------------------------------------

1.243 008 163 I gfxrecon com.khronos.vulkan_samples --------------------------------------
1.243 033 632 I gfxrecon com.khronos.vulkan_samples WriteState()
1.243 037 226 I gfxrecon com.khronos.vulkan_samples saved in 1156 ms
1.243 039 687 I gfxrecon com.khronos.vulkan_samples --------------------------------------

I think that logging is fine if the operation takes a second, that is long enough to warrant a note. I wonder if we should not log if it is much faster, but I did not add an if. Any time chosen is arbitrary. Anyway, proposing to log this just as a single entry/line.

BTW, for logcat, we could emit multiple lines in a single log call, but not sure how this works on the host, in other environments. I think for this case, just logging the value without being surrounded by ----- lines is sufficient (and better, as it does not steal as much attention away from other issues in the log)
