### PR TITLE
Set device info for deduplicate device

### DIFF
--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -631,6 +631,7 @@ gfxrecon-replay         [-h | --help] [--version] [--cpu-mask <binary-mask>] [--
                         [--dump-resources-dump-all-image-subresources] <file>
                         [--pbi-all] [--pbis <index1,index2>]
                         [--pipeline-creation-jobs | --pcj <num_jobs>]
+                        [--deduplicate-device]
 
 
 Required arguments:
@@ -898,6 +899,9 @@ Optional arguments:
                         `--load-pipeline-cache`.
   --quit-after-frame
               Specify a frame after which replay will terminate.
+
+  --deduplicate-device
+              If set, at most one VkDevice will be created for each VkPhysicalDevice.
 ```
 
 ### Key Controls

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -308,17 +308,17 @@ struct VulkanPhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>
 {
     VkPhysicalDevice                         parent{ VK_NULL_HANDLE };
-    std::unique_ptr<VulkanResourceAllocator> allocator;
+    std::shared_ptr<VulkanResourceAllocator> allocator;
     std::unordered_map<uint32_t, size_t>     array_counts;
 
     std::unordered_map<format::HandleId, uint64_t> opaque_addresses;
 
     // Map pipeline ID to ray tracing shader group handle capture replay data.
-    std::unordered_map<format::HandleId, const std::vector<uint8_t>> shader_group_handles;
+    std::unordered_map<format::HandleId, std::vector<uint8_t>> shader_group_handles;
 
     // The following values are only used when loading the initial state for trimmed files.
     std::vector<std::string>                   extensions;
-    std::unique_ptr<VulkanResourceInitializer> resource_initializer;
+    std::shared_ptr<VulkanResourceInitializer> resource_initializer;
 
     // Physical device property & feature state at device creation
     graphics::VulkanDevicePropertyFeatureInfo property_feature_info;
@@ -335,6 +335,21 @@ struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>
 
     // For use with device deduplication
     format::HandleId duplicate_source_id{ format::kNullHandleId };
+
+    void copy(VulkanDeviceInfo* source_info)
+    {
+        parent                     = source_info->parent;
+        allocator                  = source_info->allocator;
+        array_counts               = source_info->array_counts;
+        opaque_addresses           = source_info->opaque_addresses;
+        shader_group_handles       = source_info->shader_group_handles;
+        extensions                 = source_info->extensions;
+        resource_initializer       = source_info->resource_initializer;
+        property_feature_info      = source_info->property_feature_info;
+        enabled_queue_family_flags = source_info->enabled_queue_family_flags;
+        replay_device_group        = source_info->replay_device_group;
+        duplicate_source_id        = source_info->capture_id;
+    }
 };
 
 struct VulkanQueueInfo : public VulkanObjectInfo<VkQueue>

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -334,7 +334,7 @@ struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>
     std::vector<VkPhysicalDevice> replay_device_group;
 
     // For use with device deduplication
-    bool is_duplicate{ false };
+    format::HandleId duplicate_source_id{ format::kNullHandleId };
 };
 
 struct VulkanQueueInfo : public VulkanObjectInfo<VkQueue>

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3246,16 +3246,13 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
     GFXRECON_ASSERT(device_info);
 
     // If we're doing device deduplication, check if we've already seen this create device request
-    std::bitset<VK_UUID_SIZE * 8> casted_uuid;
-    util::platform::MemoryCopy(
-        &casted_uuid, format::kUuidSize, physical_device_info->capture_pipeline_cache_uuid, VK_UUID_SIZE);
     if (options_.do_device_deduplication)
     {
-        auto it = device_uuid_map_.find(casted_uuid);
-        if (it != device_uuid_map_.end())
+        auto it = device_phy_id_map_.find(physical_device_info->capture_id);
+        if (it != device_phy_id_map_.end())
         {
             // We have seen this device before
-            auto      extant_device_id = device_uuid_map_[casted_uuid];
+            auto      extant_device_id = it->second;
             VkDevice* replay_device    = pDevice->GetHandlePointer();
 
             return SetDuplicateDeviceInfo(
@@ -3299,7 +3296,7 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
     {
         // Insert this device info into map
         auto capture_id = *pDevice->GetPointer();
-        device_uuid_map_.insert(std::pair(casted_uuid, capture_id));
+        device_phy_id_map_.insert(std::pair(physical_device_info->capture_id, capture_id));
     }
 
     return result;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1027,7 +1027,7 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
             have_shader_stencil_write = true;
         }
 
-        device_info->resource_initializer = std::make_unique<VulkanResourceInitializer>(
+        device_info->resource_initializer = std::make_shared<VulkanResourceInitializer>(
             device_info, max_copy_size, properties, have_shader_stencil_write, allocator, table);
     }
 }
@@ -3170,7 +3170,7 @@ VkResult VulkanReplayConsumerBase::PostCreateDeviceUpdateState(VulkanPhysicalDev
                                                     create_state.modified_create_info.enabledExtensionCount);
     InitializeResourceAllocator(physical_device_info, replay_device, enabled_extensions, allocator);
 
-    device_info->allocator = std::unique_ptr<VulkanResourceAllocator>(allocator);
+    device_info->allocator = std::shared_ptr<VulkanResourceAllocator>(allocator);
 
     // Track state of physical device properties and features at device creation
     device_info->property_feature_info = create_state.property_feature_info;
@@ -3223,14 +3223,11 @@ VulkanReplayConsumerBase::SetDuplicateDeviceInfo(VulkanPhysicalDeviceInfo* physi
                                                  VulkanDeviceInfo*                                       device_info,
                                                  format::HandleId extant_device_id)
 {
-    auto* extant_device_info         = object_info_table_->GetVkDeviceInfo(extant_device_id);
-    *replay_device                   = extant_device_info->handle;
-    device_info->duplicate_source_id = extant_device_id;
+    auto* extant_device_info = object_info_table_->GetVkDeviceInfo(extant_device_id);
+    *replay_device           = extant_device_info->handle;
+    device_info->copy(extant_device_info);
 
-    CreateDeviceInfoState create_state;
-    ModifyCreateDeviceInfo(physical_device_info, create_info, create_state);
-
-    return PostCreateDeviceUpdateState(physical_device_info, *replay_device, create_state, device_info);
+    return VK_SUCCESS;
 }
 
 VkResult

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3217,6 +3217,23 @@ VkResult VulkanReplayConsumerBase::PostCreateDeviceUpdateState(VulkanPhysicalDev
 }
 
 VkResult
+VulkanReplayConsumerBase::SetDuplicateDeviceInfo(VulkanPhysicalDeviceInfo* physical_device_info,
+                                                 VkDevice*                 replay_device,
+                                                 const StructPointerDecoder<Decoded_VkDeviceCreateInfo>* create_info,
+                                                 VulkanDeviceInfo*                                       device_info,
+                                                 format::HandleId extant_device_id)
+{
+    auto* extant_device_info         = object_info_table_->GetVkDeviceInfo(extant_device_id);
+    *replay_device                   = extant_device_info->handle;
+    device_info->duplicate_source_id = extant_device_id;
+
+    CreateDeviceInfoState create_state;
+    ModifyCreateDeviceInfo(physical_device_info, create_info, create_state);
+
+    return PostCreateDeviceUpdateState(physical_device_info, *replay_device, create_state, device_info);
+}
+
+VkResult
 VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  original_result,
                                                VulkanPhysicalDeviceInfo* physical_device_info,
                                                const StructPointerDecoder<Decoded_VkDeviceCreateInfo>*    pCreateInfo,
@@ -3241,11 +3258,11 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
         if (it != device_uuid_map_.end())
         {
             // We have seen this device before
-            VkDevice& extant_device   = device_uuid_map_[casted_uuid];
-            device_info->is_duplicate = true;
-            VkDevice* replay_device   = pDevice->GetHandlePointer();
-            *replay_device            = extant_device;
-            return VK_SUCCESS;
+            auto      extant_device_id = device_uuid_map_[casted_uuid];
+            VkDevice* replay_device    = pDevice->GetHandlePointer();
+
+            return SetDuplicateDeviceInfo(
+                physical_device_info, replay_device, pCreateInfo, device_info, extant_device_id);
         }
     }
 
@@ -3284,7 +3301,8 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
     if (options_.do_device_deduplication)
     {
         // Insert this device info into map
-        device_uuid_map_.insert(std::pair(casted_uuid, *replay_device));
+        auto capture_id = *pDevice->GetPointer();
+        device_uuid_map_.insert(std::pair(casted_uuid, capture_id));
     }
 
     return result;
@@ -3297,7 +3315,7 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
 {
     VkDevice device = VK_NULL_HANDLE;
 
-    if (device_info != nullptr && !device_info->is_duplicate)
+    if (device_info != nullptr && device_info->duplicate_source_id == format::kNullHandleId)
     {
         device = device_info->handle;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1690,6 +1690,12 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void DestroyInternalInstanceResources(const VulkanInstanceInfo* instance_info);
 
+    VkResult SetDuplicateDeviceInfo(VulkanPhysicalDeviceInfo*                               physical_device_info,
+                                    VkDevice*                                               replay_device,
+                                    const StructPointerDecoder<Decoded_VkDeviceCreateInfo>* create_info,
+                                    VulkanDeviceInfo*                                       device_info,
+                                    format::HandleId                                        extant_device_id);
+
   private:
     struct HardwareBufferInfo
     {
@@ -1725,7 +1731,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unordered_map<graphics::VulkanDispatchKey, PFN_vkCreateDevice>            create_device_procs_;
     std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanInstanceTable> instance_tables_;
     std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanDeviceTable>   device_tables_;
-    std::unordered_map<std::bitset<VK_UUID_SIZE * 8>, VkDevice>                    device_uuid_map_;
+    std::unordered_map<std::bitset<VK_UUID_SIZE * 8>, format::HandleId>            device_uuid_map_;
     std::function<void(const char*)>                                               fatal_error_handler_;
     std::shared_ptr<application::Application>                                      application_;
     CommonObjectInfoTable*                                                         object_info_table_;

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1731,7 +1731,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unordered_map<graphics::VulkanDispatchKey, PFN_vkCreateDevice>            create_device_procs_;
     std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanInstanceTable> instance_tables_;
     std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanDeviceTable>   device_tables_;
-    std::unordered_map<std::bitset<VK_UUID_SIZE * 8>, format::HandleId>            device_uuid_map_;
+    std::unordered_map<format::HandleId, format::HandleId>                         device_phy_id_map_;
     std::function<void(const char*)>                                               fatal_error_handler_;
     std::shared_ptr<application::Application>                                      application_;
     CommonObjectInfoTable*                                                         object_info_table_;


### PR DESCRIPTION
Some discussion need for it.  Should the second device info  be from its create info? or from the source device info? This PR chose its create info because it passed test, but the source device info failed during replay. I didn't look deeply the reason.

Plus, should we add more requirements for deduplicate device? Like both create info should be similar and their instances should be the same. Is it possible to have deduplicate instance option?

I added two issues about it.
https://github.com/LunarG/gfxreconstruct/issues/2311
https://github.com/LunarG/gfxreconstruct/issues/2312