### PR TITLE
clear replacers before allocator and device destroy

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -261,9 +261,6 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     // Idle all devices before destroying other resources.
     WaitDevicesIdle();
 
-    // free replacer internal vulkan-resources
-    _device_address_replacers.clear();
-
     // process queued async tasks
     background_queue_.join_all();
     main_thread_queue_.poll();
@@ -3253,6 +3250,8 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
 
             decode::EndInjectedCommands();
         }
+        // free replacer internal vulkan-resources
+        _device_address_replacers.clear();
 
         device_info->allocator->Destroy();
     }


### PR DESCRIPTION
Replacers have many Vulkan objects that need to be destroyed.  If it's cleared in `~VulkanReplayConsumerBase`,  it will happen errors because allocator and device have been destroyed.
`SaschaWillems/raytracingbasic` with `-m rebind` could trigger these errors.
https://github.com/SaschaWillems/Vulkan/tree/master/examples/raytracingbasic