### PR TITLE
Revert "Fix `VK_EXT_frame_boundary` fake support"

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -100,6 +100,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_captured_swapchain.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_captured_swapchain.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_enum_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_feature_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_feature_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_handle_mapping_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_handle_mapping_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_cleanup_util.h
@@ -170,6 +172,7 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_consumer.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_feature_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_pnext_struct_decoder.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.cpp

--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -14,14 +14,11 @@ target_sources(gfxrecon_graphics
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_resources_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.cpp
-                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_feature_util.h
-                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_feature_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_deep_copy.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_get_pnext.h
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_dispatch_table.h
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
-                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_feature_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_extract_handles.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_extract_handles.cpp
               )

--- a/framework/application/headless_context.cpp
+++ b/framework/application/headless_context.cpp
@@ -23,7 +23,7 @@
 #include "application/headless_context.h"
 #include "application/application.h"
 #include "application/headless_window.h"
-#include "graphics/vulkan_feature_util.h"
+#include "decode/vulkan_feature_util.h"
 #include "graphics/vulkan_util.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -46,9 +46,9 @@ HeadlessContext::HeadlessContext(Application* application, bool dpi_aware) : Wsi
                 get_instance_proc_addr(nullptr, "vkEnumerateInstanceExtensionProperties"));
             std::vector<VkExtensionProperties> properties;
 
-            if (graphics::feature_util::GetInstanceExtensions(instance_extension_proc, &properties) == VK_SUCCESS)
+            if (decode::feature_util::GetInstanceExtensions(instance_extension_proc, &properties) == VK_SUCCESS)
             {
-                if (graphics::feature_util::IsSupportedExtension(properties, VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME))
+                if (decode::feature_util::IsSupportedExtension(properties, VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME))
                 {
                     supported = true;
                 }

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -200,6 +200,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/marker_json_consumer.h
                     ${CMAKE_CURRENT_LIST_DIR}/metadata_json_consumer.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_enum_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_mapping_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_mapping_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.h
@@ -278,6 +280,7 @@ target_sources(gfxrecon_decode
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_enum_to_json.cpp
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_json_consumer.h
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_json_consumer.cpp
+                    ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_feature_util.cpp
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_pnext_struct_decoder.cpp
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.h
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.cpp

--- a/framework/decode/vulkan_feature_util.cpp
+++ b/framework/decode/vulkan_feature_util.cpp
@@ -20,7 +20,7 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include "graphics/vulkan_feature_util.h"
+#include "decode/vulkan_feature_util.h"
 
 #include "util/logging.h"
 #include "util/platform.h"
@@ -32,7 +32,7 @@
 #include <algorithm>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
-GFXRECON_BEGIN_NAMESPACE(graphics)
+GFXRECON_BEGIN_NAMESPACE(decode)
 GFXRECON_BEGIN_NAMESPACE(feature_util)
 
 // There are some extensions which can be enabled by the application, but can be ignored during replay if
@@ -207,7 +207,7 @@ void RemoveExtensionIfUnsupported(const std::vector<VkExtensionProperties>& prop
                                   std::vector<const char*>*                 extensions,
                                   const char*                               extension_to_remove)
 {
-    if (!IsSupportedExtension(properties, extension_to_remove))
+    if (!feature_util::IsSupportedExtension(properties, extension_to_remove))
     {
         auto extension_iter =
             std::find_if(extensions->begin(), extensions->end(), [&extension_to_remove](const char* extension) {
@@ -256,5 +256,5 @@ void RemoveIgnorableExtensions(const std::vector<VkExtensionProperties>& propert
 }
 
 GFXRECON_END_NAMESPACE(feature_util)
-GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_feature_util.h
+++ b/framework/decode/vulkan_feature_util.h
@@ -30,7 +30,7 @@
 #include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
-GFXRECON_BEGIN_NAMESPACE(graphics)
+GFXRECON_BEGIN_NAMESPACE(decode)
 GFXRECON_BEGIN_NAMESPACE(feature_util)
 
 VkResult GetInstanceLayers(PFN_vkEnumerateInstanceLayerProperties instance_layer_proc,
@@ -71,7 +71,7 @@ void CheckUnsupportedFeatures(VkPhysicalDevice                 physicalDevice,
                               bool                             remove_unsupported);
 
 GFXRECON_END_NAMESPACE(feature_util)
-GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
 #endif // GFXRECON_DECODE_VULKAN_FEATURE_FILTER_UTIL_H

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -32,7 +32,7 @@
 #include "decode/vulkan_offscreen_swapchain.h"
 #include "decode/vulkan_address_replacer.h"
 #include "decode/vulkan_enum_util.h"
-#include "graphics/vulkan_feature_util.h"
+#include "decode/vulkan_feature_util.h"
 #include "decode/vulkan_object_cleanup_util.h"
 #include "format/format.h"
 #include "format/format_util.h"
@@ -2721,7 +2721,7 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
 
     // Sanity checks depending on extension availability
     std::vector<VkExtensionProperties> available_extensions;
-    if (graphics::feature_util::GetInstanceExtensions(instance_extension_proc, &available_extensions) == VK_SUCCESS)
+    if (feature_util::GetInstanceExtensions(instance_extension_proc, &available_extensions) == VK_SUCCESS)
     {
         // Always enable portability enumeration if available
         modified_create_info.flags &= ~VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
@@ -2739,27 +2739,26 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
         if (modified_create_info.pApplicationInfo != nullptr &&
             modified_create_info.pApplicationInfo->apiVersion < VK_MAKE_VERSION(1, 1, 0))
         {
-            graphics::feature_util::EnableExtensionIfSupported(
+            feature_util::EnableExtensionIfSupported(
                 available_extensions, &modified_extensions, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         }
 
         if (options_.remove_unsupported_features)
         {
             // Remove enabled extensions that are not available from the replay instance.
-            graphics::feature_util::RemoveUnsupportedExtensions(available_extensions, &modified_extensions);
+            feature_util::RemoveUnsupportedExtensions(available_extensions, &modified_extensions);
         }
         else if (options_.use_colorspace_fallback)
         {
             for (auto& extension_name : kColorSpaceExtensionNames)
             {
-                graphics::feature_util::RemoveExtensionIfUnsupported(
-                    available_extensions, &modified_extensions, extension_name);
+                feature_util::RemoveExtensionIfUnsupported(available_extensions, &modified_extensions, extension_name);
             }
         }
         else
         {
             // Remove enabled extensions that are ignorable from the replay instance.
-            graphics::feature_util::RemoveIgnorableExtensions(available_extensions, &modified_extensions);
+            feature_util::RemoveIgnorableExtensions(available_extensions, &modified_extensions);
         }
     }
     else
@@ -2772,7 +2771,7 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
     // debug messages from layers are displayed during replay.
     // Note that if the app also included one or more VkDebugUtilsMessengerCreateInfoEXT structs
     // in the pNext chain, those messengers will also be created.
-    if (graphics::feature_util::IsSupportedExtension(available_extensions, VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
+    if (feature_util::IsSupportedExtension(available_extensions, VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
     {
         modified_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 
@@ -2810,9 +2809,9 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
     if (options_.enable_validation_layer)
     {
         std::vector<VkLayerProperties> available_layers;
-        if (graphics::feature_util::GetInstanceLayers(instance_layer_proc, &available_layers) == VK_SUCCESS)
+        if (feature_util::GetInstanceLayers(instance_layer_proc, &available_layers) == VK_SUCCESS)
         {
-            if (graphics::feature_util::IsSupportedLayer(available_layers, kValidationLayerName))
+            if (feature_util::IsSupportedLayer(available_layers, kValidationLayerName))
             {
                 modified_layers.push_back(kValidationLayerName);
             }
@@ -3059,7 +3058,7 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
     // Add VK_EXT_frame_boundary if an option uses it
     if (options_.offscreen_swapchain_frame_boundary)
     {
-        if (!graphics::feature_util::IsSupportedExtension(modified_extensions, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
+        if (!feature_util::IsSupportedExtension(modified_extensions, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
         {
             modified_extensions.push_back(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME);
         }
@@ -3067,14 +3066,14 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
 
     // Sanity checks depending on extension availability
     std::vector<VkExtensionProperties> available_extensions;
-    if (graphics::feature_util::GetDeviceExtensions(
+    if (feature_util::GetDeviceExtensions(
             physical_device, instance_table->EnumerateDeviceExtensionProperties, &available_extensions) == VK_SUCCESS)
     {
         // If VK_EXT_frame_boundary is not supported but requested, fake it
         bool ext_frame_boundary_is_supported =
-            graphics::feature_util::IsSupportedExtension(available_extensions, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME);
+            feature_util::IsSupportedExtension(available_extensions, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME);
         bool ext_frame_boundary_is_requested =
-            graphics::feature_util::IsSupportedExtension(modified_extensions, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME);
+            feature_util::IsSupportedExtension(modified_extensions, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME);
 
         if (ext_frame_boundary_is_requested && !ext_frame_boundary_is_supported)
         {
@@ -3082,31 +3081,17 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
                 return util::platform::StringCompare(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME, extension) == 0;
             });
             modified_extensions.erase(iter);
-
-            VkBaseOutStructure* current = reinterpret_cast<VkBaseOutStructure*>(&modified_create_info);
-
-            while (current->pNext != nullptr)
-            {
-                if (current->pNext->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT)
-                {
-                    current->pNext = current->pNext->pNext;
-                    GFXRECON_LOG_WARNING(
-                        "VkPhysicalDeviceFrameBoundaryFeaturesEXT instance was removed from replay device creation");
-                    break;
-                }
-                current = current->pNext;
-            }
         }
 
         if (options_.remove_unsupported_features)
         {
-            graphics::feature_util::RemoveUnsupportedExtensions(available_extensions, &modified_extensions);
+            feature_util::RemoveUnsupportedExtensions(available_extensions, &modified_extensions);
         }
         else
         {
             // Remove enabled extensions that are not available on the replay device, but
             // that can still be safely ignored.
-            graphics::feature_util::RemoveIgnorableExtensions(available_extensions, &modified_extensions);
+            feature_util::RemoveIgnorableExtensions(available_extensions, &modified_extensions);
         }
     }
     else
@@ -3123,12 +3108,12 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
         physical_device_info->parent_info, instance_table, physical_device, &modified_create_info);
 
     // Abort on/Remove unsupported features
-    graphics::feature_util::CheckUnsupportedFeatures(physical_device,
-                                                     instance_table->GetPhysicalDeviceFeatures,
-                                                     instance_table->GetPhysicalDeviceFeatures2,
-                                                     modified_create_info.pNext,
-                                                     modified_create_info.pEnabledFeatures,
-                                                     options_.remove_unsupported_features);
+    feature_util::CheckUnsupportedFeatures(physical_device,
+                                           instance_table->GetPhysicalDeviceFeatures,
+                                           instance_table->GetPhysicalDeviceFeatures2,
+                                           modified_create_info.pNext,
+                                           modified_create_info.pEnabledFeatures,
+                                           options_.remove_unsupported_features);
 }
 
 VkResult VulkanReplayConsumerBase::PostCreateDeviceUpdateState(VulkanPhysicalDeviceInfo* physical_device_info,

--- a/framework/generated/generated_vulkan_feature_util.cpp
+++ b/framework/generated/generated_vulkan_feature_util.cpp
@@ -27,14 +27,14 @@
 **
 */
 
-#include "graphics/vulkan_feature_util.h"
+#include "decode/vulkan_feature_util.h"
 
 #include "util/logging.h"
 
 #include "format/platform_types.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
-GFXRECON_BEGIN_NAMESPACE(graphics)
+GFXRECON_BEGIN_NAMESPACE(decode)
 GFXRECON_BEGIN_NAMESPACE(feature_util)
 
 void CheckUnsupportedFeatures(VkPhysicalDevice physicalDevice,
@@ -5786,5 +5786,5 @@ void CheckUnsupportedFeatures(VkPhysicalDevice physicalDevice,
 }
 
 GFXRECON_END_NAMESPACE(feature_util)
-GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_feature_util_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_feature_util_body_generator.py
@@ -49,7 +49,7 @@ class VulkanFeatureUtilBodyGeneratorOptions(VulkanBaseGeneratorOptions):
         )
 
         self.begin_end_file_data.specific_headers.extend((
-            'graphics/vulkan_feature_util.h',
+            'decode/vulkan_feature_util.h',
             '',
             'util/logging.h',
             '',
@@ -57,7 +57,7 @@ class VulkanFeatureUtilBodyGeneratorOptions(VulkanBaseGeneratorOptions):
         ))
         self.begin_end_file_data.namespaces.extend((
             'gfxrecon',
-            'graphics',
+            'decode',
             'feature_util',
         ))
         self.begin_end_file_data.common_api_headers = []

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -52,13 +52,10 @@ target_sources(gfxrecon_graphics
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_instance_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.cpp
-                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.h
-                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_deep_copy.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_get_pnext.h
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy_stype.cpp
-                    ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_feature_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_extract_handles.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_extract_handles.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_dispatch_table.h


### PR DESCRIPTION
Reverts LunarG/gfxreconstruct#1902

This commit caused `dev` to fail to compile.  My guess is that GitHub didn't detect a merge conflict and yet the code either used a lost function or didn't bring in a function it needed.  