### PR TITLE
Fix Composition/CoreWindow SwapChain replay

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -1176,15 +1176,20 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     void RaiseFatalError(const char* message) const;
 
+    uint64_t GetUniqueProxyWindowId()
+    {
+        return ++unique_proxy_window_id_counter_;
+    }
+
     HRESULT
-    CreateSwapChainForHwnd(DxObjectInfo*                                                  replay_object_info,
-                           HRESULT                                                        original_result,
-                           DxObjectInfo*                                                  device_info,
-                           uint64_t                                                       hwnd_id,
-                           StructPointerDecoder<Decoded_DXGI_SWAP_CHAIN_DESC1>*           desc,
-                           StructPointerDecoder<Decoded_DXGI_SWAP_CHAIN_FULLSCREEN_DESC>* full_screen_desc,
-                           DxObjectInfo*                                                  restrict_to_output_info,
-                           HandlePointerDecoder<IDXGISwapChain1*>*                        swapchain);
+    CreateSwapChainForHwnd(DxObjectInfo*                           replay_object_info,
+                           HRESULT                                 original_result,
+                           DxObjectInfo*                           device_info,
+                           uint64_t                                hwnd_id,
+                           DXGI_SWAP_CHAIN_DESC1*                  desc,
+                           DXGI_SWAP_CHAIN_FULLSCREEN_DESC*        full_screen_desc,
+                           DxObjectInfo*                           restrict_to_output_info,
+                           HandlePointerDecoder<IDXGISwapChain1*>* swapchain);
 
     void SetSwapchainInfo(DxObjectInfo* info,
                           Window*       window,
@@ -1294,6 +1299,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     std::string                                           screenshot_file_prefix_;
     util::ScreenshotFormat                                screenshot_format_;
     std::unique_ptr<ScreenshotHandlerBase>                screenshot_handler_;
+    uint64_t                                              unique_proxy_window_id_counter_;
     std::unordered_map<ID3D12Resource*, ResourceInitInfo> resource_init_infos_;
     uint64_t                                              frame_end_marker_count_;
     std::unordered_map<ID3D12MetaCommand*, GUID>          meta_command_guids_;


### PR DESCRIPTION
D3D12 replay currently converts CreateSwapChainForComposition and CreateSwapChainForCoreWindow to CreateSwapChainForHwnd, but the HWND based swapchain does not support some composition features available to the Composition and CoreWindow swapchains, resulting in swapchain creation failure when composition is enabled. The conversions will also always specify the same window ID of 0, leading to swapchain creation failure when multiple swapchains are created because they all attempt to use the same window. This change addresses these issues with the following:
- Clear values related to composition from DXGI_SWAP_CHAIN_DESC1 prior to calling CreateSwapChainForHwnd.
- Specify a unique window ID for CreateSwapChainForCompostion and CreateSwapChainForCoreWindow conversions to CreateSwapChainForHwnd.

For these cases, the original application would have composed images from multiple swapchains into a single window, while replay will display the swapchain images in separate windows.