### PR TITLE
VDR: Add option to compress files that are dumped raw

### DIFF
--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -145,6 +145,7 @@ def CreateReplayParser():
     parser.add_argument('--dump-resources-dump-raw-images', action='store_true', default=False, help= 'Dump images verbatim as raw binary files.')
     parser.add_argument('--dump-resources-dump-separate-alpha', action='store_true', default=False, help= 'Dump image alpha in a separate image file.')
     parser.add_argument('--dump-resources-dump-unused-vertex-bindings', action='store_true', default=False, help= 'Dump a vertex binding even if no vertex attributes references it.')
+    parser.add_argument('--dump-resources-binary-file-compression-type', metavar='FORMAT', choices=['none', 'lz4', 'zlib', 'zstd'], help='Compress files that are dumped as binary. Available compression types are: [none, lz4 (block format), zlib, zstd]. Default is none (no compression).')
     parser.add_argument('--pbi-all', action='store_true', default=False, help='Print all block information.')
     parser.add_argument('--pbis', metavar='RANGES', default=False, help='Print block information between block index1 and block index2')
     parser.add_argument('--pcj', '--pipeline-creation-jobs', action='store_true', default=False, help='Specify the number of pipeline-creation-jobs or background-threads.')
@@ -337,6 +338,10 @@ def MakeExtrasString(args):
 
     if args.dump_resources_dump_unused_vertex_bindings:
         arg_list.append('--dump-resources-dump-unused-vertex-bindings')
+
+    if args.dump_resources_binary_file_compression_type:
+        arg_list.append('--dump-resources-binary-file-compression-type')
+        arg_list.append('{}'.format(args.dump_resources_binary_file_compression_type))
 
     if args.pbi_all:
         arg_list.append('--pbi-all')

--- a/framework/decode/vulkan_replay_dump_resources.h
+++ b/framework/decode/vulkan_replay_dump_resources.h
@@ -34,11 +34,13 @@
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "format/format.h"
 #include "generated/generated_vulkan_struct_decoders.h"
+#include "util/compressor.h"
 #include "util/defines.h"
 #include "vulkan/vulkan_core.h"
 
 #include <cstdint>
 #include <type_traits>
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -567,6 +569,8 @@ class VulkanReplayDumpResourcesBase
     std::unique_ptr<DefaultVulkanDumpResourcesDelegate> default_delegate_;
     VulkanDumpResourcesDelegate*                        user_delegate_;
     VulkanDumpResourcesDelegate*                        active_delegate_;
+
+    std::unique_ptr<util::Compressor> compressor_;
 
     std::string capture_filename;
 

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -492,8 +492,7 @@ VkResult DumpImageToFile(const VulkanImageInfo*               image_info,
         };
 
         image_resource.resource_size =
-            resource_util.GetImageResourceSizesOptimal(image_resource.image,
-                                                       use_blit ? dst_format : image_resource.format,
+            resource_util.GetImageResourceSizesOptimal(use_blit ? dst_format : image_resource.format,
                                                        image_resource.type,
                                                        use_blit ? scaled_extent : image_resource.extent,
                                                        image_resource.level_count,

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -22,6 +22,7 @@
 
 #include "decode/vulkan_replay_dump_resources_common.h"
 #include "decode/vulkan_object_info.h"
+#include "util/compressor.h"
 #include "util/logging.h"
 #include "util/image_writer.h"
 #include "util/buffer_writer.h"
@@ -416,6 +417,7 @@ VkResult DumpImageToFile(const VulkanImageInfo*               image_info,
                          float                                scale,
                          bool&                                scaling_supported,
                          util::ScreenshotFormat               image_file_format,
+                         const util::Compressor*              compressor,
                          bool                                 dump_all_subresources,
                          bool                                 dump_image_raw,
                          bool                                 dump_separate_alpha,
@@ -626,7 +628,8 @@ VkResult DumpImageToFile(const VulkanImageInfo*               image_info,
                             util::ToString<VkFormat>(image_info->format).c_str());
                     }
 
-                    util::bufferwriter::WriteBuffer(filename, offsetted_data, subresource_sizes[sub_res_idx]);
+                    util::bufferwriter::WriteBuffer(
+                        filename, offsetted_data, subresource_sizes[sub_res_idx], compressor);
                 }
 
                 if (!dump_all_subresources)

--- a/framework/decode/vulkan_replay_dump_resources_common.h
+++ b/framework/decode/vulkan_replay_dump_resources_common.h
@@ -25,8 +25,8 @@
 
 #include "decode/common_object_info_table.h"
 #include "vulkan/vulkan_core.h"
+#include "util/compressor.h"
 #include "util/defines.h"
-#include "util/image_writer.h"
 #include "util/options.h"
 #include <vector>
 
@@ -111,6 +111,7 @@ VkResult DumpImageToFile(const VulkanImageInfo*               image_info,
                          float                                scale,
                          bool&                                scaling_supported,
                          util::ScreenshotFormat               image_file_format,
+                         const util::Compressor*              compressor            = nullptr,
                          bool                                 dump_all_subresources = false,
                          bool                                 dump_image_raw        = false,
                          bool                                 dump_separate_alpha   = false,

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
@@ -28,7 +28,7 @@
 #include "decode/vulkan_object_info.h"
 #include "decode/vulkan_replay_options.h"
 #include "generated/generated_vulkan_dispatch_table.h"
-#include "format/format.h"
+#include "util/compressor.h"
 #include "util/defines.h"
 #include "util/logging.h"
 #include "vulkan/vulkan_core.h"
@@ -51,7 +51,8 @@ class DispatchTraceRaysDumpingContext
                                     const std::vector<uint64_t>* trace_rays_indices,
                                     CommonObjectInfoTable&       object_info_table,
                                     const VulkanReplayOptions&   options,
-                                    VulkanDumpResourcesDelegate& delegate);
+                                    VulkanDumpResourcesDelegate& delegate,
+                                    const util::Compressor*      compressor);
 
     ~DispatchTraceRaysDumpingContext();
 
@@ -142,6 +143,7 @@ class DispatchTraceRaysDumpingContext
     bool                           dump_resources_before_;
     VulkanDumpResourcesDelegate&   delegate_;
     bool                           dump_immutable_resources_;
+    const util::Compressor*        compressor_;
 
     // One entry per descriptor set for each compute and ray tracing binding points
     BoundDescriptorSets bound_descriptor_sets_compute_;

--- a/framework/decode/vulkan_replay_dump_resources_delegate.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.cpp
@@ -23,9 +23,13 @@
 #include "decode/vulkan_replay_dump_resources_delegate.h"
 #include "decode/vulkan_object_info.h"
 #include "decode/vulkan_replay_dump_resources_common.h"
+#include "format/format.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "generated/generated_vulkan_enum_to_string.h"
+#include "graphics/vulkan_resources_util.h"
 #include "util/buffer_writer.h"
+#include "util/logging.h"
+#include <vulkan/vulkan_core.h>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -645,6 +649,9 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
             rt_entry["imageId"]   = image_info->capture_id;
             rt_entry["format"]    = util::ToString<VkFormat>(image_info->format);
             rt_entry["imageType"] = util::ToString<VkImageType>(image_info->type);
+            rt_entry["imageType"] = util::ToString<VkImageType>(image_info->type);
+            rt_entry["levels"]    = image_info->level_count;
+            rt_entry["layers"]    = image_info->layer_count;
 
             if (ImageFailedScaling(image_info))
             {
@@ -654,6 +661,10 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
             size_t subresource_entry = 0;
             for (auto aspect : aspects)
             {
+                std::vector<uint64_t> subresource_sizes;
+                GetImageResourceSizes(
+                    image_info, aspect, instance_table, draw_call_info.device_table, subresource_sizes);
+
                 for (uint32_t mip = 0; mip < image_info->level_count; ++mip)
                 {
                     for (uint32_t layer = 0; layer < image_info->layer_count; ++layer)
@@ -689,8 +700,10 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                                                               extent,
                                                               filenameAfter,
                                                               aspect,
+                                                              image_info->layer_count,
                                                               mip,
                                                               layer,
+                                                              &subresource_sizes,
                                                               options_.dump_resources_dump_separate_alpha,
                                                               options_.dump_resources_before ? &filenameBefore
                                                                                              : nullptr);
@@ -737,6 +750,13 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
         size_t subresource_entry = 0;
         for (auto aspect : aspects)
         {
+            std::vector<uint64_t> subresource_sizes;
+            if (options_.dump_resources_dump_raw_images)
+            {
+                GetImageResourceSizes(
+                    image_info, aspect, instance_table, draw_call_info.device_table, subresource_sizes);
+            }
+
             for (uint32_t mip = 0; mip < image_info->level_count; ++mip)
             {
                 for (uint32_t layer = 0; layer < image_info->layer_count; ++layer)
@@ -771,8 +791,10 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                                                           extent,
                                                           filenameAfter,
                                                           aspect,
+                                                          image_info->layer_count,
                                                           mip,
                                                           layer,
+                                                          &subresource_sizes,
                                                           options_.dump_resources_dump_separate_alpha,
                                                           options_.dump_resources_before ? &filenameBefore : nullptr);
 
@@ -854,6 +876,7 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                 json_entry["offset"]   = draw_call_info.dc_param->json_output_info.index_buffer_info.offset;
                 json_entry["indexType"] =
                     util::ToString<VkIndexType>(draw_call_info.dc_param->referenced_index_buffer.index_type);
+                json_entry["size"] = draw_call_info.dc_param->referenced_index_buffer.actual_size;
             }
         }
 
@@ -889,6 +912,7 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                     json_entry[i]["vertexBufferBinding"] = vb_binding.first;
                     json_entry[i]["file"]                = vb_filename;
                     json_entry[i]["offset"]              = json_info_entry->second.offset;
+                    json_entry[i]["size"]                = vb_binding_buffer->second.actual_size;
                     ++i;
                 }
             }
@@ -956,6 +980,16 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                                 size_t subresource_entry = 0;
                                 for (auto aspect : aspects)
                                 {
+                                    std::vector<uint64_t> subresource_sizes;
+                                    if (options_.dump_resources_dump_raw_images)
+                                    {
+                                        GetImageResourceSizes(image_info,
+                                                              aspect,
+                                                              instance_table,
+                                                              draw_call_info.device_table,
+                                                              subresource_sizes);
+                                    }
+
                                     for (uint32_t mip = 0; mip < image_info->level_count; ++mip)
                                     {
                                         for (uint32_t layer = 0; layer < image_info->layer_count; ++layer)
@@ -975,8 +1009,10 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                                                 extent,
                                                 filename,
                                                 aspect,
+                                                image_info->layer_count,
                                                 mip,
                                                 layer,
+                                                &subresource_sizes,
                                                 options_.dump_resources_dump_separate_alpha);
 
                                             if (!options_.dump_resources_dump_all_image_subresources)
@@ -1017,6 +1053,10 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                                     res_info.type                   = DumpResourceType::kBufferDescriptor;
                                     res_info.buffer_info            = buf_info;
 
+                                    const VkDeviceSize size = buf_desc.second->range == VK_WHOLE_SIZE
+                                                                  ? buf_info->size - buf_desc.second->offset
+                                                                  : buf_desc.second->range;
+                                    desc_json_entry["size"] = size;
                                     desc_json_entry["file"] = GenerateBufferDescriptorFilename(res_info);
                                 }
                             }
@@ -1046,6 +1086,10 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonDrawCallInfo(
                                     res_info.type                   = DumpResourceType::kBufferDescriptor;
                                     res_info.buffer_info            = buf_info;
 
+                                    const VkDeviceSize size = buf_desc.second.range == VK_WHOLE_SIZE
+                                                                  ? buf_info->size - buf_desc.second.offset
+                                                                  : buf_desc.second.range;
+                                    desc_json_entry["size"] = size;
                                     desc_json_entry["file"] = GenerateBufferDescriptorFilename(res_info);
                                 }
                             }
@@ -1450,6 +1494,18 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
             size_t subresource_entry = 0;
             for (auto aspect : aspects)
             {
+                std::vector<uint64_t> subresource_sizes;
+                if (options_.dump_resources_dump_raw_images)
+                {
+                    GFXRECON_ASSERT(draw_call_info.instance_table != nullptr);
+
+                    GetImageResourceSizes(img_info,
+                                          aspect,
+                                          draw_call_info.instance_table,
+                                          draw_call_info.device_table,
+                                          subresource_sizes);
+                }
+
                 for (uint32_t mip = 0; mip < img_info->level_count; ++mip)
                 {
                     for (uint32_t layer = 0; layer < img_info->layer_count; ++layer)
@@ -1484,8 +1540,10 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                                                                   extent,
                                                                   filename,
                                                                   aspect,
+                                                                  img_info->layer_count,
                                                                   mip,
                                                                   layer,
+                                                                  &subresource_sizes,
                                                                   options_.dump_resources_dump_separate_alpha,
                                                                   &filename_before);
                         }
@@ -1498,8 +1556,10 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                                                                   extent,
                                                                   filename,
                                                                   aspect,
+                                                                  img_info->layer_count,
                                                                   mip,
                                                                   layer,
+                                                                  &subresource_sizes,
                                                                   options_.dump_resources_dump_separate_alpha);
                         }
 
@@ -1541,6 +1601,7 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
             entry["binding"]            = binding;
             entry["arrayIndex"]         = array_index;
             entry["bufferId"]           = buffer_info->capture_id;
+            entry["size"]               = buffer.cloned_size;
 
             VulkanDumpResourceInfo res_info = res_info_base;
             res_info.type                   = DumpResourceType::kDispatchTraceRaysBuffer;
@@ -1616,6 +1677,19 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                                 size_t subresource_entry = 0;
                                 for (auto aspect : aspects)
                                 {
+                                    std::vector<uint64_t> subresource_sizes;
+                                    if (options_.dump_resources_dump_raw_images)
+                                    {
+                                        GFXRECON_ASSERT(draw_call_info.instance_table != nullptr);
+                                        GFXRECON_ASSERT(draw_call_info.device_table != nullptr);
+
+                                        GetImageResourceSizes(img_info,
+                                                              aspect,
+                                                              draw_call_info.instance_table,
+                                                              draw_call_info.device_table,
+                                                              subresource_sizes);
+                                    }
+
                                     for (uint32_t mip = 0; mip < img_info->level_count; ++mip)
                                     {
                                         for (uint32_t layer = 0; layer < img_info->layer_count; ++layer)
@@ -1640,8 +1714,10 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                                                 extent,
                                                 filename,
                                                 aspect,
+                                                img_info->layer_count,
                                                 mip,
                                                 layer,
+                                                &subresource_sizes,
                                                 options_.dump_resources_dump_separate_alpha);
 
                                             if (!options_.dump_resources_dump_all_image_subresources)
@@ -1681,6 +1757,11 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                                     res_info.buffer_info = buffer_info;
 
                                     entry["file"] = GenerateDispatchTraceRaysBufferDescriptorFilename(res_info);
+
+                                    const VkDeviceSize size = buf_desc.second->range == VK_WHOLE_SIZE
+                                                                  ? buffer_info->size - buf_desc.second->offset
+                                                                  : buf_desc.second->range;
+                                    entry["size"]           = size;
                                 }
                             }
                         }
@@ -1707,6 +1788,12 @@ void DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysDescriptorsJso
                                     res_info.buffer_info = buf_desc.second.buffer_info;
 
                                     entry["file"] = GenerateDispatchTraceRaysBufferDescriptorFilename(res_info);
+
+                                    const VkDeviceSize size =
+                                        buf_desc.second.range == VK_WHOLE_SIZE
+                                            ? buf_desc.second.buffer_info->size - buf_desc.second.offset
+                                            : buf_desc.second.range;
+                                    entry["size"] = size;
                                 }
                             }
                         }
@@ -1943,6 +2030,54 @@ void DefaultVulkanDumpResourcesDelegate::GenerateOutputJsonTraceRaysIndex(
         dump_json_.BlockEnd();
         dump_json_.Close();
     }
+}
+
+uint64_t DefaultVulkanDumpResourcesDelegate::GetImageResourceSizes(const VulkanImageInfo*               image_info,
+                                                                   VkImageAspectFlagBits                aspect,
+                                                                   const graphics::VulkanInstanceTable* instance_table,
+                                                                   const graphics::VulkanDeviceTable*   device_table,
+                                                                   std::vector<uint64_t>& subresource_sizes)
+{
+    GFXRECON_ASSERT(image_info != nullptr);
+    GFXRECON_ASSERT(instance_table != nullptr);
+    GFXRECON_ASSERT(device_table != nullptr);
+
+    const VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(image_info->parent_id);
+    GFXRECON_ASSERT(device_info != nullptr);
+
+    const VulkanPhysicalDeviceInfo* phys_dev_info = object_info_table_.GetVkPhysicalDeviceInfo(device_info->parent_id);
+    GFXRECON_ASSERT(phys_dev_info != nullptr);
+
+    graphics::VulkanResourcesUtil resource_util(device_info->handle,
+                                                device_info->parent,
+                                                *device_table,
+                                                *instance_table,
+                                                *phys_dev_info->replay_device_info->memory_properties);
+
+    VkExtent3D extent;
+    if (options_.dump_resources_scale != 1.0f && !ImageFailedScaling(image_info))
+    {
+        extent.width = static_cast<uint32_t>(
+            std::max(static_cast<float>(image_info->extent.width) * options_.dump_resources_scale, 1.0f));
+        extent.height = static_cast<uint32_t>(
+            std::max(static_cast<float>(image_info->extent.height) * options_.dump_resources_scale, 1.0f));
+        extent.depth = static_cast<uint32_t>(
+            std::max(static_cast<float>(image_info->extent.depth) * options_.dump_resources_scale, 1.0f));
+    }
+    else
+    {
+        extent = image_info->extent;
+    }
+
+    return resource_util.GetImageResourceSizesOptimal(image_info->format,
+                                                      image_info->type,
+                                                      extent,
+                                                      image_info->level_count,
+                                                      image_info->layer_count,
+                                                      image_info->tiling,
+                                                      aspect,
+                                                      nullptr,
+                                                      &subresource_sizes);
 }
 
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_replay_dump_resources_delegate.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.cpp
@@ -167,6 +167,7 @@ VkResult DefaultVulkanDumpResourcesDelegate::DumpRenderTargetImage(const VulkanD
                                    options_.dump_resources_scale,
                                    scaling_supported,
                                    options_.dump_resources_image_format,
+                                   resource_info.compressor,
                                    options_.dump_resources_dump_all_image_subresources,
                                    options_.dump_resources_dump_raw_images,
                                    options_.dump_resources_dump_separate_alpha,
@@ -302,6 +303,7 @@ VkResult DefaultVulkanDumpResourcesDelegate::DumpImageDescriptor(const VulkanDum
                                    options_.dump_resources_scale,
                                    scaling_supported,
                                    options_.dump_resources_image_format,
+                                   resource_info.compressor,
                                    options_.dump_resources_dump_all_image_subresources,
                                    options_.dump_resources_dump_raw_images,
                                    options_.dump_resources_dump_separate_alpha,
@@ -375,7 +377,8 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateImageDescriptorFilename(
 VkResult DefaultVulkanDumpResourcesDelegate::DumpBufferDescriptor(const VulkanDumpResourceInfo& resource_info)
 {
     const std::string filename = GenerateBufferDescriptorFilename(resource_info);
-    return util::bufferwriter::WriteBuffer(filename, resource_info.data.data(), resource_info.data.size())
+    return util::bufferwriter::WriteBuffer(
+               filename, resource_info.data.data(), resource_info.data.size(), resource_info.compressor)
                ? VK_SUCCESS
                : VK_ERROR_UNKNOWN;
 }
@@ -398,7 +401,8 @@ VkResult
 DefaultVulkanDumpResourcesDelegate::DumpInlineUniformBufferDescriptor(const VulkanDumpResourceInfo& resource_info)
 {
     std::string filename = GenerateInlineUniformBufferDescriptorFilename(resource_info);
-    return util::bufferwriter::WriteBuffer(filename, resource_info.data.data(), resource_info.data.size())
+    return util::bufferwriter::WriteBuffer(
+               filename, resource_info.data.data(), resource_info.data.size(), resource_info.compressor)
                ? VK_SUCCESS
                : VK_ERROR_UNKNOWN;
 }
@@ -419,7 +423,8 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateInlineUniformBufferDescr
 VkResult DefaultVulkanDumpResourcesDelegate::DumpVertexBuffer(const VulkanDumpResourceInfo& resource_info)
 {
     std::string filename = GenerateVertexBufferFilename(resource_info);
-    return util::bufferwriter::WriteBuffer(filename, resource_info.data.data(), resource_info.data.size())
+    return util::bufferwriter::WriteBuffer(
+               filename, resource_info.data.data(), resource_info.data.size(), resource_info.compressor)
                ? VK_SUCCESS
                : VK_ERROR_UNKNOWN;
 }
@@ -441,7 +446,8 @@ DefaultVulkanDumpResourcesDelegate::GenerateVertexBufferFilename(const VulkanDum
 VkResult DefaultVulkanDumpResourcesDelegate::DumpIndexBuffer(const VulkanDumpResourceInfo& resource_info)
 {
     std::string filename = GenerateIndexBufferFilename(resource_info);
-    return util::bufferwriter::WriteBuffer(filename, resource_info.data.data(), resource_info.data.size())
+    return util::bufferwriter::WriteBuffer(
+               filename, resource_info.data.data(), resource_info.data.size(), resource_info.compressor)
                ? VK_SUCCESS
                : VK_ERROR_UNKNOWN;
 }
@@ -1122,6 +1128,7 @@ VkResult DefaultVulkanDumpResourcesDelegate::DumpeDispatchTraceRaysImage(const V
                                    options_.dump_resources_scale,
                                    scaling_supported,
                                    options_.dump_resources_image_format,
+                                   resource_info.compressor,
                                    false,
                                    options_.dump_resources_dump_raw_images,
                                    options_.dump_resources_dump_separate_alpha,
@@ -1206,7 +1213,8 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysImageFi
 VkResult DefaultVulkanDumpResourcesDelegate::DumpeDispatchTraceRaysBuffer(const VulkanDumpResourceInfo& resource_info)
 {
     std::string filename = GenerateDispatchTraceRaysBufferFilename(resource_info);
-    return util::bufferwriter::WriteBuffer(filename, resource_info.data.data(), resource_info.data.size())
+    return util::bufferwriter::WriteBuffer(
+               filename, resource_info.data.data(), resource_info.data.size(), resource_info.compressor)
                ? VK_SUCCESS
                : VK_ERROR_UNKNOWN;
 }
@@ -1284,6 +1292,7 @@ DefaultVulkanDumpResourcesDelegate::DumpDispatchTraceRaysImageDescriptor(const V
                                    options_.dump_resources_scale,
                                    scaling_supported,
                                    options_.dump_resources_image_format,
+                                   resource_info.compressor,
                                    options_.dump_resources_dump_all_image_subresources,
                                    options_.dump_resources_dump_raw_images,
                                    options_.dump_resources_dump_separate_alpha);
@@ -1345,7 +1354,8 @@ VkResult
 DefaultVulkanDumpResourcesDelegate::DumpDispatchTraceRaysBufferDescriptor(const VulkanDumpResourceInfo& resource_info)
 {
     const std::string filename = GenerateDispatchTraceRaysBufferDescriptorFilename(resource_info);
-    return util::bufferwriter::WriteBuffer(filename, resource_info.data.data(), resource_info.data.size())
+    return util::bufferwriter::WriteBuffer(
+               filename, resource_info.data.data(), resource_info.data.size(), resource_info.compressor)
                ? VK_SUCCESS
                : VK_ERROR_UNKNOWN;
 }
@@ -1367,7 +1377,8 @@ VkResult DefaultVulkanDumpResourcesDelegate::DumpDispatchTraceRaysInlineUniformB
     const VulkanDumpResourceInfo& resource_info)
 {
     std::string filename = GenerateDispatchTraceRaysInlineUniformBufferDescriptorFilename(resource_info);
-    return util::bufferwriter::WriteBuffer(filename, resource_info.data.data(), resource_info.data.size())
+    return util::bufferwriter::WriteBuffer(
+               filename, resource_info.data.data(), resource_info.data.size(), resource_info.compressor)
                ? VK_SUCCESS
                : VK_ERROR_UNKNOWN;
 }

--- a/framework/decode/vulkan_replay_dump_resources_delegate.h
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.h
@@ -225,6 +225,12 @@ class DefaultVulkanDumpResourcesDelegate : public VulkanDumpResourcesDelegate
 
     bool ImageFailedScaling(const VulkanImageInfo* img_info) const { return images_failed_scaling_.count(img_info); }
 
+    uint64_t GetImageResourceSizes(const VulkanImageInfo*               image_info,
+                                   VkImageAspectFlagBits                aspect,
+                                   const graphics::VulkanInstanceTable* instance_table,
+                                   const graphics::VulkanDeviceTable*   device_table,
+                                   std::vector<uint64_t>&               subresource_sizes);
+
     void GenerateDispatchTraceRaysDescriptorsJsonInfo(
         const VulkanDumpDrawCallInfo&                                         draw_call_info,
         nlohmann::ordered_json&                                               dispatch_json_entry,

--- a/framework/decode/vulkan_replay_dump_resources_delegate.h
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.h
@@ -23,6 +23,7 @@
 #ifndef GFXRECON_VULKAN_REPLAY_DUMP_RESOURCES_DELEGATE_H
 #define GFXRECON_VULKAN_REPLAY_DUMP_RESOURCES_DELEGATE_H
 
+#include "util/compressor.h"
 #include "decode/vulkan_object_info.h"
 #include "decode/vulkan_replay_dump_resources_draw_calls.h"
 #include "decode/vulkan_replay_dump_resources_compute_ray_tracing.h"
@@ -85,6 +86,8 @@ struct VulkanDumpResourceInfo
     bool               before_cmd;
     uint32_t           array_index;
     VkShaderStageFlags stages;
+
+    const util::Compressor* compressor;
 
     VulkanDumpResourceInfo& operator=(const VulkanDumpDrawCallInfo& draw_call_info)
     {

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -28,7 +28,7 @@
 #include "decode/vulkan_object_info.h"
 #include "decode/vulkan_replay_options.h"
 #include "generated/generated_vulkan_dispatch_table.h"
-#include "format/format.h"
+#include "util/compressor.h"
 #include "util/defines.h"
 #include "vulkan/vulkan_core.h"
 
@@ -62,7 +62,8 @@ class DrawCallsDumpingContext
                             const RenderPassIndices*     rp_indices,
                             CommonObjectInfoTable&       object_info_table,
                             const VulkanReplayOptions&   options,
-                            VulkanDumpResourcesDelegate& delegate);
+                            VulkanDumpResourcesDelegate& delegate,
+                            const util::Compressor*      compressor);
 
     ~DrawCallsDumpingContext();
 
@@ -232,6 +233,7 @@ class DrawCallsDumpingContext
     bool                         dump_vertex_index_buffers_;
     bool                         dump_immutable_resources_;
     bool                         dump_unused_vertex_bindings_;
+    const util::Compressor*      compressor_;
 
     // Execute commands block index : DrawCallContexts
     std::unordered_map<uint64_t, std::vector<DrawCallsDumpingContext*>> secondaries_;

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -20,6 +20,7 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
+#include "format/format_util.h"
 #include "Vulkan-Utility-Libraries/vk_format_utils.h"
 #include "util/file_path.h"
 #include PROJECT_VERSION_HEADER_FILE
@@ -55,6 +56,8 @@ VulkanReplayDumpResourcesJson::VulkanReplayDumpResourcesJson(const VulkanReplayO
     dr_options["dumpResourcesDumpRawImages"]            = options.dump_resources_dump_raw_images;
     dr_options["dumpResourcesDumpSeparateAlpha"]        = options.dump_resources_dump_separate_alpha;
     dr_options["dumpResourcesDumpUnusedVertexBindings"] = options.dump_resources_dump_unused_vertex_bindings;
+    dr_options["dumpResourcesBinaryFileCompressionType"] =
+        format::GetCompressionTypeName(options.dump_resources_binary_file_compression_type);
 };
 
 bool VulkanReplayDumpResourcesJson::InitializeFile(const std::string& filename)

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -21,8 +21,11 @@
 */
 
 #include "format/format_util.h"
+#include "util/file_path.h"
 #include "Vulkan-Utility-Libraries/vk_format_utils.h"
 #include "util/file_path.h"
+#include "util/logging.h"
+#include <cstdint>
 #include PROJECT_VERSION_HEADER_FILE
 #include "generated/generated_vulkan_enum_to_string.h"
 #include "vulkan_replay_dump_resources_json.h"
@@ -165,17 +168,19 @@ nlohmann::ordered_json& VulkanReplayDumpResourcesJson::GetCurrentSubEntry()
     return current_entry != nullptr ? *current_entry : json_data_;
 }
 
-void VulkanReplayDumpResourcesJson::InsertImageSubresourceInfo(nlohmann::ordered_json& json_entry,
-                                                               VkFormat                image_format,
-                                                               VkImageType             image_type,
-                                                               format::HandleId        image_id,
-                                                               const VkExtent3D&       extent,
-                                                               const std::string&      filename,
-                                                               VkImageAspectFlagBits   aspect,
-                                                               uint32_t                mip_level,
-                                                               uint32_t                array_layer,
-                                                               bool                    separate_alpha,
-                                                               const std::string*      filename_before)
+void VulkanReplayDumpResourcesJson::InsertImageSubresourceInfo(nlohmann::ordered_json&      json_entry,
+                                                               VkFormat                     image_format,
+                                                               VkImageType                  image_type,
+                                                               format::HandleId             image_id,
+                                                               const VkExtent3D&            extent,
+                                                               const std::string&           filename,
+                                                               VkImageAspectFlagBits        aspect,
+                                                               uint32_t                     layer_count,
+                                                               uint32_t                     mip_level,
+                                                               uint32_t                     array_layer,
+                                                               const std::vector<uint64_t>* subresource_sizes,
+                                                               bool                         separate_alpha,
+                                                               const std::string*           filename_before)
 {
     const std::string aspect_str_whole(util::ToString<VkImageAspectFlagBits>(aspect));
     const std::string aspect_str(aspect_str_whole.begin() + 16, aspect_str_whole.end() - 4);
@@ -216,6 +221,21 @@ void VulkanReplayDumpResourcesJson::InsertImageSubresourceInfo(nlohmann::ordered
         else
         {
             json_entry["file"] = filename;
+        }
+    }
+
+    if (subresource_sizes != nullptr)
+    {
+        const std::string file_extension      = util::filepath::GetFilenameExtension(filename);
+        const bool        is_image_dumped_raw = !file_extension.compare(".bin");
+
+        if (is_image_dumped_raw)
+        {
+            const uint32_t sub_res_idx = mip_level * layer_count + array_layer;
+            GFXRECON_ASSERT(sub_res_idx < subresource_sizes->size());
+
+            const uint64_t subresource_size = (*subresource_sizes)[sub_res_idx];
+            json_entry["size"]              = subresource_size;
         }
     }
 }

--- a/framework/decode/vulkan_replay_dump_resources_json.h
+++ b/framework/decode/vulkan_replay_dump_resources_json.h
@@ -59,17 +59,19 @@ class VulkanReplayDumpResourcesJson
 
     nlohmann::ordered_json& GetCurrentSubEntry();
 
-    void InsertImageSubresourceInfo(nlohmann::ordered_json& json_entry,
-                                    VkFormat                image_format,
-                                    VkImageType             image_type,
-                                    format::HandleId        image_id,
-                                    const VkExtent3D&       extent,
-                                    const std::string&      filename,
-                                    VkImageAspectFlagBits   aspect,
-                                    uint32_t                mip_level       = 0,
-                                    uint32_t                array_layer     = 0,
-                                    bool                    separate_alpha  = false,
-                                    const std::string*      filename_before = nullptr);
+    void InsertImageSubresourceInfo(nlohmann::ordered_json&      json_entry,
+                                    VkFormat                     image_format,
+                                    VkImageType                  image_type,
+                                    format::HandleId             image_id,
+                                    const VkExtent3D&            extent,
+                                    const std::string&           filename,
+                                    VkImageAspectFlagBits        aspect,
+                                    uint32_t                     layer_count,
+                                    uint32_t                     mip_level         = 0,
+                                    uint32_t                     array_layer       = 0,
+                                    const std::vector<uint64_t>* subresource_sizes = nullptr,
+                                    bool                         separate_alpha    = false,
+                                    const std::string*           filename_before   = nullptr);
 
     uint32_t FetchAndAddDrawCallsEntryIndex() { return draw_calls_entry_index++; }
 

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -27,6 +27,7 @@
 #include "decode/replay_options.h"
 
 #include "decode/vulkan_resource_allocator.h"
+#include "format/format.h"
 #include "util/defines.h"
 
 #include <cstdint>
@@ -111,6 +112,8 @@ struct VulkanReplayOptions : public ReplayOptions
     bool  dump_resources_dump_raw_images{ false };
     bool  dump_resources_dump_separate_alpha{ false };
     bool  dump_resources_dump_unused_vertex_bindings{ false };
+
+    format::CompressionType dump_resources_binary_file_compression_type{ format::CompressionType::kNone };
 
     bool preload_measurement_range{ false };
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2041,8 +2041,7 @@ void VulkanCaptureManager::ProcessImportFdForImage(VkDevice device, VkImage imag
             // Combined size of all layers in a mip level.
             std::vector<uint64_t> level_sizes;
 
-            uint64_t resource_size = resource_util.GetImageResourceSizesOptimal(img.image,
-                                                                                img.format,
+            uint64_t resource_size = resource_util.GetImageResourceSizesOptimal(img.format,
                                                                                 img.type,
                                                                                 img.extent,
                                                                                 img.level_count,

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -3066,8 +3066,7 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
                     else
                     {
                         snapshot_info.resource_size =
-                            resource_util.GetImageResourceSizesOptimal(wrapper->handle,
-                                                                       wrapper->format,
+                            resource_util.GetImageResourceSizesOptimal(wrapper->format,
                                                                        wrapper->image_type,
                                                                        wrapper->extent,
                                                                        wrapper->mip_levels,

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -812,8 +812,7 @@ VulkanResourcesUtil::~VulkanResourcesUtil()
     }
 }
 
-uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkImage                image,
-                                                           VkFormat               format,
+uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkFormat               format,
                                                            VkImageType            type,
                                                            const VkExtent3D&      extent,
                                                            uint32_t               mip_levels,
@@ -1716,8 +1715,7 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
         }
         else if (resource_size == 0 || img.level_sizes == nullptr)
         {
-            resource_size = GetImageResourceSizesOptimal(img.image,
-                                                         tmp_data[i].use_blit ? dst_format : img.format,
+            resource_size = GetImageResourceSizesOptimal(tmp_data[i].use_blit ? dst_format : img.format,
                                                          img.type,
                                                          tmp_data[i].use_blit ? tmp_data[i].scaled_extent : img.extent,
                                                          img.level_count,

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -61,8 +61,8 @@ class VulkanResourcesUtil
     // resource and the size of the biggest staging buffer necessary is known in advance.
     VkResult CreateStagingBuffer(VkDeviceSize size);
 
-    // Will return the size requirements and offsets for each subresource contained in the specified image.
-    // Sizes and offsets are calculated in such a way that the each subresource will be tightly packed.
+    // Will return the size requirements and offsets for each subresource contained for an image with the specified
+    // attributes. Sizes and offsets are calculated in such a way that the each subresource will be tightly packed.
     //
     // The sizes are returned in the subresource_sizes vector and will be in the order:
     //    M0 L0 L1 ... La M1 L0 L1 ... La ... Mm L0 L1 ... La
@@ -71,8 +71,7 @@ class VulkanResourcesUtil
     // all_layers_per_level boolean determines if all array layer per mip map level will be accounted as one.
     //
     // Return value is the total size of the image.
-    uint64_t GetImageResourceSizesOptimal(VkImage                image,
-                                          VkFormat               format,
+    uint64_t GetImageResourceSizesOptimal(VkFormat               format,
                                           VkImageType            type,
                                           const VkExtent3D&      extent,
                                           uint32_t               mip_levels,

--- a/framework/util/buffer_writer.h
+++ b/framework/util/buffer_writer.h
@@ -24,6 +24,7 @@
 #define GFXRECON_UTIL_BUFFER_WRITER_H
 
 #include "util/defines.h"
+#include "util/compressor.h"
 
 #include <string>
 
@@ -31,7 +32,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
 GFXRECON_BEGIN_NAMESPACE(bufferwriter)
 
-bool WriteBuffer(const std::string& filename, const void* data, size_t size);
+bool WriteBuffer(const std::string& filename, const void* data, size_t size, const Compressor* compressor = nullptr);
 
 GFXRECON_END_NAMESPACE(gfxrecon)
 GFXRECON_END_NAMESPACE(util)

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -46,7 +46,7 @@ const char kArguments[] =
     "force-windowed,--fwo|--force-windowed-origin,--batching-memory-usage,--measurement-file,--swapchain,--sgfs|--skip-"
     "get-fence-status,--sgfr|--"
     "skip-get-fence-ranges,--dump-resources,--dump-resources-scale,--dump-resources-"
-    "image-format,--dump-resources-dir,"
+    "image-format,--dump-resources-dir,--dump-resources-binary-file-compression-type,"
     "--dump-resources-dump-color-attachment-index,--pbis,--pcj|--pipeline-creation-jobs,--save-pipeline-cache,--load-"
     "pipeline-cache,--quit-after-frame";
 
@@ -363,6 +363,10 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tDump all available mip levels and layers when dumping images.");
     GFXRECON_WRITE_CONSOLE("  --dump-resources-dump-unused-vertex-bindings");
     GFXRECON_WRITE_CONSOLE("          \t\tDump a vertex binding even if no vertex attributes references it.");
+    GFXRECON_WRITE_CONSOLE("  --dump-resources-binary-file-compression-type");
+    GFXRECON_WRITE_CONSOLE("          \t\tCompress files that are dumped as binary. Available compression types");
+    GFXRECON_WRITE_CONSOLE("          \t\tare: [none, lz4 (block format), zlib, zstd]. Default is none");
+    GFXRECON_WRITE_CONSOLE("          \t\t(no compression).");
     GFXRECON_WRITE_CONSOLE("  --pipeline-creation-jobs <num_jobs>");
     GFXRECON_WRITE_CONSOLE("          \t\tSpecify the number of asynchronous pipeline-creation jobs as integer.");
     GFXRECON_WRITE_CONSOLE("          \t\tIf <num_jobs> is negative it will be added to the number of cpu-cores");

--- a/vulkan_dump_resources.md
+++ b/vulkan_dump_resources.md
@@ -310,6 +310,9 @@ Dump resources feature can be control in several ways. To do so, a number of par
               When enabled all image resources will be dumped verbatim as raw bin files.
   --dump-resources-dump-separate-alpha
               When enabled alpha channel of dumped images will be dumped in a separate file.
+  --dump-resources-binary-file-compression-type
+              Compress files that are dumped as binary. Available compression types are: [none, lz4 (block format), zlib,
+              zlib, zstd]. Default is none (no compression).
 ```
 
 ## Output


### PR DESCRIPTION
`--dump-resources-binary-file-compression-type` chooses between the available options. Default is uncompressed