### PR TITLE
VDR: Merge comp and RT outputs into descriptors

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -491,6 +491,9 @@ struct VulkanPipelineInfo : public VulkanObjectInfoAsync<VkPipeline>
         uint32_t offset;
     };
 
+    // Aggregated shader stages flags
+    VkShaderStageFlags shader_stages{ 0 };
+
     // One entry per binding
     using VertexInputBindingMap = std::unordered_map<uint32_t, InputBindingDescription>;
     VertexInputBindingMap vertex_input_binding_map;

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -386,6 +386,8 @@ struct VulkanBufferInfo : public VulkanObjectInfo<VkBuffer>
 struct VulkanBufferViewInfo : public VulkanObjectInfo<VkBufferView>
 {
     format::HandleId buffer_id{ format::kNullHandleId };
+    VkDeviceSize     offset{ 0 };
+    VkDeviceSize     range{ 0 };
 };
 
 struct VulkanImageInfo : public VulkanObjectInfo<VkImage>

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -8837,7 +8837,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
     {
         if (options_.dumping_resources)
         {
-            resource_dumper_->DumpComputeRayTracingPipelineInfos(pCreateInfos, createInfoCount, pPipelines);
+            resource_dumper_->DumpRayTracingPipelineInfos(pCreateInfos, createInfoCount, pPipelines);
         }
     }
 
@@ -9021,7 +9021,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesNV(
     {
         if (options_.dumping_resources)
         {
-            resource_dumper_->DumpComputeRayTracingPipelineInfos(pCreateInfos, createInfoCount, pPipelines);
+            resource_dumper_->DumpRayTracingPipelineInfos(pCreateInfos, createInfoCount, pPipelines);
         }
     }
 
@@ -10800,7 +10800,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateComputePipelines(
     {
         if (options_.dumping_resources)
         {
-            resource_dumper_->DumpComputeRayTracingPipelineInfos(pCreateInfos, create_info_count, pPipelines);
+            resource_dumper_->DumpComputePipelineInfos(pCreateInfos, create_info_count, pPipelines);
         }
     }
 
@@ -11147,7 +11147,7 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
     // Information is stored in the created PipelineInfos only when the dumping resources feature is in use
     if (returnValue == VK_SUCCESS && options_.dumping_resources)
     {
-        resource_dumper_->DumpComputeRayTracingPipelineInfos(pCreateInfos, createInfoCount, pPipelines);
+        resource_dumper_->DumpComputePipelineInfos(pCreateInfos, createInfoCount, pPipelines);
     }
 
     // populate VulkanPipelineInfo structs with information related to shader-modules

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5543,6 +5543,31 @@ VulkanReplayConsumerBase::OverrideCreateBuffer(PFN_vkCreateBuffer               
     return result;
 }
 
+VkResult VulkanReplayConsumerBase::OverrideCreateBufferView(
+    PFN_vkCreateBufferView                                      func,
+    VkResult                                                    original_result,
+    const VulkanDeviceInfo*                                     device_info,
+    const StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
+    const StructPointerDecoder<Decoded_VkAllocationCallbacks>*  pAllocator,
+    HandlePointerDecoder<VkBufferView>*                         pBufferView)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(original_result);
+
+    auto     in_p_create_info = pCreateInfo->GetPointer();
+    auto     buffer_view      = pBufferView->GetHandlePointer();
+    VkResult result = func(device_info->handle, in_p_create_info, GetAllocationCallbacks(pAllocator), buffer_view);
+    if (result == VK_SUCCESS)
+    {
+        auto in_p_create_meta       = pCreateInfo->GetMetaStructPointer();
+        auto buffer_view_info       = reinterpret_cast<VulkanBufferViewInfo*>(pBufferView->GetConsumerData(0));
+        buffer_view_info->buffer_id = in_p_create_meta->buffer;
+        buffer_view_info->offset    = in_p_create_info->offset;
+        buffer_view_info->range     = in_p_create_info->range;
+    }
+
+    return result;
+}
+
 void VulkanReplayConsumerBase::OverrideDestroyBuffer(
     PFN_vkDestroyBuffer                                        func,
     const VulkanDeviceInfo*                                    device_info,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -867,6 +867,13 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                   const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                   HandlePointerDecoder<VkBuffer>*                            pBuffer);
 
+    VkResult OverrideCreateBufferView(PFN_vkCreateBufferView                                      func,
+                                      VkResult                                                    original_result,
+                                      const VulkanDeviceInfo*                                     device_info,
+                                      const StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
+                                      const StructPointerDecoder<Decoded_VkAllocationCallbacks>*  pAllocator,
+                                      HandlePointerDecoder<VkBufferView>*                         pBufferView);
+
     void OverrideDestroyBuffer(PFN_vkDestroyBuffer                                        func,
                                const VulkanDeviceInfo*                                    device_info,
                                VulkanBufferInfo*                                          buffer_info,

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -2182,6 +2182,12 @@ void VulkanReplayDumpResourcesBase::DumpGraphicsPipelineInfos(
                 pipeline_info->desc_set_layouts = ppl_layout_info->desc_set_layouts;
             }
         }
+
+        // Aggregate used shader stages flags
+        for (uint32_t ss = 0; ss < in_p_create_infos[i].stageCount; ++ss)
+        {
+            pipeline_info->shader_stages |= static_cast<VkShaderStageFlags>(in_p_create_infos[i].pStages[ss].stage);
+        }
     }
 }
 

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -1089,42 +1089,42 @@ void ShaderStageFlagsToStageNames(VkShaderStageFlags flags, std::vector<std::str
         stage_names.push_back("compute");
     }
 
-    if ((flags & VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR) == VK_SHADER_STAGE_RAYGEN_BIT_KHR)
+    if ((flags & VK_SHADER_STAGE_RAYGEN_BIT_KHR) == VK_SHADER_STAGE_RAYGEN_BIT_KHR)
     {
         stage_names.push_back("raygen");
     }
 
-    if ((flags & VK_SHADER_STAGE_MISS_BIT_KHR) == VK_SHADER_STAGE_ANY_HIT_BIT_KHR)
+    if ((flags & VK_SHADER_STAGE_ANY_HIT_BIT_KHR) == VK_SHADER_STAGE_ANY_HIT_BIT_KHR)
     {
         stage_names.push_back("any_hit");
     }
 
-    if ((flags & VK_SHADER_STAGE_INTERSECTION_BIT_KHR) == VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR)
+    if ((flags & VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR) == VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR)
     {
         stage_names.push_back("closest_hit");
     }
 
-    if ((flags & VK_SHADER_STAGE_CALLABLE_BIT_KHR) == VK_SHADER_STAGE_MISS_BIT_KHR)
+    if ((flags & VK_SHADER_STAGE_MISS_BIT_KHR) == VK_SHADER_STAGE_MISS_BIT_KHR)
     {
         stage_names.push_back("miss");
     }
 
-    if ((flags & VK_SHADER_STAGE_TASK_BIT_EXT) == VK_SHADER_STAGE_INTERSECTION_BIT_KHR)
+    if ((flags & VK_SHADER_STAGE_INTERSECTION_BIT_KHR) == VK_SHADER_STAGE_INTERSECTION_BIT_KHR)
     {
         stage_names.push_back("intersection");
     }
 
-    if ((flags & VK_SHADER_STAGE_MESH_BIT_EXT) == VK_SHADER_STAGE_CALLABLE_BIT_KHR)
+    if ((flags & VK_SHADER_STAGE_CALLABLE_BIT_KHR) == VK_SHADER_STAGE_CALLABLE_BIT_KHR)
     {
         stage_names.push_back("callable");
     }
 
-    if ((flags & VK_SHADER_STAGE_ALL_GRAPHICS) == VK_SHADER_STAGE_TASK_BIT_EXT)
+    if ((flags & VK_SHADER_STAGE_TASK_BIT_EXT) == VK_SHADER_STAGE_TASK_BIT_EXT)
     {
         stage_names.push_back("task");
     }
 
-    if ((flags & VK_SHADER_STAGE_ALL) == VK_SHADER_STAGE_MESH_BIT_EXT)
+    if ((flags & VK_SHADER_STAGE_MESH_BIT_EXT) == VK_SHADER_STAGE_MESH_BIT_EXT)
     {
         stage_names.push_back("mesh");
     }

--- a/framework/decode/vulkan_replay_dump_resources_common.h
+++ b/framework/decode/vulkan_replay_dump_resources_common.h
@@ -61,7 +61,7 @@ struct MinMaxVertexIndex
     uint32_t max = 0;
 };
 
-using BoundDescriptorSets = std::unordered_map<uint32_t, VulkanDescriptorSetInfo>;
+using BoundDescriptorSets = std::unordered_map<uint32_t, VulkanDescriptorSetInfo::VulkanDescriptorBindingsInfo>;
 
 DumpedImageFormat GetDumpedImageFormat(const VulkanDeviceInfo*              device_info,
                                        const graphics::VulkanDeviceTable*   device_table,

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -478,7 +478,8 @@ static void SnapshotBoundDescriptorsDispatch(DispatchTraceRaysDumpingContext::Di
                 // Check against pipeline layout
                 const auto layout_entry =
                     bound_pipeline_compute->desc_set_layouts[desc_set_index].find(desc_binding_index);
-                if (layout_entry == bound_pipeline_compute->desc_set_layouts[desc_set_index].end())
+                if (layout_entry == bound_pipeline_compute->desc_set_layouts[desc_set_index].end() ||
+                    !(bound_pipeline_compute->shader_stages & binding_info.stage_flags))
                 {
                     continue;
                 }
@@ -486,7 +487,7 @@ static void SnapshotBoundDescriptorsDispatch(DispatchTraceRaysDumpingContext::Di
                 disp_params.referenced_descriptors[desc_set_index][desc_binding_index].desc_type =
                     binding_info.desc_type;
                 disp_params.referenced_descriptors[desc_set_index][desc_binding_index].stage_flags =
-                    binding_info.stage_flags;
+                    (bound_pipeline_compute->shader_stages & binding_info.stage_flags);
 
                 switch (binding_info.desc_type)
                 {
@@ -572,14 +573,15 @@ static void SnapshotBoundDescriptorsTraceRays(DispatchTraceRaysDumpingContext::T
                 // Check against pipeline layout
                 const auto layout_entry =
                     bound_pipeline_trace_rays->desc_set_layouts[desc_set_index].find(desc_binding_index);
-                if (layout_entry == bound_pipeline_trace_rays->desc_set_layouts[desc_set_index].end())
+                if (layout_entry == bound_pipeline_trace_rays->desc_set_layouts[desc_set_index].end() ||
+                    !(bound_pipeline_trace_rays->shader_stages & binding_info.stage_flags))
                 {
                     continue;
                 }
 
                 tr_params.referenced_descriptors[desc_set_index][desc_binding_index].desc_type = binding_info.desc_type;
                 tr_params.referenced_descriptors[desc_set_index][desc_binding_index].stage_flags =
-                    binding_info.stage_flags;
+                    (bound_pipeline_trace_rays->shader_stages & binding_info.stage_flags);
 
                 switch (binding_info.desc_type)
                 {

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -1334,7 +1334,6 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
                 {
                     case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
                     case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
                     case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
                     {
                         for (const auto& img_desc : desc_binding_info.image_info)
@@ -1355,11 +1354,8 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
                     break;
 
                     case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
                     case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
                     case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
                     {
                         for (const auto& buf_desc : desc_binding_info.buffer_info)
                         {
@@ -1377,6 +1373,10 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
                     }
                     break;
 
+                    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+                    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
                     case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
                     case VK_DESCRIPTOR_TYPE_SAMPLER:
                         break;
@@ -1418,7 +1418,6 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
                 {
                     case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
                     case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
                     case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
                     {
                         for (const auto& img_desc : desc_binding_info.image_info)
@@ -1439,11 +1438,8 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
                     break;
 
                     case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
                     case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
                     case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
                     {
                         for (const auto& buf_desc : desc_binding_info.buffer_info)
                         {
@@ -1461,6 +1457,10 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
                     }
                     break;
 
+                    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+                    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
                     case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
                     case VK_DESCRIPTOR_TYPE_SAMPLER:
                         break;

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -1382,208 +1382,103 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
     std::unordered_map<const std::vector<uint8_t>*, inline_uniform_block_info> inline_uniform_blocks;
 
     DumpedDescriptors& dumped_descriptors = is_dispatch ? dispatch_dumped_descriptors_ : trace_rays_dumped_descriptors_;
+    GFXRECON_ASSERT((dispatch_params_.find(cmd_index) != dispatch_params_.end()) ||
+                    (trace_rays_params_.find(cmd_index) != trace_rays_params_.end()));
+    const BoundDescriptorSets& referenced_descriptors = is_dispatch
+                                                            ? (dispatch_params_[cmd_index]->referenced_descriptors)
+                                                            : (trace_rays_params_[cmd_index]->referenced_descriptors);
 
-    if (is_dispatch)
+    for (const auto& [desc_set_index, desc_set_info] : referenced_descriptors)
     {
-        const auto disp_params_entry = dispatch_params_.find(cmd_index);
-        GFXRECON_ASSERT(disp_params_entry != dispatch_params_.end());
-
-        const DispatchParams* disp_params = disp_params_entry->second.get();
-        for (const auto& [desc_set_index, desc_set_info] : disp_params->referenced_descriptors)
+        for (const auto& [desc_binding_index, desc_binding_info] : desc_set_info)
         {
-            for (const auto& [desc_binding_index, desc_binding_info] : desc_set_info)
+            switch (desc_binding_info.desc_type)
             {
-                switch (desc_binding_info.desc_type)
+                case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+                case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+                case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
                 {
-                    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-                    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-                    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+                    for (const auto& img_desc : desc_binding_info.image_info)
                     {
-                        for (const auto& img_desc : desc_binding_info.image_info)
+                        if (img_desc.second.image_view_info != nullptr)
                         {
-                            if (img_desc.second.image_view_info != nullptr)
+                            const VulkanImageInfo* img_info =
+                                object_info_table_.GetVkImageInfo(img_desc.second.image_view_info->image_id);
+                            if (img_info != nullptr && dumped_descriptors.image_descriptors.find(img_info) ==
+                                                           dumped_descriptors.image_descriptors.end())
                             {
-                                const VulkanImageInfo* img_info =
-                                    object_info_table_.GetVkImageInfo(img_desc.second.image_view_info->image_id);
-                                if (img_info != nullptr && dumped_descriptors.image_descriptors.find(img_info) ==
-                                                               dumped_descriptors.image_descriptors.end())
-                                {
-                                    image_descriptors.insert(img_info);
-                                    dumped_descriptors.image_descriptors.insert(img_info);
-                                }
+                                image_descriptors.insert(img_info);
+                                dumped_descriptors.image_descriptors.insert(img_info);
                             }
                         }
                     }
-                    break;
-
-                    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-                    {
-                        for (const auto& buf_desc : desc_binding_info.texel_buffer_view_info)
-                        {
-                            const VulkanBufferInfo* buffer_info =
-                                object_info_table_.GetVkBufferInfo(buf_desc.second->buffer_id);
-                            if (buffer_info != nullptr && dumped_descriptors.buffer_descriptors.find(buffer_info) ==
-                                                              dumped_descriptors.buffer_descriptors.end())
-                            {
-                                buffer_descriptors.emplace(std::piecewise_construct,
-                                                           std::forward_as_tuple(buffer_info),
-                                                           std::forward_as_tuple(buffer_descriptor_info{
-                                                               buf_desc.second->offset, buf_desc.second->range }));
-                                dumped_descriptors.buffer_descriptors.insert(buffer_info);
-                            }
-                        }
-                    }
-                    break;
-
-                    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-                    {
-                        for (const auto& buf_desc : desc_binding_info.buffer_info)
-                        {
-                            const VulkanBufferInfo* buffer_info = buf_desc.second.buffer_info;
-                            if (buffer_info != nullptr && dumped_descriptors.buffer_descriptors.find(buffer_info) ==
-                                                              dumped_descriptors.buffer_descriptors.end())
-                            {
-                                buffer_descriptors.emplace(std::piecewise_construct,
-                                                           std::forward_as_tuple(buffer_info),
-                                                           std::forward_as_tuple(buffer_descriptor_info{
-                                                               buf_desc.second.offset, buf_desc.second.range }));
-                                dumped_descriptors.buffer_descriptors.insert(buffer_info);
-                            }
-                        }
-                    }
-                    break;
-
-                    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-                    case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-                    case VK_DESCRIPTOR_TYPE_SAMPLER:
-                        break;
-
-                    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
-                    {
-                        if (dumped_descriptors.inline_uniform_blocks.find(&(desc_binding_info.inline_uniform_block)) ==
-                            dumped_descriptors.inline_uniform_blocks.end())
-                        {
-                            inline_uniform_blocks[&(desc_binding_info.inline_uniform_block)] = {
-                                desc_set_index, desc_binding_index, &(desc_binding_info.inline_uniform_block)
-                            };
-                            dumped_descriptors.inline_uniform_blocks.insert(&(desc_binding_info.inline_uniform_block));
-                        }
-                    }
-                    break;
-
-                    default:
-                        GFXRECON_LOG_WARNING_ONCE(
-                            "%s(): Descriptor type (%s) not handled",
-                            __func__,
-                            util::ToString<VkDescriptorType>(desc_binding_info.desc_type).c_str());
-                        break;
                 }
-            }
-        }
-    }
-    else
-    {
-        const auto tr_params_entry = trace_rays_params_.find(cmd_index);
-        GFXRECON_ASSERT(tr_params_entry != trace_rays_params_.end());
+                break;
 
-        const TraceRaysParams* tr_params = tr_params_entry->second.get();
-        for (const auto& [desc_set_index, desc_set_info] : tr_params->referenced_descriptors)
-        {
-            for (const auto& [desc_binding_index, desc_binding_info] : desc_set_info)
-            {
-                switch (desc_binding_info.desc_type)
+                case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
                 {
-                    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-                    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-                    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+                    for (const auto& buf_desc : desc_binding_info.texel_buffer_view_info)
                     {
-                        for (const auto& img_desc : desc_binding_info.image_info)
+                        const VulkanBufferInfo* buffer_info =
+                            object_info_table_.GetVkBufferInfo(buf_desc.second->buffer_id);
+                        if (buffer_info != nullptr && dumped_descriptors.buffer_descriptors.find(buffer_info) ==
+                                                          dumped_descriptors.buffer_descriptors.end())
                         {
-                            if (img_desc.second.image_view_info != nullptr)
-                            {
-                                const VulkanImageInfo* img_info =
-                                    object_info_table_.GetVkImageInfo(img_desc.second.image_view_info->image_id);
-                                if (img_info != nullptr && dumped_descriptors.image_descriptors.find(img_info) ==
-                                                               dumped_descriptors.image_descriptors.end())
-                                {
-                                    image_descriptors.insert(img_info);
-                                    dumped_descriptors.image_descriptors.insert(img_info);
-                                }
-                            }
+                            buffer_descriptors.emplace(std::piecewise_construct,
+                                                       std::forward_as_tuple(buffer_info),
+                                                       std::forward_as_tuple(buffer_descriptor_info{
+                                                           buf_desc.second->offset, buf_desc.second->range }));
+                            dumped_descriptors.buffer_descriptors.insert(buffer_info);
                         }
                     }
-                    break;
-
-                    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-                    {
-                        for (const auto& buf_desc : desc_binding_info.texel_buffer_view_info)
-                        {
-                            const VulkanBufferInfo* buffer_info =
-                                object_info_table_.GetVkBufferInfo(buf_desc.second->buffer_id);
-                            if (buffer_info != nullptr && dumped_descriptors.buffer_descriptors.find(buffer_info) ==
-                                                              dumped_descriptors.buffer_descriptors.end())
-                            {
-                                buffer_descriptors.emplace(std::piecewise_construct,
-                                                           std::forward_as_tuple(buffer_info),
-                                                           std::forward_as_tuple(buffer_descriptor_info{
-                                                               buf_desc.second->offset, buf_desc.second->range }));
-                                dumped_descriptors.buffer_descriptors.insert(buffer_info);
-                            }
-                        }
-                    }
-                    break;
-
-                    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-                    {
-                        for (const auto& buf_desc : desc_binding_info.buffer_info)
-                        {
-                            const VulkanBufferInfo* buffer_info = buf_desc.second.buffer_info;
-                            if (buffer_info != nullptr && dumped_descriptors.buffer_descriptors.find(buffer_info) ==
-                                                              dumped_descriptors.buffer_descriptors.end())
-                            {
-                                buffer_descriptors.emplace(std::piecewise_construct,
-                                                           std::forward_as_tuple(buf_desc.second.buffer_info),
-                                                           std::forward_as_tuple(buffer_descriptor_info{
-                                                               buf_desc.second.offset, buf_desc.second.range }));
-                                dumped_descriptors.buffer_descriptors.insert(buffer_info);
-                            }
-                        }
-                    }
-                    break;
-
-                    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-                    case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-                    case VK_DESCRIPTOR_TYPE_SAMPLER:
-                        break;
-
-                    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
-                    {
-                        if (dumped_descriptors.inline_uniform_blocks.find(&(desc_binding_info.inline_uniform_block)) ==
-                            dumped_descriptors.inline_uniform_blocks.end())
-                        {
-                            inline_uniform_blocks[&(desc_binding_info.inline_uniform_block)] = {
-                                desc_set_index, desc_binding_index, &(desc_binding_info.inline_uniform_block)
-                            };
-                            dumped_descriptors.inline_uniform_blocks.insert(&(desc_binding_info.inline_uniform_block));
-                        }
-                    }
-                    break;
-
-                    default:
-                        GFXRECON_LOG_WARNING_ONCE(
-                            "%s(): Descriptor type (%s) not handled",
-                            __func__,
-                            util::ToString<VkDescriptorType>(desc_binding_info.desc_type).c_str());
-                        break;
                 }
+                break;
+
+                case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+                case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+                {
+                    for (const auto& buf_desc : desc_binding_info.buffer_info)
+                    {
+                        const VulkanBufferInfo* buffer_info = buf_desc.second.buffer_info;
+                        if (buffer_info != nullptr && dumped_descriptors.buffer_descriptors.find(buffer_info) ==
+                                                          dumped_descriptors.buffer_descriptors.end())
+                        {
+                            buffer_descriptors.emplace(std::piecewise_construct,
+                                                       std::forward_as_tuple(buffer_info),
+                                                       std::forward_as_tuple(buffer_descriptor_info{
+                                                           buf_desc.second.offset, buf_desc.second.range }));
+                            dumped_descriptors.buffer_descriptors.insert(buffer_info);
+                        }
+                    }
+                }
+                break;
+
+                case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+                case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+                case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+                case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+                case VK_DESCRIPTOR_TYPE_SAMPLER:
+                    break;
+
+                case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
+                {
+                    if (dumped_descriptors.inline_uniform_blocks.find(&(desc_binding_info.inline_uniform_block)) ==
+                        dumped_descriptors.inline_uniform_blocks.end())
+                    {
+                        inline_uniform_blocks[&(desc_binding_info.inline_uniform_block)] = {
+                            desc_set_index, desc_binding_index, &(desc_binding_info.inline_uniform_block)
+                        };
+                        dumped_descriptors.inline_uniform_blocks.insert(&(desc_binding_info.inline_uniform_block));
+                    }
+                }
+                break;
+
+                default:
+                    GFXRECON_LOG_WARNING_ONCE("%s(): Descriptor type (%s) not handled",
+                                              __func__,
+                                              util::ToString<VkDescriptorType>(desc_binding_info.desc_type).c_str());
+                    break;
             }
         }
     }

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
@@ -176,6 +176,7 @@ class DispatchTraceRaysDumpingContext
             const VulkanBufferInfo* original_buffer{ nullptr };
             VkBuffer                buffer{ VK_NULL_HANDLE };
             VkDeviceMemory          buffer_memory{ VK_NULL_HANDLE };
+            VkDeviceSize            cloned_size{ 0 };
             VkShaderStageFlags      stages;
             VkDescriptorType        desc_type;
             uint32_t                desc_set;
@@ -315,7 +316,7 @@ class DispatchTraceRaysDumpingContext
 
         DispatchTypes type;
 
-        std::unordered_map<uint32_t, VulkanDescriptorSetInfo::VulkanDescriptorBindingsInfo> referenced_descriptors;
+        BoundDescriptorSets referenced_descriptors;
 
         MutableResourcesBackupContext mutable_resources_clones;
         MutableResourcesBackupContext mutable_resources_clones_before;
@@ -426,9 +427,7 @@ class DispatchTraceRaysDumpingContext
 
         TraceRaysTypes type;
 
-        using ReferencedDescriptors =
-            std::unordered_map<uint32_t, VulkanDescriptorSetInfo::VulkanDescriptorBindingsInfo>;
-        ReferencedDescriptors referenced_descriptors;
+        BoundDescriptorSets referenced_descriptors;
 
         // Keep copies of all mutable resources that are changed by the dumped commands/shaders
         MutableResourcesBackupContext mutable_resources_clones;
@@ -440,9 +439,8 @@ class DispatchTraceRaysDumpingContext
     };
 
   private:
-    VkResult CloneMutableResources(const TraceRaysParams::ReferencedDescriptors& referenced_descriptors,
-                                   MutableResourcesBackupContext&                backup_context,
-                                   bool                                          is_dispatch);
+    VkResult CloneMutableResources(const BoundDescriptorSets&     referenced_descriptors,
+                                   MutableResourcesBackupContext& backup_context);
 
     void SnapshotDispatchState(DispatchParams& disp_params);
 

--- a/framework/decode/vulkan_replay_dump_resources_delegate.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.cpp
@@ -187,13 +187,11 @@ VkResult DefaultVulkanDumpResourcesDelegate::DumpRenderTargetImage(const VulkanD
     }
 
     // Keep track of images for which scaling failed
-    for (size_t i = 0; i < filenames.size(); ++i)
+    if (!scaling_supported)
     {
-        if (!scaling_supported)
-        {
-            images_failed_scaling_.insert(filenames[i]);
-        }
+        images_failed_scaling_.insert(image_info);
     }
+
     return res;
 }
 
@@ -335,13 +333,11 @@ VkResult DefaultVulkanDumpResourcesDelegate::DumpImageDescriptor(const VulkanDum
     }
 
     // Keep track of images for which scaling failed
-    for (size_t i = 0; i < filenames.size(); ++i)
+    if (!scaling_supported)
     {
-        if (!scaling_supported)
-        {
-            images_failed_scaling_.insert(filenames[i]);
-        }
+        images_failed_scaling_.insert(image_info);
     }
+
     return res;
 }
 
@@ -665,6 +661,11 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
             rt_entry["format"]    = util::ToString<VkFormat>(image_info->format);
             rt_entry["imageType"] = util::ToString<VkImageType>(image_info->type);
 
+            if (ImageFailedScaling(image_info))
+            {
+                rt_entry["scaleFailed"] = true;
+            }
+
             size_t subresource_entry = 0;
             for (auto aspect : aspects)
             {
@@ -703,7 +704,6 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                                                               extent,
                                                               filenameAfter,
                                                               aspect,
-                                                              ImageFailedScaling(filenameAfter),
                                                               mip,
                                                               layer,
                                                               options_.dump_resources_dump_separate_alpha,
@@ -744,6 +744,11 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
         rt_entry["format"]    = util::ToString<VkFormat>(image_info->format);
         rt_entry["imageType"] = util::ToString<VkImageType>(image_info->type);
 
+        if (ImageFailedScaling(image_info))
+        {
+            rt_entry["scaleFailed"] = true;
+        }
+
         size_t subresource_entry = 0;
         for (auto aspect : aspects)
         {
@@ -781,7 +786,6 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                                                           extent,
                                                           filenameAfter,
                                                           aspect,
-                                                          ImageFailedScaling(filenameAfter),
                                                           mip,
                                                           layer,
                                                           options_.dump_resources_dump_separate_alpha,
@@ -952,6 +956,11 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                                 desc_json_entry["format"]     = util::ToString<VkFormat>(image_info->format);
                                 desc_json_entry["imageType"]  = util::ToString<VkImageType>(image_info->type);
 
+                                if (ImageFailedScaling(image_info))
+                                {
+                                    desc_json_entry["scaleFailed"] = true;
+                                }
+
                                 std::vector<VkImageAspectFlagBits> aspects;
                                 GetFormatAspects(image_info->format, aspects);
 
@@ -981,7 +990,6 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                                                 extent,
                                                 filename,
                                                 aspect,
-                                                ImageFailedScaling(filename),
                                                 mip,
                                                 layer,
                                                 options_.dump_resources_dump_separate_alpha);
@@ -1129,13 +1137,11 @@ VkResult DefaultVulkanDumpResourcesDelegate::DumpeDispatchTraceRaysImage(const V
     }
 
     // Keep track of images for which scaling failed
-    for (size_t i = 0; i < filenames.size(); ++i)
+    if (!scaling_supported)
     {
-        if (!scaling_supported)
-        {
-            images_failed_scaling_.insert(filenames[i]);
-        }
+        images_failed_scaling_.insert(image_info);
     }
+
     return res;
 }
 
@@ -1286,13 +1292,11 @@ DefaultVulkanDumpResourcesDelegate::DumpDispatchTraceRaysImageDescriptor(const V
     }
 
     // Keep track of images for which scaling failed
-    for (size_t i = 0; i < filenames.size(); ++i)
+    if (scaling_supported)
     {
-        if (scaling_supported)
-        {
-            images_failed_scaling_.insert(filenames[i]);
-        }
+        images_failed_scaling_.insert(image_info);
     }
+
     return res;
 }
 
@@ -1432,6 +1436,11 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
             entry["format"]             = util::ToString<VkFormat>(img_info->format);
             entry["imageType"]          = util::ToString<VkImageType>(img_info->type);
 
+            if (ImageFailedScaling(img_info))
+            {
+                entry["scaleFailed"] = true;
+            }
+
             std::vector<VkImageAspectFlagBits> aspects;
             GetFormatAspects(img_info->format, aspects);
 
@@ -1472,7 +1481,6 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                                                                   extent,
                                                                   filename,
                                                                   aspect,
-                                                                  ImageFailedScaling(filename),
                                                                   mip,
                                                                   layer,
                                                                   options_.dump_resources_dump_separate_alpha,
@@ -1487,7 +1495,6 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                                                                   extent,
                                                                   filename,
                                                                   aspect,
-                                                                  ImageFailedScaling(filename),
                                                                   mip,
                                                                   layer,
                                                                   options_.dump_resources_dump_separate_alpha);
@@ -1595,6 +1602,11 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                                 entry["format"]     = util::ToString<VkFormat>(img_info->format);
                                 entry["imageType"]  = util::ToString<VkImageType>(img_info->type);
 
+                                if (ImageFailedScaling(img_info))
+                                {
+                                    entry["scaleFailed"] = true;
+                                }
+
                                 std::vector<VkImageAspectFlagBits> aspects;
                                 GetFormatAspects(img_info->format, aspects);
 
@@ -1625,7 +1637,6 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                                                 extent,
                                                 filename,
                                                 aspect,
-                                                ImageFailedScaling(filename),
                                                 mip,
                                                 layer,
                                                 options_.dump_resources_dump_separate_alpha);

--- a/framework/decode/vulkan_replay_dump_resources_delegate.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.cpp
@@ -248,24 +248,13 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateRenderTargetImageFilenam
         }
     }
 
-    if (options_.dump_resources_dump_all_image_subresources)
-    {
-        std::stringstream subresource_sting;
-        subresource_sting << "_mip_" << mip_level << "_layer_" << layer;
-        subresource_sting << ImageFileExtension(output_image_format);
+    std::stringstream subresource_sting;
+    subresource_sting << "_mip_" << mip_level << "_layer_" << layer;
+    subresource_sting << ImageFileExtension(output_image_format);
 
-        std::filesystem::path filedirname(options_.dump_resources_output_dir);
-        std::filesystem::path filebasename(filename.str() + subresource_sting.str());
-        return (filedirname / filebasename).string();
-    }
-    else
-    {
-        filename << ImageFileExtension(output_image_format);
-
-        std::filesystem::path filedirname(options_.dump_resources_output_dir);
-        std::filesystem::path filebasename(filename.str());
-        return (filedirname / filebasename).string();
-    }
+    std::filesystem::path filedirname(options_.dump_resources_output_dir);
+    std::filesystem::path filebasename(filename.str() + subresource_sting.str());
+    return (filedirname / filebasename).string();
 }
 
 VkResult DefaultVulkanDumpResourcesDelegate::DumpImageDescriptor(const VulkanDumpResourceInfo& resource_info)
@@ -374,23 +363,13 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateImageDescriptorFilename(
                       << aspect_str;
     }
 
-    if (options_.dump_resources_dump_all_image_subresources)
-    {
-        std::stringstream sub_resources_str;
-        sub_resources_str << base_filename.str() << "_mip_" << mip_level << "_layer_" << layer;
-        sub_resources_str << ImageFileExtension(output_image_format);
+    std::stringstream sub_resources_str;
+    sub_resources_str << base_filename.str() << "_mip_" << mip_level << "_layer_" << layer;
+    sub_resources_str << ImageFileExtension(output_image_format);
 
-        std::filesystem::path filedirname(options_.dump_resources_output_dir);
-        std::filesystem::path filebasename(sub_resources_str.str());
-        return (filedirname / filebasename).string();
-    }
-    else
-    {
-        base_filename << ImageFileExtension(output_image_format);
-        std::filesystem::path filedirname(options_.dump_resources_output_dir);
-        std::filesystem::path filebasename(base_filename.str());
-        return (filedirname / filebasename).string();
-    }
+    std::filesystem::path filedirname(options_.dump_resources_output_dir);
+    std::filesystem::path filebasename(sub_resources_str.str());
+    return (filedirname / filebasename).string();
 }
 
 VkResult DefaultVulkanDumpResourcesDelegate::DumpBufferDescriptor(const VulkanDumpResourceInfo& resource_info)
@@ -1215,10 +1194,7 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysImageFi
         filename << "_aspect_" << aspect_str;
     }
 
-    if (options_.dump_resources_dump_all_image_subresources)
-    {
-        filename << "_mip_" << mip_level << "_layer_" << layer;
-    }
+    filename << "_mip_" << mip_level << "_layer_" << layer;
 
     filename << ImageFileExtension(output_image_format);
 
@@ -1357,22 +1333,12 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysImageDe
                       << resource_info.bcb_index << "_" << format_name << "_aspect_" << aspect_str;
     }
 
-    if (options_.dump_resources_dump_all_image_subresources)
-    {
-        std::stringstream sub_resources_str;
-        sub_resources_str << base_filename.str() << "_mip_" << mip_level << "_layer_" << layer;
-        sub_resources_str << ImageFileExtension(output_image_format);
-        std::filesystem::path filedirname(options_.dump_resources_output_dir);
-        std::filesystem::path filebasename(sub_resources_str.str());
-        return (filedirname / filebasename).string();
-    }
-    else
-    {
-        base_filename << ImageFileExtension(output_image_format);
-        std::filesystem::path filedirname(options_.dump_resources_output_dir);
-        std::filesystem::path filebasename(base_filename.str());
-        return (filedirname / filebasename).string();
-    }
+    std::stringstream sub_resources_str;
+    sub_resources_str << base_filename.str() << "_mip_" << mip_level << "_layer_" << layer;
+    sub_resources_str << ImageFileExtension(output_image_format);
+    std::filesystem::path filedirname(options_.dump_resources_output_dir);
+    std::filesystem::path filebasename(sub_resources_str.str());
+    return (filedirname / filebasename).string();
 }
 
 VkResult

--- a/framework/decode/vulkan_replay_dump_resources_delegate.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.cpp
@@ -1012,6 +1012,32 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
 
                         case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
                         case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                        {
+                            for (const auto& buf_desc : desc.second.texel_buffer_view_info)
+                            {
+                                const VulkanBufferInfo* buf_info =
+                                    object_info_table_.GetVkBufferInfo(buf_desc.second->buffer_id);
+                                if (buf_info != nullptr)
+                                {
+                                    uint32_t& stage_entry_index = per_stage_json_entry_indices[stage_name];
+                                    auto&     desc_json_entry =
+                                        draw_call_entry["descriptors"][stage_name][stage_entry_index++];
+                                    desc_json_entry["type"] = util::ToString<VkDescriptorType>(desc.second.desc_type);
+                                    desc_json_entry["set"]  = desc_set_index;
+                                    desc_json_entry["binding"]    = desc_set_binding_index;
+                                    desc_json_entry["arrayIndex"] = buf_desc.first;
+                                    desc_json_entry["bufferId"]   = buf_desc.second->buffer_id;
+
+                                    VulkanDumpResourceInfo res_info = res_info_base;
+                                    res_info.type                   = DumpResourceType::kBufferDescriptor;
+                                    res_info.buffer_info            = buf_info;
+
+                                    desc_json_entry["file"] = GenerateBufferDescriptorFilename(res_info);
+                                }
+                            }
+                        }
+                        break;
+
                         case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
                         case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
                         case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
@@ -1658,6 +1684,31 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                         break;
 
                         case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+                        {
+                            for (const auto& buf_desc : desc_binding_info.texel_buffer_view_info)
+                            {
+                                const auto buffer_info = object_info_table_.GetVkBufferInfo(buf_desc.second->buffer_id);
+                                if (buffer_info != nullptr)
+                                {
+                                    uint32_t& stage_entry_index = per_stage_json_entry_indices[stage_name];
+                                    auto& entry = dispatch_json_entry["descriptors"][stage_name][stage_entry_index++];
+
+                                    entry["type"]       = util::ToString<VkDescriptorType>(desc_binding_info.desc_type);
+                                    entry["set"]        = desc_set_index;
+                                    entry["binding"]    = desc_binding_index;
+                                    entry["arrayIndex"] = buf_desc.first;
+                                    entry["bufferId"]   = buffer_info->capture_id;
+
+                                    VulkanDumpResourceInfo res_info = res_info_base;
+                                    res_info.type        = DumpResourceType::kDispatchTraceRaysBufferDescriptor;
+                                    res_info.buffer_info = buffer_info;
+
+                                    entry["file"] = GenerateDispatchTraceRaysBufferDescriptorFilename(res_info);
+                                }
+                            }
+                        }
+                        break;
+
                         case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
                         case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
                         {

--- a/framework/decode/vulkan_replay_dump_resources_delegate.h
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.h
@@ -221,6 +221,14 @@ class DefaultVulkanDumpResourcesDelegate : public VulkanDumpResourcesDelegate
 
     bool ImageFailedScaling(const std::string& filename) const { return images_failed_scaling_.count(filename); }
 
+    void GenerateDispatchTraceRaysDescriptorsJsonInfo(
+        const VulkanDumpDrawCallInfo&                                         draw_call_info,
+        nlohmann::ordered_json&                                               dispatch_json_entry,
+        const BoundDescriptorSets&                                            referenced_descriptors,
+        const DispatchTraceRaysDumpingContext::MutableResourcesBackupContext& cloned_resources,
+        const DispatchTraceRaysDumpingContext::MutableResourcesBackupContext& cloned_resources_before,
+        bool                                                                  is_dispatch);
+
     VulkanReplayDumpResourcesJson dump_json_;
     const VulkanReplayOptions&    options_;
     CommonObjectInfoTable&        object_info_table_;

--- a/framework/decode/vulkan_replay_dump_resources_delegate.h
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.h
@@ -23,6 +23,7 @@
 #ifndef GFXRECON_VULKAN_REPLAY_DUMP_RESOURCES_DELEGATE_H
 #define GFXRECON_VULKAN_REPLAY_DUMP_RESOURCES_DELEGATE_H
 
+#include "decode/vulkan_object_info.h"
 #include "decode/vulkan_replay_dump_resources_draw_calls.h"
 #include "decode/vulkan_replay_dump_resources_compute_ray_tracing.h"
 #include "decode/vulkan_replay_dump_resources_json.h"
@@ -217,9 +218,9 @@ class DefaultVulkanDumpResourcesDelegate : public VulkanDumpResourcesDelegate
 
     // Keep track of images for which scalling failed so we can
     // note them in the output json
-    std::unordered_set<std::string> images_failed_scaling_;
+    std::unordered_set<const VulkanImageInfo*> images_failed_scaling_;
 
-    bool ImageFailedScaling(const std::string& filename) const { return images_failed_scaling_.count(filename); }
+    bool ImageFailedScaling(const VulkanImageInfo* img_info) const { return images_failed_scaling_.count(img_info); }
 
     void GenerateDispatchTraceRaysDescriptorsJsonInfo(
         const VulkanDumpDrawCallInfo&                                         draw_call_info,

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -502,7 +502,7 @@ static void SnapshotBoundDescriptors(DrawCallsDumpingContext::DrawCallParams& dc
             continue;
         }
 
-        for (const auto& [desc_binding_index, binding_info] : set_info.descriptors)
+        for (const auto& [desc_binding_index, binding_info] : set_info)
         {
             // Check against pipeline layout
             const auto layout_entry = bound_pipeline->desc_set_layouts[desc_set_index].find(desc_binding_index);
@@ -1979,7 +1979,7 @@ void DrawCallsDumpingContext::BindDescriptorSets(
 
         if (descriptor_sets_infos[i] != nullptr)
         {
-            bound_descriptor_sets_gr_[set_index] = *descriptor_sets_infos[i];
+            bound_descriptor_sets_gr_[set_index] = descriptor_sets_infos[i]->descriptors;
 
             if (dynamicOffsetCount && pDynamicOffsets != nullptr)
             {
@@ -1990,8 +1990,7 @@ void DrawCallsDumpingContext::BindDescriptorSets(
                     if (binding.second.desc_type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC ||
                         binding.second.desc_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)
                     {
-                        for (auto& [ai, buf_info] :
-                             bound_descriptor_sets_gr_[set_index].descriptors[binding_index].buffer_info)
+                        for (auto& [ai, buf_info] : bound_descriptor_sets_gr_[set_index][binding_index].buffer_info)
                         {
                             buf_info.offset += pDynamicOffsets[dynamic_offset_index];
                             ++dynamic_offset_index;

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -506,13 +506,16 @@ static void SnapshotBoundDescriptors(DrawCallsDumpingContext::DrawCallParams& dc
         {
             // Check against pipeline layout
             const auto layout_entry = bound_pipeline->desc_set_layouts[desc_set_index].find(desc_binding_index);
-            if (layout_entry == bound_pipeline->desc_set_layouts[desc_set_index].end())
+
+            if (layout_entry == bound_pipeline->desc_set_layouts[desc_set_index].end() ||
+                !(bound_pipeline->shader_stages & binding_info.stage_flags))
             {
                 continue;
             }
 
-            dc_params.referenced_descriptors[desc_set_index][desc_binding_index].desc_type   = binding_info.desc_type;
-            dc_params.referenced_descriptors[desc_set_index][desc_binding_index].stage_flags = binding_info.stage_flags;
+            dc_params.referenced_descriptors[desc_set_index][desc_binding_index].desc_type = binding_info.desc_type;
+            dc_params.referenced_descriptors[desc_set_index][desc_binding_index].stage_flags =
+                (bound_pipeline->shader_stages & binding_info.stage_flags);
 
             switch (binding_info.desc_type)
             {

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -655,7 +655,7 @@ class DrawCallsDumpingContext
         BoundIndexBuffer referenced_index_buffer;
 
         // Keep copies of the descriptor bindings referenced by each draw call
-        std::unordered_map<uint32_t, VulkanDescriptorSetInfo::VulkanDescriptorBindingsInfo> referenced_descriptors;
+        BoundDescriptorSets referenced_descriptors;
 
         // These are used to store information calculated when dumping vertex and index buffers.
         // This information is latter used when writting the output json file.

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -162,23 +162,18 @@ nlohmann::ordered_json& VulkanReplayDumpResourcesJson::GetCurrentSubEntry()
     return current_entry != nullptr ? *current_entry : json_data_;
 }
 
-void VulkanReplayDumpResourcesJson::InsertImageInfo(nlohmann::ordered_json& json_entry,
-                                                    VkFormat                image_format,
-                                                    VkImageType             image_type,
-                                                    format::HandleId        image_id,
-                                                    const VkExtent3D&       extent,
-                                                    const std::string&      filename,
-                                                    VkImageAspectFlagBits   aspect,
-                                                    bool                    scale_failed,
-                                                    uint32_t                mip_level,
-                                                    uint32_t                array_layer,
-                                                    bool                    separate_alpha,
-                                                    const std::string*      filename_before)
+void VulkanReplayDumpResourcesJson::InsertImageSubresourceInfo(nlohmann::ordered_json& json_entry,
+                                                               VkFormat                image_format,
+                                                               VkImageType             image_type,
+                                                               format::HandleId        image_id,
+                                                               const VkExtent3D&       extent,
+                                                               const std::string&      filename,
+                                                               VkImageAspectFlagBits   aspect,
+                                                               uint32_t                mip_level,
+                                                               uint32_t                array_layer,
+                                                               bool                    separate_alpha,
+                                                               const std::string*      filename_before)
 {
-    json_entry["imageId"]   = image_id;
-    json_entry["format"]    = util::ToString<VkFormat>(image_format);
-    json_entry["imageType"] = util::ToString<VkImageType>(image_type);
-
     const std::string aspect_str_whole(util::ToString<VkImageAspectFlagBits>(aspect));
     const std::string aspect_str(aspect_str_whole.begin() + 16, aspect_str_whole.end() - 4);
     json_entry["aspect"] = aspect_str;

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -185,11 +185,6 @@ void VulkanReplayDumpResourcesJson::InsertImageSubresourceInfo(nlohmann::ordered
     json_entry["mipLevel"]   = mip_level;
     json_entry["arrayLayer"] = array_layer;
 
-    if (scale_failed)
-    {
-        json_entry["scaleFailed"] = true;
-    }
-
     const bool raw_image = !util::filepath::GetFilenameExtension(filename).compare(".bin");
 
     if (separate_alpha && !raw_image && vkuFormatHasAlpha(image_format))

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -175,9 +175,9 @@ void VulkanReplayDumpResourcesJson::InsertImageInfo(nlohmann::ordered_json& json
                                                     bool                    separate_alpha,
                                                     const std::string*      filename_before)
 {
-    json_entry["imageId"] = image_id;
-    json_entry["format"]  = util::ToString<VkFormat>(image_format);
-    json_entry["type"]    = util::ToString<VkImageType>(image_type);
+    json_entry["imageId"]   = image_id;
+    json_entry["format"]    = util::ToString<VkFormat>(image_format);
+    json_entry["imageType"] = util::ToString<VkImageType>(image_type);
 
     const std::string aspect_str_whole(util::ToString<VkImageAspectFlagBits>(aspect));
     const std::string aspect_str(aspect_str_whole.begin() + 16, aspect_str_whole.end() - 4);
@@ -225,16 +225,6 @@ void VulkanReplayDumpResourcesJson::InsertImageInfo(nlohmann::ordered_json& json
             json_entry["file"] = filename;
         }
     }
-}
-
-void VulkanReplayDumpResourcesJson::InsertBufferInfo(nlohmann::ordered_json& json_entry,
-                                                     const VulkanBufferInfo* buffer_info,
-                                                     const std::string&      filename)
-{
-    assert(buffer_info != nullptr);
-
-    json_entry["bufferId"] = buffer_info->capture_id;
-    json_entry["file"]     = filename;
 }
 
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_replay_dump_resources_json.h
+++ b/framework/decode/vulkan_replay_dump_resources_json.h
@@ -72,10 +72,6 @@ class VulkanReplayDumpResourcesJson
                          bool                    separate_alpha  = false,
                          const std::string*      filename_before = nullptr);
 
-    void InsertBufferInfo(nlohmann::ordered_json& json_entry,
-                          const VulkanBufferInfo* buffer_info,
-                          const std::string&      filename);
-
     uint32_t FetchAndAddDrawCallsEntryIndex() { return draw_calls_entry_index++; }
 
     uint32_t FetchAndAddDispatchEntryIndex() { return dispatch_entry_index++; }

--- a/framework/decode/vulkan_replay_dump_resources_json.h
+++ b/framework/decode/vulkan_replay_dump_resources_json.h
@@ -59,18 +59,17 @@ class VulkanReplayDumpResourcesJson
 
     nlohmann::ordered_json& GetCurrentSubEntry();
 
-    void InsertImageInfo(nlohmann::ordered_json& json_entry,
-                         VkFormat                image_format,
-                         VkImageType             image_type,
-                         format::HandleId        image_id,
-                         const VkExtent3D&       extent,
-                         const std::string&      filename,
-                         VkImageAspectFlagBits   aspect,
-                         bool                    scale_failed,
-                         uint32_t                mip_level       = 0,
-                         uint32_t                array_layer     = 0,
-                         bool                    separate_alpha  = false,
-                         const std::string*      filename_before = nullptr);
+    void InsertImageSubresourceInfo(nlohmann::ordered_json& json_entry,
+                                    VkFormat                image_format,
+                                    VkImageType             image_type,
+                                    format::HandleId        image_id,
+                                    const VkExtent3D&       extent,
+                                    const std::string&      filename,
+                                    VkImageAspectFlagBits   aspect,
+                                    uint32_t                mip_level       = 0,
+                                    uint32_t                array_layer     = 0,
+                                    bool                    separate_alpha  = false,
+                                    const std::string*      filename_before = nullptr);
 
     uint32_t FetchAndAddDrawCallsEntryIndex() { return draw_calls_entry_index++; }
 

--- a/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
@@ -148,6 +148,7 @@
     "vkCmdExecuteCommands": "OverrideCmdExecuteCommands",
     "vkCreateSamplerYcbcrConversion": "OverrideCreateSamplerYcbcrConversion",
     "vkCreateSamplerYcbcrConversionKHR": "OverrideCreateSamplerYcbcrConversionKHR",
-    "vkCreatePipelineLayout": "OverrideCreatePipelineLayout"
+    "vkCreatePipelineLayout": "OverrideCreatePipelineLayout",
+    "vkCreateBufferView": "OverrideCreateBufferView"
   }
 }


### PR DESCRIPTION
When dumping descriptors for compute and ray tracing there was an
attempt to distinguish between "outputs" (storage descriptors) and the
rest of the descriptors. This commit merges outputs into descriptors.