### PR TITLE
Fix for trimming AccelerationStructures

### DIFF
--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -935,7 +935,7 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
             // keep track of used handles
             buffer_set.insert(buffer_info->handle);
 
-            if(buffer_info->capture_address != buffer_info->replay_address)
+            if (buffer_info->capture_address != buffer_info->replay_address)
             {
                 uint64_t offset = capture_address - buffer_info->capture_address;
 
@@ -1107,7 +1107,7 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                     auto& instances = geometry->geometry.instances;
 
                     // check if replacement is actually required
-                    if(address_remap(instances.data.deviceAddress))
+                    if (address_remap(instances.data.deviceAddress))
                     {
                         // replace VkAccelerationStructureInstanceKHR::accelerationStructureReference inside buffer
                         for (uint32_t k = 0; k < range_infos[j].primitiveCount; ++k)

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -996,7 +996,8 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
             uint32_t scratch_size      = build_geometry_info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR
                                              ? build_size_info.buildScratchSize
                                              : build_size_info.updateScratchSize;
-            bool scratch_buffer_usable = scratch_buffer_info != nullptr && scratch_buffer_info->size >= scratch_size;
+            bool scratch_buffer_usable = scratch_buffer_info != nullptr && scratch_buffer_info->size >= scratch_size &&
+                                         (scratch_buffer_info->usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
             if (!as_buffer_usable || !scratch_buffer_usable)
             {

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10813,7 +10813,7 @@ void VulkanReplayConsumerBase::ProcessBuildVulkanAccelerationStructuresMetaComma
         VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(device);
         GFXRECON_ASSERT(device_info != nullptr);
 
-        if (UseAddressReplacement(device_info))
+//        if (UseAddressReplacement(device_info))
         {
             MapStructArrayHandles(pInfos->GetMetaStructPointer(), pInfos->GetLength(), GetObjectInfoTable());
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10813,17 +10813,14 @@ void VulkanReplayConsumerBase::ProcessBuildVulkanAccelerationStructuresMetaComma
         VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(device);
         GFXRECON_ASSERT(device_info != nullptr);
 
-//        if (UseAddressReplacement(device_info))
-        {
-            MapStructArrayHandles(pInfos->GetMetaStructPointer(), pInfos->GetLength(), GetObjectInfoTable());
+        MapStructArrayHandles(pInfos->GetMetaStructPointer(), pInfos->GetLength(), GetObjectInfoTable());
 
-            VkAccelerationStructureBuildGeometryInfoKHR* build_geometry_infos = pInfos->GetPointer();
-            VkAccelerationStructureBuildRangeInfoKHR**   range_infos          = ppRangeInfos->GetPointer();
+        VkAccelerationStructureBuildGeometryInfoKHR* build_geometry_infos = pInfos->GetPointer();
+        VkAccelerationStructureBuildRangeInfoKHR**   range_infos          = ppRangeInfos->GetPointer();
 
-            GetDeviceAddressReplacer(device_info)
-                .ProcessBuildVulkanAccelerationStructuresMetaCommand(
-                    info_count, pInfos->GetPointer(), ppRangeInfos->GetPointer(), GetDeviceAddressTracker(device_info));
-        }
+        GetDeviceAddressReplacer(device_info)
+            .ProcessBuildVulkanAccelerationStructuresMetaCommand(
+                info_count, pInfos->GetPointer(), ppRangeInfos->GetPointer(), GetDeviceAddressTracker(device_info));
     }
 }
 

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -650,7 +650,6 @@ struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStru
         std::vector<VkAccelerationStructureBuildRangeInfoKHR> build_range_infos;
         std::unordered_map<format::HandleId, ASInputBuffer>   input_buffers;
     };
-//    std::optional<AccelerationStructureKHRBuildCommandData> latest_update_command_{ std::nullopt };
     std::optional<AccelerationStructureKHRBuildCommandData> latest_build_command_{ std::nullopt };
 
     struct AccelerationStructureCopyCommandData

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -650,7 +650,7 @@ struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStru
         std::vector<VkAccelerationStructureBuildRangeInfoKHR> build_range_infos;
         std::unordered_map<format::HandleId, ASInputBuffer>   input_buffers;
     };
-    std::optional<AccelerationStructureKHRBuildCommandData> latest_update_command_{ std::nullopt };
+//    std::optional<AccelerationStructureKHRBuildCommandData> latest_update_command_{ std::nullopt };
     std::optional<AccelerationStructureKHRBuildCommandData> latest_build_command_{ std::nullopt };
 
     struct AccelerationStructureCopyCommandData

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -513,21 +513,14 @@ void VulkanStateTracker::TrackAccelerationStructureBuildCommand(
         }
 
         // track all AS builds as regular builds, we'll have no AS to 'update'
-//        if (build_info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR)
+        if (wrapper->latest_build_command_)
         {
-            if (wrapper->latest_build_command_)
-            {
-                // TODO: keep original scratch-buffer, check if that makes sense
-                dst_command.geometry_info.scratchData = wrapper->latest_build_command_->geometry_info.scratchData;
-            }
-            dst_command.geometry_info.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
-            dst_command.geometry_info.srcAccelerationStructure = VK_NULL_HANDLE;
-            wrapper->latest_build_command_ = std::move(dst_command);
+            // TODO: keep original scratch-buffer, check if that makes sense
+            dst_command.geometry_info.scratchData = wrapper->latest_build_command_->geometry_info.scratchData;
         }
-//        else if (build_info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR)
-//        {
-//            wrapper->latest_update_command_ = std::move(dst_command);
-//        }
+        dst_command.geometry_info.mode                     = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+        dst_command.geometry_info.srcAccelerationStructure = VK_NULL_HANDLE;
+        wrapper->latest_build_command_                     = std::move(dst_command);
 
         wrapper->blas.clear();
 

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -513,15 +513,9 @@ void VulkanStateTracker::TrackAccelerationStructureBuildCommand(
         }
 
         // track all AS builds as regular builds, we'll have no AS to 'update'
-        if (wrapper->latest_build_command_)
-        {
-            // TODO: keep original scratch-buffer, check if that makes sense
-            dst_command.geometry_info.scratchData = wrapper->latest_build_command_->geometry_info.scratchData;
-        }
         dst_command.geometry_info.mode                     = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
         dst_command.geometry_info.srcAccelerationStructure = VK_NULL_HANDLE;
         wrapper->latest_build_command_                     = std::move(dst_command);
-
         wrapper->blas.clear();
 
         for (uint32_t g = 0; g < build_info.geometryCount; ++g)

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1727,8 +1727,8 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
         std::vector<AccelerationStructureBuildCommandData*>          tlas_build;
         std::vector<AccelerationStructureWritePropertiesCommandData> write_properties;
         std::vector<VkCopyAccelerationStructureInfoKHR>              copy_infos;
-        std::vector<AccelerationStructureBuildCommandData*>          blas_update;
-        std::vector<AccelerationStructureBuildCommandData*>          tlas_update;
+//        std::vector<AccelerationStructureBuildCommandData*>          blas_update;
+//        std::vector<AccelerationStructureBuildCommandData*>          tlas_update;
     };
 
     std::unordered_map<format::HandleId, AccelerationStructureCommands> commands;
@@ -1739,17 +1739,17 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
 
         auto& per_device_container                                            = commands[wrapper->device->handle_id];
         std::vector<AccelerationStructureBuildCommandData*>* build_container  = nullptr;
-        std::vector<AccelerationStructureBuildCommandData*>* update_container = nullptr;
+//        std::vector<AccelerationStructureBuildCommandData*>* update_container = nullptr;
 
         if (wrapper->type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR)
         {
             build_container  = &per_device_container.blas_build;
-            update_container = &per_device_container.blas_update;
+//            update_container = &per_device_container.blas_update;
         }
         else if (wrapper->type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR)
         {
             build_container  = &per_device_container.tlas_build;
-            update_container = &per_device_container.tlas_update;
+//            update_container = &per_device_container.tlas_update;
         }
 
         if (wrapper->latest_build_command_)
@@ -1761,14 +1761,14 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
             }
         }
 
-        if (wrapper->latest_update_command_)
-        {
-            update_container->push_back(&wrapper->latest_update_command_.value());
-            for (const auto& [handle_id, buffer] : wrapper->latest_update_command_->input_buffers)
-            {
-                max_resource_size = std::max(max_resource_size, buffer.bytes.size());
-            }
-        }
+//        if (wrapper->latest_update_command_)
+//        {
+//            update_container->push_back(&wrapper->latest_update_command_.value());
+//            for (const auto& [handle_id, buffer] : wrapper->latest_update_command_->input_buffers)
+//            {
+//                max_resource_size = std::max(max_resource_size, buffer.bytes.size());
+//            }
+//        }
 
         if (wrapper->latest_copy_command_)
         {
@@ -1809,15 +1809,15 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
             WriteAccelerationStructureBuildState(device, *tlas_build);
         }
 
-        for (auto& blas_update : command.blas_update)
-        {
-            WriteAccelerationStructureBuildState(device, *blas_update);
-        }
-
-        for (auto& tlas_update : command.tlas_update)
-        {
-            WriteAccelerationStructureBuildState(device, *tlas_update);
-        }
+//        for (auto& blas_update : command.blas_update)
+//        {
+//            WriteAccelerationStructureBuildState(device, *blas_update);
+//        }
+//
+//        for (auto& tlas_update : command.tlas_update)
+//        {
+//            WriteAccelerationStructureBuildState(device, *tlas_update);
+//        }
         EndAccelerationStructureSection(device);
     }
 }

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1727,8 +1727,6 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
         std::vector<AccelerationStructureBuildCommandData*>          tlas_build;
         std::vector<AccelerationStructureWritePropertiesCommandData> write_properties;
         std::vector<VkCopyAccelerationStructureInfoKHR>              copy_infos;
-//        std::vector<AccelerationStructureBuildCommandData*>          blas_update;
-//        std::vector<AccelerationStructureBuildCommandData*>          tlas_update;
     };
 
     std::unordered_map<format::HandleId, AccelerationStructureCommands> commands;
@@ -1739,17 +1737,14 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
 
         auto& per_device_container                                            = commands[wrapper->device->handle_id];
         std::vector<AccelerationStructureBuildCommandData*>* build_container  = nullptr;
-//        std::vector<AccelerationStructureBuildCommandData*>* update_container = nullptr;
 
         if (wrapper->type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR)
         {
             build_container  = &per_device_container.blas_build;
-//            update_container = &per_device_container.blas_update;
         }
         else if (wrapper->type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR)
         {
             build_container  = &per_device_container.tlas_build;
-//            update_container = &per_device_container.tlas_update;
         }
 
         if (wrapper->latest_build_command_)
@@ -1760,15 +1755,6 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
                 max_resource_size = std::max(max_resource_size, buffer.bytes.size());
             }
         }
-
-//        if (wrapper->latest_update_command_)
-//        {
-//            update_container->push_back(&wrapper->latest_update_command_.value());
-//            for (const auto& [handle_id, buffer] : wrapper->latest_update_command_->input_buffers)
-//            {
-//                max_resource_size = std::max(max_resource_size, buffer.bytes.size());
-//            }
-//        }
 
         if (wrapper->latest_copy_command_)
         {
@@ -1809,15 +1795,6 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
             WriteAccelerationStructureBuildState(device, *tlas_build);
         }
 
-//        for (auto& blas_update : command.blas_update)
-//        {
-//            WriteAccelerationStructureBuildState(device, *blas_update);
-//        }
-//
-//        for (auto& tlas_update : command.tlas_update)
-//        {
-//            WriteAccelerationStructureBuildState(device, *tlas_update);
-//        }
         EndAccelerationStructureSection(device);
     }
 }


### PR DESCRIPTION
Simplify acceleration-structure (AS) tracking and trimming by **not** differentiating between build-modes: 'build' and 'update', just treat everything as 'build'.
 
when replaying a trimmed capture, during state-init, we rebuild acceleration-structures from scratch.
`VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR` would rely on a pre-existing AS, which does not apply here.

associated scratch-buffers for an 'update' are normally smaller compared to 'build', so they could not be used when rebuilding from scratch.
for this reason we relax a condition and allow VulkanAddressReplacer to substitute those missing (or not large enough) buffers, also without using `-m rebind`.

**Fixed in this PR**:

capture:
`[gfxrecon] WARNING - vulkan_wrappers::GetWrappedId() couldn't find Handle: 0x46d6c0e27d0's wrapper. It might have been destroyed`

replay:
```
[gfxrecon] ERROR - DEBUG MESSENGER: Frame #1: VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03667: vkCmdBuildAccelerationStructuresKHR(): pInfos[0].mode is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, srcAccelerationStructure must have been previously built.
The Vulkan spec states: For each element of pInfos, if its mode member is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, its srcAccelerationStructure member must have previously been constructed with VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR

[gfxrecon] ERROR - DEBUG MESSENGER: Frame #1: VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674: vkCmdBuildAccelerationStructuresKHR(): pInfos[0].scratchData.deviceAddress (0xe00a34b000) has no buffer(s) associated that are valid.
The following buffers are missing VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT usage flag: ...

and/or consecutive

[gfxrecon] ERROR - DEBUG MESSENGER: Frame #1: VUID-vkResetFences-pFences-01123: vkResetFences(): pFences[0] (VkFence 0xa4f0000000a4f) is in use.
The Vulkan spec states: Each element of pFences must not be currently associated with any queue command that has not yet completed execution on that queue (https://vulkan.lunarg.com/doc/view/1.4.321.1/linux/antora/spec/latest/chapters/synchronization.html#VUID-vkResetFences-pFences-01123)
[gfxrecon] ERROR - DEBUG MESSENGER: Frame #1: VUID-vkBeginCommandBuffer-commandBuffer-00049: vkBeginCommandBuffer(): on active VkCommandBuffer 0x653113198190 before it has completed. You must check command buffer fence before this call.
The Vulkan spec states: commandBuffer must not be in the recording or pending state (https://vulkan.lunarg.com/doc/view/1.4.321.1/linux/antora/spec/latest/chapters/cmdbuffers.html#VUID-vkBeginCommandBuffer-commandBuffer-00049)
```

in effect, this PR enabled me to successfully capture/replay scenarios with many animated AS (general using `VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR`) with trimming, that would have failed before.

example scene used for testing AS-trimming, captured on steamdeck (combined w. test portability/address-sanitizer):
<img width="1280" height="800" alt="screenshot_frame_100" src="https://github.com/user-attachments/assets/13b505c6-184f-4ebf-b492-b2d7250250ee" />
