### PR TITLE
[openxr] Add support for dynamic loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,6 +393,7 @@ target_include_directories(spirv_registry SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}
 
 add_library(OpenXR INTERFACE)
 if (OPENXR_SUPPORT_ENABLED)
+    option(DYNAMIC_LOADER "" ON)
     add_subdirectory(${PROJECT_SOURCE_DIR}/external/OpenXR-SDK)
     target_include_directories(OpenXR INTERFACE ${PROJECT_SOURCE_DIR}/external/OpenXR-SDK/include)
     target_compile_definitions(OpenXR INTERFACE XR_NO_PROTOTYPES ENABLE_OPENXR_SUPPORT=1)

--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(gfxrecon_graphics
                PRIVATE
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/fps_info.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/fps_info.cpp
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/khronos_util.h
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/khronos_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_check_buffer_references.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_check_buffer_references.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.h
@@ -12,8 +14,6 @@ target_sources(gfxrecon_graphics
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_instance_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_resources_util.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_resources_util.cpp
-                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.h
-                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_deep_copy.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_get_pnext.h
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_dispatch_table.h

--- a/framework/application/CMakeLists.txt
+++ b/framework/application/CMakeLists.txt
@@ -74,7 +74,6 @@ target_link_libraries(gfxrecon_application
                       gfxrecon_format
                       gfxrecon_util
                       vulkan_registry
-                      OpenXR
                       platform_specific
                      )
 

--- a/framework/application/headless_context.cpp
+++ b/framework/application/headless_context.cpp
@@ -24,7 +24,7 @@
 #include "application/application.h"
 #include "application/headless_window.h"
 #include "decode/vulkan_feature_util.h"
-#include "graphics/vulkan_util.h"
+#include "graphics/khronos_util.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
@@ -34,7 +34,7 @@ HeadlessContext::HeadlessContext(Application* application, bool dpi_aware) : Wsi
     bool supported = false;
 
     // Check for headless extension support, and report initialization failure when the extension is not present.
-    auto loader_handle = graphics::InitializeLoader();
+    auto loader_handle = graphics::InitializeKhronosLoader(graphics::KhronosLoader_Vulkan);
     if (loader_handle != nullptr)
     {
         auto get_instance_proc_addr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(
@@ -55,7 +55,7 @@ HeadlessContext::HeadlessContext(Application* application, bool dpi_aware) : Wsi
             }
         }
 
-        graphics::ReleaseLoader(loader_handle);
+        graphics::ReleaseKhronosLoader(loader_handle);
     }
 
     if (supported)

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -419,7 +419,6 @@ target_link_libraries(gfxrecon_decode
                         platform_specific
                         spirv-reflect-static
                         nlohmann_json::nlohmann_json
-                        $<$<BOOL:${OPENXR_SUPPORT_ENABLED}>:OpenXR::openxr_loader>
                         $<$<BOOL:${D3D12_SUPPORT}>:dxguid.lib>)
 
 common_build_directives(gfxrecon_decode)

--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -482,7 +482,11 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
   private:
     void RaiseFatalError(const char* message) const;
 
+    void InitializeLoaderLibrary();
+
+    util::platform::LibraryHandle                               loader_handle_;
     PFN_xrGetInstanceProcAddr                                   get_instance_proc_addr_;
+    PFN_xrCreateInstance                                        create_instance_proc_;
     CommonObjectInfoTable*                                      object_info_table_;
     std::unordered_map<XrInstance, encode::OpenXrInstanceTable> instance_tables_;
     std::shared_ptr<application::Application>                   application_;

--- a/framework/decode/openxr_resource_tracking_consumer.cpp
+++ b/framework/decode/openxr_resource_tracking_consumer.cpp
@@ -62,11 +62,12 @@ void OpenXrResourceTrackingConsumer::InitializeLoader()
     {
         XrResult result = get_instance_proc_addr_(
             XR_NULL_HANDLE, "xrCreateInstance", reinterpret_cast<PFN_xrVoidFunction*>(create_instance_function_));
-        if (create_instance_function_ == nullptr)
-        {
-            GFXRECON_LOG_FATAL("Failed to load OpenXR runtime library; please ensure that the path to the OpenXR "
-                               "loader has been added to the appropriate system path");
-        }
+    }
+
+    if (create_instance_function_ == nullptr)
+    {
+        GFXRECON_LOG_FATAL("Failed to load OpenXR runtime library; please ensure that the path to the OpenXR "
+                           "loader has been added to the appropriate system path");
     }
 }
 

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -20,7 +20,7 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include "graphics/vulkan_util.h"
+#include "graphics/khronos_util.h"
 #include "graphics/vulkan_struct_get_pnext.h"
 #include "decode/vulkan_address_replacer.h"
 #include "decode/vulkan_address_replacer_shaders.h"

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -58,7 +58,7 @@
 #include "format/format_util.h"
 #include "util/alignment_utils.h"
 #include "util/platform.h"
-#include "graphics/vulkan_util.h"
+#include "graphics/khronos_util.h"
 #include "graphics/vulkan_resources_util.h"
 #include "graphics/vulkan_struct_get_pnext.h"
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -39,9 +39,9 @@
 #include "generated/generated_vulkan_struct_decoders.h"
 #include "generated/generated_vulkan_struct_handle_mappers.h"
 #include "generated/generated_vulkan_constant_maps.h"
+#include "graphics/khronos_util.h"
 #include "graphics/vulkan_check_buffer_references.h"
 #include "graphics/vulkan_device_util.h"
-#include "graphics/vulkan_util.h"
 #include "graphics/vulkan_resources_util.h"
 #include "graphics/vulkan_struct_get_pnext.h"
 #include "graphics/vulkan_struct_deep_copy.h"
@@ -306,7 +306,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
 
     if (loader_handle_ != nullptr)
     {
-        graphics::ReleaseLoader(loader_handle_);
+        graphics::ReleaseKhronosLoader(loader_handle_);
     }
 
     resource_dumper_ = nullptr;
@@ -1266,7 +1266,7 @@ void VulkanReplayConsumerBase::RaiseFatalError(const char* message) const
 
 void VulkanReplayConsumerBase::InitializeLoader()
 {
-    loader_handle_ = graphics::InitializeLoader();
+    loader_handle_ = graphics::InitializeKhronosLoader(graphics::KhronosLoader_Vulkan);
     if (loader_handle_ != nullptr)
     {
         get_instance_proc_addr_ = reinterpret_cast<PFN_vkGetInstanceProcAddr>(
@@ -1282,8 +1282,7 @@ void VulkanReplayConsumerBase::InitializeLoader()
     if (create_instance_proc_ == nullptr)
     {
         GFXRECON_LOG_FATAL("Failed to load Vulkan runtime library; please ensure that the path to the Vulkan "
-                           "loader (eg. %s) has been added to the appropriate system path",
-                           graphics::kLoaderLibNames[0].c_str());
+                           "loader has been added to the appropriate system path");
         RaiseFatalError("Failed to load Vulkan runtime library");
     }
 }

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -25,7 +25,7 @@
 
 #include "decode/copy_shaders.h"
 #include "decode/decoder_util.h"
-#include "graphics/vulkan_util.h"
+#include "graphics/khronos_util.h"
 #include "util/platform.h"
 
 #include "Vulkan-Utility-Libraries/vk_format_utils.h"

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -39,7 +39,7 @@
 #include "graphics/vulkan_check_buffer_references.h"
 #include "graphics/vulkan_device_util.h"
 #include "graphics/vulkan_struct_get_pnext.h"
-#include "graphics/vulkan_util.h"
+#include "graphics/khronos_util.h"
 #include "util/compressor.h"
 #include "util/logging.h"
 #include "util/page_guard_manager.h"

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -32,7 +32,7 @@
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "generated/generated_vulkan_state_table.h"
 #include "util/defines.h"
-#include "graphics/vulkan_util.h"
+#include "graphics/khronos_util.h"
 
 #include <algorithm>
 #include <iterator>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -29,7 +29,7 @@
 #include "encode/handle_unwrap_memory.h"
 #include "format/format.h"
 #include "generated/generated_vulkan_dispatch_table.h"
-#include "graphics/vulkan_util.h"
+#include "graphics/khronos_util.h"
 #include "graphics/vulkan_device_util.h"
 #include "graphics/vulkan_instance_util.h"
 #include "graphics/vulkan_resources_util.h"

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -42,6 +42,8 @@ target_sources(gfxrecon_graphics
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_image_renderer.cpp>
                     ${CMAKE_CURRENT_LIST_DIR}/fps_info.h
                     ${CMAKE_CURRENT_LIST_DIR}/fps_info.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/khronos_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/khronos_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_check_buffer_references.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_check_buffer_references.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_resources_util.h
@@ -50,8 +52,6 @@ target_sources(gfxrecon_graphics
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_instance_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_instance_util.cpp
-                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.h
-                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_deep_copy.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_get_pnext.h
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy.cpp

--- a/framework/graphics/khronos_util.cpp
+++ b/framework/graphics/khronos_util.cpp
@@ -20,19 +20,50 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include "graphics/vulkan_util.h"
+#include "graphics/khronos_util.h"
 
 #include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
-util::platform::LibraryHandle InitializeLoader()
+const std::vector<std::string> kVulkanLoaderLibNames = {
+#if defined(WIN32)
+    "vulkan-1.dll"
+#elif defined(__APPLE__)
+    "libvulkan.dylib", "libvulkan.1.dylib", "libMoltenVK.dylib"
+#else
+    "libvulkan.so.1", "libvulkan.so"
+#endif
+};
+const std::vector<std::string> kOpenXrLoaderLibNames = {
+#if defined(WIN32)
+    "openxr_loader-1.dll"
+#elif defined(__APPLE__)
+    "libopenxr_loader.dylib", "libopenxr_loader.1.dylib"
+#else
+    "libopenxr_loader.so.1", "libopenxr_loader.so"
+#endif
+};
+
+util::platform::LibraryHandle InitializeKhronosLoader(KhronosLoaderType type)
 {
-    return util::platform::OpenLibrary(kLoaderLibNames);
+    switch (type)
+    {
+        case KhronosLoader_Vulkan:
+            return util::platform::OpenLibrary(kVulkanLoaderLibNames);
+        case KhronosLoader_OpenXR:
+            return util::platform::OpenLibrary(kOpenXrLoaderLibNames);
+        default:
+#if defined(WIN32)
+            return reinterpret_cast<util::platform::LibraryHandle>(INVALID_HANDLE_VALUE);
+#else
+            return nullptr;
+#endif
+    }
 }
 
-void ReleaseLoader(util::platform::LibraryHandle loader_handle)
+void ReleaseKhronosLoader(util::platform::LibraryHandle loader_handle)
 {
     if (loader_handle != nullptr)
     {

--- a/framework/graphics/khronos_util.cpp
+++ b/framework/graphics/khronos_util.cpp
@@ -55,6 +55,9 @@ util::platform::LibraryHandle InitializeKhronosLoader(KhronosLoaderType type)
         case KhronosLoader_OpenXR:
             return util::platform::OpenLibrary(kOpenXrLoaderLibNames);
         default:
+            GFXRECON_LOG_FATAL("Unsupported Khronos Loader option %d", type);
+            GFXRECON_ASSERT(false);
+
 #if defined(WIN32)
             return reinterpret_cast<util::platform::LibraryHandle>(INVALID_HANDLE_VALUE);
 #else

--- a/framework/graphics/khronos_util.h
+++ b/framework/graphics/khronos_util.h
@@ -42,19 +42,16 @@ GFXRECON_BEGIN_NAMESPACE(graphics)
 
 typedef uint64_t PresentId;
 
-const std::vector<std::string> kLoaderLibNames = {
-#if defined(WIN32)
-    "vulkan-1.dll"
-#elif defined(__APPLE__)
-    "libvulkan.dylib", "libvulkan.1.dylib", "libMoltenVK.dylib"
-#else
-    "libvulkan.so.1", "libvulkan.so"
-#endif
+enum KhronosLoaderType : uint16_t
+{
+    KhronosLoader_None,
+    KhronosLoader_Vulkan,
+    KhronosLoader_OpenXR,
 };
 
-util::platform::LibraryHandle InitializeLoader();
+util::platform::LibraryHandle InitializeKhronosLoader(KhronosLoaderType type);
 
-void ReleaseLoader(util::platform::LibraryHandle loader_handle);
+void ReleaseKhronosLoader(util::platform::LibraryHandle loader_handle);
 
 bool ImageHasUsage(VkImageUsageFlags usage_flags, VkImageUsageFlagBits bit);
 

--- a/framework/graphics/khronos_util.h
+++ b/framework/graphics/khronos_util.h
@@ -44,7 +44,6 @@ typedef uint64_t PresentId;
 
 enum KhronosLoaderType : uint16_t
 {
-    KhronosLoader_None,
     KhronosLoader_Vulkan,
     KhronosLoader_OpenXR,
 };

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -21,7 +21,7 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include "vulkan_util.h"
+#include "khronos_util.h"
 #include "Vulkan-Utility-Libraries/vk_format_utils.h"
 #include "generated/generated_vulkan_enum_to_string.h"
 #include "util/logging.h"


### PR DESCRIPTION
Load the OpenXR loader dynamically not statically.  This prevents having to incorporate it into the standard GFXR replay app since most people will only need OpenXR when using OpenXR applications.  So it's an unnecessary inclusion.

@jzulauf-lunarg, it would be good to know if this continues to work with your Monado.