### PR TITLE
Fix cleanup for VulkanAddressreplacer

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -266,6 +266,9 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     // Idle all devices before destroying other resources.
     WaitDevicesIdle();
 
+    // free replacer internal vulkan-resources
+    _device_address_replacers.clear();
+
     // process queued async tasks
     background_queue_.join_all();
     main_thread_queue_.poll();
@@ -3262,8 +3265,9 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
 
             decode::EndInjectedCommands();
         }
-        // free replacer internal vulkan-resources
-        _device_address_replacers.clear();
+
+        // free replacer internal vulkan-resources for the device
+        _device_address_replacers.erase(device_info);
 
         device_info->allocator->Destroy();
     }


### PR DESCRIPTION
- account both for trimming and non-trimming case
- cleanup only for relevant device(s)

follow up on https://github.com/LunarG/gfxreconstruct/pull/2267

tested using SaschaWillems/raytracinggltf using `-m rebind` with and without trimming.