### PR TITLE
Fix D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT Heap's State Writing

### DIFF
--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -848,6 +848,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateHeap(
         info->memory_pool     = desc->Properties.MemoryPoolPreference;
         info->has_write_watch = UseWriteWatch(info->heap_type, desc->Flags, info->page_property);
         info->heap_size       = desc->SizeInBytes;
+        info->heap_flags      = desc->Flags;
 
         CheckWriteWatchIgnored(desc->Flags, heap_wrapper->GetCaptureId());
     }
@@ -1093,6 +1094,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device4_CreateHeap1(ID3D12Device4_Wr
         info->page_property   = desc->Properties.CPUPageProperty;
         info->memory_pool     = desc->Properties.MemoryPoolPreference;
         info->has_write_watch = UseWriteWatch(info->heap_type, desc->Flags, info->page_property);
+        info->heap_flags      = desc->Flags;
 
         CheckWriteWatchIgnored(desc->Flags, heap_wrapper->GetCaptureId());
     }

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -438,6 +438,7 @@ struct ID3D12HeapInfo : public DxWrapperInfo
     D3D12_MEMORY_POOL         memory_pool{};
     uint64_t                  heap_size{ 0 };
     D3D12_GPU_VIRTUAL_ADDRESS gpu_va{ 0 };
+    D3D12_HEAP_FLAGS          heap_flags{ D3D12_HEAP_FLAG_NONE };
 
     const void* open_existing_address{ nullptr }; ///< Address used to create heap with OpenExistingHeapFromAddress.
 };

--- a/framework/encode/dx12_state_writer.h
+++ b/framework/encode/dx12_state_writer.h
@@ -117,6 +117,8 @@ class Dx12StateWriter
     // Returns true if memory information was successfully retrieved and written and false otherwise.
     bool WriteCreateHeapAllocationCmd(const void* address);
 
+    void WriteHeapMakeResidentCmd(const ID3D12Heap_Wrapper* wrapper);
+
     void WriteDescriptorState(const Dx12StateTable& state_table);
 
     void WriteAddRefAndReleaseCommands(const IUnknown_Wrapper* wrapper);


### PR DESCRIPTION
The heap is created in a non-resident state, must be calling MakeResident() explicatly in tha application.The state tracking/writting have to inject MakeResident() to the heaps.