### PR TITLE
convert: Fix binary out dir when stdout used

### DIFF
--- a/framework/decode/json_writer.cpp
+++ b/framework/decode/json_writer.cpp
@@ -224,7 +224,7 @@ void RepresentBinaryFile(JsonWriter&             writer,
     {
         std::string filename = writer.GenerateFilename(filename_base);
         std::string basename = gfxrecon::util::filepath::Join(json_options.data_sub_dir, filename);
-        std::string filepath = gfxrecon::util::filepath::Join(json_options.root_dir, basename);
+        std::string filepath = gfxrecon::util::filepath::Join(json_options.root_dir, filename);
         if (writer.WriteBinaryFile(filepath, data_size, data))
         {
             FieldToJson(jdata, basename, json_options);

--- a/framework/util/json_util.cpp
+++ b/framework/util/json_util.cpp
@@ -409,7 +409,7 @@ bool RepresentBinaryFile(const util::JsonOptions& json_options,
         {
             std::string filename = GenerateFilename(filename_base, instance_counter);
             std::string basename = gfxrecon::util::filepath::Join(json_options.data_sub_dir, filename);
-            std::string filepath = gfxrecon::util::filepath::Join(json_options.root_dir, basename);
+            std::string filepath = gfxrecon::util::filepath::Join(json_options.root_dir, filename);
             if (WriteBinaryFile(filepath, data_size, data))
             {
                 FieldToJson(jdata, basename, json_options);


### PR DESCRIPTION
When stdout is set for the output, and a "--include-binaries" option is used, we were outputting to a folder called "stdout". This should not have been the case because according to our own usage info, it should have reverted to the GFXR capture file name.

Fixes #2202