### PR TITLE
Align async pipeline creation with pipeline caches

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -227,14 +227,6 @@ VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::
             num_threads += (int32_t)std::thread::hardware_concurrency();
         }
         background_queue_.set_num_threads(std::clamp<uint32_t>(num_threads, 0, std::thread::hardware_concurrency()));
-
-        if (options_.add_new_pipeline_caches || !options_.save_pipeline_cache_filename.empty() ||
-            !options_.load_pipeline_cache_filename.empty())
-        {
-            GFXRECON_LOG_WARNING("Requested both asynchronous pipeline-creation (--pipeline-creation-jobs) and "
-                                 "explicit pipeline-caches (--save-pipeline-cache | --load-pipeline-cache). This is "
-                                 "currently not supported and will prevent usage of pipeline-caches.");
-        }
     }
 
     // If we want to save a pipeline cache file, we do this to be sure the file exists, is empty, and optionally, is

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10597,7 +10597,6 @@ VkResult VulkanReplayConsumerBase::OverrideCreateGraphicsPipelines(
     VkPipelineCache override_pipeline_cache = in_pipeline_cache;
 
     // If there is no pipeline cache and we want to create a new one
-
     if (in_pipeline_cache == VK_NULL_HANDLE && options_.add_new_pipeline_caches)
     {
         override_pipeline_cache = CreateNewPipelineCache(device_info, *pPipelines->GetPointer());
@@ -10627,7 +10626,6 @@ VkResult VulkanReplayConsumerBase::OverrideCreateGraphicsPipelines(
                                   out_pipelines);
 
     // If a pipeline cache was created, track it to know when to destroy it/save it to file
-
     if (in_pipeline_cache != override_pipeline_cache && replay_result == VK_SUCCESS)
     {
         TrackNewPipelineCache(device_info,
@@ -10928,6 +10926,14 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
     VkPipelineCache                     pipeline_cache_handle =
         (pipeline_cache_info != nullptr) ? pipeline_cache_info->handle : VK_NULL_HANDLE;
 
+    auto override_pipeline_cache = pipeline_cache_handle;
+
+    // If there is no pipeline cache and we want to create a new one
+    if (pipeline_cache_handle == VK_NULL_HANDLE && options_.add_new_pipeline_caches)
+    {
+        override_pipeline_cache = CreateNewPipelineCache(device_info, *pPipelines->GetPointer());
+    }
+
     // populate VulkanPipelineInfo structs with information related to shader-modules
     graphics::populate_shader_stages(pCreateInfos, pPipelines, GetObjectInfoTable());
 
@@ -10941,14 +10947,14 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
     uint32_t             num_bytes = graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, nullptr);
     std::vector<uint8_t> create_info_data(num_bytes);
     graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, create_info_data.data());
-    std::vector<format::HandleId> pipelines(createInfoCount);
+    std::vector<format::HandleId> pipeline_ids(createInfoCount);
 
     // extract handle-dependencies and track those
     auto                  handle_deps = graphics::vulkan_struct_extract_handle_ids(pCreateInfos);
     std::function<void()> sync_fn;
     if (pPipelines != nullptr && createInfoCount > 0)
     {
-        std::copy_n(pPipelines->GetPointer(), createInfoCount, pipelines.begin());
+        std::copy_n(pPipelines->GetPointer(), createInfoCount, pipeline_ids.begin());
 
         sync_fn = [this, parent_id = pPipelines->GetPointer()[0]]() {
             MapHandle<VulkanPipelineInfo>(parent_id, &VulkanObjectInfoTable::GetVkPipelineInfo);
@@ -10958,8 +10964,9 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
 
     // define pipeline-creation task, assert object-lifetimes by copying/moving into closure
     auto task = [this,
-                 device_handle,
+                 device_info,
                  pipeline_cache_handle,
+                 override_pipeline_cache,
                  func,
                  returnValue,
                  call_info,
@@ -10967,22 +10974,44 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
                  createInfoCount,
                  create_info_data = std::move(create_info_data),
                  handle_deps      = std::move(handle_deps),
-                 pipelines        = std::move(pipelines)]() mutable -> handle_create_result_t<VkPipeline> {
+                 pipeline_ids     = std::move(pipeline_ids)]() mutable -> handle_create_result_t<VkPipeline> {
         std::vector<VkPipeline> out_pipelines(createInfoCount);
         auto                    create_infos = reinterpret_cast<VkGraphicsPipelineCreateInfo*>(create_info_data.data());
 
         std::vector<std::unique_ptr<char[]>> replaced_file_code;
         if (returnValue >= 0 && !options_.replace_shader_dir.empty())
         {
-            replaced_file_code = ReplaceShaders(createInfoCount, create_infos, pipelines.data());
+            replaced_file_code = ReplaceShaders(createInfoCount, create_infos, pipeline_ids.data());
         }
 
-        VkResult replay_result = func(
-            device_handle, pipeline_cache_handle, createInfoCount, create_infos, in_pAllocator, out_pipelines.data());
+        VkResult replay_result = func(device_info->handle,
+                                      override_pipeline_cache,
+                                      createInfoCount,
+                                      create_infos,
+                                      in_pAllocator,
+                                      out_pipelines.data());
         CheckResult("vkCreateGraphicsPipelines", returnValue, replay_result, call_info);
 
         // schedule dependency-clear on main-thread
-        MainThreadQueue().post([this, handle_deps = std::move(handle_deps)] { ClearAsyncHandles(handle_deps); });
+        MainThreadQueue().post([this,
+                                device_info,
+                                replay_result,
+                                handle_deps = std::move(handle_deps),
+                                pipeline_cache_handle,
+                                override_pipeline_cache,
+                                pipeline_id      = pipeline_ids.front(),
+                                pipeline_handles = out_pipelines.data(),
+                                num_pipelines    = out_pipelines.size()] {
+            // asynchronous operation is done. clear tracked handles, call deferred deletes
+            ClearAsyncHandles(handle_deps);
+
+            // if a pipeline cache was created, track it to know when to destroy it/save it to file
+            if (pipeline_cache_handle != override_pipeline_cache && replay_result == VK_SUCCESS)
+            {
+                TrackNewPipelineCache(
+                    device_info, pipeline_id, override_pipeline_cache, pipeline_handles, num_pipelines);
+            }
+        });
         return { replay_result, std::move(out_pipelines) };
     };
     return task;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10597,9 +10597,11 @@ VkResult VulkanReplayConsumerBase::OverrideCreateGraphicsPipelines(
     VkPipelineCache override_pipeline_cache = in_pipeline_cache;
 
     // If there is no pipeline cache and we want to create a new one
+    format::HandleId cache_pipeline_id = format::kNullHandleId;
     if (in_pipeline_cache == VK_NULL_HANDLE && options_.add_new_pipeline_caches)
     {
-        override_pipeline_cache = CreateNewPipelineCache(device_info, *pPipelines->GetPointer());
+        cache_pipeline_id = *pPipelines->GetPointer();
+        override_pipeline_cache = CreateNewPipelineCache(device_info, cache_pipeline_id);
     }
 
     std::vector<uint8_t>                 create_info_data;
@@ -10626,10 +10628,10 @@ VkResult VulkanReplayConsumerBase::OverrideCreateGraphicsPipelines(
                                   out_pipelines);
 
     // If a pipeline cache was created, track it to know when to destroy it/save it to file
-    if (in_pipeline_cache != override_pipeline_cache && replay_result == VK_SUCCESS)
+    if (cache_pipeline_id != format::kNullHandleId)
     {
         TrackNewPipelineCache(device_info,
-                              *pPipelines->GetPointer(),
+                              cache_pipeline_id,
                               override_pipeline_cache,
                               pPipelines->GetHandlePointer(),
                               create_info_count);
@@ -10672,10 +10674,11 @@ VkResult VulkanReplayConsumerBase::OverrideCreateComputePipelines(
     VkPipelineCache override_pipeline_cache = in_pipeline_cache;
 
     // If there is no pipeline cache and we want to create a new one
-
+    format::HandleId cache_pipeline_id = format::kNullHandleId;
     if (in_pipeline_cache == VK_NULL_HANDLE && options_.add_new_pipeline_caches)
     {
-        override_pipeline_cache = CreateNewPipelineCache(device_info, *pPipelines->GetPointer());
+        cache_pipeline_id = *pPipelines->GetPointer();
+        override_pipeline_cache = CreateNewPipelineCache(device_info, cache_pipeline_id);
     }
 
     VkResult replay_result = func(in_device,
@@ -10923,15 +10926,14 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
     const VkGraphicsPipelineCreateInfo* in_pCreateInfos = pCreateInfos->GetPointer();
     const VkAllocationCallbacks*        in_pAllocator   = GetAllocationCallbacks(pAllocator);
     VkDevice                            device_handle   = device_info->handle;
-    VkPipelineCache                     pipeline_cache_handle =
-        (pipeline_cache_info != nullptr) ? pipeline_cache_info->handle : VK_NULL_HANDLE;
-
-    auto override_pipeline_cache = pipeline_cache_handle;
+    VkPipelineCache pipeline_cache = (pipeline_cache_info != nullptr) ? pipeline_cache_info->handle : VK_NULL_HANDLE;
 
     // If there is no pipeline cache and we want to create a new one
-    if (pipeline_cache_handle == VK_NULL_HANDLE && options_.add_new_pipeline_caches)
+    format::HandleId cache_pipeline_id = format::kNullHandleId;
+    if (pipeline_cache == VK_NULL_HANDLE && options_.add_new_pipeline_caches)
     {
-        override_pipeline_cache = CreateNewPipelineCache(device_info, *pPipelines->GetPointer());
+        cache_pipeline_id = *pPipelines->GetPointer();
+        pipeline_cache    = CreateNewPipelineCache(device_info, cache_pipeline_id);
     }
 
     // populate VulkanPipelineInfo structs with information related to shader-modules
@@ -10965,8 +10967,8 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
     // define pipeline-creation task, assert object-lifetimes by copying/moving into closure
     auto task = [this,
                  device_info,
-                 pipeline_cache_handle,
-                 override_pipeline_cache,
+                 pipeline_cache,
+                 cache_pipeline_id,
                  func,
                  returnValue,
                  call_info,
@@ -10984,32 +10986,25 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
             replaced_file_code = ReplaceShaders(createInfoCount, create_infos, pipeline_ids.data());
         }
 
-        VkResult replay_result = func(device_info->handle,
-                                      override_pipeline_cache,
-                                      createInfoCount,
-                                      create_infos,
-                                      in_pAllocator,
-                                      out_pipelines.data());
+        VkResult replay_result = func(
+            device_info->handle, pipeline_cache, createInfoCount, create_infos, in_pAllocator, out_pipelines.data());
         CheckResult("vkCreateGraphicsPipelines", returnValue, replay_result, call_info);
 
         // schedule dependency-clear on main-thread
         MainThreadQueue().post([this,
                                 device_info,
-                                replay_result,
-                                handle_deps = std::move(handle_deps),
-                                pipeline_cache_handle,
-                                override_pipeline_cache,
-                                pipeline_id      = pipeline_ids.front(),
+                                pipeline_cache,
+                                cache_pipeline_id,
                                 pipeline_handles = out_pipelines.data(),
-                                num_pipelines    = out_pipelines.size()] {
+                                num_pipelines    = out_pipelines.size(),
+                                handle_deps      = std::move(handle_deps)] {
             // asynchronous operation is done. clear tracked handles, call deferred deletes
             ClearAsyncHandles(handle_deps);
 
             // if a pipeline cache was created, track it to know when to destroy it/save it to file
-            if (pipeline_cache_handle != override_pipeline_cache && replay_result == VK_SUCCESS)
+            if (cache_pipeline_id != format::kNullHandleId)
             {
-                TrackNewPipelineCache(
-                    device_info, pipeline_id, override_pipeline_cache, pipeline_handles, num_pipelines);
+                TrackNewPipelineCache(device_info, cache_pipeline_id, pipeline_cache, pipeline_handles, num_pipelines);
             }
         });
         return { replay_result, std::move(out_pipelines) };
@@ -11037,8 +11032,15 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
     const VkComputePipelineCreateInfo* in_pCreateInfos = pCreateInfos->GetPointer();
     const VkAllocationCallbacks*       in_pAllocator   = GetAllocationCallbacks(pAllocator);
     VkDevice                           device_handle   = device_info->handle;
-    VkPipelineCache                    pipeline_cache_handle =
-        (pipeline_cache_info != nullptr) ? pipeline_cache_info->handle : VK_NULL_HANDLE;
+    VkPipelineCache pipeline_cache = (pipeline_cache_info != nullptr) ? pipeline_cache_info->handle : VK_NULL_HANDLE;
+
+    // If there is no pipeline cache and we want to create a new one
+    format::HandleId cache_pipeline_id = format::kNullHandleId;
+    if (pipeline_cache == VK_NULL_HANDLE && options_.add_new_pipeline_caches)
+    {
+        cache_pipeline_id = *pPipelines->GetPointer();
+        pipeline_cache    = CreateNewPipelineCache(device_info, cache_pipeline_id);
+    }
 
     // populate VulkanPipelineInfo structs with information related to shader-modules
     graphics::populate_shader_stages(pCreateInfos, pPipelines, GetObjectInfoTable());
@@ -11061,8 +11063,9 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
 
     // define pipeline-creation task, assert object-lifetimes by copying/moving into closure
     auto task = [this,
-                 device_handle,
-                 pipeline_cache_handle,
+                 device_info,
+                 pipeline_cache,
+                 cache_pipeline_id,
                  func,
                  returnValue,
                  call_info,
@@ -11073,11 +11076,26 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
         std::vector<VkPipeline> out_pipelines(createInfoCount);
         auto     create_infos  = reinterpret_cast<const VkComputePipelineCreateInfo*>(create_info_data.data());
         VkResult replay_result = func(
-            device_handle, pipeline_cache_handle, createInfoCount, create_infos, in_pAllocator, out_pipelines.data());
+            device_info->handle, pipeline_cache, createInfoCount, create_infos, in_pAllocator, out_pipelines.data());
         CheckResult("vkCreateComputePipelines", returnValue, replay_result, call_info);
 
         // schedule dependency-clear on main-thread
-        MainThreadQueue().post([this, handle_deps = std::move(handle_deps)] { ClearAsyncHandles(handle_deps); });
+        MainThreadQueue().post([this,
+                                device_info,
+                                pipeline_cache,
+                                cache_pipeline_id,
+                                pipeline_handles = out_pipelines.data(),
+                                num_pipelines    = out_pipelines.size(),
+                                handle_deps      = std::move(handle_deps)] {
+            // asynchronous operation is done. clear tracked handles, call deferred deletes
+            ClearAsyncHandles(handle_deps);
+
+            // if a pipeline cache was created, track it to know when to destroy it/save it to file
+            if (cache_pipeline_id != format::kNullHandleId)
+            {
+                TrackNewPipelineCache(device_info, cache_pipeline_id, pipeline_cache, pipeline_handles, num_pipelines);
+            }
+        });
         return { replay_result, std::move(out_pipelines) };
     };
     return task;


### PR DESCRIPTION
Fix interop of CLI-options:

we had this warning since external pipeline-caches were introduced:

>Requested both asynchronous pipeline-creation (--pipeline-creation-jobs) and 
explicit pipeline-caches (--save-pipeline-cache | --load-pipeline-cache). This is
currently not supported and will prevent usage of pipeline-caches.

This PR consolidates the behavior across regular and asynchronous pipeline-creation
and removes the warning.