### PR TITLE
Fix `VK_EXT_frame_boundary` fake support

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -100,8 +100,6 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_captured_swapchain.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_captured_swapchain.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_enum_util.h
-                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_feature_util.h
-                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_feature_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_handle_mapping_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_handle_mapping_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_cleanup_util.h
@@ -172,7 +170,6 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_consumer.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.cpp
-                   ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_feature_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_pnext_struct_decoder.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.cpp

--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -14,11 +14,14 @@ target_sources(gfxrecon_graphics
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_resources_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.cpp
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_feature_util.h
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_feature_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_deep_copy.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_get_pnext.h
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_dispatch_table.h
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_deep_copy_stype.cpp
+                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_feature_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_extract_handles.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_struct_extract_handles.cpp
               )

--- a/framework/application/headless_context.cpp
+++ b/framework/application/headless_context.cpp
@@ -23,7 +23,7 @@
 #include "application/headless_context.h"
 #include "application/application.h"
 #include "application/headless_window.h"
-#include "decode/vulkan_feature_util.h"
+#include "graphics/vulkan_feature_util.h"
 #include "graphics/vulkan_util.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -46,9 +46,9 @@ HeadlessContext::HeadlessContext(Application* application, bool dpi_aware) : Wsi
                 get_instance_proc_addr(nullptr, "vkEnumerateInstanceExtensionProperties"));
             std::vector<VkExtensionProperties> properties;
 
-            if (decode::feature_util::GetInstanceExtensions(instance_extension_proc, &properties) == VK_SUCCESS)
+            if (graphics::feature_util::GetInstanceExtensions(instance_extension_proc, &properties) == VK_SUCCESS)
             {
-                if (decode::feature_util::IsSupportedExtension(properties, VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME))
+                if (graphics::feature_util::IsSupportedExtension(properties, VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME))
                 {
                     supported = true;
                 }

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -200,8 +200,6 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/marker_json_consumer.h
                     ${CMAKE_CURRENT_LIST_DIR}/metadata_json_consumer.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_enum_util.h
-                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.h
-                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_mapping_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_mapping_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.h
@@ -280,7 +278,6 @@ target_sources(gfxrecon_decode
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_enum_to_json.cpp
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_json_consumer.h
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_json_consumer.cpp
-                    ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_feature_util.cpp
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_pnext_struct_decoder.cpp
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.h
                     ${PROJECT_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.cpp

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -41,6 +41,7 @@
 #include "graphics/vulkan_device_util.h"
 #include "graphics/vulkan_struct_get_pnext.h"
 #include "graphics/vulkan_util.h"
+#include "graphics/vulkan_feature_util.h"
 #include "util/compressor.h"
 #include "util/logging.h"
 #include "util/page_guard_manager.h"
@@ -656,6 +657,10 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
     const char* const*       extensions      = pCreateInfo_unwrapped->ppEnabledExtensionNames;
     std::vector<const char*> modified_extensions;
 
+    std::vector<VkExtensionProperties> supported_extensions;
+    graphics::feature_util::GetDeviceExtensions(
+        physicalDevice, instance_table->EnumerateDeviceExtensionProperties, &supported_extensions);
+
     bool has_ext_mem      = false;
     bool has_ext_mem_host = false;
 
@@ -688,6 +693,40 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
         if (!has_ext_mem_host)
         {
             modified_extensions.push_back(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
+        }
+    }
+
+    // Check if VK_EXT_frame_boundary need to be faked (querried but not actually supported by the capture device)
+    VkBaseOutStructure*                       frame_boundary_features_parent = nullptr;
+    VkPhysicalDeviceFrameBoundaryFeaturesEXT* frame_boundary_features        = nullptr;
+    if (graphics::feature_util::IsSupportedExtension(modified_extensions, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME) &&
+        !graphics::feature_util::IsSupportedExtension(supported_extensions, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
+    {
+        auto iter = std::find_if(modified_extensions.begin(), modified_extensions.end(), [](const char* extension) {
+            return util::platform::StringCompare(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME, extension) == 0;
+        });
+        modified_extensions.erase(iter);
+
+        frame_boundary_features_parent = (VkBaseOutStructure*)pCreateInfo_unwrapped;
+
+        while (frame_boundary_features_parent->pNext != nullptr &&
+               frame_boundary_features_parent->pNext->sType !=
+                   VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT)
+        {
+            frame_boundary_features_parent = frame_boundary_features_parent->pNext;
+        }
+
+        if (frame_boundary_features_parent->pNext == nullptr)
+        {
+            frame_boundary_features_parent = nullptr;
+        }
+        else
+        {
+            frame_boundary_features =
+                reinterpret_cast<VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(frame_boundary_features_parent->pNext);
+            frame_boundary_features_parent->pNext = frame_boundary_features_parent->pNext->pNext;
+            GFXRECON_LOG_WARNING(
+                "VkPhysicalDeviceFrameBoundaryFeaturesEXT instance was removed from capture device creation");
         }
     }
 
@@ -756,6 +795,11 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
             wrapper->queue_family_creation_flags[queue_create_info->queueFamilyIndex] = queue_create_info->flags;
             wrapper->queue_family_indices[q] = pCreateInfo_unwrapped->pQueueCreateInfos[q].queueFamilyIndex;
         }
+    }
+
+    if (frame_boundary_features != nullptr)
+    {
+        frame_boundary_features_parent->pNext = reinterpret_cast<VkBaseOutStructure*>(frame_boundary_features);
     }
 
     // Restore modified property/feature create info values to the original application values

--- a/framework/generated/generated_vulkan_feature_util.cpp
+++ b/framework/generated/generated_vulkan_feature_util.cpp
@@ -27,14 +27,14 @@
 **
 */
 
-#include "decode/vulkan_feature_util.h"
+#include "graphics/vulkan_feature_util.h"
 
 #include "util/logging.h"
 
 #include "format/platform_types.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
-GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(graphics)
 GFXRECON_BEGIN_NAMESPACE(feature_util)
 
 void CheckUnsupportedFeatures(VkPhysicalDevice physicalDevice,
@@ -5786,5 +5786,5 @@ void CheckUnsupportedFeatures(VkPhysicalDevice physicalDevice,
 }
 
 GFXRECON_END_NAMESPACE(feature_util)
-GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_feature_util_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_feature_util_body_generator.py
@@ -49,7 +49,7 @@ class VulkanFeatureUtilBodyGeneratorOptions(VulkanBaseGeneratorOptions):
         )
 
         self.begin_end_file_data.specific_headers.extend((
-            'decode/vulkan_feature_util.h',
+            'graphics/vulkan_feature_util.h',
             '',
             'util/logging.h',
             '',
@@ -57,7 +57,7 @@ class VulkanFeatureUtilBodyGeneratorOptions(VulkanBaseGeneratorOptions):
         ))
         self.begin_end_file_data.namespaces.extend((
             'gfxrecon',
-            'decode',
+            'graphics',
             'feature_util',
         ))
         self.begin_end_file_data.common_api_headers = []

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -52,10 +52,13 @@ target_sources(gfxrecon_graphics
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_instance_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_deep_copy.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_get_pnext.h
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_struct_deep_copy_stype.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_feature_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_extract_handles.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_struct_extract_handles.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/../generated/generated_vulkan_dispatch_table.h

--- a/framework/graphics/vulkan_feature_util.cpp
+++ b/framework/graphics/vulkan_feature_util.cpp
@@ -20,7 +20,7 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include "decode/vulkan_feature_util.h"
+#include "graphics/vulkan_feature_util.h"
 
 #include "util/logging.h"
 #include "util/platform.h"
@@ -32,7 +32,7 @@
 #include <algorithm>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
-GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(graphics)
 GFXRECON_BEGIN_NAMESPACE(feature_util)
 
 // There are some extensions which can be enabled by the application, but can be ignored during replay if
@@ -207,7 +207,7 @@ void RemoveExtensionIfUnsupported(const std::vector<VkExtensionProperties>& prop
                                   std::vector<const char*>*                 extensions,
                                   const char*                               extension_to_remove)
 {
-    if (!feature_util::IsSupportedExtension(properties, extension_to_remove))
+    if (!IsSupportedExtension(properties, extension_to_remove))
     {
         auto extension_iter =
             std::find_if(extensions->begin(), extensions->end(), [&extension_to_remove](const char* extension) {
@@ -256,5 +256,5 @@ void RemoveIgnorableExtensions(const std::vector<VkExtensionProperties>& propert
 }
 
 GFXRECON_END_NAMESPACE(feature_util)
-GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/vulkan_feature_util.h
+++ b/framework/graphics/vulkan_feature_util.h
@@ -30,7 +30,7 @@
 #include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
-GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(graphics)
 GFXRECON_BEGIN_NAMESPACE(feature_util)
 
 VkResult GetInstanceLayers(PFN_vkEnumerateInstanceLayerProperties instance_layer_proc,
@@ -71,7 +71,7 @@ void CheckUnsupportedFeatures(VkPhysicalDevice                 physicalDevice,
                               bool                             remove_unsupported);
 
 GFXRECON_END_NAMESPACE(feature_util)
-GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
 #endif // GFXRECON_DECODE_VULKAN_FEATURE_FILTER_UTIL_H


### PR DESCRIPTION
Fix `VK_EXT_frame_boundary` fake support at device creation at capture and replay time when `VkPhysicalDeviceFrameBoundaryFeaturesEXT` is present by removing it before the actual call to the driver (and adding it again at capture time to not have a visible difference from user's perspective)

Also fixes bad merge.

Change-Id: I52e3fbf6e413703582a38be6a098c98089edca7d
