### PR TITLE
android, build: Do not build 32b Android by default

### DIFF
--- a/android/layer/build.gradle
+++ b/android/layer/build.gradle
@@ -19,7 +19,7 @@ android {
             } else if (project.hasProperty("x86_64")) {
                 abiFilters 'x86_64'
             } else {
-                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a', 'x86_64'
             }
         }
         externalNativeBuild {

--- a/android/test/test_apps/launcher/build.gradle
+++ b/android/test/test_apps/launcher/build.gradle
@@ -20,7 +20,7 @@ android {
             } else if (project.hasProperty("x86_64")) {
                 abiFilters 'x86_64'
             } else {
-                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a', 'x86_64'
             }
         }
         externalNativeBuild {

--- a/android/tools/multi-win-replay/build.gradle
+++ b/android/tools/multi-win-replay/build.gradle
@@ -20,7 +20,7 @@ android {
             } else if (project.hasProperty("x86_64")) {
                 abiFilters 'x86_64'
             } else {
-                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a', 'x86_64'
             }
         }
         externalNativeBuild {

--- a/android/tools/replay/build.gradle
+++ b/android/tools/replay/build.gradle
@@ -20,7 +20,7 @@ android {
             } else if (project.hasProperty("x86_64")) {
                 abiFilters 'x86_64'
             } else {
-                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a', 'x86_64'
             }
         }
         externalNativeBuild {


### PR DESCRIPTION
Removes 32 bit builds from the default gradle configurations.

Fixes LunarG/Projects#969.