### PR TITLE
--deduplicate-device for RenderDoc and DXVK

### DIFF
--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -632,6 +632,7 @@ gfxrecon-replay         [-h | --help] [--version] [--cpu-mask <binary-mask>] [--
                         [--dump-resources-dump-all-image-subresources] <file>
                         [--pbi-all] [--pbis <index1,index2>]
                         [--pipeline-creation-jobs | --pcj <num_jobs>]
+                        [--deduplicate-device]
 
 
 Required arguments:
@@ -904,6 +905,9 @@ Optional arguments:
                         `--load-pipeline-cache`.
   --quit-after-frame
               Specify a frame after which replay will terminate.
+
+  --deduplicate-device
+              If set, at most one VkDevice will be created for each VkPhysicalDevice for RenderDoc and DXVK case.
 ```
 
 ### Key Controls

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -333,7 +333,7 @@ struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>
     std::vector<VkPhysicalDevice> replay_device_group;
 
     // For use with device deduplication
-    bool is_duplicate{ false };
+    format::HandleId duplicate_source_id{ format::kNullHandleId };
 };
 
 struct VulkanQueueInfo : public VulkanObjectInfo<VkQueue>

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -335,7 +335,7 @@ struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>
     // For use with device deduplication
     format::HandleId duplicate_source_id{ format::kNullHandleId };
 
-    void copy(VulkanDeviceInfo* source_info)
+    void copy_characteristics(const VulkanDeviceInfo* source_info)
     {
         parent                     = source_info->parent;
         allocator                  = source_info->allocator;

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -307,17 +307,17 @@ struct VulkanPhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>
 {
     VkPhysicalDevice                         parent{ VK_NULL_HANDLE };
-    std::unique_ptr<VulkanResourceAllocator> allocator;
+    std::shared_ptr<VulkanResourceAllocator> allocator;
     std::unordered_map<uint32_t, size_t>     array_counts;
 
     std::unordered_map<format::HandleId, uint64_t> opaque_addresses;
 
     // Map pipeline ID to ray tracing shader group handle capture replay data.
-    std::unordered_map<format::HandleId, const std::vector<uint8_t>> shader_group_handles;
+    std::unordered_map<format::HandleId, std::vector<uint8_t>> shader_group_handles;
 
     // The following values are only used when loading the initial state for trimmed files.
     std::vector<std::string>                   extensions;
-    std::unique_ptr<VulkanResourceInitializer> resource_initializer;
+    std::shared_ptr<VulkanResourceInitializer> resource_initializer;
 
     // Physical device property & feature state at device creation
     graphics::VulkanDevicePropertyFeatureInfo property_feature_info;
@@ -334,6 +334,21 @@ struct VulkanDeviceInfo : public VulkanObjectInfo<VkDevice>
 
     // For use with device deduplication
     format::HandleId duplicate_source_id{ format::kNullHandleId };
+
+    void copy(VulkanDeviceInfo* source_info)
+    {
+        parent                     = source_info->parent;
+        allocator                  = source_info->allocator;
+        array_counts               = source_info->array_counts;
+        opaque_addresses           = source_info->opaque_addresses;
+        shader_group_handles       = source_info->shader_group_handles;
+        extensions                 = source_info->extensions;
+        resource_initializer       = source_info->resource_initializer;
+        property_feature_info      = source_info->property_feature_info;
+        enabled_queue_family_flags = source_info->enabled_queue_family_flags;
+        replay_device_group        = source_info->replay_device_group;
+        duplicate_source_id        = source_info->capture_id;
+    }
 };
 
 struct VulkanQueueInfo : public VulkanObjectInfo<VkQueue>

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3261,16 +3261,13 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
     GFXRECON_ASSERT(device_info);
 
     // If we're doing device deduplication, check if we've already seen this create device request
-    std::bitset<VK_UUID_SIZE * 8> casted_uuid;
-    util::platform::MemoryCopy(
-        &casted_uuid, format::kUuidSize, physical_device_info->capture_pipeline_cache_uuid, VK_UUID_SIZE);
     if (options_.do_device_deduplication)
     {
-        auto it = device_uuid_map_.find(casted_uuid);
-        if (it != device_uuid_map_.end())
+        auto it = device_phy_id_map_.find(physical_device_info->capture_id);
+        if (it != device_phy_id_map_.end())
         {
             // We have seen this device before
-            auto      extant_device_id = device_uuid_map_[casted_uuid];
+            auto      extant_device_id = it->second;
             VkDevice* replay_device    = pDevice->GetHandlePointer();
 
             return SetDuplicateDeviceInfo(
@@ -3314,7 +3311,7 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
     {
         // Insert this device info into map
         auto capture_id = *pDevice->GetPointer();
-        device_uuid_map_.insert(std::pair(casted_uuid, capture_id));
+        device_phy_id_map_.insert(std::pair(physical_device_info->capture_id, capture_id));
     }
 
     return result;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3232,7 +3232,7 @@ VkResult VulkanReplayConsumerBase::PostCreateDeviceUpdateState(VulkanPhysicalDev
 }
 
 VulkanDeviceInfo*
-VulkanReplayConsumerBase::FindkDuplciateDeviceInfo(const VulkanPhysicalDeviceInfo* physical_device_info,
+VulkanReplayConsumerBase::FindkDuplicateDeviceInfo(const VulkanPhysicalDeviceInfo* physical_device_info,
                                                    const StructPointerDecoder<Decoded_VkDeviceCreateInfo>* create_info)
 {
     auto it = device_phy_id_map_.find(physical_device_info->capture_id);
@@ -3273,7 +3273,7 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                  origina
     // If we're doing device deduplication, check if we've already seen this create device request
     if (options_.do_device_deduplication)
     {
-        auto* extant_device_info = FindkDuplciateDeviceInfo(physical_device_info, pCreateInfo);
+        auto* extant_device_info = FindkDuplicateDeviceInfo(physical_device_info, pCreateInfo);
         if (extant_device_info)
         {
             // We have seen this device before

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1027,7 +1027,7 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
             have_shader_stencil_write = true;
         }
 
-        device_info->resource_initializer = std::make_unique<VulkanResourceInitializer>(
+        device_info->resource_initializer = std::make_shared<VulkanResourceInitializer>(
             device_info, max_copy_size, properties, have_shader_stencil_write, allocator, table);
     }
 }
@@ -3185,7 +3185,7 @@ VkResult VulkanReplayConsumerBase::PostCreateDeviceUpdateState(VulkanPhysicalDev
                                                     create_state.modified_create_info.enabledExtensionCount);
     InitializeResourceAllocator(physical_device_info, replay_device, enabled_extensions, allocator);
 
-    device_info->allocator = std::unique_ptr<VulkanResourceAllocator>(allocator);
+    device_info->allocator = std::shared_ptr<VulkanResourceAllocator>(allocator);
 
     // Track state of physical device properties and features at device creation
     device_info->property_feature_info = create_state.property_feature_info;
@@ -3238,14 +3238,11 @@ VulkanReplayConsumerBase::SetDuplicateDeviceInfo(VulkanPhysicalDeviceInfo* physi
                                                  VulkanDeviceInfo*                                       device_info,
                                                  format::HandleId extant_device_id)
 {
-    auto* extant_device_info         = object_info_table_->GetVkDeviceInfo(extant_device_id);
-    *replay_device                   = extant_device_info->handle;
-    device_info->duplicate_source_id = extant_device_id;
+    auto* extant_device_info = object_info_table_->GetVkDeviceInfo(extant_device_id);
+    *replay_device           = extant_device_info->handle;
+    device_info->copy(extant_device_info);
 
-    CreateDeviceInfoState create_state;
-    ModifyCreateDeviceInfo(physical_device_info, create_info, create_state);
-
-    return PostCreateDeviceUpdateState(physical_device_info, *replay_device, create_state, device_info);
+    return VK_SUCCESS;
 }
 
 VkResult

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3250,7 +3250,7 @@ VkResult VulkanReplayConsumerBase::SetDuplicateDeviceInfo(VkDevice*         repl
                                                           VulkanDeviceInfo* extant_device_info)
 {
     *replay_device = extant_device_info->handle;
-    device_info->copy(extant_device_info);
+    device_info->copy_characteristics(extant_device_info);
 
     return VK_SUCCESS;
 }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1773,7 +1773,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void DestroyInternalInstanceResources(const VulkanInstanceInfo* instance_info);
 
-    VulkanDeviceInfo* FindkDuplciateDeviceInfo(const VulkanPhysicalDeviceInfo* physical_device_info,
+    VulkanDeviceInfo* FindkDuplicateDeviceInfo(const VulkanPhysicalDeviceInfo* physical_device_info,
                                                const StructPointerDecoder<Decoded_VkDeviceCreateInfo>* create_info);
 
     VkResult SetDuplicateDeviceInfo(VkDevice*         replay_device,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1814,7 +1814,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unordered_map<graphics::VulkanDispatchKey, PFN_vkCreateDevice>            create_device_procs_;
     std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanInstanceTable> instance_tables_;
     std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanDeviceTable>   device_tables_;
-    std::unordered_map<std::bitset<VK_UUID_SIZE * 8>, format::HandleId>            device_uuid_map_;
+    std::unordered_map<format::HandleId, format::HandleId>                         device_phy_id_map_;
     std::function<void(const char*)>                                               fatal_error_handler_;
     std::shared_ptr<application::Application>                                      application_;
     CommonObjectInfoTable*                                                         object_info_table_;

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1773,6 +1773,12 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void DestroyInternalInstanceResources(const VulkanInstanceInfo* instance_info);
 
+    VkResult SetDuplicateDeviceInfo(VulkanPhysicalDeviceInfo*                               physical_device_info,
+                                    VkDevice*                                               replay_device,
+                                    const StructPointerDecoder<Decoded_VkDeviceCreateInfo>* create_info,
+                                    VulkanDeviceInfo*                                       device_info,
+                                    format::HandleId                                        extant_device_id);
+
   private:
     struct HardwareBufferInfo
     {
@@ -1808,7 +1814,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unordered_map<graphics::VulkanDispatchKey, PFN_vkCreateDevice>            create_device_procs_;
     std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanInstanceTable> instance_tables_;
     std::unordered_map<graphics::VulkanDispatchKey, graphics::VulkanDeviceTable>   device_tables_;
-    std::unordered_map<std::bitset<VK_UUID_SIZE * 8>, VkDevice>                    device_uuid_map_;
+    std::unordered_map<std::bitset<VK_UUID_SIZE * 8>, format::HandleId>            device_uuid_map_;
     std::function<void(const char*)>                                               fatal_error_handler_;
     std::shared_ptr<application::Application>                                      application_;
     CommonObjectInfoTable*                                                         object_info_table_;

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1773,11 +1773,12 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void DestroyInternalInstanceResources(const VulkanInstanceInfo* instance_info);
 
-    VkResult SetDuplicateDeviceInfo(VulkanPhysicalDeviceInfo*                               physical_device_info,
-                                    VkDevice*                                               replay_device,
-                                    const StructPointerDecoder<Decoded_VkDeviceCreateInfo>* create_info,
-                                    VulkanDeviceInfo*                                       device_info,
-                                    format::HandleId                                        extant_device_id);
+    VulkanDeviceInfo* FindkDuplciateDeviceInfo(const VulkanPhysicalDeviceInfo* physical_device_info,
+                                               const StructPointerDecoder<Decoded_VkDeviceCreateInfo>* create_info);
+
+    VkResult SetDuplicateDeviceInfo(VkDevice*         replay_device,
+                                    VulkanDeviceInfo* device_info,
+                                    VulkanDeviceInfo* extant_device_info);
 
   private:
     struct HardwareBufferInfo

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -388,7 +388,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tIf set, frames switced with vkFrameBoundANDROID will be ignored from");
     GFXRECON_WRITE_CONSOLE("          \t\tthe screenshot handler.");
     GFXRECON_WRITE_CONSOLE("  --deduplicate-device");
-    GFXRECON_WRITE_CONSOLE("          \t\tIf set, at most one VkDevice will be created for each VkPhysicalDevice.");
+    GFXRECON_WRITE_CONSOLE("          \t\tIf set, at most one VkDevice will be created for each VkPhysicalDevice for "
+                           "RenderDoc and DXVK case.");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("D3D12 only:")


### PR DESCRIPTION
Source: https://github.com/LunarG/gfxreconstruct/issues/2121
Outdated PR: https://github.com/LunarG/gfxreconstruct/pull/2306

Here is the detail of my investigation for using `RenderDoc` and `DXVK`.

1. When it uses `DXVK`, it will create two duplicate devices for one physical device. Plus, we can see `pEngineName` in `vkCreateInstance` is `DXVK`.

2. When `RenderDoc` launches `gfxrecon-replay` to replay this file, it gets these errors:
`[gfxrecon] ERROR - DEBUG MESSENGER: Frame #1: (nullptr): RenderDoc does not support multiple simultaneous logical devices.`
`[gfxrecon] FATAL - API call at index: 2020 thread: 1 vkCreateDevice returned error value VK_ERROR_INITIALIZATION_FAILED that does not match the result from the capture file: VK_SUCCESS. Replay cannot continue.`
`RenderDoc` support only one device, and the second create device is failed. The purpose of `--deduplicate-device` is to fix this issue. It will use the same device for the two duplicate devices.

3. It could get fixed in another way. Capturing the game with `RenderDoc`. The capture file could be replayed with `RenderDoc` successfully.
Add `export VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_gfxreconstruct:VK_LAYER_RENDERDOC_Capture` and `steam steam://run/app-id` could capture the game with `RenderDoc`. `RenderDoc` causes the second create device failed. GFXR captures the failed result `VK_ERROR_INITIALIZATION_FAILED`. In this case, it won't happen the replay results don't match to cause stopping replaying.

5. If we change the layer order to be `export VK_INSTANCE_LAYERS=VK_LAYER_RENDERDOC_Capture:VK_LAYER_LUNARG_gfxreconstruct`, the second create device won't be captured, and `pApplicationName` and `pEngineName` in `vkCreateInstance` are `RenderDoc Capturing App` and `RenderDoc`.  It looks that `RenderDoc` could wipe out `DXVK` effect.

6. For No. 3 and No. 4 cases,  they don't have duplicate devices issue and don't need `--deduplicate-device`.

7. But for No. 4 case, `RenderDoc` layer is before `GFXR` layer, so `GFXR` captures some `RenderDoc` code, like `GetDeviceMemoryOpaqueCaptureAddress`. Some capture code from `RenderDoc` might cause unknown errors during replay.

8. If two devices are created by different instances, `RenderDoc` could run it successfully, so this case also doesn't need `--deduplicate-device`.