### PR TITLE
VDR: Option to dump unreferenced vertex bindings

### DIFF
--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -142,6 +142,7 @@ def CreateReplayParser():
     parser.add_argument('--dump-resources-dump-all-image-subresources', action='store_true', default=False, help= 'Dump all available mip levels and layers when dumping images.')
     parser.add_argument('--dump-resources-dump-raw-images', action='store_true', default=False, help= 'Dump images verbatim as raw binary files.')
     parser.add_argument('--dump-resources-dump-separate-alpha', action='store_true', default=False, help= 'Dump image alpha in a separate image file.')
+    parser.add_argument('--dump-resources-dump-unused-vertex-bindings', action='store_true', default=False, help= 'Dump a vertex binding even if no vertex attributes references it.')
     parser.add_argument('--pbi-all', action='store_true', default=False, help='Print all block information.')
     parser.add_argument('--pbis', metavar='RANGES', default=False, help='Print block information between block index1 and block index2')
     parser.add_argument('--pcj', '--pipeline-creation-jobs', action='store_true', default=False, help='Specify the number of pipeline-creation-jobs or background-threads.')
@@ -325,6 +326,9 @@ def MakeExtrasString(args):
 
     if args.dump_resources_dump_separate_alpha:
         arg_list.append('--dump-resources-dump-separate-alpha')
+
+    if args.dump_resources_dump_unused_vertex_bindings:
+        arg_list.append('--dump-resources-dump-unused-vertex-bindings')
 
     if args.pbi_all:
         arg_list.append('--pbi-all')

--- a/framework/decode/vulkan_replay_dump_resources_delegate.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.cpp
@@ -799,11 +799,19 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
 
             auto&    bindings_json_entry = vertex_input_state_json_entry["bindings"];
             uint32_t i                   = 0;
-            for (const auto& vb_binding : draw_call_info.dc_param->vertex_input_state.vertex_input_binding_map)
+            for (const auto& [binding_index, vb_binding] :
+                 draw_call_info.dc_param->vertex_input_state.vertex_input_binding_map)
             {
-                bindings_json_entry[i]["binding"]   = vb_binding.first;
-                bindings_json_entry[i]["stride"]    = vb_binding.second.stride;
-                bindings_json_entry[i]["inputRate"] = util::ToString<VkVertexInputRate>(vb_binding.second.inputRate);
+                bindings_json_entry[i]["binding"]   = binding_index;
+                bindings_json_entry[i]["stride"]    = vb_binding.stride;
+                bindings_json_entry[i]["inputRate"] = util::ToString<VkVertexInputRate>(vb_binding.inputRate);
+
+                if (!options_.dump_resources_dump_unused_vertex_bindings &&
+                    !draw_call_info.dc_param->vertex_input_state.IsVertexBindingReferenced(binding_index))
+                {
+                    bindings_json_entry[i]["unused"] = true;
+                }
+
                 ++i;
             }
         }

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -231,6 +231,7 @@ class DrawCallsDumpingContext
     int32_t                      color_attachment_to_dump_;
     bool                         dump_vertex_index_buffers_;
     bool                         dump_immutable_resources_;
+    bool                         dump_unused_vertex_bindings_;
 
     // Execute commands block index : DrawCallContexts
     std::unordered_map<uint64_t, std::vector<DrawCallsDumpingContext*>> secondaries_;
@@ -283,6 +284,20 @@ class DrawCallsDumpingContext
 
         // One entry per location
         VulkanPipelineInfo::VertexInputAttributeMap vertex_input_attribute_map;
+
+        // Check if one of the vertex attributes references a specific vertex biding
+        bool IsVertexBindingReferenced(uint32_t binding_index) const
+        {
+            for (const auto& attrib_desc : vertex_input_attribute_map)
+            {
+                if (attrib_desc.second.binding == binding_index)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     };
 
   private:

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -54,6 +54,7 @@ VulkanReplayDumpResourcesJson::VulkanReplayDumpResourcesJson(const VulkanReplayO
     dr_options["dumpResourcesDumpAllImageSubresources"] = options.dump_resources_dump_all_image_subresources;
     dr_options["dumpResourcesDumpRawImages"]            = options.dump_resources_dump_raw_images;
     dr_options["dumpResourcesDumpSeparateAlpha"]        = options.dump_resources_dump_separate_alpha;
+    dr_options["dumpResourcesDumpUnusedVertexBindings"] = options.dump_resources_dump_unused_vertex_bindings;
 };
 
 bool VulkanReplayDumpResourcesJson::InitializeFile(const std::string& filename)

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -109,6 +109,7 @@ struct VulkanReplayOptions : public ReplayOptions
     bool  dump_resources_dump_all_image_subresources{ false };
     bool  dump_resources_dump_raw_images{ false };
     bool  dump_resources_dump_separate_alpha{ false };
+    bool  dump_resources_dump_unused_vertex_bindings{ false };
 
     bool preload_measurement_range{ false };
 

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -37,7 +37,7 @@ const char kOptions[] =
     "--dump-resources-json-output-per-command,--dump-resources-dump-immutable-resources,"
     "--dump-resources-dump-all-image-subresources,--dump-resources-dump-raw-images,--dump-resources-dump-"
     "separate-alpha,--dump-resources-modifiable-state-only,--pbi-all,--preload-measurement-range,"
-    "--add-new-pipeline-caches,--screenshot-ignore-FrameBoundaryANDROID";
+    "--add-new-pipeline-caches,--screenshot-ignore-FrameBoundaryANDROID,--dump-resources-dump-unused-vertex-bindings";
 const char kArguments[] =
     "--log-level,--log-file,--cpu-mask,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--screenshot-interval,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -353,6 +353,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tDump immutable shader resources.");
     GFXRECON_WRITE_CONSOLE("  --dump-resources-dump-all-image-subresources");
     GFXRECON_WRITE_CONSOLE("          \t\tDump all available mip levels and layers when dumping images.");
+    GFXRECON_WRITE_CONSOLE("  --dump-resources-dump-unused-vertex-bindings");
+    GFXRECON_WRITE_CONSOLE("          \t\tDump a vertex binding even if no vertex attributes references it.");
     GFXRECON_WRITE_CONSOLE("  --pipeline-creation-jobs <num_jobs>");
     GFXRECON_WRITE_CONSOLE("          \t\tSpecify the number of asynchronous pipeline-creation jobs as integer.");
     GFXRECON_WRITE_CONSOLE("          \t\tIf <num_jobs> is negative it will be added to the number of cpu-cores");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -152,20 +152,21 @@ const char kDxAgsMarkRenderPasses[]       = "--dx12-ags-inject-markers";
 const char kBatchingMemoryUsageArgument[] = "--batching-memory-usage";
 #endif
 
-const char kDumpResourcesArgument[]               = "--dump-resources";
-const char kDumpResourcesBeforeDrawOption[]       = "--dump-resources-before-draw";
-const char kDumpResourcesImageFormat[]            = "--dump-resources-image-format";
-const char kDumpResourcesScaleArgument[]          = "--dump-resources-scale";
-const char kDumpResourcesDepth[]                  = "--dump-resources-dump-depth-attachment";
-const char kDumpResourcesDirArgument[]            = "--dump-resources-dir";
-const char kDumpResourcesModifiableStateOnly[]    = "--dump-resources-modifiable-state-only";
-const char kDumpResourcesColorAttIdxArg[]         = "--dump-resources-dump-color-attachment-index";
-const char kDumpResourcesDumpVertexIndexBuffers[] = "--dump-resources-dump-vertex-index-buffers";
-const char kDumpResourcesJsonPerCommand[]         = "--dump-resources-json-output-per-command";
-const char kDumpResourcesDumpImmutableResources[] = "--dump-resources-dump-immutable-resources";
-const char kDumpResourcesDumpImageSubresources[]  = "--dump-resources-dump-all-image-subresources";
-const char kDumpResourcesDumpRawImages[]          = "--dump-resources-dump-raw-images";
-const char kDumpResourcesDumpSeparateAlpha[]      = "--dump-resources-dump-separate-alpha";
+const char kDumpResourcesArgument[]                 = "--dump-resources";
+const char kDumpResourcesBeforeDrawOption[]         = "--dump-resources-before-draw";
+const char kDumpResourcesImageFormat[]              = "--dump-resources-image-format";
+const char kDumpResourcesScaleArgument[]            = "--dump-resources-scale";
+const char kDumpResourcesDepth[]                    = "--dump-resources-dump-depth-attachment";
+const char kDumpResourcesDirArgument[]              = "--dump-resources-dir";
+const char kDumpResourcesModifiableStateOnly[]      = "--dump-resources-modifiable-state-only";
+const char kDumpResourcesColorAttIdxArg[]           = "--dump-resources-dump-color-attachment-index";
+const char kDumpResourcesDumpVertexIndexBuffers[]   = "--dump-resources-dump-vertex-index-buffers";
+const char kDumpResourcesJsonPerCommand[]           = "--dump-resources-json-output-per-command";
+const char kDumpResourcesDumpImmutableResources[]   = "--dump-resources-dump-immutable-resources";
+const char kDumpResourcesDumpImageSubresources[]    = "--dump-resources-dump-all-image-subresources";
+const char kDumpResourcesDumpRawImages[]            = "--dump-resources-dump-raw-images";
+const char kDumpResourcesDumpSeparateAlpha[]        = "--dump-resources-dump-separate-alpha";
+const char kDumpResourcesDumpUnusedVertexBindings[] = "--dump-resources-dump-unused-vertex-bindigs";
 
 enum class WsiPlatform
 {
@@ -1222,6 +1223,8 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
         arg_parser.IsOptionSet(kDumpResourcesDumpImageSubresources);
     replay_options.dump_resources_dump_raw_images     = arg_parser.IsOptionSet(kDumpResourcesDumpRawImages);
     replay_options.dump_resources_dump_separate_alpha = arg_parser.IsOptionSet(kDumpResourcesDumpSeparateAlpha);
+    replay_options.dump_resources_dump_unused_vertex_bindings =
+        arg_parser.IsOptionSet(kDumpResourcesDumpUnusedVertexBindings);
 
     std::string dr_color_att_idx = arg_parser.GetArgumentValue(kDumpResourcesColorAttIdxArg);
     if (!dr_color_att_idx.empty())


### PR DESCRIPTION
The new replay option --dump-resources-dump-unused-vertex-bindings can be used to dump vertex bindings which are not referenced by a vertex attribute