### PR TITLE
Report frame number in debug callback during replay

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -199,6 +199,7 @@ class ApiDecoder
 
     virtual void SetCurrentBlockIndex(uint64_t block_index){};
 
+    // Expects zero-based frame_number to match the way FileProcessor::current_frame_number_ works
     virtual void SetCurrentFrameNumber(uint64_t frame_number){};
 
     virtual void SetCurrentApiCallId(format::ApiCallId api_call_id){};

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -199,7 +199,7 @@ class ApiDecoder
 
     virtual void SetCurrentBlockIndex(uint64_t block_index){};
 
-    virtual void SetCurrentFrameNumber(uint64_t frame_number) {};
+    virtual void SetCurrentFrameNumber(uint64_t frame_number){};
 
     virtual void SetCurrentApiCallId(format::ApiCallId api_call_id){};
 

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -199,6 +199,8 @@ class ApiDecoder
 
     virtual void SetCurrentBlockIndex(uint64_t block_index){};
 
+    virtual void SetCurrentFrameNumber(uint64_t frame_number) {};
+
     virtual void SetCurrentApiCallId(format::ApiCallId api_call_id){};
 
     virtual void DispatchSetTlasToBlasDependencyCommand(format::HandleId                     tlas,

--- a/framework/decode/common_consumer_base.h
+++ b/framework/decode/common_consumer_base.h
@@ -52,9 +52,14 @@ class CommonConsumerBase : public MetadataConsumerBase, public MarkerConsumerBas
 
     virtual void SetCurrentBlockIndex(uint64_t block_index) override { block_index_ = block_index; }
 
+    virtual void SetCurrentFrameNumber(uint64_t frame_number) { frame_number_ = frame_number; }
+
     virtual void ProcessSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
                                                        const char*                             env_string)
     {}
+
+  protected:
+    uint64_t frame_number_{ 0 };
 };
 
 /* Utility */

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -141,6 +141,10 @@ bool FileProcessor::ProcessNextFrame()
 
     if (success)
     {
+        for (ApiDecoder* decoder : decoders_)
+        {
+            decoder->SetCurrentFrameNumber(current_frame_number_);
+        }
         success = ProcessBlocks();
     }
     else

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -569,6 +569,14 @@ void VulkanDecoderBase::SetCurrentBlockIndex(uint64_t block_index)
     }
 }
 
+void VulkanDecoderBase::SetCurrentFrameNumber(uint64_t frame_number)
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->SetCurrentFrameNumber(frame_number);
+    }
+}
+
 void VulkanDecoderBase::DispatchVulkanAccelerationStructuresBuildMetaCommand(const uint8_t* parameter_buffer,
                                                                              size_t         buffer_size)
 {

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -201,6 +201,8 @@ class VulkanDecoderBase : public ApiDecoder
 
     virtual void SetCurrentBlockIndex(uint64_t block_index) override;
 
+    virtual void SetCurrentFrameNumber(uint64_t frame_number) override;
+
     void DispatchVulkanAccelerationStructuresBuildMetaCommand(const uint8_t* parameter_buffer,
                                                               size_t         buffer_size) override;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -120,7 +120,7 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeve
                                                          void*                                       pUserData)
 {
     VulkanReplayConsumerBase* replay_consumer = static_cast<VulkanReplayConsumerBase*>(pUserData);
-    uint64_t frame_number = replay_consumer->GetFrameNumber();
+    uint64_t                  frame_number    = replay_consumer->GetFrameNumber();
 
     // Allow pCallbackData->pMessageIdName to be nullptr by defining a default string for message id name
     const char* message_id_name = "(nullptr)";

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -120,7 +120,7 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeve
                                                          void*                                       pUserData)
 {
     VulkanReplayConsumerBase* replay_consumer = static_cast<VulkanReplayConsumerBase*>(pUserData);
-    uint64_t frame_number = replay_consumer->GetFrameNumber() + 1; // Add 1 because of one-based indexing of frames
+    uint64_t frame_number = replay_consumer->GetFrameNumber();
 
     // Allow pCallbackData->pMessageIdName to be nullptr by defining a default string for message id name
     const char* message_id_name = "(nullptr)";
@@ -1918,9 +1918,9 @@ void VulkanReplayConsumerBase::InitializeReplayDumpResources()
     }
 }
 
-uint64_t VulkanReplayConsumerBase::GetFrameNumber()
+const uint64_t VulkanReplayConsumerBase::GetFrameNumber()
 {
-    return this->frame_number_;
+    return this->frame_number_ + 1; // Add 1 because of one-based indexing of frames
 }
 
 void VulkanReplayConsumerBase::GetMatchingDeviceGroup(VulkanInstanceInfo*                  instance_info,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -310,7 +310,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void InitializeReplayDumpResources();
 
-    uint64_t GetFrameNumber();
+    const uint64_t GetFrameNumber();
 
   protected:
     const CommonObjectInfoTable& GetObjectInfoTable() const { return *object_info_table_; }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -81,6 +81,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void SetCurrentBlockIndex(uint64_t block_index) override;
 
+    void SetCurrentFrameNumber(uint64_t frame_number) override;
+
     void Process_ExeFileInfo(util::filepath::FileInfo& info_record) override
     {
         gfxrecon::util::filepath::CheckReplayerName(info_record.AppName);
@@ -307,6 +309,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void GetMatchingDevice(VulkanPhysicalDeviceInfo* physical_device_info);
 
     void InitializeReplayDumpResources();
+
+    uint64_t GetFrameNumber();
 
   protected:
     const CommonObjectInfoTable& GetObjectInfoTable() const { return *object_info_table_; }


### PR DESCRIPTION
Fixes #1859 

This PR adds logic to propagate the frame number down from the FileProcessor to the consumers, so that the frame number can appear in messages emitted by the debug callback.