### PR TITLE
android: Fix orientation when pre-rotation is set

### DIFF
--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -69,25 +69,26 @@ void AndroidWindow::SetSizePreTransform(const uint32_t width, const uint32_t hei
         if (((width != height) && ((width < height) != (pixel_width < pixel_height))) ||
             (pre_transform != format::ResizeWindowPreTransform::kPreTransform0))
         {
-            const std::array<AndroidContext::ScreenOrientation, 2> kOrientations{
-                AndroidContext::ScreenOrientation::kLandscape, AndroidContext::ScreenOrientation::kPortrait
-            };
-
-            uint32_t orientation_index = 0;
+            auto orientation = AndroidContext::ScreenOrientation::kLandscape;
 
             if (height > width)
             {
-                orientation_index = 1;
+                orientation = AndroidContext::ScreenOrientation::kPortrait;
             }
 
-            // Toggle orientation between landscape and portrait for 90 and 270 degree pre-transform values.
+            // Pre-transform is a different story. Supposing identity transform of capture and
+            // replay device match and it is portrait, then the following holds true.
             if ((pre_transform == format::ResizeWindowPreTransform::kPreTransform90) ||
                 (pre_transform == format::ResizeWindowPreTransform::kPreTransform270))
             {
-                orientation_index ^= 1;
+                orientation = AndroidContext::ScreenOrientation::kLandscape;
+            }
+            else if (pre_transform == format::ResizeWindowPreTransform::kPreTransform180)
+            {
+                orientation = AndroidContext::ScreenOrientation::kPortrait;
             }
 
-            android_context_->SetOrientation(kOrientations[orientation_index]);
+            android_context_->SetOrientation(orientation);
         }
 
         int32_t result = ANativeWindow_setBuffersGeometry(window_, width, height, ANativeWindow_getFormat(window_));

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -6926,12 +6926,6 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
         {
             SetSwapchainWindowSize(meta_info);
 
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-            // On Android, SetSwapchainWindowSize will take care of non identity transformations by requesting the
-            // appropriate orientation with setRequestedOrientation
-            modified_create_info.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
-#endif
-
             const auto surface_info = object_info_table_->GetVkSurfaceKHRInfo(meta_info->surface);
 
             if (surface_info && (surface_info->window != nullptr))


### PR DESCRIPTION
We currently assume identity orientation of capture and replay device match and it is portrait, then when pre-rotation is requested, we set the orientation accordingly.

It might still show some issues with devices that have a landscape native orientation (either capture or replay device, or both), so my guess is that it will need more testing on different devices.