### PR TITLE
Fix Vulkan WSI instance extensions

### DIFF
--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -58,19 +58,20 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
 Application::Application(const std::string& name, decode::FileProcessor* file_processor) :
-    Application(name, std::string(), file_processor)
+    Application(name, file_processor, std::string(), nullptr)
 {}
 
 Application::Application(const std::string&     name,
+                         decode::FileProcessor* file_processor,
                          const std::string&     cli_wsi_extension,
-                         decode::FileProcessor* file_processor) :
+                         void*                  platform_specific_wsi_data) :
     name_(name),
     file_processor_(file_processor), running_(false), paused_(false), pause_frame_(0),
     cli_wsi_extension_(cli_wsi_extension), fps_info_(nullptr)
 {
     if (!cli_wsi_extension_.empty())
     {
-        InitializeWsiContext(cli_wsi_extension_.c_str());
+        InitializeWsiContext(cli_wsi_extension_.c_str(), platform_specific_wsi_data);
     }
 }
 

--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -46,7 +46,10 @@ class Application final
   public:
     Application(const std::string& name, decode::FileProcessor* file_processor);
 
-    Application(const std::string& name, const std::string& cli_wsi_extension, decode::FileProcessor* file_processor);
+    Application(const std::string&     name,
+                decode::FileProcessor* file_processor,
+                const std::string&     cli_wsi_extension,
+                void*                  platform_specific_wsi_data);
 
     ~Application();
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -77,10 +77,12 @@ const char kUnknownDeviceLabel[]  = "<Unknown>";
 const char kValidationLayerName[] = "VK_LAYER_KHRONOS_validation";
 
 const std::unordered_set<std::string> kSurfaceExtensions = {
-    VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, VK_MVK_IOS_SURFACE_EXTENSION_NAME, VK_MVK_MACOS_SURFACE_EXTENSION_NAME,
-    VK_KHR_MIR_SURFACE_EXTENSION_NAME,     VK_NN_VI_SURFACE_EXTENSION_NAME,   VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME,
-    VK_KHR_WIN32_SURFACE_EXTENSION_NAME,   VK_KHR_XCB_SURFACE_EXTENSION_NAME, VK_KHR_XLIB_SURFACE_EXTENSION_NAME,
-    VK_EXT_METAL_SURFACE_EXTENSION_NAME,
+    VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,  VK_MVK_IOS_SURFACE_EXTENSION_NAME,
+    VK_MVK_MACOS_SURFACE_EXTENSION_NAME,    VK_KHR_MIR_SURFACE_EXTENSION_NAME,
+    VK_NN_VI_SURFACE_EXTENSION_NAME,        VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME,
+    VK_KHR_WIN32_SURFACE_EXTENSION_NAME,    VK_KHR_XCB_SURFACE_EXTENSION_NAME,
+    VK_KHR_XLIB_SURFACE_EXTENSION_NAME,     VK_EXT_METAL_SURFACE_EXTENSION_NAME,
+    VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME,
 };
 
 // Device extensions to enable for trimming state setup, when available.
@@ -2690,6 +2692,20 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
         else
         {
             modified_extensions.push_back(current_extension);
+        }
+    }
+
+    // If a WSI was specified by CLI but there was none at capture time, it's possible to end up with a surface
+    // extension without having VK_KHR_surface. Check for that and fix that.
+    if (!feature_util::IsSupportedExtension(modified_extensions, VK_KHR_SURFACE_EXTENSION_NAME))
+    {
+        for (const std::string& current_extension : modified_extensions)
+        {
+            if (kSurfaceExtensions.find(current_extension) != kSurfaceExtensions.end())
+            {
+                modified_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+                break;
+            }
         }
     }
 

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -136,9 +136,8 @@ void android_main(struct android_app* app)
             }
             else
             {
-                auto application =
-                    std::make_shared<gfxrecon::application::Application>(kApplicationName, file_processor.get());
-                application->InitializeWsiContext(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, app);
+                auto application = std::make_shared<gfxrecon::application::Application>(
+                    kApplicationName, file_processor.get(), VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, app);
 
                 gfxrecon::decode::VulkanTrackedObjectInfoTable tracked_object_info_table;
                 gfxrecon::decode::VulkanReplayOptions          replay_options =

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -153,7 +153,7 @@ int main(int argc, const char** argv)
             // Select WSI context based on CLI
             std::string wsi_extension = GetWsiExtensionName(GetWsiPlatform(arg_parser));
             auto        application   = std::make_shared<gfxrecon::application::Application>(
-                kApplicationName, wsi_extension, file_processor.get());
+                kApplicationName, file_processor.get(), wsi_extension, nullptr);
 
             gfxrecon::decode::VulkanTrackedObjectInfoTable tracked_object_info_table;
             gfxrecon::decode::VulkanReplayOptions          vulkan_replay_options =


### PR DESCRIPTION
This commit fixes 3 bugs:
- `VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME` missing in `kSurfaceExtensions`
- `cli_wsi_extension_` not being set (nor possible to set) when replaying on Android
- If offscreen content is captured and replayed specifying a WSI, it was possible to end up with instance extensions containing a surface extension but no `VK_KHR_surface`