### PR TITLE
Allocator supports more functions

### DIFF
--- a/framework/decode/vulkan_default_allocator.cpp
+++ b/framework/decode/vulkan_default_allocator.cpp
@@ -1073,15 +1073,12 @@ VkResult VulkanDefaultAllocator::QueueBindSparse(VkQueue                 queue,
                                                  VkFence                 fence,
                                                  ResourceData*           allocator_buf_datas,
                                                  const MemoryData*       allocator_buf_mem_datas,
-                                                 const format::HandleId* buf_mem_capture_ids,
                                                  VkMemoryPropertyFlags*  bind_buf_mem_properties,
                                                  ResourceData*           allocator_img_op_datas,
                                                  const MemoryData*       allocator_img_op_mem_datas,
-                                                 const format::HandleId* img_op_mem_capture_ids,
                                                  VkMemoryPropertyFlags*  bind_img_op_mem_properties,
                                                  ResourceData*           allocator_img_datas,
                                                  const MemoryData*       allocator_img_mem_datas,
-                                                 const format::HandleId* img_mem_capture_ids,
                                                  VkMemoryPropertyFlags*  bind_img_mem_properties)
 {
     VkResult result = VK_ERROR_INITIALIZATION_FAILED;

--- a/framework/decode/vulkan_default_allocator.h
+++ b/framework/decode/vulkan_default_allocator.h
@@ -362,15 +362,12 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
                                      VkFence                 fence,
                                      ResourceData*           allocator_buf_datas,
                                      const MemoryData*       allocator_buf_mem_datas,
-                                     const format::HandleId* buf_mem_capture_ids,
                                      VkMemoryPropertyFlags*  bind_buf_mem_properties,
                                      ResourceData*           allocator_img_op_datas,
                                      const MemoryData*       allocator_img_op_mem_datas,
-                                     const format::HandleId* img_op_mem_capture_ids,
                                      VkMemoryPropertyFlags*  bind_img_op_mem_properties,
                                      ResourceData*           allocator_img_datas,
                                      const MemoryData*       allocator_img_mem_datas,
-                                     const format::HandleId* img_mem_capture_ids,
                                      VkMemoryPropertyFlags*  bind_img_mem_properties) override;
 
     virtual uint64_t GetDeviceMemoryOpaqueCaptureAddress(const VkDeviceMemoryOpaqueCaptureAddressInfo* info,

--- a/framework/decode/vulkan_default_allocator.h
+++ b/framework/decode/vulkan_default_allocator.h
@@ -76,11 +76,11 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
                                         const VkAllocationCallbacks*       allocation_callbacks,
                                         format::HandleId                   capture_id,
                                         VkVideoSessionKHR*                 session,
-                                        std::vector<ResourceData>*         allocator_datas) override;
+                                        ResourceData*                      allocator_data) override;
 
     virtual void DestroyVideoSession(VkVideoSessionKHR            session,
                                      const VkAllocationCallbacks* allocation_callbacks,
-                                     std::vector<ResourceData>    allocator_datas) override;
+                                     ResourceData                 allocator_data) override;
 
     virtual void GetBufferMemoryRequirements(VkBuffer              buffer,
                                              VkMemoryRequirements* memory_requirements,
@@ -107,7 +107,7 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
     virtual VkResult GetVideoSessionMemoryRequirementsKHR(VkVideoSessionKHR video_session,
                                                           uint32_t*         memory_requirements_count,
                                                           VkVideoSessionMemoryRequirementsKHR* memory_requirements,
-                                                          std::vector<ResourceData> allocator_datas) override;
+                                                          ResourceData allocator_datas) override;
 
     virtual VkResult AllocateMemory(const VkMemoryAllocateInfo*  allocate_info,
                                     const VkAllocationCallbacks* allocation_callbacks,
@@ -152,7 +152,7 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
     virtual VkResult BindVideoSessionMemory(VkVideoSessionKHR                      video_session,
                                             uint32_t                               bind_info_count,
                                             const VkBindVideoSessionMemoryInfoKHR* bind_infos,
-                                            const ResourceData*                    allocator_session_datas,
+                                            const ResourceData                     allocator_session_data,
                                             const MemoryData*                      allocator_memory_datas,
                                             VkMemoryPropertyFlags*                 bind_memory_properties) override;
 
@@ -163,7 +163,12 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
                                void**           data,
                                MemoryData       allocator_data) override;
 
+    virtual VkResult
+    MapMemory2(const VkMemoryMapInfo* memory_map_info, void** data, MemoryData allocator_data) override;
+
     virtual void UnmapMemory(VkDeviceMemory memory, MemoryData allocator_data) override;
+
+    virtual VkResult UnmapMemory2(const VkMemoryUnmapInfo* memory_unmap_info, MemoryData allocator_data) override;
 
     virtual VkResult FlushMappedMemoryRanges(uint32_t                   memory_range_count,
                                              const VkMappedMemoryRange* memory_ranges,
@@ -207,8 +212,25 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
     virtual void ReportBindVideoSessionIncompatibility(VkVideoSessionKHR                      video_session,
                                                        uint32_t                               bind_info_count,
                                                        const VkBindVideoSessionMemoryInfoKHR* bind_infos,
-                                                       const ResourceData*                    allocator_resource_datas,
+                                                       const ResourceData                     allocator_resource_data,
                                                        const MemoryData* allocator_memory_datas) override;
+
+    virtual void
+    ReportBindAccelerationStructureMemoryNVIncompatibility(uint32_t bind_info_count,
+                                                           const VkBindAccelerationStructureMemoryInfoNV* bind_infos,
+                                                           const ResourceData* allocator_acc_datas,
+                                                           const MemoryData*   allocator_memory_datas) override;
+
+    virtual void ReportQueueBindSparseIncompatibility(VkQueue                 queue,
+                                                      uint32_t                bind_info_count,
+                                                      const VkBindSparseInfo* bind_infos,
+                                                      VkFence                 fence,
+                                                      const ResourceData*     allocator_buf_datas,
+                                                      const MemoryData*       allocator_buf_mem_datas,
+                                                      const ResourceData*     allocator_img_op_datas,
+                                                      const MemoryData*       allocator_img_op_mem_datas,
+                                                      const ResourceData*     allocator_img_datas,
+                                                      const MemoryData*       allocator_img_mem_datas) override;
 
     // Direct allocation methods that perform memory allocation and resource creation without performing memory
     // translation.  These methods allow the replay tool to allocate staging resources through the resource allocator so
@@ -305,12 +327,76 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
 
     virtual bool SupportBindVideoSessionMemory() override { return false; }
 
+    virtual void SetDeviceMemoryPriority(VkDeviceMemory memory, float priority, MemoryData allocator_data) override;
+
+    virtual VkResult GetMemoryRemoteAddressNV(const VkMemoryGetRemoteAddressInfoNV* memory_get_remote_address_info,
+                                              VkRemoteAddressNV*                    address,
+                                              MemoryData                            allocator_data) override;
+
+    virtual VkResult CreateAccelerationStructureNV(const VkAccelerationStructureCreateInfoNV* create_info,
+                                                   const VkAllocationCallbacks*               allocation_callbacks,
+                                                   format::HandleId                           capture_id,
+                                                   VkAccelerationStructureNV*                 acc_str,
+                                                   ResourceData*                              allocator_data) override;
+
+    virtual void DestroyAccelerationStructureNV(VkAccelerationStructureNV    acc_str,
+                                                const VkAllocationCallbacks* allocation_callbacks,
+                                                ResourceData                 allocator_data) override;
+
+    virtual void
+    GetAccelerationStructureMemoryRequirementsNV(const VkAccelerationStructureMemoryRequirementsInfoNV* info,
+                                                 VkMemoryRequirements2KHR* memory_requirements,
+                                                 ResourceData              allocator_data) override;
+
+    virtual VkResult BindAccelerationStructureMemoryNV(uint32_t                                       bind_info_count,
+                                                       const VkBindAccelerationStructureMemoryInfoNV* bind_infos,
+                                                       const ResourceData*    allocator_acc_datas,
+                                                       const MemoryData*      allocator_memory_datas,
+                                                       VkMemoryPropertyFlags* bind_memory_properties) override;
+
+    virtual VkResult GetMemoryFd(const VkMemoryGetFdInfoKHR* get_fd_info, int* pFd, MemoryData allocator_data) override;
+
+    virtual VkResult QueueBindSparse(VkQueue                 queue,
+                                     uint32_t                bind_info_count,
+                                     const VkBindSparseInfo* bind_infos,
+                                     VkFence                 fence,
+                                     ResourceData*           allocator_buf_datas,
+                                     const MemoryData*       allocator_buf_mem_datas,
+                                     const format::HandleId* buf_mem_capture_ids,
+                                     VkMemoryPropertyFlags*  bind_buf_mem_properties,
+                                     ResourceData*           allocator_img_op_datas,
+                                     const MemoryData*       allocator_img_op_mem_datas,
+                                     const format::HandleId* img_op_mem_capture_ids,
+                                     VkMemoryPropertyFlags*  bind_img_op_mem_properties,
+                                     ResourceData*           allocator_img_datas,
+                                     const MemoryData*       allocator_img_mem_datas,
+                                     const format::HandleId* img_mem_capture_ids,
+                                     VkMemoryPropertyFlags*  bind_img_mem_properties) override;
+
+    virtual uint64_t GetDeviceMemoryOpaqueCaptureAddress(const VkDeviceMemoryOpaqueCaptureAddressInfo* info,
+                                                         MemoryData allocator_data) override;
+
   protected:
+
+    enum MemoryInfoType
+    {
+        kBasic,       // single: buffer, image, acceleration_structure_nv
+        kSparse,      // array: buffer, image
+        kVideoSession // array: video_session
+    };
+
+    struct BoundMemoryInfo
+    {
+        VkDeviceMemory memory{ VK_NULL_HANDLE };
+        VkDeviceSize   offset{ 0 };
+    };
+
     struct ResourceAllocInfo
     {
-        format::HandleId capture_id{ format::kNullHandleId };
-        VkDeviceMemory   bound_memory{ VK_NULL_HANDLE };
-        VkDeviceSize     bound_offset{ 0 };
+        MemoryInfoType               memory_info_type;
+        std::vector<BoundMemoryInfo> bound_memory_infos;
+        VkObjectType                 object_type{ VK_OBJECT_TYPE_UNKNOWN };
+        format::HandleId             capture_id{ format::kNullHandleId };
     };
 
     struct MemoryAllocInfo
@@ -342,6 +428,13 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
     void ReportBindIncompatibility(const VkMemoryRequirements* requirements,
                                    const MemoryData*           allocator_memory_datas,
                                    uint32_t                    resource_count);
+
+    bool UpdateAllocInfo(ResourceData           allocator_resource_data,
+                         MemoryInfoType         memory_info_type,
+                         VkDeviceMemory         memory,
+                         VkDeviceSize           memory_offset,
+                         MemoryData             allocator_memory_data,
+                         VkMemoryPropertyFlags* bind_memory_property);
 
   private:
     VkDevice                         device_;

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -228,7 +228,6 @@ typedef VulkanObjectInfo<VkDisplayModeKHR>                     VulkanDisplayMode
 typedef VulkanObjectInfo<VkDebugReportCallbackEXT>             VulkanDebugReportCallbackEXTInfo;
 typedef VulkanObjectInfo<VkIndirectCommandsLayoutNV>           VulkanIndirectCommandsLayoutNVInfo;
 typedef VulkanObjectInfo<VkDebugUtilsMessengerEXT>             VulkanDebugUtilsMessengerEXTInfo;
-typedef VulkanObjectInfo<VkAccelerationStructureNV>            VulkanAccelerationStructureNVInfo;
 typedef VulkanObjectInfo<VkPerformanceConfigurationINTEL>      VulkanPerformanceConfigurationINTELInfo;
 typedef VulkanObjectInfo<VkMicromapEXT>                        VulkanMicromapEXTInfo;
 typedef VulkanObjectInfo<VkOpticalFlowSessionNV>               VulkanOpticalFlowSessionNVInfo;
@@ -383,6 +382,8 @@ struct VulkanBufferInfo : public VulkanObjectInfo<VkBuffer>
     // This is only used when loading the initial state for trimmed files.
     VkMemoryPropertyFlags memory_property_flags{ 0 };
 
+    std::vector<VkMemoryPropertyFlags> sparse_memory_property_flags;
+
     VkBufferUsageFlags usage{ 0 };
     VkDeviceSize       size{ 0 };
     uint32_t           queue_family_index{ 0 };
@@ -409,6 +410,8 @@ struct VulkanImageInfo : public VulkanObjectInfo<VkImage>
 
     // This is only used when loading the initial state for trimmed files.
     VkMemoryPropertyFlags memory_property_flags{ 0 };
+
+    std::vector<VkMemoryPropertyFlags> sparse_memory_property_flags;
 
     VkImageUsageFlags     usage{ 0 };
     VkImageType           type{};
@@ -621,7 +624,7 @@ struct VulkanVideoSessionKHRInfo : VulkanObjectInfo<VkVideoSessionKHR>
     std::unordered_map<uint32_t, size_t> array_counts;
 
     // The following values are only used for memory portability.
-    std::vector<VulkanResourceAllocator::ResourceData> allocator_datas;
+    VulkanResourceAllocator::ResourceData allocator_data;
 
     // This is only used when loading the initial state for trimmed files.
     std::vector<VkMemoryPropertyFlags> memory_property_flags;
@@ -711,6 +714,15 @@ struct VulkanAccelerationStructureKHRInfo : public VulkanObjectInfo<VkAccelerati
 
     //! associated buffer
     VkBuffer buffer = VK_NULL_HANDLE;
+};
+
+struct VulkanAccelerationStructureNVInfo : public VulkanObjectInfo<VkAccelerationStructureNV>
+{
+    // The following values are only used for memory portability.
+    VulkanResourceAllocator::ResourceData allocator_data{ 0 };
+
+    // This is only used when loading the initial state for trimmed files.
+    VkMemoryPropertyFlags memory_property_flags{ 0 };
 };
 
 //

--- a/framework/decode/vulkan_realign_allocator.cpp
+++ b/framework/decode/vulkan_realign_allocator.cpp
@@ -253,31 +253,9 @@ VulkanRealignAllocator::BindAccelerationStructureMemoryNV(uint32_t bind_info_cou
                                                           const MemoryData*      allocator_memory_datas,
                                                           VkMemoryPropertyFlags* bind_memory_properties)
 {
-    std::unique_ptr<VkBindAccelerationStructureMemoryInfoNV[]> realign_bind_infos;
-
-    if ((allocator_acc_datas != nullptr) && (bind_infos != nullptr))
-    {
-        realign_bind_infos = std::make_unique<VkBindAccelerationStructureMemoryInfoNV[]>(bind_info_count);
-
-        for (uint32_t i = 0; i < bind_info_count; ++i)
-        {
-            realign_bind_infos[i] = bind_infos[i];
-
-            auto resource_info = GetResourceAllocInfo(allocator_acc_datas[i]);
-            if (resource_info != nullptr)
-            {
-                // Update image to new binding offset from first pass data collected from resource tracking.
-                auto tracked_image_info = tracked_object_table_->GetTrackedVkResourceInfo(resource_info->capture_id);
-                if (tracked_image_info != nullptr)
-                {
-                    realign_bind_infos[i].memoryOffset = tracked_image_info->GetReplayBindOffset();
-                }
-            }
-        }
-    }
-
-    return VulkanDefaultAllocator::BindAccelerationStructureMemoryNV(
-        bind_info_count, realign_bind_infos.get(), allocator_acc_datas, allocator_memory_datas, bind_memory_properties);
+    GFXRECON_LOG_FATAL("-m realign doesn't support BindAccelerationStructureMemoryNV. VK_NV_ray_tracing is deprecated. "
+                       "It won't get more support.");
+    return VK_ERROR_EXTENSION_NOT_PRESENT;
 }
 
 VkResult VulkanRealignAllocator::MapMemory(VkDeviceMemory   memory,

--- a/framework/decode/vulkan_realign_allocator.h
+++ b/framework/decode/vulkan_realign_allocator.h
@@ -78,9 +78,15 @@ class VulkanRealignAllocator : public VulkanDefaultAllocator
     virtual VkResult BindVideoSessionMemory(VkVideoSessionKHR                      video_session,
                                             uint32_t                               bind_info_count,
                                             const VkBindVideoSessionMemoryInfoKHR* bind_infos,
-                                            const ResourceData*                    allocator_session_datas,
+                                            const ResourceData                     allocator_session_data,
                                             const MemoryData*                      allocator_memory_datas,
                                             VkMemoryPropertyFlags*                 bind_memory_properties) override;
+
+    virtual VkResult BindAccelerationStructureMemoryNV(uint32_t                                       bind_info_count,
+                                                       const VkBindAccelerationStructureMemoryInfoNV* bind_infos,
+                                                       const ResourceData*    allocator_acc_datas,
+                                                       const MemoryData*      allocator_memory_datas,
+                                                       VkMemoryPropertyFlags* bind_memory_properties) override;
 
     virtual VkResult MapMemory(VkDeviceMemory   memory,
                                VkDeviceSize     offset,

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -2348,8 +2348,8 @@ void VulkanRebindAllocator::GetDeviceMemoryCommitment(VkDeviceMemory memory,
 
     if (alcs.empty())
     {
-        GFXRECON_LOG_WARNING("There's no allocations or memory is VK_NULL_HANDLE for GetDeviceMemoryCommitment");
-        functions_.get_device_memory_commitment(device_, modified_mem, committed_memory_in_bytes);
+        GFXRECON_LOG_WARNING("There's no allocations or memory is VK_NULL_HANDLE. Skip GetDeviceMemoryCommitment");
+        return;
     }
 
     for (const auto& alc : alcs)
@@ -2390,8 +2390,8 @@ void VulkanRebindAllocator::SetDeviceMemoryPriority(VkDeviceMemory memory, float
 
     if (alcs.empty())
     {
-        GFXRECON_LOG_WARNING("There's no allocations or memory is VK_NULL_HANDLE for SetDeviceMemoryPriority");
-        functions_.set_device_memory_priority(device_, modified_mem, priority);
+        GFXRECON_LOG_WARNING("There's no allocations or memory is VK_NULL_HANDLE. Skip SetDeviceMemoryPriority");
+        return;
     }
 
     for (const auto& alc : alcs)
@@ -2435,10 +2435,8 @@ VulkanRebindAllocator::GetMemoryRemoteAddressNV(const VkMemoryGetRemoteAddressIn
 
     if (alcs.empty())
     {
-        GFXRECON_LOG_WARNING("There's no allocations or memory is VK_NULL_HANDLE for GetMemoryRemoteAddressNV");
-
-        modified_get_mem_remote_addr_info.memory = VK_NULL_HANDLE;
-        return functions_.get_memory_remote_address_nv(device_, &modified_get_mem_remote_addr_info, address);
+        GFXRECON_LOG_WARNING("There's no allocations or memory is VK_NULL_HANDLE. Skip GetMemoryRemoteAddressNV");
+        return VK_SUCCESS;
     }
 
     auto result = VK_ERROR_INITIALIZATION_FAILED;
@@ -2528,10 +2526,8 @@ VulkanRebindAllocator::GetMemoryFd(const VkMemoryGetFdInfoKHR* get_fd_info, int*
 
     if (alcs.empty())
     {
-        GFXRECON_LOG_ERROR("There's no allocationsor memory is VK_NULL_HANDLE for GetMemoryFd");
-
-        modified_get_fd_info.memory = VK_NULL_HANDLE;
-        return functions_.get_memory_fd(device_, &modified_get_fd_info, pFd);
+        GFXRECON_LOG_WARNING("There's no allocations or memory is VK_NULL_HANDLE. Skip GetMemoryFd");
+        return VK_SUCCESS;
     }
 
     auto result = VK_ERROR_INITIALIZATION_FAILED;
@@ -3031,10 +3027,8 @@ uint64_t VulkanRebindAllocator::GetDeviceMemoryOpaqueCaptureAddress(const VkDevi
     if (alcs.empty())
     {
         GFXRECON_LOG_WARNING(
-            "There's no allocations or memory is VK_NULL_HANDLE for GetDeviceMemoryOpaqueCaptureAddress");
-
-        modified_info.memory = VK_NULL_HANDLE;
-        return functions_.get_device_memory_opaque_capture_address(device_, &modified_info);
+            "There's no allocations or memory is VK_NULL_HANDLE. Skip GetDeviceMemoryOpaqueCaptureAddress");
+        return 0;
     }
 
     uint64_t result = 0;

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -259,7 +259,7 @@ VkResult VulkanRebindAllocator::CreateBuffer(const VkBufferCreateInfo*    create
         {
             auto resource_alloc_info         = new ResourceAllocInfo;
             resource_alloc_info->usage       = create_info->usage;
-            resource_alloc_info->object_type = ObjectType::buffer;
+            resource_alloc_info->object_type = VK_OBJECT_TYPE_BUFFER;
             (*allocator_data)                = reinterpret_cast<uintptr_t>(resource_alloc_info);
 
             if (create_info->pNext != nullptr)
@@ -277,28 +277,34 @@ void VulkanRebindAllocator::DestroyBuffer(VkBuffer                     buffer,
                                           ResourceData                 allocator_data)
 {
     GFXRECON_UNREFERENCED_PARAMETER(allocation_callbacks);
+    GFXRECON_ASSERT(buffer != VK_NULL_HANDLE);
 
     if (allocator_data != 0)
     {
-        assert(buffer != VK_NULL_HANDLE);
-
         auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
-        auto memory_alloc_info   = resource_alloc_info->memory_info;
 
-        if (memory_alloc_info != nullptr)
+        // It could bind sparse memories. It could have plural memories.
+        for (auto& mem_info : resource_alloc_info->bound_memory_infos)
         {
-            memory_alloc_info->original_buffers.erase(buffer);
+            auto mem_alc_info = mem_info.memory_info;
+            if (mem_alc_info != nullptr)
+            {
+                mem_alc_info->original_objects.erase(VK_HANDLE_TO_UINT64(buffer));
+            }
+
+            if (mem_info.allocation != VK_NULL_HANDLE)
+            {
+                if (mem_info.mapped_pointer != nullptr)
+                {
+                    vmaUnmapMemory(allocator_, mem_info.allocation);
+                }
+                vmaFreeMemory(allocator_, mem_info.allocation);
+            }
         }
-
-        if (resource_alloc_info->mapped_pointer != nullptr)
-        {
-            vmaUnmapMemory(allocator_, resource_alloc_info->allocation);
-        }
-
-        vmaDestroyBuffer(allocator_, buffer, resource_alloc_info->allocation);
-
         delete resource_alloc_info;
     }
+
+    vmaDestroyBuffer(allocator_, buffer, VK_NULL_HANDLE);
 }
 
 VkResult VulkanRebindAllocator::CreateImage(const VkImageCreateInfo*     create_info,
@@ -323,7 +329,7 @@ VkResult VulkanRebindAllocator::CreateImage(const VkImageCreateInfo*     create_
             resource_alloc_info->tiling      = create_info->tiling;
             resource_alloc_info->height      = create_info->extent.height;
             resource_alloc_info->format      = create_info->format;
-            resource_alloc_info->object_type = ObjectType::image;
+            resource_alloc_info->object_type = VK_OBJECT_TYPE_IMAGE;
             (*allocator_data)                = reinterpret_cast<uintptr_t>(resource_alloc_info);
 
             if (create_info->pNext != nullptr)
@@ -341,60 +347,60 @@ void VulkanRebindAllocator::DestroyImage(VkImage                      image,
                                          ResourceData                 allocator_data)
 {
     GFXRECON_UNREFERENCED_PARAMETER(allocation_callbacks);
+    GFXRECON_ASSERT(image != VK_NULL_HANDLE);
 
     if (allocator_data != 0)
     {
-        assert(image != VK_NULL_HANDLE);
-
         auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
-        auto memory_alloc_info   = resource_alloc_info->memory_info;
 
-        if (memory_alloc_info != nullptr)
+        // It could bind sparse memories. It could have plural memories.
+        for (auto& mem_info : resource_alloc_info->bound_memory_infos)
         {
-            memory_alloc_info->original_images.erase(image);
+            auto mem_alc_info = mem_info.memory_info;
+            if (mem_alc_info != nullptr)
+            {
+                mem_alc_info->original_objects.erase(VK_HANDLE_TO_UINT64(image));
+            }
+
+            if (mem_info.allocation != VK_NULL_HANDLE)
+            {
+                if (mem_info.mapped_pointer != nullptr)
+                {
+                    vmaUnmapMemory(allocator_, mem_info.allocation);
+                }
+                vmaFreeMemory(allocator_, mem_info.allocation);
+            }
         }
-
-        if (resource_alloc_info->mapped_pointer != nullptr)
-        {
-            vmaUnmapMemory(allocator_, resource_alloc_info->allocation);
-        }
-
-        vmaDestroyImage(allocator_, image, resource_alloc_info->allocation);
-
         delete resource_alloc_info;
     }
+
+    vmaDestroyImage(allocator_, image, VK_NULL_HANDLE);
 }
 
 VkResult VulkanRebindAllocator::CreateVideoSession(const VkVideoSessionCreateInfoKHR* create_info,
                                                    const VkAllocationCallbacks*       allocation_callbacks,
                                                    format::HandleId                   capture_id,
                                                    VkVideoSessionKHR*                 session,
-                                                   std::vector<ResourceData>*         allocator_datas)
+                                                   ResourceData*                      allocator_data)
 {
     GFXRECON_UNREFERENCED_PARAMETER(allocation_callbacks);
     GFXRECON_UNREFERENCED_PARAMETER(capture_id);
 
     VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
-    if ((create_info != nullptr) && (session != nullptr) && (allocator_datas != nullptr))
+    if ((create_info != nullptr) && (session != nullptr) && (allocator_data != nullptr))
     {
         result = functions_.create_video_session(device_, create_info, allocation_callbacks, session);
 
         if (result >= 0)
         {
-            uint32_t count = 0;
-            functions_.get_video_session_memory_requirements(device_, *session, &count, nullptr);
-            allocator_datas->resize(count);
-            for (auto& allocator_data : *allocator_datas)
-            {
-                auto resource_alloc_info         = new ResourceAllocInfo;
-                resource_alloc_info->object_type = ObjectType::video_session;
-                allocator_data                   = reinterpret_cast<uintptr_t>(resource_alloc_info);
+            auto resource_alloc_info         = new ResourceAllocInfo;
+            resource_alloc_info->object_type = VK_OBJECT_TYPE_VIDEO_SESSION_KHR;
+            (*allocator_data)                = reinterpret_cast<uintptr_t>(resource_alloc_info);
 
-                if (create_info->pNext != nullptr)
-                {
-                    resource_alloc_info->uses_extensions = true;
-                }
+            if (create_info->pNext != nullptr)
+            {
+                resource_alloc_info->uses_extensions = true;
             }
         }
     }
@@ -404,38 +410,36 @@ VkResult VulkanRebindAllocator::CreateVideoSession(const VkVideoSessionCreateInf
 
 void VulkanRebindAllocator::DestroyVideoSession(VkVideoSessionKHR            session,
                                                 const VkAllocationCallbacks* allocation_callbacks,
-                                                std::vector<ResourceData>    allocator_datas)
+                                                ResourceData                 allocator_data)
 {
     // TODO: VMA doesn't support video session(vmaDestroyVideoSession). Do it ourselves until VMA support it.
     GFXRECON_UNREFERENCED_PARAMETER(allocation_callbacks);
-
-    uint32_t index = 0;
-    for (auto& allocator_data : allocator_datas)
-    {
-        if (allocator_data != 0)
-        {
-            auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
-            auto memory_alloc_info   = resource_alloc_info->memory_info;
-
-            if (memory_alloc_info != nullptr)
-            {
-                memory_alloc_info->original_sessions.erase(session);
-            }
-
-            if (resource_alloc_info->allocation != VK_NULL_HANDLE)
-            {
-                if (resource_alloc_info->mapped_pointer != nullptr)
-                {
-                    vmaUnmapMemory(allocator_, resource_alloc_info->allocation);
-                }
-                allocator_->FreeMemory(1, &resource_alloc_info->allocation);
-            }
-            delete resource_alloc_info;
-        }
-        ++index;
-    }
-    allocator_datas.clear();
     GFXRECON_ASSERT(session != VK_NULL_HANDLE);
+
+    if (allocator_data != 0)
+    {
+        auto* resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+
+        for (auto& mem_info : resource_alloc_info->bound_memory_infos)
+        {
+            auto mem_alc_info = mem_info.memory_info;
+            if (mem_alc_info != nullptr)
+            {
+                mem_alc_info->original_objects.erase(VK_HANDLE_TO_UINT64(session));
+            }
+
+            if (mem_info.allocation != VK_NULL_HANDLE)
+            {
+                if (mem_info.mapped_pointer != nullptr)
+                {
+                    vmaUnmapMemory(allocator_, mem_info.allocation);
+                }
+                vmaFreeMemory(allocator_, mem_info.allocation);
+            }
+        }
+        delete resource_alloc_info;
+    }
+
     functions_.destroy_video_session(allocator_->m_hDevice, session, allocator_->GetAllocationCallbacks());
 }
 
@@ -445,8 +449,13 @@ void VulkanRebindAllocator::GetBufferMemoryRequirements(VkBuffer              bu
 {
     if (allocator_data != 0)
     {
-        auto resource_alloc_info           = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
-        resource_alloc_info->original_size = memory_requirements->size;
+        auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+
+        if (resource_alloc_info->original_sizes.empty())
+        {
+            resource_alloc_info->original_sizes.resize(1);
+        }
+        resource_alloc_info->original_sizes[0] = memory_requirements->size;
     }
 
     functions_.get_buffer_memory_requirements(device_, buffer, memory_requirements);
@@ -458,8 +467,13 @@ void VulkanRebindAllocator::GetBufferMemoryRequirements2(const VkBufferMemoryReq
 {
     if (allocator_data != 0)
     {
-        auto resource_alloc_info           = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
-        resource_alloc_info->original_size = memory_requirements->memoryRequirements.size;
+        auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+
+        if (resource_alloc_info->original_sizes.empty())
+        {
+            resource_alloc_info->original_sizes.resize(1);
+        }
+        resource_alloc_info->original_sizes[0] = memory_requirements->memoryRequirements.size;
     }
 
     functions_.get_buffer_memory_requirements2(device_, info, memory_requirements);
@@ -504,8 +518,13 @@ void VulkanRebindAllocator::GetImageMemoryRequirements(VkImage               ima
 {
     if (allocator_data != 0)
     {
-        auto resource_alloc_info           = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
-        resource_alloc_info->original_size = memory_requirements->size;
+        auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+
+        if (resource_alloc_info->original_sizes.empty())
+        {
+            resource_alloc_info->original_sizes.resize(1);
+        }
+        resource_alloc_info->original_sizes[0] = memory_requirements->size;
     }
 
     functions_.get_image_memory_requirements(device_, image, memory_requirements);
@@ -517,8 +536,13 @@ void VulkanRebindAllocator::GetImageMemoryRequirements2(const VkImageMemoryRequi
 {
     if (allocator_data != 0)
     {
-        auto resource_alloc_info           = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
-        resource_alloc_info->original_size = memory_requirements->memoryRequirements.size;
+        auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+
+        if (resource_alloc_info->original_sizes.empty())
+        {
+            resource_alloc_info->original_sizes.resize(1);
+        }
+        resource_alloc_info->original_sizes[0] = memory_requirements->memoryRequirements.size;
     }
 
     functions_.get_image_memory_requirements2(device_, info, memory_requirements);
@@ -528,18 +552,16 @@ VkResult
 VulkanRebindAllocator::GetVideoSessionMemoryRequirementsKHR(VkVideoSessionKHR video_session,
                                                             uint32_t*         memory_requirements_count,
                                                             VkVideoSessionMemoryRequirementsKHR* memory_requirements,
-                                                            std::vector<ResourceData>            allocator_datas)
+                                                            ResourceData                         allocator_data)
 {
-    if (memory_requirements != nullptr)
+    if (memory_requirements != nullptr && allocator_data != 0)
     {
-        GFXRECON_ASSERT(*memory_requirements_count == allocator_datas.size());
+        auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+        resource_alloc_info->original_sizes.resize(*memory_requirements_count);
+
         for (uint32_t i = 0; i < *memory_requirements_count; ++i)
         {
-            if (allocator_datas[i] != 0)
-            {
-                auto resource_alloc_info           = reinterpret_cast<ResourceAllocInfo*>(allocator_datas[i]);
-                resource_alloc_info->original_size = memory_requirements[i].memoryRequirements.size;
-            }
+            resource_alloc_info->original_sizes[i] = memory_requirements[i].memoryRequirements.size;
         }
     }
 
@@ -565,6 +587,7 @@ VkResult VulkanRebindAllocator::AllocateMemory(const VkMemoryAllocateInfo*  allo
         // memory allocation that will be used to reconstruct the content of the original memory object.  The
         // reconstructed data will be used to populate the memory allocations created by VMA.
         auto memory_alloc_info             = new MemoryAllocInfo;
+        memory_alloc_info->capture_id      = capture_id;
         memory_alloc_info->allocation_size = allocate_info->allocationSize;
         memory_alloc_info->original_index  = allocate_info->memoryTypeIndex;
 
@@ -600,33 +623,116 @@ void VulkanRebindAllocator::FreeMemory(VkDeviceMemory               memory,
             functions_.free_memory(device_, memory_alloc_info->ahb_memory, nullptr);
         }
 
-        for (const auto& entry : memory_alloc_info->original_buffers)
+        for (const auto& entry : memory_alloc_info->original_objects)
         {
-            entry.second->memory_info = nullptr;
-        }
-
-        for (const auto& entry : memory_alloc_info->original_images)
-        {
-            entry.second->memory_info = nullptr;
-        }
-
-        for (const auto& entry : memory_alloc_info->original_sessions)
-        {
-            entry.second->memory_info = nullptr;
+            for (auto& entry_bound : entry.second->bound_memory_infos)
+            {
+                if (entry_bound.memory_info == memory_alloc_info)
+                {
+                    entry_bound.memory_info = nullptr;
+                }
+            }
         }
 
         delete memory_alloc_info;
     }
 }
 
-void VulkanRebindAllocator::GetDeviceMemoryCommitment(VkDeviceMemory memory,
-                                                      VkDeviceSize*  committed_memory_in_bytes,
-                                                      MemoryData     allocator_data)
+VkResult
+VulkanRebindAllocator::AllocateMemoryForBuffer(VkBuffer                                buffer,
+                                               const VkPhysicalDeviceMemoryProperties& device_memory_properties,
+                                               const ResourceAllocInfo&                resource_alloc_info,
+                                               const MemoryAllocInfo&                  memory_alloc_info,
+                                               VmaAllocation&                          allocation,
+                                               VmaAllocationInfo&                      allocation_info)
 {
-    // We don't have a valid memory handle for this call.
-    GFXRECON_UNREFERENCED_PARAMETER(memory);
-    GFXRECON_UNREFERENCED_PARAMETER(committed_memory_in_bytes);
-    GFXRECON_UNREFERENCED_PARAMETER(allocator_data);
+    VkMemoryRequirements requirements;
+    functions_.get_buffer_memory_requirements(device_, buffer, &requirements);
+    requirements.alignment = std::max<VkDeviceSize>(requirements.alignment, min_buffer_alignment_);
+
+    VmaAllocationCreateInfo create_info;
+    create_info.flags = 0;
+    create_info.usage =
+        GetBufferMemoryUsage(resource_alloc_info.usage,
+                             device_memory_properties.memoryTypes[memory_alloc_info.original_index].propertyFlags,
+                             requirements);
+    create_info.requiredFlags  = 0;
+    create_info.preferredFlags = 0;
+    create_info.memoryTypeBits = 0;
+    create_info.pool           = VK_NULL_HANDLE;
+    create_info.pUserData      = nullptr;
+
+    return vmaAllocateMemoryForBuffer(allocator_, buffer, &create_info, &allocation, &allocation_info);
+}
+
+void VulkanRebindAllocator::UpdateAllocInfo(ResourceAllocInfo&       resource_alloc_info,
+                                            uint64_t                 object_handle,
+                                            MemoryInfoType           memory_info_type,
+                                            VkDeviceSize             memory_offset,
+                                            const VmaAllocation&     allocation,
+                                            const VmaAllocationInfo& allocation_info,
+                                            MemoryAllocInfo&         memory_alloc_info,
+                                            VkMemoryPropertyFlags&   bind_memory_property)
+{
+    resource_alloc_info.memory_info_type = memory_info_type;
+
+    BoundMemoryInfo* mem_info = nullptr;
+    switch (memory_info_type)
+    {
+        case MemoryInfoType::kBasic:
+        {
+            if (resource_alloc_info.bound_memory_infos.empty())
+            {
+                resource_alloc_info.bound_memory_infos.resize(1);
+            }
+            mem_info = &resource_alloc_info.bound_memory_infos[0];
+            break;
+        }
+        case MemoryInfoType::kSparse:
+        case MemoryInfoType::kVideoSession:
+        {
+            resource_alloc_info.bound_memory_infos.resize(resource_alloc_info.bound_memory_infos.size() + 1);
+            mem_info = &resource_alloc_info.bound_memory_infos.back();
+            break;
+        }
+        default:
+            break;
+    }
+
+    mem_info->allocation      = allocation;
+    mem_info->mapped_pointer  = nullptr;
+    mem_info->memory_info     = &memory_alloc_info;
+    mem_info->original_offset = memory_offset;
+    mem_info->rebind_offset   = allocation_info.offset;
+    mem_info->rebind_size     = allocation_info.size;
+
+    VkMemoryPropertyFlags property_flags =
+        replay_memory_properties_.memoryTypes[allocation_info.memoryType].propertyFlags;
+
+    if ((property_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+    {
+        mem_info->is_host_visible = true;
+    }
+
+    memory_alloc_info.original_objects.insert(std::make_pair(object_handle, &resource_alloc_info));
+
+    if (memory_alloc_info.original_content != nullptr)
+    {
+        // Memory has been mapped and written prior to bind.  Copy the original content to the new
+        // allocation to ensure it contains the correct data.
+
+        // If the buffer is bigger at replay time than at capture time, you don't want to read
+        // memory_alloc_info->original_content out of bounds
+        VkDeviceSize copy_size = std::min(allocation_info.size, memory_alloc_info.allocation_size - memory_offset);
+
+        WriteBoundResource(
+            &resource_alloc_info, mem_info, memory_offset, 0, copy_size, memory_alloc_info.original_content.get());
+    }
+
+    bind_memory_property = property_flags;
+
+    SetBindingDebugUtilsNameAndTag(
+        &memory_alloc_info, &resource_alloc_info, allocation_info.deviceMemory, object_handle);
 }
 
 VkResult VulkanRebindAllocator::BindBufferMemory(VkBuffer                                buffer,
@@ -644,28 +750,13 @@ VkResult VulkanRebindAllocator::BindBufferMemory(VkBuffer                       
     if ((buffer != VK_NULL_HANDLE) && (allocator_buffer_data != 0) && (allocator_memory_data != 0) &&
         (bind_memory_properties != nullptr))
     {
-        VmaAllocation allocation          = VK_NULL_HANDLE;
-        auto          resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_buffer_data);
-        auto          memory_alloc_info   = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
+        VmaAllocation     allocation = VK_NULL_HANDLE;
+        VmaAllocationInfo allocation_info{};
+        auto              resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_buffer_data);
+        auto              memory_alloc_info   = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
 
-        VkMemoryRequirements requirements;
-        functions_.get_buffer_memory_requirements(device_, buffer, &requirements);
-        requirements.alignment = std::max<VkDeviceSize>(requirements.alignment, min_buffer_alignment_);
-
-        VmaAllocationCreateInfo create_info;
-        create_info.flags = 0;
-        create_info.usage =
-            GetBufferMemoryUsage(resource_alloc_info->usage,
-                                 device_memory_properties.memoryTypes[memory_alloc_info->original_index].propertyFlags,
-                                 requirements);
-        create_info.requiredFlags  = 0;
-        create_info.preferredFlags = 0;
-        create_info.memoryTypeBits = 0;
-        create_info.pool           = VK_NULL_HANDLE;
-        create_info.pUserData      = nullptr;
-
-        VmaAllocationInfo allocation_info;
-        result = vmaAllocateMemoryForBuffer(allocator_, buffer, &create_info, &allocation, &allocation_info);
+        result = AllocateMemoryForBuffer(
+            buffer, device_memory_properties, *resource_alloc_info, *memory_alloc_info, allocation, allocation_info);
 
         if (result >= 0)
         {
@@ -673,44 +764,14 @@ VkResult VulkanRebindAllocator::BindBufferMemory(VkBuffer                       
 
             if (result >= 0)
             {
-                resource_alloc_info->allocation      = allocation;
-                resource_alloc_info->mapped_pointer  = nullptr;
-                resource_alloc_info->memory_info     = memory_alloc_info;
-                resource_alloc_info->original_offset = memory_offset;
-                resource_alloc_info->rebind_offset   = allocation_info.offset;
-                resource_alloc_info->rebind_size     = allocation_info.size;
-
-                VkMemoryPropertyFlags property_flags =
-                    replay_memory_properties_.memoryTypes[allocation_info.memoryType].propertyFlags;
-
-                if ((property_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-                {
-                    resource_alloc_info->is_host_visible = true;
-                }
-
-                memory_alloc_info->original_buffers.insert(std::make_pair(buffer, resource_alloc_info));
-
-                if (memory_alloc_info->original_content != nullptr)
-                {
-                    // Memory has been mapped and written prior to bind.  Copy the original content to the new
-                    // allocation to ensure it contains the correct data.
-
-                    // If the buffer is bigger at replay time than at capture time, you don't want to read
-                    // memory_alloc_info->original_content out of bounds
-                    VkDeviceSize copy_size =
-                        std::min(allocation_info.size, memory_alloc_info->allocation_size - memory_offset);
-
-                    WriteBoundResource(
-                        resource_alloc_info, memory_offset, 0, copy_size, memory_alloc_info->original_content.get());
-                }
-
-                (*bind_memory_properties) = property_flags;
-
-                SetBindingDebugUtilsNameAndTag(memory_alloc_info,
-                                               resource_alloc_info,
-                                               allocation_info.deviceMemory,
-                                               VK_OBJECT_TYPE_BUFFER,
-                                               VK_HANDLE_TO_UINT64(buffer));
+                UpdateAllocInfo(*resource_alloc_info,
+                                VK_HANDLE_TO_UINT64(buffer),
+                                MemoryInfoType::kBasic,
+                                memory_offset,
+                                allocation,
+                                allocation_info,
+                                *memory_alloc_info,
+                                *bind_memory_properties);
             }
         }
     }
@@ -737,28 +798,17 @@ VkResult VulkanRebindAllocator::BindBufferMemory2(uint32_t                      
 
             if ((buffer != VK_NULL_HANDLE) && (allocator_buffer_data != 0) && (allocator_memory_data != 0))
             {
-                VmaAllocation allocation          = VK_NULL_HANDLE;
-                auto          resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_buffer_data);
-                auto          memory_alloc_info   = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
+                VmaAllocation     allocation = VK_NULL_HANDLE;
+                VmaAllocationInfo allocation_info{};
+                auto              resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_buffer_data);
+                auto              memory_alloc_info   = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
 
-                VkMemoryRequirements requirements;
-                functions_.get_buffer_memory_requirements(device_, buffer, &requirements);
-                requirements.alignment = std::max<VkDeviceSize>(requirements.alignment, min_buffer_alignment_);
-
-                VmaAllocationCreateInfo create_info;
-                create_info.flags = 0;
-                create_info.usage = GetBufferMemoryUsage(
-                    resource_alloc_info->usage,
-                    capture_memory_properties_.memoryTypes[memory_alloc_info->original_index].propertyFlags,
-                    requirements);
-                create_info.requiredFlags  = 0;
-                create_info.preferredFlags = 0;
-                create_info.memoryTypeBits = 0;
-                create_info.pool           = VK_NULL_HANDLE;
-                create_info.pUserData      = nullptr;
-
-                VmaAllocationInfo allocation_info;
-                result = vmaAllocateMemoryForBuffer(allocator_, buffer, &create_info, &allocation, &allocation_info);
+                result = AllocateMemoryForBuffer(buffer,
+                                                 capture_memory_properties_,
+                                                 *resource_alloc_info,
+                                                 *memory_alloc_info,
+                                                 allocation,
+                                                 allocation_info);
 
                 if (result >= 0)
                 {
@@ -768,48 +818,14 @@ VkResult VulkanRebindAllocator::BindBufferMemory2(uint32_t                      
 
                     if (result >= 0)
                     {
-                        resource_alloc_info->allocation      = allocation;
-                        resource_alloc_info->mapped_pointer  = nullptr;
-                        resource_alloc_info->memory_info     = memory_alloc_info;
-                        resource_alloc_info->original_offset = bind_info->memoryOffset;
-                        resource_alloc_info->rebind_offset   = allocation_info.offset;
-                        resource_alloc_info->rebind_size     = allocation_info.size;
-
-                        VkMemoryPropertyFlags property_flags =
-                            replay_memory_properties_.memoryTypes[allocation_info.memoryType].propertyFlags;
-
-                        if ((property_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ==
-                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-                        {
-                            resource_alloc_info->is_host_visible = true;
-                        }
-
-                        if (memory_alloc_info->original_content != nullptr)
-                        {
-                            // Memory has been mapped and written prior to bind.  Copy the original content to the new
-                            // allocation to ensure it contains the correct data.
-
-                            // If the buffer is bigger at replay time than at capture time, you don't want to read
-                            // memory_alloc_info->original_content out of bounds
-                            VkDeviceSize copy_size = std::min(
-                                allocation_info.size, memory_alloc_info->allocation_size - bind_info->memoryOffset);
-
-                            WriteBoundResource(resource_alloc_info,
-                                               bind_info->memoryOffset,
-                                               0,
-                                               copy_size,
-                                               memory_alloc_info->original_content.get());
-                        }
-
-                        memory_alloc_info->original_buffers.insert(std::make_pair(buffer, resource_alloc_info));
-
-                        bind_memory_properties[i] = property_flags;
-
-                        SetBindingDebugUtilsNameAndTag(memory_alloc_info,
-                                                       resource_alloc_info,
-                                                       allocation_info.deviceMemory,
-                                                       VK_OBJECT_TYPE_BUFFER,
-                                                       VK_HANDLE_TO_UINT64(buffer));
+                        UpdateAllocInfo(*resource_alloc_info,
+                                        VK_HANDLE_TO_UINT64(buffer),
+                                        MemoryInfoType::kBasic,
+                                        bind_info->memoryOffset,
+                                        allocation,
+                                        allocation_info,
+                                        *memory_alloc_info,
+                                        bind_memory_properties[i]);
                     }
                 }
             }
@@ -853,6 +869,32 @@ VkResult VulkanRebindAllocator::AllocateAHBMemory(MemoryAllocInfo* memory_alloc_
     return result;
 }
 
+VkResult VulkanRebindAllocator::AllocateMemoryForImage(VkImage                                 image,
+                                                       const VkPhysicalDeviceMemoryProperties& device_memory_properties,
+                                                       const ResourceAllocInfo&                resource_alloc_info,
+                                                       const MemoryAllocInfo&                  memory_alloc_info,
+                                                       VmaAllocation&                          allocation,
+                                                       VmaAllocationInfo&                      allocation_info)
+{
+    VkMemoryRequirements requirements;
+    functions_.get_image_memory_requirements(device_, image, &requirements);
+
+    VmaAllocationCreateInfo create_info;
+    create_info.flags = 0;
+    create_info.usage =
+        GetImageMemoryUsage(resource_alloc_info.usage,
+                            resource_alloc_info.tiling,
+                            device_memory_properties.memoryTypes[memory_alloc_info.original_index].propertyFlags,
+                            requirements);
+    create_info.requiredFlags  = 0;
+    create_info.preferredFlags = 0;
+    create_info.memoryTypeBits = 0;
+    create_info.pool           = VK_NULL_HANDLE;
+    create_info.pUserData      = nullptr;
+
+    return vmaAllocateMemoryForImage(allocator_, image, &create_info, &allocation, &allocation_info);
+}
+
 VkResult VulkanRebindAllocator::BindImageMemory(VkImage                                 image,
                                                 VkDeviceMemory                          memory,
                                                 VkDeviceSize                            memory_offset,
@@ -881,27 +923,12 @@ VkResult VulkanRebindAllocator::BindImageMemory(VkImage                         
         }
         else
         {
-            VmaAllocation allocation          = VK_NULL_HANDLE;
-            auto          resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_image_data);
+            VmaAllocation     allocation = VK_NULL_HANDLE;
+            VmaAllocationInfo allocation_info{};
+            auto              resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_image_data);
 
-            VkMemoryRequirements requirements;
-            functions_.get_image_memory_requirements(device_, image, &requirements);
-
-            VmaAllocationCreateInfo create_info;
-            create_info.flags = 0;
-            create_info.usage = GetImageMemoryUsage(
-                resource_alloc_info->usage,
-                resource_alloc_info->tiling,
-                device_memory_properties.memoryTypes[memory_alloc_info->original_index].propertyFlags,
-                requirements);
-            create_info.requiredFlags  = 0;
-            create_info.preferredFlags = 0;
-            create_info.memoryTypeBits = 0;
-            create_info.pool           = VK_NULL_HANDLE;
-            create_info.pUserData      = nullptr;
-
-            VmaAllocationInfo allocation_info;
-            result = vmaAllocateMemoryForImage(allocator_, image, &create_info, &allocation, &allocation_info);
+            result = AllocateMemoryForImage(
+                image, device_memory_properties, *resource_alloc_info, *memory_alloc_info, allocation, allocation_info);
 
             if (result >= 0)
             {
@@ -909,47 +936,14 @@ VkResult VulkanRebindAllocator::BindImageMemory(VkImage                         
 
                 if (result >= 0)
                 {
-                    resource_alloc_info->allocation      = allocation;
-                    resource_alloc_info->mapped_pointer  = nullptr;
-                    resource_alloc_info->memory_info     = memory_alloc_info;
-                    resource_alloc_info->original_offset = memory_offset;
-                    resource_alloc_info->rebind_offset   = allocation_info.offset;
-                    resource_alloc_info->rebind_size     = allocation_info.size;
-
-                    VkMemoryPropertyFlags property_flags =
-                        replay_memory_properties_.memoryTypes[allocation_info.memoryType].propertyFlags;
-
-                    if ((property_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-                    {
-                        resource_alloc_info->is_host_visible = true;
-                    }
-
-                    memory_alloc_info->original_images.insert(std::make_pair(image, resource_alloc_info));
-
-                    if (memory_alloc_info->original_content != nullptr)
-                    {
-                        // Memory has been mapped and written prior to bind.  Copy the original content to the new
-                        // allocation to ensure it contains the correct data.
-
-                        // If the image is bigger at replay time than at capture time, you don't want to read
-                        // memory_alloc_info->original_content out of bounds
-                        VkDeviceSize copy_size =
-                            std::min(allocation_info.size, memory_alloc_info->allocation_size - memory_offset);
-
-                        WriteBoundResource(resource_alloc_info,
-                                           memory_offset,
-                                           0,
-                                           copy_size,
-                                           memory_alloc_info->original_content.get());
-                    }
-
-                    (*bind_memory_properties) = property_flags;
-
-                    SetBindingDebugUtilsNameAndTag(memory_alloc_info,
-                                                   resource_alloc_info,
-                                                   allocation_info.deviceMemory,
-                                                   VK_OBJECT_TYPE_IMAGE,
-                                                   VK_HANDLE_TO_UINT64(image));
+                    UpdateAllocInfo(*resource_alloc_info,
+                                    VK_HANDLE_TO_UINT64(image),
+                                    MemoryInfoType::kBasic,
+                                    memory_offset,
+                                    allocation,
+                                    allocation_info,
+                                    *memory_alloc_info,
+                                    *bind_memory_properties);
                 }
             }
         }
@@ -997,27 +991,16 @@ VkResult VulkanRebindAllocator::BindImageMemory2(uint32_t                     bi
                 }
                 else
                 {
-                    VmaAllocation allocation          = VK_NULL_HANDLE;
-                    auto          resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_image_data);
+                    VmaAllocation     allocation = VK_NULL_HANDLE;
+                    VmaAllocationInfo allocation_info{};
+                    auto              resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_image_data);
 
-                    VkMemoryRequirements requirements;
-                    functions_.get_image_memory_requirements(device_, image, &requirements);
-
-                    VmaAllocationCreateInfo create_info;
-                    create_info.flags = 0;
-                    create_info.usage = GetImageMemoryUsage(
-                        resource_alloc_info->usage,
-                        resource_alloc_info->tiling,
-                        capture_memory_properties_.memoryTypes[memory_alloc_info->original_index].propertyFlags,
-                        requirements);
-                    create_info.requiredFlags  = 0;
-                    create_info.preferredFlags = 0;
-                    create_info.memoryTypeBits = 0;
-                    create_info.pool           = VK_NULL_HANDLE;
-                    create_info.pUserData      = nullptr;
-
-                    VmaAllocationInfo allocation_info;
-                    result = vmaAllocateMemoryForImage(allocator_, image, &create_info, &allocation, &allocation_info);
+                    result = AllocateMemoryForImage(image,
+                                                    capture_memory_properties_,
+                                                    *resource_alloc_info,
+                                                    *memory_alloc_info,
+                                                    allocation,
+                                                    allocation_info);
 
                     if (result >= 0)
                     {
@@ -1027,48 +1010,14 @@ VkResult VulkanRebindAllocator::BindImageMemory2(uint32_t                     bi
 
                         if (result >= 0)
                         {
-                            resource_alloc_info->allocation      = allocation;
-                            resource_alloc_info->mapped_pointer  = nullptr;
-                            resource_alloc_info->memory_info     = memory_alloc_info;
-                            resource_alloc_info->original_offset = bind_info->memoryOffset;
-                            resource_alloc_info->rebind_offset   = allocation_info.offset;
-                            resource_alloc_info->rebind_size     = allocation_info.size;
-
-                            VkMemoryPropertyFlags property_flags =
-                                replay_memory_properties_.memoryTypes[allocation_info.memoryType].propertyFlags;
-
-                            if ((property_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ==
-                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-                            {
-                                resource_alloc_info->is_host_visible = true;
-                            }
-
-                            if (memory_alloc_info->original_content != nullptr)
-                            {
-                                // Memory has been mapped and written prior to bind.  Copy the original content to the
-                                // new allocation to ensure it contains the correct data.
-
-                                // If the image is bigger at replay time than at capture time, you don't want to read
-                                // memory_alloc_info->original_content out of bounds
-                                VkDeviceSize copy_size = std::min(
-                                    allocation_info.size, memory_alloc_info->allocation_size - bind_info->memoryOffset);
-
-                                WriteBoundResource(resource_alloc_info,
-                                                   bind_info->memoryOffset,
-                                                   0,
-                                                   copy_size,
-                                                   memory_alloc_info->original_content.get());
-                            }
-
-                            memory_alloc_info->original_images.insert(std::make_pair(image, resource_alloc_info));
-
-                            bind_memory_properties[i] = property_flags;
-
-                            SetBindingDebugUtilsNameAndTag(memory_alloc_info,
-                                                           resource_alloc_info,
-                                                           allocation_info.deviceMemory,
-                                                           VK_OBJECT_TYPE_IMAGE,
-                                                           VK_HANDLE_TO_UINT64(image));
+                            UpdateAllocInfo(*resource_alloc_info,
+                                            VK_HANDLE_TO_UINT64(image),
+                                            MemoryInfoType::kBasic,
+                                            bind_info->memoryOffset,
+                                            allocation,
+                                            allocation_info,
+                                            *memory_alloc_info,
+                                            bind_memory_properties[i]);
                         }
                     }
                 }
@@ -1082,7 +1031,7 @@ VkResult VulkanRebindAllocator::BindImageMemory2(uint32_t                     bi
 VkResult VulkanRebindAllocator::BindVideoSessionMemory(VkVideoSessionKHR                      video_session,
                                                        uint32_t                               bind_info_count,
                                                        const VkBindVideoSessionMemoryInfoKHR* bind_infos,
-                                                       const ResourceData*                    allocator_session_datas,
+                                                       const ResourceData                     allocator_session_data,
                                                        const MemoryData*                      allocator_memory_datas,
                                                        VkMemoryPropertyFlags*                 bind_memory_properties)
 {
@@ -1090,7 +1039,7 @@ VkResult VulkanRebindAllocator::BindVideoSessionMemory(VkVideoSessionKHR        
     //       Do it ourselves until VMA support it.
     VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
-    if ((video_session != VK_NULL_HANDLE) && (bind_infos != nullptr) && (allocator_session_datas != nullptr) &&
+    if ((video_session != VK_NULL_HANDLE) && (bind_infos != nullptr) && (allocator_session_data != 0) &&
         (allocator_memory_datas != nullptr) && (bind_memory_properties != nullptr))
     {
         uint32_t session_requirements_count = 0;
@@ -1102,144 +1051,67 @@ VkResult VulkanRebindAllocator::BindVideoSessionMemory(VkVideoSessionKHR        
         functions_.get_video_session_memory_requirements(
             device_, video_session, &session_requirements_count, session_requirements.data());
 
+        auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_session_data);
+
         // Use replay MemoryRequeirements to AllocateMemory and Bind.
-        for (uint32_t mem_index = 0; mem_index < session_requirements_count; ++mem_index)
+        for (uint32_t bind_i = 0; bind_i < bind_info_count; ++bind_i)
         {
-            uintptr_t allocator_session_data = allocator_session_datas[mem_index];
-            uintptr_t allocator_memory_data  = allocator_memory_datas[mem_index];
-
-            if (allocator_session_data != 0)
+            uintptr_t allocator_memory_data = allocator_memory_datas[bind_i];
+            if (allocator_memory_data == 0)
             {
-                VmaAllocation allocation          = VK_NULL_HANDLE;
-                auto          resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_session_data);
+                continue;
+            }
 
-                // if allocator_memory_data is 0, it means replay MemoryRequirements has more count.
-                MemoryAllocInfo* memory_alloc_info = (allocator_memory_data == 0)
-                                                         ? new MemoryAllocInfo
-                                                         : reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
+            auto*       memory_alloc_info = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
+            const auto& bind_info         = bind_infos[bind_i];
+            auto        requirements      = session_requirements[bind_info.memoryBindIndex].memoryRequirements;
 
-                auto requirements = session_requirements[mem_index].memoryRequirements;
-                if (allocator_memory_data == 0)
+            auto usage = GetVideoSeesionMemoryUsage(
+                capture_memory_properties_.memoryTypes[memory_alloc_info->original_index].propertyFlags, requirements);
+
+            VmaAllocation allocation = VK_NULL_HANDLE;
+            auto          result     = VmaAllocateMemory(requirements, usage, allocation);
+            if (result >= 0)
+            {
+                VmaAllocationInfo allocation_info{};
+                allocator_->GetAllocationInfo(allocation, &allocation_info);
+
+                VkBindVideoSessionMemoryInfoKHR modified_bind_info = bind_info;
+                modified_bind_info.memory                          = allocation_info.deviceMemory;
+                modified_bind_info.memoryOffset                    = allocation_info.offset;
+
+                switch (allocation->GetType())
                 {
-                    memory_alloc_info->allocation_size = requirements.size;
-                    memory_alloc_info->original_index  = requirements.memoryTypeBits;
-                }
-                VmaAllocationCreateInfo create_info;
-                create_info.flags = 0;
-                create_info.usage = GetVideoSeesionMemoryUsage(
-                    capture_memory_properties_.memoryTypes[memory_alloc_info->original_index].propertyFlags,
-                    requirements);
-                create_info.requiredFlags  = 0;
-                create_info.preferredFlags = 0;
-                create_info.memoryTypeBits = 0;
-                create_info.pool           = VK_NULL_HANDLE;
-                create_info.pUserData      = nullptr;
+                    case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+                    {
+                        result = functions_.bind_video_session_memory(device_, video_session, 1, &modified_bind_info);
+                        break;
+                    }
+                    case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+                    {
+                        VmaDeviceMemoryBlock* const pBlock = allocation->GetBlock();
+                        VMA_ASSERT(pBlock && "Binding Video Seesion to allocation that doesn't belong to any block.");
 
-                VmaAllocationInfo allocation_info;
-                result = allocator_->AllocateMemory(session_requirements[mem_index].memoryRequirements,
-                                                    false,
-                                                    false,
-                                                    VK_NULL_HANDLE,               // dedicatedBuffer
-                                                    VK_NULL_HANDLE,               // dedicatedImage
-                                                    VmaBufferImageUsage::UNKNOWN, // dedicatedBufferImageUsage
-                                                    create_info,
-                                                    VMA_SUBALLOCATION_TYPE_FREE,
-                                                    1, // allocationCount
-                                                    &allocation);
-
-                if (result == VK_SUCCESS)
-                {
-                    allocator_->GetAllocationInfo(allocation, &allocation_info);
+                        // This lock is important so that we don't call vkBind... and/or vkMap... simultaneously
+                        // on the same VkDeviceMemory from multiple threads.
+                        VmaMutexLock lock(pBlock->m_MapAndBindMutex, allocator_->m_UseMutex);
+                        result = functions_.bind_video_session_memory(device_, video_session, 1, &modified_bind_info);
+                        break;
+                    }
+                    default:
+                        VMA_ASSERT(0);
                 }
 
                 if (result >= 0)
                 {
-                    VkBindVideoSessionMemoryInfoKHR modified_bind_info{};
-                    modified_bind_info.sType           = VK_STRUCTURE_TYPE_BIND_VIDEO_SESSION_MEMORY_INFO_KHR;
-                    modified_bind_info.memoryBindIndex = mem_index;
-                    modified_bind_info.memoryOffset    = 0;
-                    modified_bind_info.memorySize      = session_requirements[mem_index].memoryRequirements.size;
-
-                    switch (allocation->GetType())
-                    {
-                        case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
-                        {
-                            modified_bind_info.memory = allocation->GetMemory();
-                            result =
-                                functions_.bind_video_session_memory(device_, video_session, 1, &modified_bind_info);
-                            break;
-                        }
-                        case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
-                        {
-                            VmaDeviceMemoryBlock* const pBlock = allocation->GetBlock();
-                            VMA_ASSERT(pBlock &&
-                                       "Binding Video Seesion to allocation that doesn't belong to any block.");
-
-                            // This lock is important so that we don't call vkBind... and/or vkMap... simultaneously
-                            // on the same VkDeviceMemory from multiple threads.
-                            VmaMutexLock lock(pBlock->m_MapAndBindMutex, allocator_->m_UseMutex);
-                            modified_bind_info.memory = pBlock->m_hMemory;
-                            modified_bind_info.memoryOffset += allocation->GetOffset();
-                            result =
-                                functions_.bind_video_session_memory(device_, video_session, 1, &modified_bind_info);
-                            break;
-                        }
-                        default:
-                            VMA_ASSERT(0);
-                    }
-
-                    if (result >= 0)
-                    {
-                        resource_alloc_info->allocation     = allocation;
-                        resource_alloc_info->mapped_pointer = nullptr;
-                        resource_alloc_info->memory_info    = memory_alloc_info;
-
-                        // The new bind_infos's index and captured bind_infos's index meanings are different.
-                        VkDeviceSize src_offset = 0;
-
-                        for (uint32_t i = 0; i < bind_info_count; ++i)
-                        {
-                            if (bind_infos[i].memoryBindIndex == mem_index)
-                            {
-                                src_offset = bind_infos[mem_index].memoryOffset;
-                                break;
-                            }
-                        }
-
-                        resource_alloc_info->original_offset = src_offset;
-                        resource_alloc_info->rebind_offset   = allocation_info.offset;
-                        resource_alloc_info->rebind_size     = allocation_info.size;
-
-                        VkMemoryPropertyFlags property_flags =
-                            replay_memory_properties_.memoryTypes[allocation_info.memoryType].propertyFlags;
-
-                        if ((property_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ==
-                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-                        {
-                            resource_alloc_info->is_host_visible = true;
-                        }
-
-                        if (memory_alloc_info->original_content != nullptr)
-                        {
-                            // Memory has been mapped and written prior to bind. Copy the original content to the new
-                            // allocation to ensure it contains the correct data.
-
-                            // If the session is bigger at replay time than at capture time, you don't want to read
-                            // memory_alloc_info->original_content out of bounds
-                            VkDeviceSize copy_size =
-                                std::min(allocation_info.size, memory_alloc_info->allocation_size - src_offset);
-
-                            WriteBoundResource(resource_alloc_info,
-                                               src_offset,
-                                               0,
-                                               copy_size,
-                                               memory_alloc_info->original_content.get());
-                        }
-
-                        memory_alloc_info->original_sessions.insert(std::make_pair(video_session, resource_alloc_info));
-
-                        bind_memory_properties[mem_index] = property_flags;
-                    }
+                    UpdateAllocInfo(*resource_alloc_info,
+                                    VK_HANDLE_TO_UINT64(video_session),
+                                    MemoryInfoType::kVideoSession,
+                                    bind_info.memoryOffset,
+                                    allocation,
+                                    allocation_info,
+                                    *memory_alloc_info,
+                                    bind_memory_properties[bind_i]);
                 }
             }
         }
@@ -1273,6 +1145,23 @@ VkResult VulkanRebindAllocator::MapMemory(VkDeviceMemory   memory,
     return result;
 }
 
+VkResult
+VulkanRebindAllocator::MapMemory2(const VkMemoryMapInfo* memory_map_info, void** data, MemoryData allocator_data)
+{
+    VkResult result = VK_ERROR_MEMORY_MAP_FAILED;
+
+    if (allocator_data != 0)
+    {
+        auto memory_alloc_info           = reinterpret_cast<MemoryAllocInfo*>(allocator_data);
+        memory_alloc_info->is_mapped     = true;
+        memory_alloc_info->mapped_offset = memory_map_info->offset;
+        result                           = VK_SUCCESS;
+        (*data)                          = reinterpret_cast<void*>(kPlaceholderAddress);
+    }
+
+    return result;
+}
+
 void VulkanRebindAllocator::UnmapMemory(VkDeviceMemory memory, MemoryData allocator_data)
 {
     GFXRECON_UNREFERENCED_PARAMETER(memory);
@@ -1283,6 +1172,19 @@ void VulkanRebindAllocator::UnmapMemory(VkDeviceMemory memory, MemoryData alloca
         memory_alloc_info->is_mapped     = false;
         memory_alloc_info->mapped_offset = 0;
     }
+}
+
+VkResult VulkanRebindAllocator::UnmapMemory2(const VkMemoryUnmapInfo* memory_unmap_info, MemoryData allocator_data)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(memory_unmap_info);
+
+    if (allocator_data != 0)
+    {
+        auto memory_alloc_info           = reinterpret_cast<MemoryAllocInfo*>(allocator_data);
+        memory_alloc_info->is_mapped     = false;
+        memory_alloc_info->mapped_offset = 0;
+    }
+    return VK_SUCCESS;
 }
 
 VkResult VulkanRebindAllocator::FlushMappedMemoryRanges(uint32_t                   memory_range_count,
@@ -1309,35 +1211,40 @@ VkResult VulkanRebindAllocator::SetDebugUtilsObjectNameEXT(VkDevice             
         {
             case VK_OBJECT_TYPE_DEVICE_MEMORY:
             {
-                MemoryAllocInfo* memory_alloc_info = reinterpret_cast<MemoryAllocInfo*>(allocator_data);
-                if (memory_alloc_info->original_buffers.empty() && memory_alloc_info->original_images.empty())
+                std::vector<VmaAllocation> allocations;
+                GetVmaAllocations(allocator_data, allocations);
+
+                if (allocations.empty())
                 {
+                    MemoryAllocInfo* memory_alloc_info  = reinterpret_cast<MemoryAllocInfo*>(allocator_data);
                     memory_alloc_info->debug_utils_name = name_info->pObjectName;
                     return VK_SUCCESS;
                 }
                 else
                 {
-                    VmaAllocationInfo allocation_info;
-                    if (!memory_alloc_info->original_buffers.empty())
-                    {
-                        auto it = memory_alloc_info->original_buffers.begin();
-                        vmaGetAllocationInfo(allocator_, it->second->allocation, &allocation_info);
-                    }
-                    else
-                    {
-                        auto it = memory_alloc_info->original_images.begin();
-                        vmaGetAllocationInfo(allocator_, it->second->allocation, &allocation_info);
-                    }
-
-                    name_info->objectHandle = VK_HANDLE_TO_UINT64(allocation_info.deviceMemory);
+                    name_info->objectHandle = VK_HANDLE_TO_UINT64(allocations[0]->GetMemory());
+                    break;
                 }
                 break;
             }
             case VK_OBJECT_TYPE_BUFFER:
             case VK_OBJECT_TYPE_IMAGE:
+            case VK_OBJECT_TYPE_VIDEO_SESSION_KHR:
+            case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
             {
                 ResourceAllocInfo* resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
-                if (resource_alloc_info->memory_info == nullptr)
+
+                bool found_memory_info = false;
+                for (const auto& mem_info : resource_alloc_info->bound_memory_infos)
+                {
+                    if (mem_info.memory_info)
+                    {
+                        found_memory_info = true;
+                        break;
+                    }
+                }
+
+                if (!found_memory_info)
                 {
                     resource_alloc_info->debug_utils_name = name_info->pObjectName;
                     return VK_SUCCESS;
@@ -1364,11 +1271,14 @@ VkResult VulkanRebindAllocator::SetDebugUtilsObjectTagEXT(VkDevice              
         {
             case VK_OBJECT_TYPE_DEVICE_MEMORY:
             {
-                MemoryAllocInfo* memory_alloc_info = reinterpret_cast<MemoryAllocInfo*>(allocator_data);
-                if (memory_alloc_info->original_buffers.empty() && memory_alloc_info->original_images.empty())
+                std::vector<VmaAllocation> allocations;
+                GetVmaAllocations(allocator_data, allocations);
+
+                if (allocations.empty())
                 {
-                    std::vector<uint8_t>& buffer = memory_alloc_info->debug_utils_tag;
-                    const uint8_t*        data   = reinterpret_cast<const uint8_t*>(tag_info->pTag);
+                    MemoryAllocInfo*      memory_alloc_info = reinterpret_cast<MemoryAllocInfo*>(allocator_data);
+                    std::vector<uint8_t>& buffer            = memory_alloc_info->debug_utils_tag;
+                    const uint8_t*        data              = reinterpret_cast<const uint8_t*>(tag_info->pTag);
 
                     buffer.clear();
                     buffer.insert(buffer.end(), data, data + tag_info->tagSize);
@@ -1378,27 +1288,29 @@ VkResult VulkanRebindAllocator::SetDebugUtilsObjectTagEXT(VkDevice              
                 }
                 else
                 {
-                    VmaAllocationInfo allocation_info;
-                    if (!memory_alloc_info->original_buffers.empty())
-                    {
-                        auto it = memory_alloc_info->original_buffers.begin();
-                        vmaGetAllocationInfo(allocator_, it->second->allocation, &allocation_info);
-                    }
-                    else
-                    {
-                        auto it = memory_alloc_info->original_images.begin();
-                        vmaGetAllocationInfo(allocator_, it->second->allocation, &allocation_info);
-                    }
-
-                    tag_info->objectHandle = VK_HANDLE_TO_UINT64(allocation_info.deviceMemory);
+                    tag_info->objectHandle = VK_HANDLE_TO_UINT64(allocations[0]->GetMemory());
+                    break;
                 }
                 break;
             }
             case VK_OBJECT_TYPE_BUFFER:
             case VK_OBJECT_TYPE_IMAGE:
+            case VK_OBJECT_TYPE_VIDEO_SESSION_KHR:
+            case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
             {
                 ResourceAllocInfo* resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
-                if (resource_alloc_info->memory_info == nullptr)
+
+                bool found_memory_info = false;
+                for (const auto& mem_info : resource_alloc_info->bound_memory_infos)
+                {
+                    if (mem_info.memory_info)
+                    {
+                        found_memory_info = true;
+                        break;
+                    }
+                }
+
+                if (!found_memory_info)
                 {
                     std::vector<uint8_t>& buffer = resource_alloc_info->debug_utils_tag;
                     const uint8_t*        data   = reinterpret_cast<const uint8_t*>(tag_info->pTag);
@@ -1454,19 +1366,12 @@ VkResult VulkanRebindAllocator::WriteMappedMemoryRange(MemoryData     allocator_
             VkDeviceSize write_end   = write_start + size;
 
             // Copy to the resources that were bound to this range at capture.
-            for (const auto& entry : memory_alloc_info->original_buffers)
+            for (const auto& entry : memory_alloc_info->original_objects)
             {
-                UpdateBoundResource(entry.second, write_start, write_end, data);
-            }
-
-            for (const auto& entry : memory_alloc_info->original_images)
-            {
-                UpdateBoundResource(entry.second, write_start, write_end, data);
-            }
-
-            for (const auto& entry : memory_alloc_info->original_sessions)
-            {
-                UpdateBoundResource(entry.second, write_start, write_end, data);
+                for (auto& entry_bound : entry.second->bound_memory_infos)
+                {
+                    UpdateBoundResource(entry.second, &entry_bound, write_start, write_end, data);
+                }
             }
 
             result = VK_SUCCESS;
@@ -1532,87 +1437,128 @@ void VulkanRebindAllocator::ReportBindImage2Incompatibility(uint32_t            
 void VulkanRebindAllocator::ReportBindVideoSessionIncompatibility(VkVideoSessionKHR video_session,
                                                                   uint32_t          bind_info_count,
                                                                   const VkBindVideoSessionMemoryInfoKHR* bind_infos,
-                                                                  const ResourceData* allocator_resource_datas,
-                                                                  const MemoryData*   allocator_memory_datas)
+                                                                  const ResourceData allocator_resource_data,
+                                                                  const MemoryData*  allocator_memory_datas)
 {
     GFXRECON_UNREFERENCED_PARAMETER(video_session);
     GFXRECON_UNREFERENCED_PARAMETER(bind_infos);
     GFXRECON_UNREFERENCED_PARAMETER(allocator_memory_datas);
 
-    ReportBindIncompatibility(allocator_resource_datas, bind_info_count);
+    ReportBindIncompatibility(&allocator_resource_data, 1);
 }
 
-void VulkanRebindAllocator::WriteBoundResourceDirect(
-    ResourceAllocInfo* resource_alloc_info, size_t src_offset, size_t dst_offset, size_t data_size, const uint8_t* data)
+void VulkanRebindAllocator::ReportBindAccelerationStructureMemoryNVIncompatibility(
+    uint32_t                                       bind_info_count,
+    const VkBindAccelerationStructureMemoryInfoNV* bind_infos,
+    const ResourceData*                            allocator_acc_datas,
+    const MemoryData*                              allocator_memory_datas)
 {
-    if (resource_alloc_info->object_type == ObjectType::buffer)
+    GFXRECON_UNREFERENCED_PARAMETER(bind_infos);
+    GFXRECON_UNREFERENCED_PARAMETER(allocator_memory_datas);
+
+    ReportBindIncompatibility(allocator_acc_datas, bind_info_count);
+}
+
+void VulkanRebindAllocator::WriteBoundResourceDirect(ResourceAllocInfo* resource_alloc_info,
+                                                     BoundMemoryInfo*   bound_memory_info,
+                                                     size_t             src_offset,
+                                                     size_t             dst_offset,
+                                                     size_t             data_size,
+                                                     const uint8_t*     data)
+{
+    switch (resource_alloc_info->object_type)
     {
-        util::platform::MemoryCopy(static_cast<uint8_t*>(resource_alloc_info->mapped_pointer) + dst_offset,
-                                   data_size,
-                                   data + src_offset,
-                                   data_size);
-    }
-    else if (resource_alloc_info->object_type == ObjectType::image)
-    {
-        if (!resource_alloc_info->layouts.empty())
+        case VK_OBJECT_TYPE_BUFFER:
         {
-            if (resource_alloc_info->layouts.size() == 1)
-            {
-                const auto& layouts = resource_alloc_info->layouts[0];
-
-                GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, layouts.original.rowPitch);
-                GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, layouts.rebind.rowPitch);
-
-                size_t original_row_pitch = static_cast<size_t>(layouts.original.rowPitch);
-                size_t rebind_row_pitch   = static_cast<size_t>(layouts.rebind.rowPitch);
-
-                resource::CopyImageSubresourceMemory(static_cast<uint8_t*>(resource_alloc_info->mapped_pointer),
-                                                     data + src_offset,
-                                                     dst_offset,
-                                                     data_size,
-                                                     rebind_row_pitch,
-                                                     original_row_pitch,
-                                                     resource_alloc_info->height);
-            }
-            else
-            {
-                // TODO: multi-plane image format support when strides do not match.
-                GFXRECON_LOG_ERROR("Skipping mapped memory write for image with multiple subresources: support "
-                                   "not yet implemented");
-            }
-        }
-        else
-        {
-            GFXRECON_LOG_WARNING("Image subresource layout info is not available for mapped memory write; "
-                                 "capture/replay memory alignment differences will not be handled properly");
-
-            util::platform::MemoryCopy(static_cast<uint8_t*>(resource_alloc_info->mapped_pointer) + dst_offset,
+            util::platform::MemoryCopy(static_cast<uint8_t*>(bound_memory_info->mapped_pointer) + dst_offset,
                                        data_size,
                                        data + src_offset,
                                        data_size);
+            break;
         }
-    }
-    else if (resource_alloc_info->object_type == ObjectType::video_session)
-    {
-        // TODO: implement direct video session copy
-        GFXRECON_LOG_WARNING("Skipping video session in direct write: support not yet implemented");
+        case VK_OBJECT_TYPE_IMAGE:
+        {
+            if (!resource_alloc_info->layouts.empty())
+            {
+                if (resource_alloc_info->layouts.size() == 1)
+                {
+                    const auto& layouts = resource_alloc_info->layouts[0];
+
+                    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, layouts.original.rowPitch);
+                    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, layouts.rebind.rowPitch);
+
+                    size_t original_row_pitch = static_cast<size_t>(layouts.original.rowPitch);
+                    size_t rebind_row_pitch   = static_cast<size_t>(layouts.rebind.rowPitch);
+
+                    resource::CopyImageSubresourceMemory(static_cast<uint8_t*>(bound_memory_info->mapped_pointer),
+                                                         data + src_offset,
+                                                         dst_offset,
+                                                         data_size,
+                                                         rebind_row_pitch,
+                                                         original_row_pitch,
+                                                         resource_alloc_info->height);
+                }
+                else
+                {
+                    // TODO: multi-plane image format support when strides do not match.
+                    GFXRECON_LOG_ERROR("Skipping mapped memory write for image with multiple subresources: support "
+                                       "not yet implemented");
+                }
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING("Image subresource layout info is not available for mapped memory write; "
+                                     "capture/replay memory alignment differences will not be handled properly");
+
+                util::platform::MemoryCopy(static_cast<uint8_t*>(bound_memory_info->mapped_pointer) + dst_offset,
+                                           data_size,
+                                           data + src_offset,
+                                           data_size);
+            }
+            break;
+        }
+        case VK_OBJECT_TYPE_VIDEO_SESSION_KHR:
+        {
+            // TODO: implement direct video session copy
+            GFXRECON_LOG_WARNING("Skipping video session in direct write: support not yet implemented");
+            break;
+        }
+        case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
+        {
+            // TODO: Implement it when it's necessary.
+            GFXRECON_LOG_WARNING("Skipping acceleration structure NV in direct write: support not yet implemented");
+            break;
+        }
+        default:
+            break;
     }
 }
 
-void VulkanRebindAllocator::WriteBoundResourceStaging(
-    ResourceAllocInfo* resource_alloc_info, size_t src_offset, size_t dst_offset, size_t data_size, const uint8_t* data)
+void VulkanRebindAllocator::WriteBoundResourceStaging(ResourceAllocInfo* resource_alloc_info,
+                                                      BoundMemoryInfo*   bound_memory_info,
+                                                      size_t             src_offset,
+                                                      size_t             dst_offset,
+                                                      size_t             data_size,
+                                                      const uint8_t*     data)
 {
-    if (resource_alloc_info->object_type == ObjectType::image && dst_offset != 0)
+    if (resource_alloc_info->object_type == VK_OBJECT_TYPE_IMAGE && dst_offset != 0)
     {
         // TODO: implement offset based stagging image copy
         GFXRECON_LOG_WARNING("Skipping image with offset in staging write: support not yet implemented");
         return;
     }
 
-    if (resource_alloc_info->object_type == ObjectType::video_session)
+    if (resource_alloc_info->object_type == VK_OBJECT_TYPE_VIDEO_SESSION_KHR)
     {
-        // TODO: implement stagging video session copy
+        // TODO: Implement it when it's necessary.
         GFXRECON_LOG_WARNING("Skipping video session in staging write: support not yet implemented");
+        return;
+    }
+
+    if (resource_alloc_info->object_type == VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV)
+    {
+        // TODO: Implement it when it's necessary.
+        GFXRECON_LOG_WARNING("Skipping acceleration structure NV in staging write: support not yet implemented");
         return;
     }
 
@@ -1636,17 +1582,17 @@ void VulkanRebindAllocator::WriteBoundResourceStaging(
                                       &staging_alloc,
                                       &staging_alloc_info);
 
-    void* copy_mapped_pointer{ resource_alloc_info->mapped_pointer };
+    void* copy_mapped_pointer{ bound_memory_info->mapped_pointer };
 
     if (result == VK_SUCCESS)
     {
-        result = vmaMapMemory(allocator_, staging_alloc, &resource_alloc_info->mapped_pointer);
+        result = vmaMapMemory(allocator_, staging_alloc, &bound_memory_info->mapped_pointer);
     }
 
     if (result == VK_SUCCESS)
     {
-        WriteBoundResourceDirect(resource_alloc_info, src_offset, 0, data_size, data);
-        resource_alloc_info->mapped_pointer = copy_mapped_pointer;
+        WriteBoundResourceDirect(resource_alloc_info, bound_memory_info, src_offset, 0, data_size, data);
+        bound_memory_info->mapped_pointer = copy_mapped_pointer;
         vmaFlushAllocation(allocator_, staging_alloc, 0, VK_WHOLE_SIZE);
         vmaUnmapMemory(allocator_, staging_alloc);
 
@@ -1658,16 +1604,15 @@ void VulkanRebindAllocator::WriteBoundResourceStaging(
 
     if (result == VK_SUCCESS)
     {
-        if (resource_alloc_info->object_type == ObjectType::image)
+        if (resource_alloc_info->object_type == VK_OBJECT_TYPE_IMAGE)
         {
             VkImage original_image{};
 
-            for (const std::pair<const VkImage, VulkanRebindAllocator::ResourceAllocInfo*>& elt :
-                 resource_alloc_info->memory_info->original_images)
+            for (const auto& elt : bound_memory_info->memory_info->original_objects)
             {
                 if (elt.second == resource_alloc_info)
                 {
-                    original_image = elt.first;
+                    original_image = UINT64_TO_VK_HANDLE(VkImage, elt.first);
                     break;
                 }
             }
@@ -1699,15 +1644,14 @@ void VulkanRebindAllocator::WriteBoundResourceStaging(
                 result = functions_.end_command_buffer(cmd_buffer_);
             }
         }
-        else if (resource_alloc_info->object_type == ObjectType::buffer)
+        else if (resource_alloc_info->object_type == VK_OBJECT_TYPE_BUFFER)
         {
             VkBuffer original_buffer{};
-            for (const std::pair<const VkBuffer, VulkanRebindAllocator::ResourceAllocInfo*>& elt :
-                 resource_alloc_info->memory_info->original_buffers)
+            for (const auto& elt : bound_memory_info->memory_info->original_objects)
             {
                 if (elt.second == resource_alloc_info)
                 {
-                    original_buffer = elt.first;
+                    original_buffer = UINT64_TO_VK_HANDLE(VkBuffer, elt.first);
                     break;
                 }
             }
@@ -1749,12 +1693,15 @@ void VulkanRebindAllocator::WriteBoundResourceStaging(
 }
 
 void VulkanRebindAllocator::WriteBoundResource(ResourceAllocInfo* resource_alloc_info,
+                                               BoundMemoryInfo*   bound_memory_info,
                                                VkDeviceSize       src_offset,
                                                VkDeviceSize       dst_offset,
                                                VkDeviceSize       data_size,
                                                const uint8_t*     data)
 {
-    assert(resource_alloc_info != nullptr);
+    GFXRECON_ASSERT(resource_alloc_info != nullptr);
+    GFXRECON_ASSERT(bound_memory_info != nullptr);
+    GFXRECON_ASSERT(bound_memory_info->memory_info != nullptr);
 
     GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, src_offset);
     GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, dst_offset);
@@ -1764,19 +1711,20 @@ void VulkanRebindAllocator::WriteBoundResource(ResourceAllocInfo* resource_alloc
     size_t copy_dst_offset = static_cast<size_t>(dst_offset);
     size_t copy_size       = static_cast<size_t>(data_size);
 
-    if (resource_alloc_info->is_host_visible)
+    if (bound_memory_info->is_host_visible)
     {
         VkResult result = VK_SUCCESS;
 
-        if (resource_alloc_info->mapped_pointer == nullptr)
+        if (bound_memory_info->mapped_pointer == nullptr)
         {
             // After first map, the allocation will stay mapped until it is destroyed.
-            result = vmaMapMemory(allocator_, resource_alloc_info->allocation, &resource_alloc_info->mapped_pointer);
+            result = vmaMapMemory(allocator_, bound_memory_info->allocation, &bound_memory_info->mapped_pointer);
         }
 
         if (result == VK_SUCCESS)
         {
-            WriteBoundResourceDirect(resource_alloc_info, copy_src_offset, copy_dst_offset, copy_size, data);
+            WriteBoundResourceDirect(
+                resource_alloc_info, bound_memory_info, copy_src_offset, copy_dst_offset, copy_size, data);
         }
         else
         {
@@ -1786,11 +1734,13 @@ void VulkanRebindAllocator::WriteBoundResource(ResourceAllocInfo* resource_alloc
     }
     else
     {
-        WriteBoundResourceStaging(resource_alloc_info, copy_src_offset, copy_dst_offset, copy_size, data);
+        WriteBoundResourceStaging(
+            resource_alloc_info, bound_memory_info, copy_src_offset, copy_dst_offset, copy_size, data);
     }
 }
 
 bool VulkanRebindAllocator::TranslateMemoryRange(const ResourceAllocInfo* resource_alloc_info,
+                                                 const BoundMemoryInfo*   bound_memory_info,
                                                  VkDeviceSize             original_start,
                                                  VkDeviceSize             original_end,
                                                  VkDeviceSize*            src_offset,
@@ -1799,16 +1749,21 @@ bool VulkanRebindAllocator::TranslateMemoryRange(const ResourceAllocInfo* resour
 {
     assert((src_offset != nullptr) && (dst_offset != nullptr) && (data_size));
 
-    VkDeviceSize resource_start = resource_alloc_info->original_offset;
+    if (bound_memory_info->memory_info == nullptr)
+    {
+        return false;
+    }
+
+    VkDeviceSize resource_start = bound_memory_info->original_offset;
 
     // This should correspond to the offset to the end of the resource at capture time.
     //
     // However, if the rebind size is smaller than the original size, we don't want data_size to be big enough to cause
     // an overflow, so the original size is artifically clamped to the rebind size.
     VkDeviceSize resource_end =
-        resource_start + (resource_alloc_info->original_size != 0
-                              ? std::min(resource_alloc_info->original_size, resource_alloc_info->rebind_size)
-                              : resource_alloc_info->rebind_size);
+        resource_start + (bound_memory_info->original_size != 0
+                              ? std::min(bound_memory_info->original_size, bound_memory_info->rebind_size)
+                              : bound_memory_info->rebind_size);
 
     // Range ends are exclusive.
     if ((resource_end <= original_start) || (original_end <= resource_start))
@@ -1849,6 +1804,7 @@ bool VulkanRebindAllocator::TranslateMemoryRange(const ResourceAllocInfo* resour
 }
 
 void VulkanRebindAllocator::UpdateBoundResource(ResourceAllocInfo* resource_alloc_info,
+                                                BoundMemoryInfo*   bound_memory_info,
                                                 VkDeviceSize       write_start,
                                                 VkDeviceSize       write_end,
                                                 const uint8_t*     data)
@@ -1859,14 +1815,16 @@ void VulkanRebindAllocator::UpdateBoundResource(ResourceAllocInfo* resource_allo
     VkDeviceSize dst_offset = 0;
     VkDeviceSize data_size  = 0;
 
-    if (TranslateMemoryRange(resource_alloc_info, write_start, write_end, &src_offset, &dst_offset, &data_size))
+    if (TranslateMemoryRange(
+            resource_alloc_info, bound_memory_info, write_start, write_end, &src_offset, &dst_offset, &data_size))
     {
-        WriteBoundResource(resource_alloc_info, src_offset, dst_offset, data_size, data);
+        WriteBoundResource(resource_alloc_info, bound_memory_info, src_offset, dst_offset, data_size, data);
     }
 }
 
 VkResult VulkanRebindAllocator::UpdateMappedMemoryRange(
     ResourceAllocInfo* resource_alloc_info,
+    BoundMemoryInfo*   bound_memory_info,
     VkDeviceSize       original_start,
     VkDeviceSize       original_end,
     VkResult (*update_func)(VmaAllocator, VmaAllocation, VkDeviceSize, VkDeviceSize))
@@ -1876,17 +1834,18 @@ VkResult VulkanRebindAllocator::UpdateMappedMemoryRange(
     VkDeviceSize dst_offset = 0;
     VkDeviceSize data_size  = 0;
 
-    if (TranslateMemoryRange(resource_alloc_info, original_start, original_end, &src_offset, &dst_offset, &data_size))
+    if (TranslateMemoryRange(
+            resource_alloc_info, bound_memory_info, original_start, original_end, &src_offset, &dst_offset, &data_size))
     {
-        if (resource_alloc_info->mapped_pointer == nullptr)
+        if (bound_memory_info->mapped_pointer == nullptr)
         {
             // After first map, the allocation will stay mapped until it is destroyed.
-            result = vmaMapMemory(allocator_, resource_alloc_info->allocation, &resource_alloc_info->mapped_pointer);
+            result = vmaMapMemory(allocator_, bound_memory_info->allocation, &bound_memory_info->mapped_pointer);
         }
 
         if (result == VK_SUCCESS)
         {
-            result = update_func(allocator_, resource_alloc_info->allocation, dst_offset, data_size);
+            result = update_func(allocator_, bound_memory_info->allocation, dst_offset, data_size);
         }
     }
 
@@ -1920,27 +1879,15 @@ VkResult VulkanRebindAllocator::UpdateMappedMemoryRanges(
                 VkDeviceSize range_start = memory_ranges[i].offset;
                 VkDeviceSize range_end   = range_start + size;
 
-                for (const auto& entry : memory_alloc_info->original_buffers)
+                for (const auto& entry : memory_alloc_info->original_objects)
                 {
-                    if (UpdateMappedMemoryRange(entry.second, range_start, range_end, update_func) != VK_SUCCESS)
+                    for (auto& entry_bound : entry.second->bound_memory_infos)
                     {
-                        result = VK_ERROR_MEMORY_MAP_FAILED;
-                    }
-                }
-
-                for (const auto& entry : memory_alloc_info->original_images)
-                {
-                    if (UpdateMappedMemoryRange(entry.second, range_start, range_end, update_func) != VK_SUCCESS)
-                    {
-                        result = VK_ERROR_MEMORY_MAP_FAILED;
-                    }
-                }
-
-                for (const auto& entry : memory_alloc_info->original_sessions)
-                {
-                    if (UpdateMappedMemoryRange(entry.second, range_start, range_end, update_func) != VK_SUCCESS)
-                    {
-                        result = VK_ERROR_MEMORY_MAP_FAILED;
+                        if (UpdateMappedMemoryRange(entry.second, &entry_bound, range_start, range_end, update_func) !=
+                            VK_SUCCESS)
+                        {
+                            result = VK_ERROR_MEMORY_MAP_FAILED;
+                        }
                     }
                 }
             }
@@ -2107,6 +2054,13 @@ VmaMemoryUsage VulkanRebindAllocator::GetVideoSeesionMemoryUsage(VkMemoryPropert
     return AdjustMemoryUsage(memory_usage, replay_requirements);
 }
 
+VmaMemoryUsage
+VulkanRebindAllocator::GetAccelerationStructureMemoryNVUsage(VkMemoryPropertyFlags       capture_properties,
+                                                             const VkMemoryRequirements& replay_requirements)
+{
+    return GetVideoSeesionMemoryUsage(capture_properties, replay_requirements);
+}
+
 VmaMemoryUsage VulkanRebindAllocator::AdjustMemoryUsage(VmaMemoryUsage              desired_usage,
                                                         const VkMemoryRequirements& replay_requirements)
 {
@@ -2201,18 +2155,41 @@ VkResult VulkanRebindAllocator::MapResourceMemoryDirect(VkDeviceSize     size,
     {
         auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
 
-        if (resource_alloc_info->mapped_pointer == nullptr)
+        if (!resource_alloc_info->bound_memory_infos.empty())
         {
-            result = vmaMapMemory(allocator_, resource_alloc_info->allocation, &resource_alloc_info->mapped_pointer);
-        }
-        else
-        {
-            result = VK_SUCCESS;
+            auto& mem_info = resource_alloc_info->bound_memory_infos[0];
+
+            if (mem_info.mapped_pointer == nullptr)
+            {
+                result = vmaMapMemory(allocator_, mem_info.allocation, &mem_info.mapped_pointer);
+            }
+            else
+            {
+                result = VK_SUCCESS;
+            }
+
+            if (result == VK_SUCCESS)
+            {
+                (*data) = reinterpret_cast<uint8_t*>(mem_info.mapped_pointer);
+            }
         }
 
-        if (result == VK_SUCCESS)
+        // TODO: Implement it when it's necessary.
+        if (resource_alloc_info->bound_memory_infos.size() > 1)
         {
-            (*data) = reinterpret_cast<uint8_t*>(resource_alloc_info->mapped_pointer);
+            switch (resource_alloc_info->memory_info_type)
+            {
+                case MemoryInfoType::kSparse:
+                    GFXRECON_LOG_WARNING("VulkanRebindAllocator::MapResourceMemoryDirect map only the first memory of "
+                                         "sparse memories.");
+                    break;
+                case MemoryInfoType::kVideoSession:
+                    GFXRECON_LOG_WARNING(
+                        "VulkanRebindAllocator::MapResourceMemoryDirect map only the first memory of VideoSession.");
+                    break;
+                default:
+                    break;
+            }
         }
     }
 
@@ -2222,7 +2199,6 @@ VkResult VulkanRebindAllocator::MapResourceMemoryDirect(VkDeviceSize     size,
 void VulkanRebindAllocator::SetBindingDebugUtilsNameAndTag(const MemoryAllocInfo*   memory_alloc_info,
                                                            const ResourceAllocInfo* resource_alloc_info,
                                                            VkDeviceMemory           device_memory,
-                                                           VkObjectType             resource_type,
                                                            uint64_t                 resource_handle)
 {
     VkDebugUtilsObjectNameInfoEXT name_info;
@@ -2255,7 +2231,7 @@ void VulkanRebindAllocator::SetBindingDebugUtilsNameAndTag(const MemoryAllocInfo
 
     if (!resource_alloc_info->debug_utils_name.empty())
     {
-        name_info.objectType   = resource_type;
+        name_info.objectType   = resource_alloc_info->object_type;
         name_info.objectHandle = resource_handle;
         name_info.pObjectName  = resource_alloc_info->debug_utils_name.c_str();
 
@@ -2264,7 +2240,7 @@ void VulkanRebindAllocator::SetBindingDebugUtilsNameAndTag(const MemoryAllocInfo
 
     if (!resource_alloc_info->debug_utils_tag.empty())
     {
-        tag_info.objectType   = resource_type;
+        tag_info.objectType   = resource_alloc_info->object_type;
         tag_info.objectHandle = resource_handle;
         tag_info.tagName      = resource_alloc_info->debug_utils_tag_name;
         tag_info.tagSize      = resource_alloc_info->debug_utils_tag.size();
@@ -2272,6 +2248,459 @@ void VulkanRebindAllocator::SetBindingDebugUtilsNameAndTag(const MemoryAllocInfo
 
         functions_.set_debug_utils_object_tag(device_, &tag_info);
     }
+}
+
+VkResult VulkanRebindAllocator::VmaAllocateMemory(const VkMemoryRequirements& mem_req,
+                                                  const VmaMemoryUsage        usage,
+                                                  VmaAllocation&              allocation)
+{
+    VmaAllocationCreateInfo create_info;
+    create_info.flags          = 0;
+    create_info.usage          = usage;
+    create_info.requiredFlags  = 0;
+    create_info.preferredFlags = 0;
+    create_info.memoryTypeBits = 0;
+    create_info.pool           = VK_NULL_HANDLE;
+    create_info.pUserData      = nullptr;
+
+    return allocator_->AllocateMemory(mem_req,
+                                      false,
+                                      false,
+                                      VK_NULL_HANDLE,
+                                      VK_NULL_HANDLE,
+                                      VmaBufferImageUsage::UNKNOWN,
+                                      create_info,
+                                      VMA_SUBALLOCATION_TYPE_FREE,
+                                      1,
+                                      &allocation);
+}
+
+void VulkanRebindAllocator::GetVmaAllocations(MemoryData allocator_data, std::vector<VmaAllocation>& allocations)
+{
+    auto memory_alloc_info = reinterpret_cast<MemoryAllocInfo*>(allocator_data);
+
+    for (const auto& res_alc : memory_alloc_info->original_objects)
+    {
+        for (const auto& mem_info : res_alc.second->bound_memory_infos)
+        {
+            const auto alc = mem_info.allocation;
+            if (alc != VK_NULL_HANDLE)
+            {
+                allocations.push_back(alc);
+            }
+        }
+    }
+}
+
+void VulkanRebindAllocator::GetDeviceMemoryCommitment(VkDeviceMemory memory,
+                                                      VkDeviceSize*  committed_memory_in_bytes,
+                                                      MemoryData     allocator_data)
+{
+    std::vector<VmaAllocation> alcs;
+    GetVmaAllocations(allocator_data, alcs);
+
+    if (alcs.empty())
+    {
+        GFXRECON_LOG_ERROR("There's no allocations for GetDeviceMemoryCommitment");
+    }
+
+    for (const auto& alc : alcs)
+    {
+        VmaAllocationInfo allocation_info{};
+        allocator_->GetAllocationInfo(alc, &allocation_info);
+
+        const auto modified_mem = allocation_info.deviceMemory;
+
+        switch (alc->GetType())
+        {
+            case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+            {
+                functions_.get_device_memory_commitment(device_, modified_mem, committed_memory_in_bytes);
+                break;
+            }
+            case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+            {
+                VmaDeviceMemoryBlock* const pBlock = alc->GetBlock();
+                VMA_ASSERT(pBlock && "GetDeviceMemoryCommitment to allocation that doesn't belong to any block.");
+
+                VmaMutexLock lock(pBlock->m_MapAndBindMutex, allocator_->m_UseMutex);
+                functions_.get_device_memory_commitment(device_, modified_mem, committed_memory_in_bytes);
+                break;
+            }
+            default:
+                VMA_ASSERT(0);
+        }
+    }
+}
+
+void VulkanRebindAllocator::SetDeviceMemoryPriority(VkDeviceMemory memory, float priority, MemoryData allocator_data)
+{
+    std::vector<VmaAllocation> alcs;
+    GetVmaAllocations(allocator_data, alcs);
+
+    if (alcs.empty())
+    {
+        GFXRECON_LOG_ERROR("There's no allocations for SetDeviceMemoryPriority");
+    }
+
+    for (const auto& alc : alcs)
+    {
+        VmaAllocationInfo allocation_info{};
+        allocator_->GetAllocationInfo(alc, &allocation_info);
+
+        const auto modified_mem = allocation_info.deviceMemory;
+
+        switch (alc->GetType())
+        {
+            case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+            {
+                functions_.set_device_memory_priority(device_, modified_mem, priority);
+                break;
+            }
+            case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+            {
+                VmaDeviceMemoryBlock* const pBlock = alc->GetBlock();
+                VMA_ASSERT(pBlock && "SetDeviceMemoryPriority to allocation that doesn't belong to any block.");
+
+                VmaMutexLock lock(pBlock->m_MapAndBindMutex, allocator_->m_UseMutex);
+                functions_.set_device_memory_priority(device_, modified_mem, priority);
+                break;
+            }
+            default:
+                VMA_ASSERT(0);
+        }
+    }
+}
+
+VkResult
+VulkanRebindAllocator::GetMemoryRemoteAddressNV(const VkMemoryGetRemoteAddressInfoNV* memory_get_remote_address_info,
+                                                VkRemoteAddressNV*                    address,
+                                                MemoryData                            allocator_data)
+{
+    auto result = VK_ERROR_INITIALIZATION_FAILED;
+
+    std::vector<VmaAllocation> alcs;
+    GetVmaAllocations(allocator_data, alcs);
+
+    if (alcs.empty())
+    {
+        GFXRECON_LOG_ERROR("There's no allocations for GetMemoryRemoteAddressNV");
+    }
+
+    auto modified_get_mem_remote_addr_info = *memory_get_remote_address_info;
+
+    for (const auto& alc : alcs)
+    {
+        VmaAllocationInfo allocation_info{};
+        allocator_->GetAllocationInfo(alc, &allocation_info);
+
+        modified_get_mem_remote_addr_info.memory = allocation_info.deviceMemory;
+
+        switch (alc->GetType())
+        {
+            case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+            {
+                result = functions_.get_memory_remote_address_nv(device_, &modified_get_mem_remote_addr_info, address);
+                break;
+            }
+            case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+            {
+                VmaDeviceMemoryBlock* const pBlock = alc->GetBlock();
+                VMA_ASSERT(pBlock && "GetMemoryRemoteAddressNV to allocation that doesn't belong to any block.");
+
+                VmaMutexLock lock(pBlock->m_MapAndBindMutex, allocator_->m_UseMutex);
+                result = functions_.get_memory_remote_address_nv(device_, &modified_get_mem_remote_addr_info, address);
+                break;
+            }
+            default:
+                VMA_ASSERT(0);
+        }
+    }
+    return result;
+}
+
+VkResult VulkanRebindAllocator::CreateAccelerationStructureNV(const VkAccelerationStructureCreateInfoNV* create_info,
+                                                              const VkAllocationCallbacks* allocation_callbacks,
+                                                              format::HandleId             capture_id,
+                                                              VkAccelerationStructureNV*   acc_str,
+                                                              ResourceData*                allocator_data)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(allocation_callbacks);
+    GFXRECON_UNREFERENCED_PARAMETER(capture_id);
+
+    VkResult result = VK_ERROR_INITIALIZATION_FAILED;
+
+    if ((create_info != nullptr) && (acc_str != nullptr) && (allocator_data != nullptr))
+    {
+
+        result = functions_.create_acceleration_structure_nv(device_, create_info, nullptr, acc_str);
+
+        if (result >= 0)
+        {
+            auto resource_alloc_info         = new ResourceAllocInfo;
+            resource_alloc_info->object_type = VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV;
+            (*allocator_data)                = reinterpret_cast<uintptr_t>(resource_alloc_info);
+
+            if (create_info->pNext != nullptr)
+            {
+                resource_alloc_info->uses_extensions = true;
+            }
+        }
+    }
+
+    return result;
+}
+
+void VulkanRebindAllocator::DestroyAccelerationStructureNV(VkAccelerationStructureNV    acc_str,
+                                                           const VkAllocationCallbacks* allocation_callbacks,
+                                                           ResourceData                 allocator_data)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(allocation_callbacks);
+    GFXRECON_ASSERT(acc_str != VK_NULL_HANDLE);
+
+    if (allocator_data != 0)
+    {
+        auto* resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+
+        // It supposes only have one bind memory info.
+        if (resource_alloc_info->bound_memory_infos.size() > 1)
+        {
+            GFXRECON_LOG_WARNING("AccelerationStructureNV should have bind only one memory, but it bound more.");
+        }
+
+        for (auto& mem_info : resource_alloc_info->bound_memory_infos)
+        {
+            auto* mem_alc_info = mem_info.memory_info;
+            if (mem_alc_info != nullptr)
+            {
+                mem_alc_info->original_objects.erase(VK_HANDLE_TO_UINT64(acc_str));
+            }
+
+            if (mem_info.allocation != VK_NULL_HANDLE)
+            {
+                if (mem_info.mapped_pointer != nullptr)
+                {
+                    vmaUnmapMemory(allocator_, mem_info.allocation);
+                }
+                vmaFreeMemory(allocator_, mem_info.allocation);
+            }
+        }
+        delete resource_alloc_info;
+    }
+
+    functions_.destroy_acceleration_structure_nv(device_, acc_str, allocator_->GetAllocationCallbacks());
+}
+
+void VulkanRebindAllocator::GetAccelerationStructureMemoryRequirementsNV(
+    const VkAccelerationStructureMemoryRequirementsInfoNV* info,
+    VkMemoryRequirements2KHR*                              memory_requirements,
+    ResourceData                                           allocator_data)
+{
+    if (allocator_data != 0)
+    {
+        auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+
+        if (resource_alloc_info->original_sizes.empty())
+        {
+            resource_alloc_info->original_sizes.resize(1);
+        }
+        resource_alloc_info->original_sizes[0] = memory_requirements->memoryRequirements.size;
+    }
+
+    functions_.get_acceleration_structure_memory_requirements_nv(device_, info, memory_requirements);
+}
+
+VkResult VulkanRebindAllocator::AllocateMemoryForAccelerationStructureMemoryNV(
+    VkAccelerationStructureNV               acceleration_structure_nv,
+    const VkPhysicalDeviceMemoryProperties& device_memory_properties,
+    const ResourceAllocInfo&                resource_alloc_info,
+    const MemoryAllocInfo&                  memory_alloc_info,
+    VmaAllocation&                          allocation,
+    VmaAllocationInfo&                      allocation_info)
+{
+    VkAccelerationStructureMemoryRequirementsInfoNV acc_mem_reqs_info = {};
+    acc_mem_reqs_info.sType                 = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_NV;
+    acc_mem_reqs_info.accelerationStructure = acceleration_structure_nv;
+
+    VkMemoryRequirements2KHR mem_reqs = {};
+    mem_reqs.sType                    = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR;
+
+    functions_.get_acceleration_structure_memory_requirements_nv(device_, &acc_mem_reqs_info, &mem_reqs);
+
+    auto usage = GetAccelerationStructureMemoryNVUsage(
+        device_memory_properties.memoryTypes[memory_alloc_info.original_index].propertyFlags,
+        mem_reqs.memoryRequirements);
+
+    auto result = VmaAllocateMemory(mem_reqs.memoryRequirements, usage, allocation);
+    if (result == VK_SUCCESS)
+    {
+        allocator_->GetAllocationInfo(allocation, &allocation_info);
+    }
+
+    return result;
+}
+
+VkResult
+VulkanRebindAllocator::BindAccelerationStructureMemoryNV(uint32_t                                       bind_info_count,
+                                                         const VkBindAccelerationStructureMemoryInfoNV* bind_infos,
+                                                         const ResourceData*    allocator_acc_datas,
+                                                         const MemoryData*      allocator_memory_datas,
+                                                         VkMemoryPropertyFlags* bind_memory_properties)
+{
+    VkResult result = VK_ERROR_INITIALIZATION_FAILED;
+
+    if ((bind_info_count > 0) && (bind_infos != nullptr) && (allocator_acc_datas != nullptr) &&
+        (allocator_memory_datas != nullptr) && (bind_memory_properties != nullptr))
+    {
+        for (uint32_t i = 0; i < bind_info_count; ++i)
+        {
+            const auto&       bind_info  = bind_infos[i];
+            VmaAllocation     allocation = VK_NULL_HANDLE;
+            VmaAllocationInfo allocation_info{};
+
+            auto* resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_acc_datas[i]);
+            auto* memory_alloc_info   = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_datas[i]);
+
+            result = AllocateMemoryForAccelerationStructureMemoryNV(bind_info.accelerationStructure,
+                                                                    capture_memory_properties_,
+                                                                    *resource_alloc_info,
+                                                                    *memory_alloc_info,
+                                                                    allocation,
+                                                                    allocation_info);
+            if (result == VK_SUCCESS)
+            {
+                auto modified_bind_info         = bind_info;
+                modified_bind_info.memory       = allocation_info.deviceMemory;
+                modified_bind_info.memoryOffset = allocation_info.offset;
+
+                switch (allocation->GetType())
+                {
+                    case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+                    {
+                        result = functions_.bind_acceleration_structure_memory_nv(device_, 1, &modified_bind_info);
+                        break;
+                    }
+                    case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+                    {
+                        VmaDeviceMemoryBlock* const pBlock = allocation->GetBlock();
+                        VMA_ASSERT(pBlock &&
+                                   "BindAccelerationStructureMemoryNV to allocation that doesn't belong to any block.");
+
+                        VmaMutexLock lock(pBlock->m_MapAndBindMutex, allocator_->m_UseMutex);
+                        result = functions_.bind_acceleration_structure_memory_nv(device_, 1, &modified_bind_info);
+                        break;
+                    }
+                    default:
+                        VMA_ASSERT(0);
+                }
+
+                if (result == VK_SUCCESS)
+                {
+                    UpdateAllocInfo(*resource_alloc_info,
+                                    VK_HANDLE_TO_UINT64(bind_info.accelerationStructure),
+                                    MemoryInfoType::kBasic,
+                                    bind_info.memoryOffset,
+                                    allocation,
+                                    allocation_info,
+                                    *memory_alloc_info,
+                                    bind_memory_properties[i]);
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+VkResult
+VulkanRebindAllocator::GetMemoryFd(const VkMemoryGetFdInfoKHR* get_fd_info, int* pFd, MemoryData allocator_data)
+{
+    auto result = VK_ERROR_INITIALIZATION_FAILED;
+
+    std::vector<VmaAllocation> alcs;
+    GetVmaAllocations(allocator_data, alcs);
+
+    if (alcs.empty())
+    {
+        GFXRECON_LOG_ERROR("There's no allocations for GetMemoryFd");
+    }
+
+    auto modified_get_fd_info = *get_fd_info;
+
+    for (const auto& alc : alcs)
+    {
+        VmaAllocationInfo allocation_info{};
+        allocator_->GetAllocationInfo(alc, &allocation_info);
+
+        modified_get_fd_info.memory = allocation_info.deviceMemory;
+
+        switch (alc->GetType())
+        {
+            case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+            {
+                result = functions_.get_memory_fd(device_, &modified_get_fd_info, pFd);
+                break;
+            }
+            case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+            {
+                VmaDeviceMemoryBlock* const pBlock = alc->GetBlock();
+                VMA_ASSERT(pBlock && "GetMemoryFd to allocation that doesn't belong to any block.");
+
+                VmaMutexLock lock(pBlock->m_MapAndBindMutex, allocator_->m_UseMutex);
+                result = functions_.get_memory_fd(device_, &modified_get_fd_info, pFd);
+                break;
+            }
+            default:
+                VMA_ASSERT(0);
+        }
+    }
+    return result;
+}
+
+uint64_t VulkanRebindAllocator::GetDeviceMemoryOpaqueCaptureAddress(const VkDeviceMemoryOpaqueCaptureAddressInfo* info,
+                                                                    MemoryData allocator_data)
+{
+    uint64_t result = 0;
+
+    std::vector<VmaAllocation> alcs;
+    GetVmaAllocations(allocator_data, alcs);
+
+    if (alcs.empty())
+    {
+        GFXRECON_LOG_ERROR("There's no allocations for GetDeviceMemoryOpaqueCaptureAddress");
+    }
+
+    auto modified_info = *info;
+
+    for (const auto& alc : alcs)
+    {
+        VmaAllocationInfo allocation_info{};
+        allocator_->GetAllocationInfo(alc, &allocation_info);
+
+        modified_info.memory = allocation_info.deviceMemory;
+
+        switch (alc->GetType())
+        {
+            case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+            {
+                result = functions_.get_device_memory_opaque_capture_address(device_, &modified_info);
+                break;
+            }
+            case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+            {
+                VmaDeviceMemoryBlock* const pBlock = alc->GetBlock();
+                VMA_ASSERT(pBlock &&
+                           "GetDeviceMemoryOpaqueCaptureAddress to allocation that doesn't belong to any block.");
+
+                VmaMutexLock lock(pBlock->m_MapAndBindMutex, allocator_->m_UseMutex);
+                result = functions_.get_device_memory_opaque_capture_address(device_, &modified_info);
+                break;
+            }
+            default:
+                VMA_ASSERT(0);
+        }
+    }
+    return result;
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -80,11 +80,11 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                         const VkAllocationCallbacks*       allocation_callbacks,
                                         format::HandleId                   capture_id,
                                         VkVideoSessionKHR*                 session,
-                                        std::vector<ResourceData>*         allocator_datas) override;
+                                        ResourceData*                      allocator_data) override;
 
     virtual void DestroyVideoSession(VkVideoSessionKHR            session,
                                      const VkAllocationCallbacks* allocation_callbacks,
-                                     std::vector<ResourceData>    allocator_datas) override;
+                                     ResourceData                 allocator_data) override;
 
     virtual void GetBufferMemoryRequirements(VkBuffer              buffer,
                                              VkMemoryRequirements* memory_requirements,
@@ -111,7 +111,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     virtual VkResult GetVideoSessionMemoryRequirementsKHR(VkVideoSessionKHR video_session,
                                                           uint32_t*         memory_requirements_count,
                                                           VkVideoSessionMemoryRequirementsKHR* memory_requirements,
-                                                          std::vector<ResourceData> allocator_datas) override;
+                                                          ResourceData                         allocator_data) override;
 
     virtual VkResult AllocateMemory(const VkMemoryAllocateInfo*  allocate_info,
                                     const VkAllocationCallbacks* allocation_callbacks,
@@ -174,7 +174,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     virtual VkResult BindVideoSessionMemory(VkVideoSessionKHR                      video_session,
                                             uint32_t                               bind_info_count,
                                             const VkBindVideoSessionMemoryInfoKHR* bind_infos,
-                                            const ResourceData*                    allocator_session_datas,
+                                            const ResourceData                     allocator_session_data,
                                             const MemoryData*                      allocator_memory_datas,
                                             VkMemoryPropertyFlags*                 bind_memory_properties) override;
 
@@ -185,7 +185,12 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                void**           data,
                                MemoryData       allocator_data) override;
 
+    virtual VkResult
+    MapMemory2(const VkMemoryMapInfo* memory_map_info, void** data, MemoryData allocator_data) override;
+
     virtual void UnmapMemory(VkDeviceMemory memory, MemoryData allocator_data) override;
+
+    virtual VkResult UnmapMemory2(const VkMemoryUnmapInfo* memory_unmap_info, MemoryData allocator_data) override;
 
     virtual VkResult FlushMappedMemoryRanges(uint32_t                   memory_range_count,
                                              const VkMappedMemoryRange* memory_ranges,
@@ -229,8 +234,14 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     virtual void ReportBindVideoSessionIncompatibility(VkVideoSessionKHR                      video_session,
                                                        uint32_t                               bind_info_count,
                                                        const VkBindVideoSessionMemoryInfoKHR* bind_infos,
-                                                       const ResourceData*                    allocator_resource_datas,
+                                                       const ResourceData                     allocator_resource_data,
                                                        const MemoryData* allocator_memory_datas) override;
+
+    virtual void
+    ReportBindAccelerationStructureMemoryNVIncompatibility(uint32_t bind_info_count,
+                                                           const VkBindAccelerationStructureMemoryInfoNV* bind_infos,
+                                                           const ResourceData* allocator_acc_datas,
+                                                           const MemoryData*   allocator_memory_datas) override;
 
     // Direct allocation methods that perform memory allocation and resource creation without performing memory
     // translation.  These methods allow the replay tool to allocate staging resources through the resource allocator so
@@ -336,6 +347,38 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     virtual bool SupportsOpaqueDeviceAddresses() override { return false; }
     virtual bool SupportBindVideoSessionMemory() override { return true; }
 
+    virtual void SetDeviceMemoryPriority(VkDeviceMemory memory, float priority, MemoryData allocator_data) override;
+
+    virtual VkResult GetMemoryRemoteAddressNV(const VkMemoryGetRemoteAddressInfoNV* memory_get_remote_address_info,
+                                              VkRemoteAddressNV*                    address,
+                                              MemoryData                            allocator_data) override;
+
+    virtual VkResult CreateAccelerationStructureNV(const VkAccelerationStructureCreateInfoNV* create_info,
+                                                   const VkAllocationCallbacks*               allocation_callbacks,
+                                                   format::HandleId                           capture_id,
+                                                   VkAccelerationStructureNV*                 acc_str,
+                                                   ResourceData*                              allocator_data) override;
+
+    virtual void DestroyAccelerationStructureNV(VkAccelerationStructureNV    acc_str,
+                                                const VkAllocationCallbacks* allocation_callbacks,
+                                                ResourceData                 allocator_data) override;
+
+    virtual void
+    GetAccelerationStructureMemoryRequirementsNV(const VkAccelerationStructureMemoryRequirementsInfoNV* info,
+                                                 VkMemoryRequirements2KHR* memory_requirements,
+                                                 ResourceData              allocator_data) override;
+
+    virtual VkResult BindAccelerationStructureMemoryNV(uint32_t                                       bind_info_count,
+                                                       const VkBindAccelerationStructureMemoryInfoNV* bind_infos,
+                                                       const ResourceData*    allocator_acc_datas,
+                                                       const MemoryData*      allocator_memory_datas,
+                                                       VkMemoryPropertyFlags* bind_memory_properties) override;
+
+    virtual VkResult GetMemoryFd(const VkMemoryGetFdInfoKHR* get_fd_info, int* pFd, MemoryData allocator_data) override;
+
+    virtual uint64_t GetDeviceMemoryOpaqueCaptureAddress(const VkDeviceMemoryOpaqueCaptureAddressInfo* info,
+                                                         MemoryData allocator_data) override;
+
   private:
     struct MemoryAllocInfo;
 
@@ -346,17 +389,18 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         VkSubresourceLayout rebind{};
     };
 
-    enum ObjectType
+    enum MemoryInfoType
     {
-        none          = 0,
-        buffer        = 1,
-        image         = 2,
-        video_session = 3,
+        kBasic,       // single: buffer, image, acceleration_structure_nv
+        kSparse,      // array: buffer, image
+        kVideoSession // array: video_session
     };
 
-    struct ResourceAllocInfo
+    // Create a new allocation for a binding memory case. The binding offset is allocation_info's offset, instead of
+    // original offset.
+    struct BoundMemoryInfo
     {
-        MemoryAllocInfo* memory_info{ nullptr };
+        MemoryAllocInfo* memory_info{ nullptr }; // If memory_info is nullptr, the memory could be free.
         VmaAllocation    allocation{ VK_NULL_HANDLE };
         bool             is_host_visible{ false };
         void*            mapped_pointer{ nullptr };
@@ -364,12 +408,19 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         VkDeviceSize     rebind_offset{ 0 };
         VkDeviceSize     original_size{ 0 };
         VkDeviceSize     rebind_size{ 0 };
-        ObjectType       object_type{ none };
-        VkFlags          usage{ 0 };
-        VkImageTiling    tiling{};
-        uint32_t         height{ 0 };
-        bool             uses_extensions{ false };
-        VkFormat         format{ VK_FORMAT_UNDEFINED };
+    };
+
+    struct ResourceAllocInfo
+    {
+        MemoryInfoType               memory_info_type;
+        std::vector<BoundMemoryInfo> bound_memory_infos;
+        std::vector<VkDeviceSize>    original_sizes; // video_session is array, the others are single.
+        VkObjectType                 object_type{ VK_OBJECT_TYPE_UNKNOWN };
+        VkFlags                      usage{ 0 };
+        VkImageTiling                tiling{};
+        uint32_t                     height{ 0 };
+        bool                         uses_extensions{ false };
+        VkFormat                     format{ VK_FORMAT_UNDEFINED };
 
         std::string          debug_utils_name;
         std::vector<uint8_t> debug_utils_tag;
@@ -382,16 +433,15 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
 
     struct MemoryAllocInfo
     {
+        format::HandleId                                 capture_id{ format::kNullHandleId };
         VkDeviceSize                                     allocation_size{ 0 };
         uint32_t                                         original_index{ std::numeric_limits<uint32_t>::max() };
         bool                                             is_mapped{ false };
         VkDeviceSize                                     mapped_offset{ 0 };
-        AHardwareBuffer*                                          ahb{ nullptr };
-        VkDeviceMemory                                            ahb_memory{ VK_NULL_HANDLE };
+        AHardwareBuffer*                                 ahb{ nullptr };
+        VkDeviceMemory                                   ahb_memory{ VK_NULL_HANDLE };
         std::unique_ptr<uint8_t[]>                       original_content;
-        std::unordered_map<VkBuffer, ResourceAllocInfo*> original_buffers;
-        std::unordered_map<VkImage, ResourceAllocInfo*>  original_images;
-        std::unordered_map<VkVideoSessionKHR, ResourceAllocInfo*> original_sessions;
+        std::unordered_map<uint64_t, ResourceAllocInfo*> original_objects; // Key is object handle.
 
         std::string          debug_utils_name;
         std::vector<uint8_t> debug_utils_tag;
@@ -400,18 +450,21 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
 
   private:
     void WriteBoundResource(ResourceAllocInfo* resource_alloc_info,
+                            BoundMemoryInfo*   bound_memory_info,
                             VkDeviceSize       src_offset,
                             VkDeviceSize       dst_offset,
                             VkDeviceSize       data_size,
                             const uint8_t*     data);
 
     void WriteBoundResourceStaging(ResourceAllocInfo* resource_alloc_info,
+                                   BoundMemoryInfo*   bound_memory_info,
                                    size_t             src_offset,
                                    size_t             dst_offset,
                                    size_t             data_size,
                                    const uint8_t*     data);
 
     void WriteBoundResourceDirect(ResourceAllocInfo* resource_alloc_info,
+                                  BoundMemoryInfo*   bound_memory_info,
                                   size_t             src_offset,
                                   size_t             dst_offset,
                                   size_t             data_size,
@@ -422,6 +475,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     // resource, the dst_offset is the offset from the start of the new resource allocation, and the data_size is the
     // region of the resource that overlaps with the original memory region.
     bool TranslateMemoryRange(const ResourceAllocInfo* resource_alloc_info,
+                              const BoundMemoryInfo*   bound_memory_info,
                               VkDeviceSize             oiriginal_start,
                               VkDeviceSize             original_end,
                               VkDeviceSize*            src_offset,
@@ -429,11 +483,13 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                               VkDeviceSize*            data_size);
 
     void UpdateBoundResource(ResourceAllocInfo* resource_alloc_info,
+                             BoundMemoryInfo*   bound_memory_info,
                              VkDeviceSize       write_start,
                              VkDeviceSize       write_end,
                              const uint8_t*     data);
 
     VkResult UpdateMappedMemoryRange(ResourceAllocInfo* resource_alloc_info,
+                                     BoundMemoryInfo*   bound_memory_info,
                                      VkDeviceSize       oiriginal_start,
                                      VkDeviceSize       original_end,
                                      VkResult (*update_func)(VmaAllocator, VmaAllocation, VkDeviceSize, VkDeviceSize));
@@ -454,6 +510,9 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
 
     VmaMemoryUsage GetVideoSeesionMemoryUsage(VkMemoryPropertyFlags       capture_properties,
                                               const VkMemoryRequirements& replay_requirements);
+
+    VmaMemoryUsage GetAccelerationStructureMemoryNVUsage(VkMemoryPropertyFlags       capture_properties,
+                                                         const VkMemoryRequirements& replay_requirements);
 
     VmaMemoryUsage AdjustMemoryUsage(VmaMemoryUsage desired_usage, const VkMemoryRequirements& replay_requirements);
 
@@ -480,8 +539,43 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     void SetBindingDebugUtilsNameAndTag(const MemoryAllocInfo*   memory_alloc_info,
                                         const ResourceAllocInfo* resource_alloc_info,
                                         VkDeviceMemory           device_memory,
-                                        VkObjectType             resource_type,
                                         uint64_t                 resource_handle);
+
+    VkResult AllocateMemoryForBuffer(VkBuffer                                buffer,
+                                     const VkPhysicalDeviceMemoryProperties& device_memory_properties,
+                                     const ResourceAllocInfo&                resource_alloc_info,
+                                     const MemoryAllocInfo&                  memory_alloc_info,
+                                     VmaAllocation&                          allocation,
+                                     VmaAllocationInfo&                      allocation_info);
+
+    VkResult AllocateMemoryForImage(VkImage                                 image,
+                                    const VkPhysicalDeviceMemoryProperties& device_memory_properties,
+                                    const ResourceAllocInfo&                resource_alloc_info,
+                                    const MemoryAllocInfo&                  memory_alloc_info,
+                                    VmaAllocation&                          allocation,
+                                    VmaAllocationInfo&                      allocation_info);
+
+    VkResult
+    AllocateMemoryForAccelerationStructureMemoryNV(VkAccelerationStructureNV               acceleration_structure_nv,
+                                                   const VkPhysicalDeviceMemoryProperties& device_memory_properties,
+                                                   const ResourceAllocInfo&                resource_alloc_info,
+                                                   const MemoryAllocInfo&                  memory_alloc_info,
+                                                   VmaAllocation&                          allocation,
+                                                   VmaAllocationInfo&                      allocation_info);
+
+    VkResult
+    VmaAllocateMemory(const VkMemoryRequirements& mem_req, const VmaMemoryUsage usage, VmaAllocation& allocation);
+
+    void UpdateAllocInfo(ResourceAllocInfo&       resource_alloc_info,
+                         uint64_t                 object_handle,
+                         MemoryInfoType           memory_info_type,
+                         VkDeviceSize             memory_offset,
+                         const VmaAllocation&     allocation,
+                         const VmaAllocationInfo& allocation_info,
+                         MemoryAllocInfo&         memory_alloc_info,
+                         VkMemoryPropertyFlags&   bind_memory_property);
+
+    void GetVmaAllocations(MemoryData allocator_data, std::vector<VmaAllocation>& allocations);
 
   private:
     VkDevice                         device_ = VK_NULL_HANDLE;

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -393,15 +393,12 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                      VkFence                 fence,
                                      ResourceData*           allocator_buf_datas,
                                      const MemoryData*       allocator_buf_mem_datas,
-                                     const format::HandleId* buf_mem_capture_ids,
                                      VkMemoryPropertyFlags*  bind_buf_mem_properties,
                                      ResourceData*           allocator_img_op_datas,
                                      const MemoryData*       allocator_img_op_mem_datas,
-                                     const format::HandleId* img_op_mem_capture_ids,
                                      VkMemoryPropertyFlags*  bind_img_op_mem_properties,
                                      ResourceData*           allocator_img_datas,
                                      const MemoryData*       allocator_img_mem_datas,
-                                     const format::HandleId* img_mem_capture_ids,
                                      VkMemoryPropertyFlags*  bind_img_mem_properties) override;
 
     virtual uint64_t GetDeviceMemoryOpaqueCaptureAddress(const VkDeviceMemoryOpaqueCaptureAddressInfo* info,

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -416,7 +416,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
 
     enum MemoryInfoType
     {
-        kBasic,       // single: buffer, image, acceleration_structure_nv
+        kBasic,       // single: buffer, image
         kSparse,      // array: buffer, image
         kVideoSession // array: video_session
     };
@@ -536,9 +536,6 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     VmaMemoryUsage GetVideoSeesionMemoryUsage(VkMemoryPropertyFlags       capture_properties,
                                               const VkMemoryRequirements& replay_requirements);
 
-    VmaMemoryUsage GetAccelerationStructureMemoryNVUsage(VkMemoryPropertyFlags       capture_properties,
-                                                         const VkMemoryRequirements& replay_requirements);
-
     VmaMemoryUsage AdjustMemoryUsage(VmaMemoryUsage desired_usage, const VkMemoryRequirements& replay_requirements);
 
     void ReportBindIncompatibility(const ResourceData* allocator_resource_datas, uint32_t resource_count);
@@ -579,14 +576,6 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                     const MemoryAllocInfo&                  memory_alloc_info,
                                     VmaAllocation&                          allocation,
                                     VmaAllocationInfo&                      allocation_info);
-
-    VkResult
-    AllocateMemoryForAccelerationStructureMemoryNV(VkAccelerationStructureNV               acceleration_structure_nv,
-                                                   const VkPhysicalDeviceMemoryProperties& device_memory_properties,
-                                                   const ResourceAllocInfo&                resource_alloc_info,
-                                                   const MemoryAllocInfo&                  memory_alloc_info,
-                                                   VmaAllocation&                          allocation,
-                                                   VmaAllocationInfo&                      allocation_info);
 
     VkResult
     VmaAllocateMemory(const VkMemoryRequirements& mem_req, const VmaMemoryUsage usage, VmaAllocation& allocation);

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4389,21 +4389,18 @@ VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse         
     std::vector<const VulkanDeviceMemoryInfo*>         buf_mem_infos;
     std::vector<VulkanResourceAllocator::ResourceData> allocator_buf_datas;
     std::vector<VulkanResourceAllocator::MemoryData>   allocator_buf_mem_datas;
-    std::vector<format::HandleId>                      buf_mem_capture_ids;
     std::vector<VkMemoryPropertyFlags>                 buf_mem_prop_flags;
 
     std::vector<VulkanImageInfo*>                      img_op_infos;
     std::vector<const VulkanDeviceMemoryInfo*>         img_op_mem_infos;
     std::vector<VulkanResourceAllocator::ResourceData> allocator_img_op_datas;
     std::vector<VulkanResourceAllocator::MemoryData>   allocator_img_op_mem_datas;
-    std::vector<format::HandleId>                      img_op_mem_capture_ids;
     std::vector<VkMemoryPropertyFlags>                 img_op_mem_prop_flags;
 
     std::vector<VulkanImageInfo*>                      img_infos;
     std::vector<const VulkanDeviceMemoryInfo*>         img_mem_infos;
     std::vector<VulkanResourceAllocator::ResourceData> allocator_img_datas;
     std::vector<VulkanResourceAllocator::MemoryData>   allocator_img_mem_datas;
-    std::vector<format::HandleId>                      img_mem_capture_ids;
     std::vector<VkMemoryPropertyFlags>                 img_mem_prop_flags;
 
     for (uint32_t i = 0; i < bindInfoCount; ++i)
@@ -4438,12 +4435,10 @@ VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse         
                 if (mem_info != nullptr)
                 {
                     allocator_buf_mem_datas.push_back(mem_info->allocator_data);
-                    buf_mem_capture_ids.push_back(mem_info->capture_id);
                 }
                 else
                 {
                     allocator_buf_mem_datas.push_back(0);
-                    buf_mem_capture_ids.push_back(format::kNullHandleId);
                 }
             }
         }
@@ -4476,12 +4471,10 @@ VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse         
                 if (mem_info != nullptr)
                 {
                     allocator_img_op_mem_datas.push_back(mem_info->allocator_data);
-                    img_op_mem_capture_ids.push_back(mem_info->capture_id);
                 }
                 else
                 {
                     allocator_img_op_mem_datas.push_back(0);
-                    img_op_mem_capture_ids.push_back(0);
                 }
             }
         }
@@ -4514,12 +4507,10 @@ VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse         
                 if (mem_info != nullptr)
                 {
                     allocator_img_mem_datas.push_back(mem_info->allocator_data);
-                    img_mem_capture_ids.push_back(mem_info->capture_id);
                 }
                 else
                 {
                     allocator_img_mem_datas.push_back(0);
-                    img_mem_capture_ids.push_back(0);
                 }
             }
         }
@@ -4542,15 +4533,12 @@ VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse         
                                             fence,
                                             allocator_buf_datas.data(),
                                             allocator_buf_mem_datas.data(),
-                                            buf_mem_capture_ids.data(),
                                             buf_mem_prop_flags.data(),
                                             allocator_img_op_datas.data(),
                                             allocator_img_op_mem_datas.data(),
-                                            img_op_mem_capture_ids.data(),
                                             img_op_mem_prop_flags.data(),
                                             allocator_img_datas.data(),
                                             allocator_img_mem_datas.data(),
-                                            img_mem_capture_ids.data(),
                                             img_mem_prop_flags.data());
     }
     else
@@ -4591,15 +4579,12 @@ VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse         
                                                 fence,
                                                 allocator_buf_datas.data(),
                                                 allocator_buf_mem_datas.data(),
-                                                buf_mem_capture_ids.data(),
                                                 buf_mem_prop_flags.data(),
                                                 allocator_img_op_datas.data(),
                                                 allocator_img_op_mem_datas.data(),
-                                                img_op_mem_capture_ids.data(),
                                                 img_op_mem_prop_flags.data(),
                                                 allocator_img_datas.data(),
                                                 allocator_img_mem_datas.data(),
-                                                img_mem_capture_ids.data(),
                                                 img_mem_prop_flags.data());
         }
         else
@@ -4659,15 +4644,12 @@ VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse         
                                                 fence,
                                                 allocator_buf_datas.data(),
                                                 allocator_buf_mem_datas.data(),
-                                                buf_mem_capture_ids.data(),
                                                 buf_mem_prop_flags.data(),
                                                 allocator_img_op_datas.data(),
                                                 allocator_img_op_mem_datas.data(),
-                                                img_op_mem_capture_ids.data(),
                                                 img_op_mem_prop_flags.data(),
                                                 allocator_img_datas.data(),
                                                 allocator_img_mem_datas.data(),
-                                                img_mem_capture_ids.data(),
                                                 img_mem_prop_flags.data());
         }
     }
@@ -5163,7 +5145,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
         auto allocator = device_info->allocator.get();
         assert(allocator != nullptr);
 
-        VulkanResourceAllocator::MemoryData allocator_data;
+        VulkanResourceAllocator::MemoryData allocator_data = 0;
 
         auto* modified_allocate_info = const_cast<VkMemoryAllocateInfo*>(pAllocateInfo->GetPointer());
         auto  replay_memory          = pMemory->GetHandlePointer();
@@ -12001,7 +11983,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetMemoryRemoteAddressNV(
     auto allocator = device_info->allocator.get();
     GFXRECON_ASSERT(allocator != nullptr);
 
-    VulkanResourceAllocator::MemoryData allocator_data;
+    VulkanResourceAllocator::MemoryData allocator_data = 0;
 
     auto memory_info = object_info_table_->GetVkDeviceMemoryInfo(meta_mem_get_remote_address_info->memory);
 
@@ -12176,7 +12158,7 @@ VulkanReplayConsumerBase::OverrideGetMemoryFdKHR(PFN_vkGetMemoryFdKHR           
     auto allocator = device_info->allocator.get();
     GFXRECON_ASSERT(allocator != nullptr);
 
-    VulkanResourceAllocator::MemoryData allocator_data;
+    VulkanResourceAllocator::MemoryData allocator_data = 0;
 
     auto memory_info = object_info_table_->GetVkDeviceMemoryInfo(meta_get_fd_info->memory);
 
@@ -12199,7 +12181,7 @@ void VulkanReplayConsumerBase::OverrideGetDeviceMemoryOpaqueCaptureAddress(
     auto allocator = device_info->allocator.get();
     GFXRECON_ASSERT(allocator != nullptr);
 
-    VulkanResourceAllocator::MemoryData allocator_data;
+    VulkanResourceAllocator::MemoryData allocator_data = 0;
 
     auto memory_info = object_info_table_->GetVkDeviceMemoryInfo(meta_info->memory);
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1490,6 +1490,71 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*                 pAllocator,
         HandlePointerDecoder<VkSamplerYcbcrConversionKHR>*                         pSampler);
 
+    void OverrideGetDeviceMemoryCommitment(PFN_vkGetDeviceMemoryCommitment func,
+                                           const VulkanDeviceInfo*         device_info,
+                                           const VulkanDeviceMemoryInfo*   memory_info,
+                                           PointerDecoder<VkDeviceSize>*   pCommittedMemoryInBytes);
+
+    VkResult OverrideMapMemory2(PFN_vkMapMemory2                               func,
+                                VkResult                                       original_result,
+                                const VulkanDeviceInfo*                        device_info,
+                                StructPointerDecoder<Decoded_VkMemoryMapInfo>* pMemoryMapInfo,
+                                void**                                         ppData);
+
+    VkResult OverrideUnmapMemory2(PFN_vkUnmapMemory2                               func,
+                                  VkResult                                         original_result,
+                                  const VulkanDeviceInfo*                          device_info,
+                                  StructPointerDecoder<Decoded_VkMemoryUnmapInfo>* pMemoryUnmapInfo);
+
+    void OverrideSetDeviceMemoryPriorityEXT(PFN_vkSetDeviceMemoryPriorityEXT func,
+                                            const VulkanDeviceInfo*          device_info,
+                                            const VulkanDeviceMemoryInfo*    memory_info,
+                                            float                            priority);
+
+    VkResult OverrideGetMemoryRemoteAddressNV(
+        PFN_vkGetMemoryRemoteAddressNV                                func,
+        VkResult                                                      original_result,
+        const VulkanDeviceInfo*                                       device_info,
+        StructPointerDecoder<Decoded_VkMemoryGetRemoteAddressInfoNV>* pMemoryGetRemoteAddressInfo,
+        VkRemoteAddressNV*                                            pAddress);
+
+    VkResult OverrideCreateAccelerationStructureNV(
+        PFN_vkCreateAccelerationStructureNV                                func,
+        VkResult                                                           original_result,
+        const VulkanDeviceInfo*                                            device_info,
+        StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>*               pAllocator,
+        HandlePointerDecoder<VkAccelerationStructureNV>*                   pAccelerationStructure);
+
+    void OverrideDestroyAccelerationStructureNV(PFN_vkDestroyAccelerationStructureNV                 func,
+                                                const VulkanDeviceInfo*                              device_info,
+                                                VulkanAccelerationStructureNVInfo*                   acc_str_info,
+                                                StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
+
+    void OverrideGetAccelerationStructureMemoryRequirementsNV(
+        PFN_vkGetAccelerationStructureMemoryRequirementsNV                             func,
+        const VulkanDeviceInfo*                                                        device_info,
+        StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
+        StructPointerDecoder<Decoded_VkMemoryRequirements2>*                           pMemoryRequirements);
+
+    VkResult OverrideBindAccelerationStructureMemoryNV(
+        PFN_vkBindAccelerationStructureMemoryNV                                func,
+        VkResult                                                               original_result,
+        const VulkanDeviceInfo*                                                device_info,
+        uint32_t                                                               bindInfoCount,
+        StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>* pBindInfos);
+
+    VkResult OverrideGetMemoryFdKHR(PFN_vkGetMemoryFdKHR                                func,
+                                    VkResult                                            original_result,
+                                    const VulkanDeviceInfo*                             device_info,
+                                    StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
+                                    PointerDecoder<int>*                                pFd);
+
+    void OverrideGetDeviceMemoryOpaqueCaptureAddress(
+        PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR                          func,
+        const VulkanDeviceInfo*                                               device_info,
+        StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo);
+
     std::function<handle_create_result_t<VkPipeline>()>
     AsyncCreateGraphicsPipelines(PFN_vkCreateGraphicsPipelines                               func,
                                  VkResult                                                    returnValue,

--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -49,50 +49,64 @@ class VulkanResourceAllocator
   public:
     struct Functions
     {
-        PFN_vkGetPhysicalDeviceProperties            get_physical_device_properties{ nullptr };
-        PFN_vkGetPhysicalDeviceMemoryProperties      get_physical_device_memory_properties{ nullptr };
-        PFN_vkGetPhysicalDeviceMemoryProperties2     get_physical_device_memory_properties2{ nullptr };
-        PFN_vkAllocateMemory                         allocate_memory{ nullptr };
-        PFN_vkFreeMemory                             free_memory{ nullptr };
-        PFN_vkGetDeviceMemoryCommitment              get_device_memory_commitment{ nullptr };
-        PFN_vkMapMemory                              map_memory{ nullptr };
-        PFN_vkUnmapMemory                            unmap_memory{ nullptr };
-        PFN_vkFlushMappedMemoryRanges                flush_memory_ranges{ nullptr };
-        PFN_vkInvalidateMappedMemoryRanges           invalidate_memory_ranges{ nullptr };
-        PFN_vkCreateBuffer                           create_buffer{ nullptr };
-        PFN_vkDestroyBuffer                          destroy_buffer{ nullptr };
-        PFN_vkGetBufferMemoryRequirements            get_buffer_memory_requirements{ nullptr };
-        PFN_vkGetBufferMemoryRequirements2           get_buffer_memory_requirements2{ nullptr };
-        PFN_vkBindBufferMemory                       bind_buffer_memory{ nullptr };
-        PFN_vkBindBufferMemory2                      bind_buffer_memory2{ nullptr };
-        PFN_vkCmdCopyBuffer                          cmd_copy_buffer{ nullptr };
-        PFN_vkCreateImage                            create_image{ nullptr };
-        PFN_vkDestroyImage                           destroy_image{ nullptr };
-        PFN_vkCreateVideoSessionKHR                  create_video_session{ nullptr };
-        PFN_vkDestroyVideoSessionKHR                 destroy_video_session{ nullptr };
-        PFN_vkGetImageMemoryRequirements             get_image_memory_requirements{ nullptr };
-        PFN_vkGetImageMemoryRequirements2            get_image_memory_requirements2{ nullptr };
-        PFN_vkGetVideoSessionMemoryRequirementsKHR   get_video_session_memory_requirements{ nullptr };
-        PFN_vkGetImageSubresourceLayout              get_image_subresource_layout{ nullptr };
-        PFN_vkBindImageMemory                        bind_image_memory{ nullptr };
-        PFN_vkBindImageMemory2                       bind_image_memory2{ nullptr };
-        PFN_vkBindVideoSessionMemoryKHR              bind_video_session_memory{ nullptr };
-        PFN_vkGetInstanceProcAddr                    get_instance_proc_addr{ nullptr };
-        PFN_vkGetDeviceProcAddr                      get_device_proc_addr{ nullptr };
-        PFN_vkGetDeviceQueue                         get_device_queue{ nullptr };
-        PFN_vkCreateCommandPool                      create_command_pool{ nullptr };
-        PFN_vkAllocateCommandBuffers                 allocate_command_buffers{ nullptr };
-        PFN_vkBeginCommandBuffer                     begin_command_buffer{ nullptr };
-        PFN_vkEndCommandBuffer                       end_command_buffer{ nullptr };
-        PFN_vkQueueSubmit                            queue_submit{ nullptr };
-        PFN_vkQueueWaitIdle                          queue_wait_idle{ nullptr };
-        PFN_vkResetCommandBuffer                     reset_command_buffer{ nullptr };
-        PFN_vkCmdCopyBufferToImage                   cmd_copy_buffer_to_image{ nullptr };
-        PFN_vkFreeCommandBuffers                     free_command_buffers{ nullptr };
-        PFN_vkDestroyCommandPool                     destroy_command_pool{ nullptr };
-        PFN_vkGetPhysicalDeviceQueueFamilyProperties get_physical_device_queue_family_properties{ nullptr };
-        PFN_vkSetDebugUtilsObjectNameEXT             set_debug_utils_object_name{ nullptr };
-        PFN_vkSetDebugUtilsObjectTagEXT              set_debug_utils_object_tag{ nullptr };
+        PFN_vkGetPhysicalDeviceProperties                  get_physical_device_properties{ nullptr };
+        PFN_vkGetPhysicalDeviceMemoryProperties            get_physical_device_memory_properties{ nullptr };
+        PFN_vkGetPhysicalDeviceMemoryProperties2           get_physical_device_memory_properties2{ nullptr };
+        PFN_vkAllocateMemory                               allocate_memory{ nullptr };
+        PFN_vkFreeMemory                                   free_memory{ nullptr };
+        PFN_vkGetDeviceMemoryCommitment                    get_device_memory_commitment{ nullptr };
+        PFN_vkMapMemory                                    map_memory{ nullptr };
+        PFN_vkMapMemory2                                   map_memory2{ nullptr };
+        PFN_vkUnmapMemory                                  unmap_memory{ nullptr };
+        PFN_vkUnmapMemory2                                 unmap_memory2{ nullptr };
+        PFN_vkFlushMappedMemoryRanges                      flush_memory_ranges{ nullptr };
+        PFN_vkInvalidateMappedMemoryRanges                 invalidate_memory_ranges{ nullptr };
+        PFN_vkCreateBuffer                                 create_buffer{ nullptr };
+        PFN_vkDestroyBuffer                                destroy_buffer{ nullptr };
+        PFN_vkGetBufferMemoryRequirements                  get_buffer_memory_requirements{ nullptr };
+        PFN_vkGetBufferMemoryRequirements2                 get_buffer_memory_requirements2{ nullptr };
+        PFN_vkBindBufferMemory                             bind_buffer_memory{ nullptr };
+        PFN_vkBindBufferMemory2                            bind_buffer_memory2{ nullptr };
+        PFN_vkCmdCopyBuffer                                cmd_copy_buffer{ nullptr };
+        PFN_vkCreateImage                                  create_image{ nullptr };
+        PFN_vkDestroyImage                                 destroy_image{ nullptr };
+        PFN_vkCreateVideoSessionKHR                        create_video_session{ nullptr };
+        PFN_vkDestroyVideoSessionKHR                       destroy_video_session{ nullptr };
+        PFN_vkGetImageMemoryRequirements                   get_image_memory_requirements{ nullptr };
+        PFN_vkGetImageMemoryRequirements2                  get_image_memory_requirements2{ nullptr };
+        PFN_vkGetVideoSessionMemoryRequirementsKHR         get_video_session_memory_requirements{ nullptr };
+        PFN_vkGetImageSubresourceLayout                    get_image_subresource_layout{ nullptr };
+        PFN_vkBindImageMemory                              bind_image_memory{ nullptr };
+        PFN_vkBindImageMemory2                             bind_image_memory2{ nullptr };
+        PFN_vkBindVideoSessionMemoryKHR                    bind_video_session_memory{ nullptr };
+        PFN_vkGetInstanceProcAddr                          get_instance_proc_addr{ nullptr };
+        PFN_vkGetDeviceProcAddr                            get_device_proc_addr{ nullptr };
+        PFN_vkGetDeviceQueue                               get_device_queue{ nullptr };
+        PFN_vkCreateCommandPool                            create_command_pool{ nullptr };
+        PFN_vkAllocateCommandBuffers                       allocate_command_buffers{ nullptr };
+        PFN_vkBeginCommandBuffer                           begin_command_buffer{ nullptr };
+        PFN_vkEndCommandBuffer                             end_command_buffer{ nullptr };
+        PFN_vkQueueSubmit                                  queue_submit{ nullptr };
+        PFN_vkQueueWaitIdle                                queue_wait_idle{ nullptr };
+        PFN_vkResetCommandBuffer                           reset_command_buffer{ nullptr };
+        PFN_vkCmdCopyBufferToImage                         cmd_copy_buffer_to_image{ nullptr };
+        PFN_vkFreeCommandBuffers                           free_command_buffers{ nullptr };
+        PFN_vkDestroyCommandPool                           destroy_command_pool{ nullptr };
+        PFN_vkGetPhysicalDeviceQueueFamilyProperties       get_physical_device_queue_family_properties{ nullptr };
+        PFN_vkSetDebugUtilsObjectNameEXT                   set_debug_utils_object_name{ nullptr };
+        PFN_vkSetDebugUtilsObjectTagEXT                    set_debug_utils_object_tag{ nullptr };
+        PFN_vkSetDeviceMemoryPriorityEXT                   set_device_memory_priority{ nullptr };
+        PFN_vkGetMemoryRemoteAddressNV                     get_memory_remote_address_nv{ nullptr };
+        PFN_vkCreateAccelerationStructureNV                create_acceleration_structure_nv{ nullptr };
+        PFN_vkDestroyAccelerationStructureNV               destroy_acceleration_structure_nv{ nullptr };
+        PFN_vkBindAccelerationStructureMemoryNV            bind_acceleration_structure_memory_nv{ nullptr };
+        PFN_vkGetAccelerationStructureMemoryRequirementsNV get_acceleration_structure_memory_requirements_nv{ nullptr };
+        PFN_vkGetMemoryFdKHR                               get_memory_fd{ nullptr };
+        PFN_vkQueueBindSparse                              queue_bind_sparse{ nullptr };
+        PFN_vkGetDeviceMemoryOpaqueCaptureAddress          get_device_memory_opaque_capture_address{ nullptr };
+        PFN_vkCreateSemaphore                              create_semaphore{ nullptr };
+        PFN_vkDestroySemaphore                             destroy_semaphore{ nullptr };
+        PFN_vkWaitForFences                                wait_for_fences{ nullptr };
     };
 
   public:
@@ -132,11 +146,11 @@ class VulkanResourceAllocator
                                         const VkAllocationCallbacks*       allocation_callbacks,
                                         format::HandleId                   capture_id,
                                         VkVideoSessionKHR*                 session,
-                                        std::vector<ResourceData>*         allocator_datas) = 0;
+                                        ResourceData*                      allocator_data) = 0;
 
     virtual void DestroyVideoSession(VkVideoSessionKHR            session,
                                      const VkAllocationCallbacks* allocation_callbacks,
-                                     std::vector<ResourceData>    allocator_datas) = 0;
+                                     ResourceData                 allocator_data) = 0;
 
     virtual void GetBufferMemoryRequirements(VkBuffer              buffer,
                                              VkMemoryRequirements* memory_requirements,
@@ -163,7 +177,7 @@ class VulkanResourceAllocator
     virtual VkResult GetVideoSessionMemoryRequirementsKHR(VkVideoSessionKHR video_session,
                                                           uint32_t*         memory_requirements_count,
                                                           VkVideoSessionMemoryRequirementsKHR* memory_requirements,
-                                                          std::vector<ResourceData>            allocator_datas) = 0;
+                                                          ResourceData                         allocator_data) = 0;
 
     virtual VkResult AllocateMemory(const VkMemoryAllocateInfo*  allocate_info,
                                     const VkAllocationCallbacks* allocation_callbacks,
@@ -204,10 +218,12 @@ class VulkanResourceAllocator
                                       const MemoryData*            allocator_memory_datas,
                                       VkMemoryPropertyFlags*       bind_memory_properties) = 0;
 
+    // allocator_memory_datas and bind_memory_properties match to bind_infos, but not memoryBindIndex in
+    // VkBindVideoSessionMemoryInfoKHR.
     virtual VkResult BindVideoSessionMemory(VkVideoSessionKHR                      video_session,
                                             uint32_t                               bind_info_count,
                                             const VkBindVideoSessionMemoryInfoKHR* bind_infos,
-                                            const ResourceData*                    allocator_session_datas,
+                                            const ResourceData                     allocator_session_data,
                                             const MemoryData*                      allocator_memory_datas,
                                             VkMemoryPropertyFlags*                 bind_memory_properties) = 0;
 
@@ -218,7 +234,11 @@ class VulkanResourceAllocator
                                void**           data,
                                MemoryData       allocator_data) = 0;
 
+    virtual VkResult MapMemory2(const VkMemoryMapInfo* memory_map_info, void** data, MemoryData allocator_data) = 0;
+
     virtual void UnmapMemory(VkDeviceMemory memory, MemoryData allocator_data) = 0;
+
+    virtual VkResult UnmapMemory2(const VkMemoryUnmapInfo* memory_unmap_info, MemoryData allocator_data) = 0;
 
     virtual VkResult FlushMappedMemoryRanges(uint32_t                   memory_range_count,
                                              const VkMappedMemoryRange* memory_ranges,
@@ -262,8 +282,25 @@ class VulkanResourceAllocator
     virtual void ReportBindVideoSessionIncompatibility(VkVideoSessionKHR                      video_session,
                                                        uint32_t                               bind_info_count,
                                                        const VkBindVideoSessionMemoryInfoKHR* bind_infos,
-                                                       const ResourceData*                    allocator_resource_datas,
+                                                       const ResourceData                     allocator_resource_data,
                                                        const MemoryData* allocator_memory_datas) = 0;
+
+    virtual void
+    ReportBindAccelerationStructureMemoryNVIncompatibility(uint32_t bind_info_count,
+                                                           const VkBindAccelerationStructureMemoryInfoNV* bind_infos,
+                                                           const ResourceData* allocator_acc_datas,
+                                                           const MemoryData*   allocator_memory_datas) = 0;
+
+    virtual void ReportQueueBindSparseIncompatibility(VkQueue                 queue,
+                                                      uint32_t                bind_info_count,
+                                                      const VkBindSparseInfo* bind_infos,
+                                                      VkFence                 fence,
+                                                      const ResourceData*     allocator_buf_datas,
+                                                      const MemoryData*       allocator_buf_mem_datas,
+                                                      const ResourceData*     allocator_img_op_datas,
+                                                      const MemoryData*       allocator_img_op_mem_datas,
+                                                      const ResourceData*     allocator_img_datas,
+                                                      const MemoryData*       allocator_img_mem_datas) = 0;
 
     // Direct allocation methods allocate memory and create resources without performing memory translation, while using
     // the replay memory type of the current allocator implementation.
@@ -330,6 +367,55 @@ class VulkanResourceAllocator
 
     virtual bool SupportsOpaqueDeviceAddresses() = 0;
     virtual bool SupportBindVideoSessionMemory() = 0;
+
+    virtual void SetDeviceMemoryPriority(VkDeviceMemory memory, float priority, MemoryData allocator_data) = 0;
+
+    virtual VkResult GetMemoryRemoteAddressNV(const VkMemoryGetRemoteAddressInfoNV* memory_get_remote_address_info,
+                                              VkRemoteAddressNV*                    address,
+                                              MemoryData                            allocator_data) = 0;
+
+    virtual VkResult CreateAccelerationStructureNV(const VkAccelerationStructureCreateInfoNV* create_info,
+                                                   const VkAllocationCallbacks*               allocation_callbacks,
+                                                   format::HandleId                           capture_id,
+                                                   VkAccelerationStructureNV*                 acc_str,
+                                                   ResourceData*                              allocator_data) = 0;
+
+    virtual void DestroyAccelerationStructureNV(VkAccelerationStructureNV    acc_str,
+                                                const VkAllocationCallbacks* allocation_callbacks,
+                                                ResourceData                 allocator_data) = 0;
+
+    virtual void
+    GetAccelerationStructureMemoryRequirementsNV(const VkAccelerationStructureMemoryRequirementsInfoNV* info,
+                                                 VkMemoryRequirements2KHR* memory_requirements,
+                                                 ResourceData              allocator_data) = 0;
+
+    virtual VkResult BindAccelerationStructureMemoryNV(uint32_t                                       bind_info_count,
+                                                       const VkBindAccelerationStructureMemoryInfoNV* bind_infos,
+                                                       const ResourceData*    allocator_acc_datas,
+                                                       const MemoryData*      allocator_memory_datas,
+                                                       VkMemoryPropertyFlags* bind_memory_properties) = 0;
+
+    virtual VkResult GetMemoryFd(const VkMemoryGetFdInfoKHR* get_fd_info, int* pFd, MemoryData allocator_data) = 0;
+
+    virtual VkResult QueueBindSparse(VkQueue                 queue,
+                                     uint32_t                bind_info_count,
+                                     const VkBindSparseInfo* bind_infos,
+                                     VkFence                 fence,
+                                     ResourceData*           allocator_buf_datas,
+                                     const MemoryData*       allocator_buf_mem_datas,
+                                     const format::HandleId* buf_mem_capture_ids,
+                                     VkMemoryPropertyFlags*  bind_buf_mem_properties,
+                                     ResourceData*           allocator_img_op_datas,
+                                     const MemoryData*       allocator_img_op_mem_datas,
+                                     const format::HandleId* img_op_mem_capture_ids,
+                                     VkMemoryPropertyFlags*  bind_img_op_mem_properties,
+                                     ResourceData*           allocator_img_datas,
+                                     const MemoryData*       allocator_img_mem_datas,
+                                     const format::HandleId* img_mem_capture_ids,
+                                     VkMemoryPropertyFlags*  bind_img_mem_properties) = 0;
+
+    virtual uint64_t GetDeviceMemoryOpaqueCaptureAddress(const VkDeviceMemoryOpaqueCaptureAddressInfo* info,
+                                                         MemoryData allocator_data) = 0;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -403,15 +403,12 @@ class VulkanResourceAllocator
                                      VkFence                 fence,
                                      ResourceData*           allocator_buf_datas,
                                      const MemoryData*       allocator_buf_mem_datas,
-                                     const format::HandleId* buf_mem_capture_ids,
                                      VkMemoryPropertyFlags*  bind_buf_mem_properties,
                                      ResourceData*           allocator_img_op_datas,
                                      const MemoryData*       allocator_img_op_mem_datas,
-                                     const format::HandleId* img_op_mem_capture_ids,
                                      VkMemoryPropertyFlags*  bind_img_op_mem_properties,
                                      ResourceData*           allocator_img_datas,
                                      const MemoryData*       allocator_img_mem_datas,
-                                     const format::HandleId* img_mem_capture_ids,
                                      VkMemoryPropertyFlags*  bind_img_mem_properties) = 0;
 
     virtual uint64_t GetDeviceMemoryOpaqueCaptureAddress(const VkDeviceMemoryOpaqueCaptureAddressInfo* info,

--- a/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
@@ -150,6 +150,20 @@
     "vkCreateSamplerYcbcrConversion": "OverrideCreateSamplerYcbcrConversion",
     "vkCreateSamplerYcbcrConversionKHR": "OverrideCreateSamplerYcbcrConversionKHR",
     "vkCreatePipelineLayout": "OverrideCreatePipelineLayout",
-    "vkCreateBufferView": "OverrideCreateBufferView"
+    "vkCreateBufferView": "OverrideCreateBufferView",
+    "vkGetDeviceMemoryCommitment": "OverrideGetDeviceMemoryCommitment",
+    "vkMapMemory2": "OverrideMapMemory2",
+    "vkMapMemory2KHR": "OverrideMapMemory2",
+    "vkUnmapMemory2": "OverrideUnmapMemory2",
+    "vkUnmapMemory2KHR": "OverrideUnmapMemory2",
+    "vkSetDeviceMemoryPriorityEXT": "OverrideSetDeviceMemoryPriorityEXT",
+    "vkGetMemoryRemoteAddressNV": "OverrideGetMemoryRemoteAddressNV",
+    "vkCreateAccelerationStructureNV": "OverrideCreateAccelerationStructureNV",
+    "vkDestroyAccelerationStructureNV": "OverrideDestroyAccelerationStructureNV",
+    "vkBindAccelerationStructureMemoryNV": "OverrideBindAccelerationStructureMemoryNV",
+    "vkGetAccelerationStructureMemoryRequirementsNV": "OverrideGetAccelerationStructureMemoryRequirementsNV",
+    "vkGetMemoryFdKHR": "OverrideGetMemoryFdKHR",
+    "vkGetDeviceMemoryOpaqueCaptureAddress": "OverrideGetDeviceMemoryOpaqueCaptureAddress",
+    "vkGetDeviceMemoryOpaqueCaptureAddressKHR": "OverrideGetDeviceMemoryOpaqueCaptureAddress"
   }
 }


### PR DESCRIPTION
Test code for QueueBindSparse: `gfxreconstruct\test\test_apps\sparse-resources` and  https://github.com/SaschaWillems/Vulkan/tree/master/examples/texturesparseresidency

A lot of functions that have memory parameters needs to be supported by allocator.

For rebind, `vkAllocateMemory` didn't create a memory, only save the memory info. It creates an allocation for memory when a object binds a memory. One allocation is for one binding case. It uses `allocation_info.offset` to bind, instead of original offset. 

`VideoSession` and `BindSparse` are different cases that one object could bind multiple memories. In this case, `ResourceAllocInfo` becomes have a `vector<BoundMemoryInfo>`.

Plus, a object could re-bind the same memory through `BindSparse`, so finding existing allocation first before creating a new one.  If it re-bind the same memory, but different offset, it needs to create a new allocation for it. 

I think we could have `VulkanResourceAllocatorBase` by auto generation. When we update headers, it writes virtual functions that need to be handled by allocator in `VulkanResourceAllocatorBase`. Therefore, we could know what we need to do. Added one issue https://github.com/LunarG/gfxreconstruct/issues/2289.