### PR TITLE
Fix image-issues when using trimming

### DIFF
--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -570,6 +570,21 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
                 ->DestroyPrivateDataSlot(parent_info->handle, object_info->handle, nullptr);
         });
 
+    FreeChildObjects<VulkanDeviceInfo, VulkanMicromapEXTInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkMicromapEXT),
+        remove_entries,
+        report_leaks,
+        &CommonObjectInfoTable::GetVkDeviceInfo,
+        &CommonObjectInfoTable::VisitVkMicromapEXTInfo,
+        &CommonObjectInfoTable::RemoveVkMicromapEXTInfo,
+        [&](const VulkanDeviceInfo* parent_info, const VulkanMicromapEXTInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyMicromapEXT(parent_info->handle, object_info->handle, nullptr);
+        });
+
     FreeChildObjects<VulkanInstanceInfo, VulkanDebugReportCallbackEXTInfo>(
         table,
         GFXRECON_STR(VkInstance),

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5572,6 +5572,12 @@ VulkanReplayConsumerBase::OverrideCreateImage(PFN_vkCreateImage                 
 
         // In the case of dump resources we also want the TRANSFER_SRC_BIT in order to be able to dump all images
         modified_create_info.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+
+        if (loading_trim_state_)
+        {
+            // ensure image-initialization can copy
+            modified_create_info.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        }
     }
 
     // The original image might be external and it might be an unknown format, so perform any


### PR DESCRIPTION
Fixes production issues with missing/corrupted images when using trimming.

the visible issues went along with validation-errors:
`VUID-VkImageMemoryBarrier-oldLayout-01213: vkCmdPipelineBarrier(): pImageMemoryBarriers[0].newLayout (VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) is not compatible with VkImage 0x3180000000318 usage flags VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_SAMPLED_BIT|VK_IMAGE_USAGE_STORAGE_BIT`

and successive

`VUID-vkCmdCopyBufferToImage-dstImage-00177: vkCmdCopyBufferToImage(): dstImage (VkImage 0x31d000000031d) was created with VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_SAMPLED_BIT|VK_IMAGE_USAGE_STORAGE_BIT but requires VK_IMAGE_USAGE_TRANSFER_DST_BIT`

which suggests a straight-forward fix :)

also adds missing state-cleanup for `VkMicromapEXT`

closes #2214