### PR TITLE
Add copyright year checking to CI

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 LunarG, Inc.
+Copyright (c) 2018-2025 LunarG, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/framework/application/android_context.cpp
+++ b/framework/application/android_context.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
-** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2018,2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
-** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2018,2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/display_window.cpp
+++ b/framework/application/display_window.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 Broadcom, Inc.
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/display_window.h
+++ b/framework/application/display_window.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 Broadcom, Inc.
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/headless_window.cpp
+++ b/framework/application/headless_window.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021, Arm Limited.
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/headless_window.h
+++ b/framework/application/headless_window.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021, Arm Limited.
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/metal_window.h
+++ b/framework/application/metal_window.h
@@ -1,6 +1,6 @@
 /*
  ** Copyright (c) 2023 Codeweavers, Inc.
- ** Copyright (c) 2023 LunarG, Inc.
+ ** Copyright (c) 2025 LunarG, Inc.
  **
  ** Permission is hereby granted, free of charge, to any person obtaining a
  ** copy of this software and associated documentation files (the "Software"),

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
-** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2018,2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
-** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2018,2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
-** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2018,2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
-** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2018,2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
-** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2018,2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
-** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2018,2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/xlib_context.cpp
+++ b/framework/application/xlib_context.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2018-2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/application/xlib_window.cpp
+++ b/framework/application/xlib_window.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/application/xlib_window.h
+++ b/framework/application/xlib_window.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/common_handle_mapping_util.h
+++ b/framework/decode/common_handle_mapping_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2024 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/common_object_info_table.h
+++ b/framework/decode/common_object_info_table.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/common_struct_handle_mappers.h
+++ b/framework/decode/common_struct_handle_mappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2024 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/copy_shaders.h
+++ b/framework/decode/copy_shaders.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2020 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_dx12_struct_decoders.cpp
+++ b/framework/decode/custom_dx12_struct_decoders.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_dx12_struct_decoders.h
+++ b/framework/decode/custom_dx12_struct_decoders.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_dx12_struct_decoders_forward.h
+++ b/framework/decode/custom_dx12_struct_decoders_forward.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_dx12_struct_object_mappers.cpp
+++ b/framework/decode/custom_dx12_struct_object_mappers.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/decode/custom_dx12_struct_object_mappers.h
+++ b/framework/decode/custom_dx12_struct_object_mappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/decode/custom_openxr_struct_decoders.cpp
+++ b/framework/decode/custom_openxr_struct_decoders.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_openxr_struct_decoders.h
+++ b/framework/decode/custom_openxr_struct_decoders.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_openxr_struct_decoders_forward.h
+++ b/framework/decode/custom_openxr_struct_decoders_forward.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_openxr_struct_handle_mappers.cpp
+++ b/framework/decode/custom_openxr_struct_handle_mappers.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_openxr_struct_handle_mappers.h
+++ b/framework/decode/custom_openxr_struct_handle_mappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_openxr_struct_to_json.cpp
+++ b/framework/decode/custom_openxr_struct_to_json.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2024 LunarG, Inc.
+** Copyright (c) 2022-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_openxr_struct_to_json.h
+++ b/framework/decode/custom_openxr_struct_to_json.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2024 LunarG, Inc.
+** Copyright (c) 2022-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_vulkan_struct_decoders.cpp
+++ b/framework/decode/custom_vulkan_struct_decoders.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_vulkan_struct_decoders.h
+++ b/framework/decode/custom_vulkan_struct_decoders.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_vulkan_struct_decoders_forward.h
+++ b/framework/decode/custom_vulkan_struct_decoders_forward.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_vulkan_struct_handle_mappers.cpp
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2020 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_vulkan_struct_handle_mappers.h
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2020 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_vulkan_struct_to_json.cpp
+++ b/framework/decode/custom_vulkan_struct_to_json.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2024 LunarG, Inc.
+** Copyright (c) 2022-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/custom_vulkan_struct_to_json.h
+++ b/framework/decode/custom_vulkan_struct_to_json.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2023 LunarG, Inc.
+** Copyright (c) 2022-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/decode_allocator.cpp
+++ b/framework/decode/decode_allocator.cpp
@@ -1,6 +1,6 @@
 
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/decode_allocator.h
+++ b/framework/decode/decode_allocator.h
@@ -1,6 +1,6 @@
 
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/decode_api_detection.h
+++ b/framework/decode/decode_api_detection.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/decode_json_util.h
+++ b/framework/decode/decode_json_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2023 LunarG, Inc.
+** Copyright (c) 2022-2025 LunarG, Inc.
 ** Copyright (c) 2023 Valve Corporation
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/descriptor_update_template_decoder.h
+++ b/framework/decode/descriptor_update_template_decoder.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/dx12_descriptor_map.cpp
+++ b/framework/decode/dx12_descriptor_map.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/dx12_descriptor_map.h
+++ b/framework/decode/dx12_descriptor_map.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/dx12_dump_resources.cpp
+++ b/framework/decode/dx12_dump_resources.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/dx12_dump_resources.h
+++ b/framework/decode/dx12_dump_resources.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/dx12_enum_util.h
+++ b/framework/decode/dx12_enum_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/decode/dx12_json_consumer_base.cpp
+++ b/framework/decode/dx12_json_consumer_base.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/dx12_json_consumer_base.h
+++ b/framework/decode/dx12_json_consumer_base.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020,2022 Valve Corporation
-** Copyright (c) 2018-2020,2022 LunarG, Inc.
+** Copyright (c) 2018-2020,2025 LunarG, Inc.
 ** Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/file_transformer.cpp
+++ b/framework/decode/file_transformer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/file_transformer.h
+++ b/framework/decode/file_transformer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/handle_pointer_decoder.h
+++ b/framework/decode/handle_pointer_decoder.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2019-2020 Valve Corporation
-** Copyright (c) 2019-2023 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/json_writer.h
+++ b/framework/decode/json_writer.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2023 Valve Corporation
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/mark_injected_commands.cpp
+++ b/framework/decode/mark_injected_commands.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2024 Valve Corporation
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/mark_injected_commands.h
+++ b/framework/decode/mark_injected_commands.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2024 Valve Corporation
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_consumer_base.h
+++ b/framework/decode/openxr_consumer_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/openxr_decoder_base.cpp
+++ b/framework/decode/openxr_decoder_base.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_decoder_base.h
+++ b/framework/decode/openxr_decoder_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_detection_consumer.h
+++ b/framework/decode/openxr_detection_consumer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc. All rights reserved.
+** Copyright (c) 2025 LunarG, Inc. All rights reserved.
 ** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/openxr_enum_util.h
+++ b/framework/decode/openxr_enum_util.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_feature_util.cpp
+++ b/framework/decode/openxr_feature_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2024 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_feature_util.h
+++ b/framework/decode/openxr_feature_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2024 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_handle_mapping_util.cpp
+++ b/framework/decode/openxr_handle_mapping_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2024 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_handle_mapping_util.h
+++ b/framework/decode/openxr_handle_mapping_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2024 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_json_consumer_base.cpp
+++ b/framework/decode/openxr_json_consumer_base.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2024 LunarG, Inc.
+** Copyright (c) 2022-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_json_consumer_base.h
+++ b/framework/decode/openxr_json_consumer_base.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2024 LunarG, Inc.
+** Copyright (c) 2022-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_next_node.h
+++ b/framework/decode/openxr_next_node.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_next_typed_node.h
+++ b/framework/decode/openxr_next_typed_node.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_object_info.h
+++ b/framework/decode/openxr_object_info.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/openxr_object_info_table_base.h
+++ b/framework/decode/openxr_object_info_table_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_replay_common_state.h
+++ b/framework/decode/openxr_replay_common_state.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_replay_consumer_base.cpp
+++ b/framework/decode/openxr_replay_consumer_base.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_replay_options.h
+++ b/framework/decode/openxr_replay_options.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2019-2020 Valve Corporation
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_replay_session_state.cpp
+++ b/framework/decode/openxr_replay_session_state.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_replay_session_state.h
+++ b/framework/decode/openxr_replay_session_state.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_replay_swapchain_state.cpp
+++ b/framework/decode/openxr_replay_swapchain_state.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_replay_swapchain_state.h
+++ b/framework/decode/openxr_replay_swapchain_state.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_stats_consumer.h
+++ b/framework/decode/openxr_stats_consumer.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/openxr_tracked_object_info_table.cpp
+++ b/framework/decode/openxr_tracked_object_info_table.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/openxr_tracked_object_info_table.h
+++ b/framework/decode/openxr_tracked_object_info_table.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/pointer_decoder.h
+++ b/framework/decode/pointer_decoder.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/pointer_decoder_base.h
+++ b/framework/decode/pointer_decoder_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/preload_file_processor.cpp
+++ b/framework/decode/preload_file_processor.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 ** Copyright (c) 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/preload_file_processor.h
+++ b/framework/decode/preload_file_processor.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 ** Copyright (c) 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/referenced_resource_table.cpp
+++ b/framework/decode/referenced_resource_table.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/referenced_resource_table.h
+++ b/framework/decode/referenced_resource_table.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/string_array_decoder.h
+++ b/framework/decode/string_array_decoder.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2021 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/string_decoder.h
+++ b/framework/decode/string_decoder.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/struct_pointer_decoder.h
+++ b/framework/decode/struct_pointer_decoder.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/swapchain_image_tracker.h
+++ b/framework/decode/swapchain_image_tracker.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2020 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/value_decoder.h
+++ b/framework/decode/value_decoder.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_address_replacer.h
+++ b/framework/decode/vulkan_address_replacer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_address_replacer_shaders.h
+++ b/framework/decode/vulkan_address_replacer_shaders.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_captured_swapchain.cpp
+++ b/framework/decode/vulkan_captured_swapchain.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_captured_swapchain.h
+++ b/framework/decode/vulkan_captured_swapchain.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2020 Samsung
 // Copyright (c) 2023 Google
-// Copyright (c) 2023 LunarG, Inc
+// Copyright (c) 2024 LunarG, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/framework/decode/vulkan_cpp_consumer_base.h
+++ b/framework/decode/vulkan_cpp_consumer_base.h
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2020 Samsung
 // Copyright (c) 2023 Google
-// Copyright (c) 2023 LunarG, Inc
+// Copyright (c) 2024 LunarG, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/framework/decode/vulkan_cpp_loader_generator.cpp
+++ b/framework/decode/vulkan_cpp_loader_generator.cpp
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2021 Samsung
 // Copyright (c) 2023 Google
-// Copyright (c) 2023 LunarG, Inc
+// Copyright (c) 2024 LunarG, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/framework/decode/vulkan_cpp_loader_generator.h
+++ b/framework/decode/vulkan_cpp_loader_generator.h
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2021 Samsung
 // Copyright (c) 2023 Google
-// Copyright (c) 2023 LunarG, Inc
+// Copyright (c) 2024 LunarG, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/framework/decode/vulkan_cpp_structs.cpp
+++ b/framework/decode/vulkan_cpp_structs.cpp
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2021 Samsung
 // Copyright (c) 2023 Google
-// Copyright (c) 2023 LunarG, Inc
+// Copyright (c) 2025 LunarG, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/framework/decode/vulkan_cpp_structs.h
+++ b/framework/decode/vulkan_cpp_structs.h
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2021 Samsung
 // Copyright (c) 2023 Google
-// Copyright (c) 2023 LunarG, Inc
+// Copyright (c) 2025 LunarG, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/framework/decode/vulkan_cpp_util_datapack.h
+++ b/framework/decode/vulkan_cpp_util_datapack.h
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2021 Samsung
 // Copyright (c) 2023 Google
-// Copyright (c) 2023 LunarG, Inc
+// Copyright (c) 2024 LunarG, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/framework/decode/vulkan_cpp_utilities.cpp
+++ b/framework/decode/vulkan_cpp_utilities.cpp
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2021 Samsung
 // Copyright (c) 2023 Google
-// Copyright (c) 2023 LunarG, Inc
+// Copyright (c) 2024 LunarG, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/framework/decode/vulkan_cpp_utilities.h
+++ b/framework/decode/vulkan_cpp_utilities.h
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2021 Samsung
 // Copyright (c) 2023 Google
-// Copyright (c) 2023 LunarG, Inc
+// Copyright (c) 2024 LunarG, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_device_address_tracker.cpp
+++ b/framework/decode/vulkan_device_address_tracker.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/vulkan_device_address_tracker.h
+++ b/framework/decode/vulkan_device_address_tracker.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/vulkan_enum_util.h
+++ b/framework/decode/vulkan_enum_util.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_feature_util.cpp
+++ b/framework/decode/vulkan_feature_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2023 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_feature_util.h
+++ b/framework/decode/vulkan_feature_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2023 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_handle_mapping_util.cpp
+++ b/framework/decode/vulkan_handle_mapping_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_handle_mapping_util.h
+++ b/framework/decode/vulkan_handle_mapping_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_json_consumer_base.cpp
+++ b/framework/decode/vulkan_json_consumer_base.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2023 LunarG, Inc.
+** Copyright (c) 2022-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_json_consumer_base.h
+++ b/framework/decode/vulkan_json_consumer_base.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2023 LunarG, Inc.
+** Copyright (c) 2022-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2023 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_object_cleanup_util.h
+++ b/framework/decode/vulkan_object_cleanup_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2022 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/vulkan_object_info_table_base.h
+++ b/framework/decode/vulkan_object_info_table_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
-** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_pnext_node.h
+++ b/framework/decode/vulkan_pnext_node.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_pnext_typed_node.h
+++ b/framework/decode/vulkan_pnext_typed_node.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_realign_allocator.cpp
+++ b/framework/decode/vulkan_realign_allocator.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_realign_allocator.h
+++ b/framework/decode/vulkan_realign_allocator.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_dump_resources.h
+++ b/framework/decode/vulkan_replay_dump_resources.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_dump_resources_common.h
+++ b/framework/decode/vulkan_replay_dump_resources_common.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_dump_resources_json.h
+++ b/framework/decode/vulkan_replay_dump_resources_json.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2019-2020 Valve Corporation
-** Copyright (c) 2019-2023 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_stats_consumer.h
+++ b/framework/decode/vulkan_stats_consumer.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/vulkan_swapchain.cpp
+++ b/framework/decode/vulkan_swapchain.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/window.h
+++ b/framework/decode/window.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
-** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2018,2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/custom_dx12_struct_encoders.cpp
+++ b/framework/encode/custom_dx12_struct_encoders.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/custom_dx12_struct_encoders.h
+++ b/framework/encode/custom_dx12_struct_encoders.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_dx12_struct_unwrappers.cpp
+++ b/framework/encode/custom_dx12_struct_unwrappers.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/encode/custom_dx12_struct_unwrappers.h
+++ b/framework/encode/custom_dx12_struct_unwrappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/encode/custom_openxr_api_call_encoders.cpp
+++ b/framework/encode/custom_openxr_api_call_encoders.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/custom_openxr_api_call_encoders.h
+++ b/framework/encode/custom_openxr_api_call_encoders.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_openxr_encoder_commands.h
+++ b/framework/encode/custom_openxr_encoder_commands.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/custom_openxr_struct_encoders.cpp
+++ b/framework/encode/custom_openxr_struct_encoders.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_openxr_struct_encoders.h
+++ b/framework/encode/custom_openxr_struct_encoders.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_openxr_struct_handle_wrappers.cpp
+++ b/framework/encode/custom_openxr_struct_handle_wrappers.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_openxr_struct_handle_wrappers.h
+++ b/framework/encode/custom_openxr_struct_handle_wrappers.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/custom_vulkan_api_call_encoders.h
+++ b/framework/encode/custom_vulkan_api_call_encoders.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_vulkan_command_buffer_util.cpp
+++ b/framework/encode/custom_vulkan_command_buffer_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
-** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/custom_vulkan_layer_func_table.h
+++ b/framework/encode/custom_vulkan_layer_func_table.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2023 Valve Corporation
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_vulkan_struct_encoders.cpp
+++ b/framework/encode/custom_vulkan_struct_encoders.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_vulkan_struct_encoders.h
+++ b/framework/encode/custom_vulkan_struct_encoders.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_vulkan_struct_handle_wrappers.cpp
+++ b/framework/encode/custom_vulkan_struct_handle_wrappers.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/custom_vulkan_struct_handle_wrappers.h
+++ b/framework/encode/custom_vulkan_struct_handle_wrappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/d3d12_dispatch_table.h
+++ b/framework/encode/d3d12_dispatch_table.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2021 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/descriptor_update_template_info.h
+++ b/framework/encode/descriptor_update_template_info.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/dx12_state_tracker_initializers.h
+++ b/framework/encode/dx12_state_tracker_initializers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/handle_unwrap_memory.h
+++ b/framework/encode/handle_unwrap_memory.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019,2021 LunarG, Inc.
+** Copyright (c) 2019,2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/iunknown_wrapper.cpp
+++ b/framework/encode/iunknown_wrapper.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/openxr_capture_manager.cpp
+++ b/framework/encode/openxr_capture_manager.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/openxr_capture_manager.h
+++ b/framework/encode/openxr_capture_manager.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/openxr_handle_wrapper_util.cpp
+++ b/framework/encode/openxr_handle_wrapper_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2024 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/openxr_handle_wrapper_util.h
+++ b/framework/encode/openxr_handle_wrapper_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/openxr_handle_wrappers.h
+++ b/framework/encode/openxr_handle_wrappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/openxr_state_info.h
+++ b/framework/encode/openxr_state_info.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/openxr_state_table_base.h
+++ b/framework/encode/openxr_state_table_base.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/openxr_state_tracker.cpp
+++ b/framework/encode/openxr_state_tracker.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/openxr_state_tracker.h
+++ b/framework/encode/openxr_state_tracker.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/openxr_state_tracker_initializers.h
+++ b/framework/encode/openxr_state_tracker_initializers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/openxr_state_writer.cpp
+++ b/framework/encode/openxr_state_writer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/openxr_state_writer.h
+++ b/framework/encode/openxr_state_writer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/parameter_buffer.h
+++ b/framework/encode/parameter_buffer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/parameter_encoder.h
+++ b/framework/encode/parameter_encoder.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/struct_pointer_encoder.h
+++ b/framework/encode/struct_pointer_encoder.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -1,5 +1,5 @@
 /*
- ** Copyright (c) 2019-2020 LunarG, Inc.
+ ** Copyright (c) 2019-2025 LunarG, Inc.
  ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
  **
  ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/vulkan_state_table_base.h
+++ b/framework/encode/vulkan_state_table_base.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2021 LunarG, Inc.
+** Copyright (c) 2019-2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2024 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2021 LunarG, Inc.
+** Copyright (c) 2019-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/format/api_call_id.h
+++ b/framework/format/api_call_id.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/format/dx12_subobject_types.h
+++ b/framework/format/dx12_subobject_types.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/format/format_util.cpp
+++ b/framework/format/format_util.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/format/platform_types.h
+++ b/framework/format/platform_types.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/format/platform_types_d3d_overrides.h
+++ b/framework/format/platform_types_d3d_overrides.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/dx12_generators/dx12_add_entries_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_add_entries_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_api_call_encoders_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_api_call_encoders_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 # Copyright (c) 2022 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/dx12_generators/dx12_api_call_encoders_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_api_call_encoders_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_base_decoder_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_base_decoder_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2020 LunarG, Inc.
+# Copyright (c) 2018-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_base_replay_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_base_replay_consumer_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2020 LunarG, Inc.
+# Copyright (c) 2018-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_base_struct_decoders_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_base_struct_decoders_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2020 LunarG, Inc.
+# Copyright (c) 2018-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_base_struct_decoders_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_base_struct_decoders_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_call_id_to_string_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_call_id_to_string_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 # Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/dx12_generators/dx12_command_list_util_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_command_list_util_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_command_list_util_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_command_list_util_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_consumer_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_consumer_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_decoder_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_decoder_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_decoder_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_decoder_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_enum_to_json_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_enum_to_json_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021-2023 LunarG, Inc.
+# Copyright (c) 2021-2025 LunarG, Inc.
 # Copyright (c) 2023 Valve Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/dx12_generators/dx12_enum_to_string_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_enum_to_string_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2023 Valve Corporation
-# Copyright (c) 2021, 2023 LunarG, Inc.
+# Copyright (c) 2021, 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_enum_to_string_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_enum_to_string_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2023 Valve Corporation
-# Copyright (c) 2021, 2023 LunarG, Inc.
+# Copyright (c) 2021, 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_json_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_json_consumer_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021, 2023 LunarG, Inc.
+# Copyright (c) 2021, 2024 LunarG, Inc.
 # Copyright (c) 2023 Valve Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/dx12_generators/dx12_json_consumer_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_json_consumer_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021, 2023 LunarG, Inc.
+# Copyright (c) 2021, 2024 LunarG, Inc.
 # Copyright (c) 2023 Valve Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/dx12_generators/dx12_replay_consumer_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_replay_consumer_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_state_table_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_state_table_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_decoders_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_decoders_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_decoders_forward_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_decoders_forward_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_decoders_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_decoders_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_decoders_to_json_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_decoders_to_json_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2023 Valve Corporation
-# Copyright (c) 2021-2023 LunarG, Inc.
+# Copyright (c) 2021-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_decoders_to_json_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_decoders_to_json_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2023 Valve Corporation
-# Copyright (c) 2021-2023 LunarG, Inc.
+# Copyright (c) 2021-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_object_mappers_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_object_mappers_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_object_mappers_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_object_mappers_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_unwrappers_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_unwrappers_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_unwrappers_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_unwrappers_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_wrapper_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_wrapper_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_struct_wrapper_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_wrapper_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 # Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/dx12_generators/dx12_wrapper_creators_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_wrapper_creators_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_wrapper_creators_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_wrapper_creators_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/dx12_wrapper_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_wrapper_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/gencode.py
+++ b/framework/generated/dx12_generators/gencode.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021-2023 LunarG, Inc.
+# Copyright (c) 2021-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/dx12_generators/gencode.py
+++ b/framework/generated/dx12_generators/gencode.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021-2024 LunarG, Inc.
+# Copyright (c) 2021-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -96,7 +96,7 @@ def make_gen_opts(args):
 
     # Copyright text prefixing all headers (list of strings).
     prefix_strings = [
-        '/*', '** Copyright (c) 2021-2023 LunarG, Inc.', '**',
+        '/*', '** Copyright (c) 2021-2025 LunarG, Inc.', '**',
         '** Permission is hereby granted, free of charge, to any person obtaining a copy',
         '** of this software and associated documentation files (the "Software"), to',
         '** deal in the Software without restriction, including without limitation the',

--- a/framework/generated/dx12_generators/reformat_code.py
+++ b/framework/generated/dx12_generators/reformat_code.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2023 Valve Corporation
-# Copyright (c) 2023 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generate_dx12.py
+++ b/framework/generated/generate_dx12.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021-2023 LunarG, Inc.
+# Copyright (c) 2021-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_add_entries.h
+++ b/framework/generated/generated_dx12_add_entries.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_api_call_encoders.cpp
+++ b/framework/generated/generated_dx12_api_call_encoders.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_api_call_encoders.h
+++ b/framework/generated/generated_dx12_api_call_encoders.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_call_id_to_string.h
+++ b/framework/generated/generated_dx12_call_id_to_string.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_command_list_util.cpp
+++ b/framework/generated/generated_dx12_command_list_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_command_list_util.h
+++ b/framework/generated/generated_dx12_command_list_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_consumer.h
+++ b/framework/generated/generated_dx12_consumer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_decoder.cpp
+++ b/framework/generated/generated_dx12_decoder.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_decoder.h
+++ b/framework/generated/generated_dx12_decoder.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_enum_to_json.h
+++ b/framework/generated/generated_dx12_enum_to_json.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_enum_to_string.cpp
+++ b/framework/generated/generated_dx12_enum_to_string.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_enum_to_string.h
+++ b/framework/generated/generated_dx12_enum_to_string.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_json_consumer.cpp
+++ b/framework/generated/generated_dx12_json_consumer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_json_consumer.h
+++ b/framework/generated/generated_dx12_json_consumer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_replay_consumer.h
+++ b/framework/generated/generated_dx12_replay_consumer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_state_table.h
+++ b/framework/generated/generated_dx12_state_table.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_decoders.cpp
+++ b/framework/generated/generated_dx12_struct_decoders.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_decoders.h
+++ b/framework/generated/generated_dx12_struct_decoders.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_decoders_forward.h
+++ b/framework/generated/generated_dx12_struct_decoders_forward.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_decoders_to_json.cpp
+++ b/framework/generated/generated_dx12_struct_decoders_to_json.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_decoders_to_json.h
+++ b/framework/generated/generated_dx12_struct_decoders_to_json.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_object_mappers.cpp
+++ b/framework/generated/generated_dx12_struct_object_mappers.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_object_mappers.h
+++ b/framework/generated/generated_dx12_struct_object_mappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_unwrappers.cpp
+++ b/framework/generated/generated_dx12_struct_unwrappers.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_unwrappers.h
+++ b/framework/generated/generated_dx12_struct_unwrappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_wrappers.cpp
+++ b/framework/generated/generated_dx12_struct_wrappers.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_struct_wrappers.h
+++ b/framework/generated/generated_dx12_struct_wrappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_wrapper_creators.cpp
+++ b/framework/generated/generated_dx12_wrapper_creators.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_wrapper_creators.h
+++ b/framework/generated/generated_dx12_wrapper_creators.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_dx12_wrappers.h
+++ b/framework/generated/generated_dx12_wrappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_api_call_encoders.h
+++ b/framework/generated/generated_vulkan_api_call_encoders.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_command_buffer_util.cpp
+++ b/framework/generated/generated_vulkan_command_buffer_util.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_command_buffer_util.h
+++ b/framework/generated/generated_vulkan_command_buffer_util.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_constant_maps.h
+++ b/framework/generated/generated_vulkan_constant_maps.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_cpp_consumer.cpp
+++ b/framework/generated/generated_vulkan_cpp_consumer.cpp
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2020 Samsung
 ** Copyright (c) 2023 Google
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_cpp_consumer.h
+++ b/framework/generated/generated_vulkan_cpp_consumer.h
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2020 Samsung
 ** Copyright (c) 2023 Google
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_cpp_consumer_extension.cpp
+++ b/framework/generated/generated_vulkan_cpp_consumer_extension.cpp
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2021 Samsung
 ** Copyright (c) 2023 Google
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_cpp_consumer_extension.h
+++ b/framework/generated/generated_vulkan_cpp_consumer_extension.h
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2021 Samsung
 ** Copyright (c) 2023 Google
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_cpp_structs.cpp
+++ b/framework/generated/generated_vulkan_cpp_structs.cpp
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2021 Samsung
 ** Copyright (c) 2023 Google
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_cpp_structs.h
+++ b/framework/generated/generated_vulkan_cpp_structs.h
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2021 Samsung
 ** Copyright (c) 2023 Google
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_decoder.h
+++ b/framework/generated/generated_vulkan_decoder.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_dispatch_table.h
+++ b/framework/generated/generated_vulkan_dispatch_table.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_enum_to_json.cpp
+++ b/framework/generated/generated_vulkan_enum_to_json.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_enum_to_json.h
+++ b/framework/generated/generated_vulkan_enum_to_json.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_enum_to_string.cpp
+++ b/framework/generated/generated_vulkan_enum_to_string.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_enum_to_string.h
+++ b/framework/generated/generated_vulkan_enum_to_string.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_feature_util.cpp
+++ b/framework/generated/generated_vulkan_feature_util.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_json_consumer.cpp
+++ b/framework/generated/generated_vulkan_json_consumer.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_json_consumer.h
+++ b/framework/generated/generated_vulkan_json_consumer.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_layer_func_table.h
+++ b/framework/generated/generated_vulkan_layer_func_table.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_object_info_table_base2.h
+++ b/framework/generated/generated_vulkan_object_info_table_base2.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_pnext_struct_decoder.cpp
+++ b/framework/generated/generated_vulkan_pnext_struct_decoder.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_pnext_struct_encoder.cpp
+++ b/framework/generated/generated_vulkan_pnext_struct_encoder.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.h
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_replay_dump_resources.cpp
+++ b/framework/generated/generated_vulkan_replay_dump_resources.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_replay_dump_resources.h
+++ b/framework/generated/generated_vulkan_replay_dump_resources.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_state_table.h
+++ b/framework/generated/generated_vulkan_state_table.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_decoders.h
+++ b/framework/generated/generated_vulkan_struct_decoders.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_decoders_forward.h
+++ b/framework/generated/generated_vulkan_struct_decoders_forward.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_deep_copy.cpp
+++ b/framework/generated/generated_vulkan_struct_deep_copy.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
+++ b/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_encoders.h
+++ b/framework/generated/generated_vulkan_struct_encoders.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_to_json.cpp
+++ b/framework/generated/generated_vulkan_struct_to_json.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_struct_to_json.h
+++ b/framework/generated/generated_vulkan_struct_to_json.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/generated_vulkan_stype_util.h
+++ b/framework/generated/generated_vulkan_stype_util.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/generated/khronos_generators/khronos_decode_extended_struct_generator.py
+++ b/framework/generated/khronos_generators/khronos_decode_extended_struct_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018-2024 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_decoder_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_decoder_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2020 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_dispatch_table_generator.py
+++ b/framework/generated/khronos_generators/khronos_dispatch_table_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2019 Valve Corporation
-# Copyright (c) 2019-2024 LunarG, Inc.
+# Copyright (c) 2019-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_encode_extended_struct_generator.py
+++ b/framework/generated/khronos_generators/khronos_encode_extended_struct_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_enum_to_json_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_enum_to_json_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2024 LunarG, Inc.
+# Copyright (c) 2022-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_enum_to_json_header_generator.py
+++ b/framework/generated/khronos_generators/khronos_enum_to_json_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2023 LunarG, Inc.
+# Copyright (c) 2022-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_enum_to_string_header_generator.py
+++ b/framework/generated/khronos_generators/khronos_enum_to_string_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_json_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_json_consumer_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2024 LunarG, Inc.
+# Copyright (c) 2022-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_replay_consumer_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2024 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_struct_decoders_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_decoders_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2020 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_struct_decoders_header_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_decoders_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_struct_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_encoders_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2019 Valve Corporation
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_struct_encoders_header_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_encoders_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018-2024 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_struct_handle_mappers_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_handle_mappers_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2019-2020 Valve Corporation
-# Copyright (c) 2019-2024 LunarG, Inc.
+# Copyright (c) 2019-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_struct_handle_mappers_header_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_handle_mappers_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2019-2020 Valve Corporation
-# Copyright (c) 2019-2024 LunarG, Inc.
+# Copyright (c) 2019-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_struct_to_json_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_to_json_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2024 LunarG, Inc.
+# Copyright (c) 2022-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_struct_to_json_header_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_to_json_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2024 LunarG, Inc.
+# Copyright (c) 2022-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/khronos_struct_type_util_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_type_util_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright (c) 2024 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/gencode.py
+++ b/framework/generated/khronos_generators/openxr_generators/gencode.py
@@ -195,7 +195,7 @@ def make_gen_opts(args):
 
     # Copyright text prefixing all headers (list of strings).
     prefix_strings = [
-        '/*', '** Copyright (c) 2018-2023 Valve Corporation',
+        '/*', '** Copyright (c) 2018-2025 Valve Corporation',
         '** Copyright (c) 2018-2025 LunarG, Inc.',
         '** Copyright (c) 2023 Advanced Micro Devices, Inc.', '**',
         '** Permission is hereby granted, free of charge, to any person obtaining a',

--- a/framework/generated/khronos_generators/openxr_generators/openxr_api_call_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_api_call_encoders_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2019 Valve Corporation
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 # Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/khronos_generators/openxr_generators/openxr_api_call_encoders_header_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_api_call_encoders_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_enum_to_json_body_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_enum_to_json_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2023 LunarG, Inc.
+# Copyright (c) 2022-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_enum_to_json_header_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_enum_to_json_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2023 LunarG, Inc.
+# Copyright (c) 2022-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_enum_to_string_body_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_enum_to_string_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2021-2022 LunarG, Inc.
+# Copyright (c) 2021-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_enum_to_string_header_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_enum_to_string_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_object_info_table_header_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_object_info_table_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_replay_consumer_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2023 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 # Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/khronos_generators/openxr_generators/openxr_struct_decoders_body_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_struct_decoders_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2020 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_struct_decoders_forward_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_struct_decoders_forward_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_struct_decoders_header_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_struct_decoders_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_struct_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_struct_encoders_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2019 Valve Corporation
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_struct_encoders_header_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_struct_encoders_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_struct_handle_mappers_body_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_struct_handle_mappers_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2019-2020 Valve Corporation
-# Copyright (c) 2019-2020 LunarG, Inc.
+# Copyright (c) 2019-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_struct_handle_mappers_header_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_struct_handle_mappers_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2019-2020 Valve Corporation
-# Copyright (c) 2019-2020 LunarG, Inc.
+# Copyright (c) 2019-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_struct_next_decoders_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_struct_next_decoders_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_struct_next_encoders_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_struct_next_encoders_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/openxr_generators/openxr_type_util_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_type_util_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright (c) 2024 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/reformat_code.py
+++ b/framework/generated/khronos_generators/reformat_code.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2023 Valve Corporation
-# Copyright (c) 2023 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/gencode.py
+++ b/framework/generated/khronos_generators/vulkan_generators/gencode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2018-2023 Valve Corporation
-# Copyright (c) 2018-2023 LunarG, Inc.
+# Copyright (c) 2018-2024 LunarG, Inc.
 # Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/khronos_generators/vulkan_generators/gencode.py
+++ b/framework/generated/khronos_generators/vulkan_generators/gencode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2018-2023 Valve Corporation
-# Copyright (c) 2018-2024 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 # Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -203,7 +203,7 @@ def make_gen_opts(args):
 
     # Copyright text prefixing all headers (list of strings).
     prefix_strings = [
-        '/*', '** Copyright (c) 2018-2023 Valve Corporation',
+        '/*', '** Copyright (c) 2018-2025 Valve Corporation',
         '** Copyright (c) 2018-2023 LunarG, Inc.',
         '** Copyright (c) 2023 Advanced Micro Devices, Inc.', '**',
         '** Permission is hereby granted, free of charge, to any person obtaining a',

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2019 Valve Corporation
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 # Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_api_call_encoders_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_api_call_encoders_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_base_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_base_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2021 Valve Corporation
-# Copyright (c) 2018-2024 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_command_buffer_util_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_command_buffer_util_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2019 Valve Corporation
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_command_buffer_util_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_command_buffer_util_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2019 Valve Corporation
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_body_generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2020 Samsung
 # Copyright (c) 2023 Google
-# Copyright (c) 2024 LunarG
+# Copyright (c) 2025 LunarG
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ CPP_PREFIX_STRING = [
     '/*',
     '** Copyright (c) 2020 Samsung',
     '** Copyright (c) 2023 Google',
-    '** Copyright (c) 2024 LunarG, Inc.',
+    '** Copyright (c) 2025 LunarG, Inc.',
     '**',
     '** Permission is hereby granted, free of charge, to any person obtaining a',
     '** copy of this software and associated documentation files (the "Software"),',

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_body_generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2020 Samsung
 # Copyright (c) 2023 Google
-# Copyright (c) 2023 LunarG
+# Copyright (c) 2024 LunarG
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ CPP_PREFIX_STRING = [
     '/*',
     '** Copyright (c) 2020 Samsung',
     '** Copyright (c) 2023 Google',
-    '** Copyright (c) 2023 LunarG, Inc.',
+    '** Copyright (c) 2024 LunarG, Inc.',
     '**',
     '** Permission is hereby granted, free of charge, to any person obtaining a',
     '** copy of this software and associated documentation files (the "Software"),',

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_extension_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_extension_generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2021 Samsung
 # Copyright (c) 2023 Google
-# Copyright (c) 2024 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ CPP_PREFIX_STRING = [
     '/*',
     '** Copyright (c) 2021 Samsung',
     '** Copyright (c) 2023 Google',
-    '** Copyright (c) 2023 LunarG, Inc.',
+    '** Copyright (c) 2025 LunarG, Inc.',
     '**',
     '** Permission is hereby granted, free of charge, to any person obtaining a',
     '** copy of this software and associated documentation files (the "Software"),',

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_extension_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_extension_generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2021 Samsung
 # Copyright (c) 2023 Google
-# Copyright (c) 2023 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_header_generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2020 Samsung
 # Copyright (c) 2023 Google
-# Copyright (c) 2024 LunarG
+# Copyright (c) 2025 LunarG
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ CPP_PREFIX_STRING = [
     '/*',
     '** Copyright (c) 2020 Samsung',
     '** Copyright (c) 2023 Google',
-    '** Copyright (c) 2024 LunarG, Inc.',
+    '** Copyright (c) 2025 LunarG, Inc.',
     '**',
     '** Permission is hereby granted, free of charge, to any person obtaining a',
     '** copy of this software and associated documentation files (the "Software"),',

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_consumer_header_generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2020 Samsung
 # Copyright (c) 2023 Google
-# Copyright (c) 2023 LunarG
+# Copyright (c) 2024 LunarG
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ CPP_PREFIX_STRING = [
     '/*',
     '** Copyright (c) 2020 Samsung',
     '** Copyright (c) 2023 Google',
-    '** Copyright (c) 2023 LunarG, Inc.',
+    '** Copyright (c) 2024 LunarG, Inc.',
     '**',
     '** Permission is hereby granted, free of charge, to any person obtaining a',
     '** copy of this software and associated documentation files (the "Software"),',

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_struct_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_struct_generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2021 Samsung
 # Copyright (c) 2023 Google
-# Copyright (c) 2023 LunarG
+# Copyright (c) 2024 LunarG
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_struct_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_struct_generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2021 Samsung
 # Copyright (c) 2023 Google
-# Copyright (c) 2024 LunarG
+# Copyright (c) 2025 LunarG
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ CPP_PREFIX_STRING = [
     '/*',
     '** Copyright (c) 2021 Samsung',
     '** Copyright (c) 2023 Google',
-    '** Copyright (c) 2023 LunarG, Inc.',
+    '** Copyright (c) 2025 LunarG, Inc.',
     '**',
     '** Permission is hereby granted, free of charge, to any person obtaining a',
     '** copy of this software and associated documentation files (the "Software"),',

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_decoder_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_decoder_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2020 LunarG, Inc.
+# Copyright (c) 2018-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_dispatch_table_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_dispatch_table_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2019 Valve Corporation
-# Copyright (c) 2019 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_enum_to_json_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_enum_to_json_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2023 LunarG, Inc.
+# Copyright (c) 2022-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_enum_to_json_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_enum_to_json_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2023 LunarG, Inc.
+# Copyright (c) 2022-2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_enum_to_string_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_enum_to_string_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2021-2022 LunarG, Inc.
+# Copyright (c) 2021-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_enum_to_string_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_enum_to_string_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_feature_util_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_feature_util_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2020 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_json_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_json_consumer_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2023 LunarG, Inc.
+# Copyright (c) 2022-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_json_consumer_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_json_consumer_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2023 LunarG, Inc.
+# Copyright (c) 2022-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_layer_func_table_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_layer_func_table_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_pnext_struct_decode_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_pnext_struct_decode_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_pnext_struct_encode_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_pnext_struct_encode_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_referenced_resource_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_referenced_resource_consumer_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2020 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2020 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2023 LunarG, Inc.
+# Copyright (c) 2018-2025 LunarG, Inc.
 # Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_dump_resources_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_dump_resources_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2023 LunarG, Inc.
+# Copyright (c) 2018-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_dump_resources_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_dump_resources_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_state_table_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_state_table_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_decoders_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_decoders_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2020 Valve Corporation
-# Copyright (c) 2018-2020 LunarG, Inc.
+# Copyright (c) 2018-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_decoders_forward_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_decoders_forward_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_decoders_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_decoders_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_deep_copy_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_deep_copy_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2023 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 # Copyright (c) 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_deep_copy_stype_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_deep_copy_stype_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2023 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 # Copyright (c) 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_encoders_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018-2019 Valve Corporation
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2018-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_encoders_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_encoders_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_handle_mappers_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_handle_mappers_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2019-2020 Valve Corporation
-# Copyright (c) 2019-2020 LunarG, Inc.
+# Copyright (c) 2019-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2019-2020 Valve Corporation
-# Copyright (c) 2019-2020 LunarG, Inc.
+# Copyright (c) 2019-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2019 Valve Corporation
-# Copyright (c) 2019 LunarG, Inc.
+# Copyright (c) 2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_to_json_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_to_json_body_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2023 LunarG, Inc.
+# Copyright (c) 2022-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_to_json_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_to_json_header_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2022-2023 LunarG, Inc.
+# Copyright (c) 2022-2024 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/graphics/dx12_shader_id_map.cpp
+++ b/framework/graphics/dx12_shader_id_map.cpp
@@ -1,6 +1,6 @@
 
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/graphics/dx12_shader_id_map.h
+++ b/framework/graphics/dx12_shader_id_map.h
@@ -1,6 +1,6 @@
 
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
 **

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
 **

--- a/framework/graphics/vulkan_check_buffer_references.cpp
+++ b/framework/graphics/vulkan_check_buffer_references.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/graphics/vulkan_check_buffer_references.h
+++ b/framework/graphics/vulkan_check_buffer_references.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/graphics/vulkan_util.cpp
+++ b/framework/graphics/vulkan_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/argument_parser.h
+++ b/framework/util/argument_parser.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/compressor.h
+++ b/framework/util/compressor.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/date_time.cpp
+++ b/framework/util/date_time.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018, 2022 Valve Corporation
-** Copyright (c) 2018, 2022 LunarG, Inc.
+** Copyright (c) 2018, 2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/defines.h
+++ b/framework/util/defines.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/file_output_stream.cpp
+++ b/framework/util/file_output_stream.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/file_output_stream.h
+++ b/framework/util/file_output_stream.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/file_path.cpp
+++ b/framework/util/file_path.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018,2022-2023 LunarG, Inc.
+** Copyright (c) 2018,2022-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/file_path.h
+++ b/framework/util/file_path.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018,2022 LunarG, Inc.
+** Copyright (c) 2018,2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/hash.h
+++ b/framework/util/hash.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2020 Valve Corporation
-** Copyright (c) 2020-2023 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/image_writer.cpp
+++ b/framework/util/image_writer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
 *
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/util/image_writer.h
+++ b/framework/util/image_writer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/util/json_util.cpp
+++ b/framework/util/json_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2023 LunarG, Inc.
+** Copyright (c) 2022-2025 LunarG, Inc.
 ** Copyright (c) 2023 Valve Corporation.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/util/json_util.h
+++ b/framework/util/json_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022-2023 LunarG, Inc.
+** Copyright (c) 2022-2025 LunarG, Inc.
 ** Copyright (c) 2023 Valve Corporation.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/util/keyboard.cpp
+++ b/framework/util/keyboard.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2020 Valve Corporation
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/linear_hashmap.h
+++ b/framework/util/linear_hashmap.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/logging.h
+++ b/framework/util/logging.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2019 Valve Corporation
-** Copyright (c) 2018-2019 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/lz4_compressor.cpp
+++ b/framework/util/lz4_compressor.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
-** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2018,2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/lz4_compressor.h
+++ b/framework/util/lz4_compressor.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/options.cpp
+++ b/framework/util/options.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 ** Copyright (c) 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/util/options.h
+++ b/framework/util/options.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 ** Copyright (c) 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/util/output_stream.h
+++ b/framework/util/output_stream.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/page_guard_manager.cpp
+++ b/framework/util/page_guard_manager.cpp
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2015-2023 Valve Corporation
-** Copyright (c) 2015-2023 LunarG, Inc.
+** Copyright (c) 2015-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2015-2020 Valve Corporation
-** Copyright (c) 2015-2020 LunarG, Inc.
+** Copyright (c) 2015-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/page_guard_manager_uffd.cpp
+++ b/framework/util/page_guard_manager_uffd.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2023 Valve Corporation
-** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/page_status_tracker.h
+++ b/framework/util/page_status_tracker.h
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/settings_loader.cpp
+++ b/framework/util/settings_loader.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2020 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/settings_loader.h
+++ b/framework/util/settings_loader.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2020 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/spirv_parsing_util.cpp
+++ b/framework/util/spirv_parsing_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/spirv_parsing_util.h
+++ b/framework/util/spirv_parsing_util.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/strings.cpp
+++ b/framework/util/strings.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2022 Valve Corporation
-** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/strings.h
+++ b/framework/util/strings.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2022 Valve Corporation
-** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/test/test_linear_hashmap.cpp
+++ b/framework/util/test/test_linear_hashmap.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2021-2025 LunarG, Inc.
 ** Copyright (c) 2022-2023 Valve Corporation
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/util/xlib_loader.cpp
+++ b/framework/util/xlib_loader.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/xlib_loader.h
+++ b/framework/util/xlib_loader.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/zlib_compressor.cpp
+++ b/framework/util/zlib_compressor.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/zlib_compressor.h
+++ b/framework/util/zlib_compressor.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2019 Valve Corporation
-** Copyright (c) 2018-2019 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/zstd_compressor.cpp
+++ b/framework/util/zstd_compressor.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/util/zstd_compressor.h
+++ b/framework/util/zstd_compressor.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/layer/d3d12/dll_main.cpp
+++ b/layer/d3d12/dll_main.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/layer/d3d12_capture/dll_main.cpp
+++ b/layer/d3d12_capture/dll_main.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/layer/dxgi/dll_main.cpp
+++ b/layer/dxgi/dll_main.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -390,14 +390,19 @@ def verify_copyrights(target_files):
         commit_year = edit_date.split('-')[0]
 
         file_path = repo_relative(file)
-        copyright_pattern = 'Copyright .*([0-9]{4}) LunarG'
-        copyright_match = re.search(copyright_pattern, open(file_path, encoding=ENCODING, errors='ignore').read(1024))
+        copyright_pattern = r'Copyright .*([0-9]{4}) LunarG'
+        with open(file_path, encoding=ENCODING, errors='ignore') as f:
+            in_string = f.read(1024)
+        copyright_match = re.search(copyright_pattern, in_string)
         if copyright_match:
             copyright_year = copyright_match.group(1)
             if int(commit_year) > int(copyright_year):
                 msg = f'Change written in {commit_year} but copyright ends in {copyright_year}.'
                 print(f'\n{file_path} has an out-of-date LunarG copyright notice: {msg}')
-                #re.sub(copyright_pattern, repl, string, count=0, flags=0)
+                out_string = re.sub(r"[0-9]{4} LunarG", f'{commit_year} LunarG', in_string, count=0, flags=0)
+                with open(file_path, "r+", encoding=ENCODING, errors='ignore') as f:
+                    f.seek(0)
+                    f.write(out_string)
                 bad_files.append(file)
     
     return bad_files

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -428,7 +428,8 @@ if '__main__' == __name__:
 
         subprocess.check_output(['git', 'fetch', 'https://github.com/LunarG/gfxreconstruct.git', 'dev'])
         target_refspec = "origin/dev"
-        base_refspec = "HEAD"
+        #base_refspec = "HEAD"
+        base_refspec = "FETCH_HEAD"
 
         status = subprocess.check_output(['git', 'status'])
         print("status ==", status)
@@ -449,19 +450,19 @@ if '__main__' == __name__:
         #     #      warning if this happens locally.
         #     target_refspec = 'HEAD^'
         #     base_refspec = 'HEAD^2'
-        if "Merge" in this_commit_log:
-            # this_commit_log will be something like
-            # 835d472e Merge 789aa977b4f32539b9a6b95df8262b46b61d776c into 0c85de735c31bd1688f4cf4dbfaac41b189a46c9
+        # if "Merge" in this_commit_log:
+        #     # this_commit_log will be something like
+        #     # 835d472e Merge 789aa977b4f32539b9a6b95df8262b46b61d776c into 0c85de735c31bd1688f4cf4dbfaac41b189a46c9
             
-            base_refspec = this_commit_log.split(' ')[2]
+        #     base_refspec = this_commit_log.split(' ')[2]
             #base_refspec = 'HEAD^2'
 
-        print("target_ref == ", target_refspec)
-        print("base_ref == ", base_refspec)
-        copyright_check_failed = 0
+        print("target_ref ==", target_refspec)
+        print("base_ref ==", base_refspec)
         commits = subprocess.check_output(['git', 'log', '--format=%h', f'{target_refspec}...{base_refspec}']).split(b'\n')
         commits = commits[:-1] # Remove final, blank entry
         commits.reverse()
+        copyright_check_failed = 0
         print("Commit list: ", commits)
         for commit in commits:
             # Don't check blacklisted commits

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -431,8 +431,7 @@ if '__main__' == __name__:
         base_refspec = "HEAD"
 
         loglines = subprocess.check_output(['git', 'log', '--oneline']).decode(ENCODING).split('\n')
-        for i in range(0, 10):
-            print(loglines[i])
+        print(loglines)
 
         # Check if this is a merge commit
         commit_parents = subprocess.check_output(['git', 'rev-list', '--parents', '-n', '1', 'HEAD'])

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -432,6 +432,7 @@ if '__main__' == __name__:
 
         # Check if this is a merge commit
         commit_parents = subprocess.check_output(['git', 'rev-list', '--parents', '-n', '1', 'HEAD'])
+        print("commit_parents ==", commit_parents)
         if len(commit_parents.split(b' ')) > 2:
             # If this is a merge commit, this is a PR being built, and has been merged into main for testing.
             # The first parent (HEAD^) is going to be main, the second parent (HEAD^2) is going to be the PR commit.

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -444,8 +444,11 @@ if '__main__' == __name__:
         #     target_refspec = 'HEAD^'
         #     base_refspec = 'HEAD^2'
         if "Merge" in this_commit_log:
-            target_refspec = 'HEAD^'
-            base_refspec = 'HEAD^2'
+            # this_commit_log will be something like
+            # 835d472e Merge 789aa977b4f32539b9a6b95df8262b46b61d776c into 0c85de735c31bd1688f4cf4dbfaac41b189a46c9
+            
+            base_refspec = this_commit_log.split(' ')[2]
+            #base_refspec = 'HEAD^2'
 
         print("target_ref == ", target_refspec)
         print("base_ref == ", base_refspec)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -430,6 +430,10 @@ if '__main__' == __name__:
         target_refspec = "origin/dev"
         base_refspec = "HEAD"
 
+        loglines = subprocess.check_output(['git', 'log', '--oneline']).decode(ENCODING).split('\n')
+        for i in range(0, 10):
+            print(loglines[i])
+
         # Check if this is a merge commit
         commit_parents = subprocess.check_output(['git', 'rev-list', '--parents', '-n', '1', 'HEAD'])
         print("commit_parents ==", commit_parents)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -448,6 +448,12 @@ if '__main__' == __name__:
         commits.reverse()
         print("Commit list: ", commits)
         for commit in commits:
+            # Don't check blacklisted commits
+            # Right now, the only blacklisted commit is the one
+            # where all of the copyrights years were updated
+            BLACKLISTED_COMMITS = [b'93169ddf']
+            if commit in BLACKLISTED_COMMITS:
+                continue
 
             # Get list of files involved in this commit
             target_files_data = subprocess.check_output(['git', 'log', '-n1', '--name-only', commit])

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -428,7 +428,8 @@ if '__main__' == __name__:
 
         subprocess.check_output(['git', 'fetch', 'https://github.com/LunarG/gfxreconstruct.git', 'dev'])
         target_refspec = "origin/dev"
-        base_refspec = "HEAD"
+        #base_refspec = "HEAD"
+        base_refspec = args.check_code_style_base
 
         status = subprocess.check_output(['git', 'status'])
         print("status ==", status)
@@ -462,7 +463,7 @@ if '__main__' == __name__:
 
         print("target_ref ==", target_refspec)
         print("base_ref ==", base_refspec)
-        commits = subprocess.check_output(['git', 'log', '--format=%h', f'{base_refspec}...{target_refspec}']).split(b'\n')
+        commits = subprocess.check_output(['git', 'log', '--format=%h', f'{target_refspec}...{base_refspec}']).split(b'\n')
         commits = commits[:-1] # Remove final, blank entry
         commits.reverse()
         copyright_check_failed = 0

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -436,6 +436,10 @@ if '__main__' == __name__:
         commit_parents = subprocess.check_output(['git', 'rev-list', '--parents', '-n', '1', 'HEAD'])
         print("commit_parents ==", commit_parents)
 
+        # orig_branch = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).decode('utf-8').splitlines()[0]
+        # if orig_branch == 'HEAD':
+        #     orig_branch = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').splitlines()[0]
+
         this_commit_log = subprocess.check_output(['git', 'log', '--oneline']).decode(ENCODING).split('\n')[0]
         print("this_commit_log ==", this_commit_log)
 
@@ -458,7 +462,7 @@ if '__main__' == __name__:
 
         print("target_ref ==", target_refspec)
         print("base_ref ==", base_refspec)
-        commits = subprocess.check_output(['git', 'log', '--format=%h', f'{target_refspec}...{base_refspec}']).split(b'\n')
+        commits = subprocess.check_output(['git', 'log', '--format=%h', f'{base_refspec}...{target_refspec}']).split(b'\n')
         commits = commits[:-1] # Remove final, blank entry
         commits.reverse()
         copyright_check_failed = 0

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -431,6 +431,7 @@ if '__main__' == __name__:
         base_refspec = "HEAD"
 
         this_commit_log = subprocess.check_output(['git', 'log', '--oneline']).decode(ENCODING).split('\n')[0]
+        print("this_commit_log ==", this_commit_log)
 
         # Check if this is a merge commit
         # commit_parents = subprocess.check_output(['git', 'rev-list', '--parents', '-n', '1', 'HEAD'])

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -430,6 +430,9 @@ if '__main__' == __name__:
         target_refspec = "origin/dev"
         base_refspec = "HEAD"
 
+        status = subprocess.check_output(['git', 'status'])
+        print("status ==", status)
+
         this_commit_log = subprocess.check_output(['git', 'log', '--oneline']).decode(ENCODING).split('\n')[0]
         print("this_commit_log ==", this_commit_log)
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -414,7 +414,7 @@ def fix_copyright(in_string, commit_year, file_path):
 # Main entry point
 if '__main__' == __name__:
     args = parse_args()
-    if args.check_code_style_base:
+    if not args.skip_check_code_style:
         # exts = [".cpp", ".h", ".py"]
         # dirs = ["android", "framework", "layer", "scripts", "test", "tools"]
         # all_source_files = ["LICENSE.txt"]
@@ -428,8 +428,7 @@ if '__main__' == __name__:
 
         subprocess.check_output(['git', 'fetch', 'https://github.com/LunarG/gfxreconstruct.git', 'dev'])
         target_refspec = "origin/dev"
-        #base_refspec = "HEAD"
-        base_refspec = "FETCH_HEAD"
+        base_refspec = "HEAD"
 
         status = subprocess.check_output(['git', 'status'])
         print("status ==", status)
@@ -468,7 +467,7 @@ if '__main__' == __name__:
             # Don't check blacklisted commits
             # Right now, the only blacklisted commit is the one
             # where all of the copyrights years were updated
-            BLACKLISTED_COMMITS = [b'93169ddf']
+            BLACKLISTED_COMMITS = [b'd14a5fe2']
             if commit in BLACKLISTED_COMMITS:
                 continue
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -430,17 +430,19 @@ if '__main__' == __name__:
         target_refspec = "origin/dev"
         base_refspec = "HEAD"
 
-        loglines = subprocess.check_output(['git', 'log', '--oneline']).decode(ENCODING).split('\n')
-        print(loglines)
+        this_commit_log = subprocess.check_output(['git', 'log', '--oneline']).decode(ENCODING).split('\n')[0]
 
         # Check if this is a merge commit
-        commit_parents = subprocess.check_output(['git', 'rev-list', '--parents', '-n', '1', 'HEAD'])
-        print("commit_parents ==", commit_parents)
-        if len(commit_parents.split(b' ')) > 2:
-            # If this is a merge commit, this is a PR being built, and has been merged into main for testing.
-            # The first parent (HEAD^) is going to be main, the second parent (HEAD^2) is going to be the PR commit.
-            # TODO (nick) We should *ONLY* get here when on github CI, building a PR. Should probably print a
-            #      warning if this happens locally.
+        # commit_parents = subprocess.check_output(['git', 'rev-list', '--parents', '-n', '1', 'HEAD'])
+        # print("commit_parents ==", commit_parents)
+        # if len(commit_parents.split(b' ')) > 2:
+        #     # If this is a merge commit, this is a PR being built, and has been merged into main for testing.
+        #     # The first parent (HEAD^) is going to be main, the second parent (HEAD^2) is going to be the PR commit.
+        #     # TODO (nick) We should *ONLY* get here when on github CI, building a PR. Should probably print a
+        #     #      warning if this happens locally.
+        #     target_refspec = 'HEAD^'
+        #     base_refspec = 'HEAD^2'
+        if "Merge" in this_commit_log:
             target_refspec = 'HEAD^'
             base_refspec = 'HEAD^2'
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -433,6 +433,9 @@ if '__main__' == __name__:
         status = subprocess.check_output(['git', 'status'])
         print("status ==", status)
 
+        commit_parents = subprocess.check_output(['git', 'rev-list', '--parents', '-n', '1', 'HEAD'])
+        print("commit_parents ==", commit_parents)
+
         this_commit_log = subprocess.check_output(['git', 'log', '--oneline']).decode(ENCODING).split('\n')[0]
         print("this_commit_log ==", this_commit_log)
 

--- a/test/icd/generated/vk_typemap_helper.h
+++ b/test/icd/generated/vk_typemap_helper.h
@@ -6,7 +6,7 @@
  *
  * Copyright (c) 2015-2017 The Khronos Group Inc.
  * Copyright (c) 2015-2017 Valve Corporation
- * Copyright (c) 2015-2017 LunarG, Inc.
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Copyright (c) 2015-2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_apps/host-image-copy/app.cpp
+++ b/test/test_apps/host-image-copy/app.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/test/test_apps/host-image-copy/host_image_copy_app.h
+++ b/test/test_apps/host-image-copy/host_image_copy_app.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/test/test_apps/multisample-depth/app.cpp
+++ b/test/test_apps/multisample-depth/app.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/test/test_apps/multisample-depth/multisample_depth_app.h
+++ b/test/test_apps/multisample-depth/multisample_depth_app.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/test/test_apps/pipeline-binaries/app.cpp
+++ b/test/test_apps/pipeline-binaries/app.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/test/test_apps/shader-objects/app.cpp
+++ b/test/test_apps/shader-objects/app.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/test/test_apps/triangle/app.cpp
+++ b/test/test_apps/triangle/app.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/tools/capture-vulkan/gfxrecon-capture-vulkan.py
+++ b/tools/capture-vulkan/gfxrecon-capture-vulkan.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2020 LunarG, Inc.
+# Copyright (c) 2025 LunarG, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/tools/compress/compression_converter.cpp
+++ b/tools/compress/compression_converter.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 ** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2020 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/gfxrecon/gfxrecon.py
+++ b/tools/gfxrecon/gfxrecon.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2020-2022 LunarG, Inc.
+# Copyright (c) 2020-2023 LunarG, Inc.
 # Copyright (c) 2022 Valve Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020-2024 LunarG, Inc.
+** Copyright (c) 2020-2025 LunarG, Inc.
 ** Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/optimize/block_skipping_file_processor.cpp
+++ b/tools/optimize/block_skipping_file_processor.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 ** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/optimize/dx12_file_optimizer.cpp
+++ b/tools/optimize/dx12_file_optimizer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2023 LunarG, Inc.
 ** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/optimize/dx12_file_optimizer.h
+++ b/tools/optimize/dx12_file_optimizer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 ** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/optimize/dx12_resource_value_tracking_consumer.cpp
+++ b/tools/optimize/dx12_resource_value_tracking_consumer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/tools/optimize/file_optimizer.cpp
+++ b/tools/optimize/file_optimizer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2025 LunarG, Inc.
 ** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/tools/replay/parse_dump_resources_cli.cpp
+++ b/tools/replay/parse_dump_resources_cli.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/replay/parse_dump_resources_cli.h
+++ b/tools/replay/parse_dump_resources_cli.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2025 LunarG, Inc.
 ** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/tocpp/main.cpp
+++ b/tools/tocpp/main.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2024 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #1548 

This PR adds automated checking of the LunarG copyright year in each source file to Github Actions CI.