### PR TITLE
Fix OpenXR frame count

### DIFF
--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -2437,7 +2437,8 @@ bool FileProcessor::IsFrameDelimiter(format::ApiCallId call_id) const
         return ((call_id == format::ApiCallId::ApiCall_vkQueuePresentKHR) ||
                 (call_id == format::ApiCallId::ApiCall_vkFrameBoundaryANDROID) ||
                 (call_id == format::ApiCallId::ApiCall_IDXGISwapChain_Present) ||
-                (call_id == format::ApiCallId::ApiCall_IDXGISwapChain1_Present1));
+                (call_id == format::ApiCallId::ApiCall_IDXGISwapChain1_Present1) ||
+                (call_id == format::ApiCallId::ApiCall_xrEndFrame));
     }
 }
 

--- a/framework/decode/openxr_replay_consumer_base.cpp
+++ b/framework/decode/openxr_replay_consumer_base.cpp
@@ -57,7 +57,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 OpenXrReplayConsumerBase::OpenXrReplayConsumerBase(std::shared_ptr<application::Application> application,
                                                    const OpenXrReplayOptions&                options) :
     application_(application),
-    options_(options), get_instance_proc_addr_(nullptr)
+    options_(options), get_instance_proc_addr_(nullptr), fps_info_(nullptr)
 {
     assert(application_ != nullptr);
     object_info_table_ = CommonObjectInfoTable::GetSingleton();
@@ -576,6 +576,24 @@ void OpenXrReplayConsumerBase::AssociateParent(XrEnvironmentDepthSwapchainMETA e
 }
 
 #endif // defined(_WIN64) || defined(__x86_64__) || defined(__aarch64__)
+
+void OpenXrReplayConsumerBase::ProcessStateBeginMarker(uint64_t frame_number)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(frame_number);
+}
+
+void OpenXrReplayConsumerBase::ProcessStateEndMarker(uint64_t frame_number)
+{
+    if (fps_info_ != nullptr)
+    {
+        fps_info_->ProcessStateEndMarker(frame_number);
+    }
+}
+
+void OpenXrReplayConsumerBase::ProcessDisplayMessageCommand(const std::string& message)
+{
+    GFXRECON_LOG_INFO("OpenXr Trace Message: %s", message.c_str());
+}
 
 void OpenXrReplayConsumerBase::Process_xrInitializeLoaderKHR(
     const ApiCallInfo&                                           call_info,

--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -107,6 +107,17 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
     }
 #endif
 
+    void SetFpsInfo(graphics::FpsInfo* fps_info)
+    {
+        fps_info_ = fps_info;
+    }
+
+    virtual void ProcessStateBeginMarker(uint64_t frame_number) override;
+
+    virtual void ProcessStateEndMarker(uint64_t frame_number) override;
+
+    virtual void ProcessDisplayMessageCommand(const std::string& message) override;
+
     virtual void
     Process_xrInitializeLoaderKHR(const ApiCallInfo&                                           call_info,
                                   XrResult                                                     returnValue,
@@ -476,6 +487,8 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
     std::unordered_map<XrInstance, encode::OpenXrInstanceTable> instance_tables_;
     std::shared_ptr<application::Application>                   application_;
     std::function<void(const char*)>                            fatal_error_handler_;
+    graphics::FpsInfo*                                          fps_info_;
+
 #if defined(__ANDROID__)
     struct android_app* android_app_;
 #endif

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -353,7 +353,7 @@ void VulkanReplayConsumerBase::ProcessStateEndMarker(uint64_t frame_number)
 
 void VulkanReplayConsumerBase::ProcessDisplayMessageCommand(const std::string& message)
 {
-    GFXRECON_LOG_INFO("Trace Message: %s", message.c_str());
+    GFXRECON_LOG_INFO("Vulkan Trace Message: %s", message.c_str());
 }
 
 void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id,

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -204,6 +204,7 @@ void android_main(struct android_app* app)
                 gfxrecon::decode::OpenXrReplayConsumer openxr_replay_consumer(application, openxr_replay_options);
                 openxr_replay_consumer.SetVulkanReplayConsumer(&vulkan_replay_consumer);
                 openxr_replay_consumer.SetAndroidApp(app);
+                openxr_replay_consumer.SetFpsInfo(&fps_info);
                 openxr_decoder.AddConsumer(&openxr_replay_consumer);
                 file_processor->AddDecoder(&openxr_decoder);
 #endif

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -288,6 +288,7 @@ int main(int argc, const char** argv)
             gfxrecon::decode::OpenXrDecoder        openxr_decoder;
             gfxrecon::decode::OpenXrReplayConsumer openxr_replay_consumer(application, openxr_replay_options);
             openxr_replay_consumer.SetVulkanReplayConsumer(&vulkan_replay_consumer);
+            openxr_replay_consumer.SetFpsInfo(&fps_info);
             openxr_decoder.AddConsumer(&openxr_replay_consumer);
             file_processor->AddDecoder(&openxr_decoder);
 #endif


### PR DESCRIPTION
The capture and replay frame counts for OpenXR traces were mismatched. These changes make them match.