### PR TITLE
Use replay log settings when doing recapture

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -860,7 +860,8 @@ options:
                         Scale screenshot dimensions. Overrides --screenshot-
                         size, if specified. Expects a number which can be
                         decimal
-  --capture             Capture the replaying GFXR file. Capture option behavior and
+  --capture             Capture the replaying GFXR file. Capture uses the same log
+                        options as replay. All other capture option behavior and
                         usage is the same as when capturing with the GFXR layer. The
                         capture functionality is included in the `gfxrecon-replay`
                         executable--no GFXR capture layer is added to the Vulkan layer

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -713,7 +713,8 @@ Optional arguments:
                         unspecified screenshots will use the swapchain images
                         dimensions. If --screenshot-scale is also specified then
                         this option is ignored.
-  --capture             Capture the replaying GFXR file. Capture option behavior and
+  --capture             Capture the replaying GFXR file. Capture uses the same log
+                        options as replay. All other capture option behavior and
                         usage is the same as when capturing with the GFXR layer. The
                         capture functionality is included in the `gfxrecon-replay`
                         executable--no GFXR capture layer is added to the Vulkan layer

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -71,6 +71,8 @@ class CommonCaptureManager
 
     static format::HandleId GetUniqueId() { return ++unique_id_counter_; }
 
+    static void SetInitializeLog(bool initialize_log) { initialize_log_ = initialize_log; }
+
     using ApiSharedLockT    = std::shared_lock<ApiCallMutexT>;
     using ApiExclusiveLockT = std::unique_lock<ApiCallMutexT>;
     static auto AcquireSharedApiCallLock() { return std::move(ApiSharedLockT(api_call_mutex_)); }
@@ -526,6 +528,7 @@ class CommonCaptureManager
     static thread_local std::unique_ptr<util::ThreadData> thread_data_;
     static std::atomic<format::HandleId>                  unique_id_counter_;
     static ApiCallMutexT                                  api_call_mutex_;
+    static bool                                           initialize_log_;
 
     uint32_t instance_count_ = 0;
     struct ApiInstanceRecord

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -196,15 +196,15 @@ CaptureSettings::CaptureSettings(const TraceSettings& trace_settings)
 
 CaptureSettings::~CaptureSettings() {}
 
-void CaptureSettings::LoadSettings(CaptureSettings* settings)
+void CaptureSettings::LoadSettings(CaptureSettings* settings, bool load_log_settings)
 {
     if (settings != nullptr)
     {
         OptionsMap capture_settings;
 
         LoadOptionsFile(&capture_settings);
-        LoadOptionsEnvVar(&capture_settings);
-        ProcessOptions(&capture_settings, settings);
+        LoadOptionsEnvVar(&capture_settings, load_log_settings);
+        ProcessOptions(&capture_settings, settings, load_log_settings);
 
         LoadRunTimeEnvVarSettings(settings);
 
@@ -257,7 +257,7 @@ void CaptureSettings::LoadLogSettings(CaptureSettings* settings)
         OptionsMap capture_settings;
 
         LoadOptionsFile(&capture_settings);
-        LoadOptionsEnvVar(&capture_settings);
+        LoadOptionsEnvVar(&capture_settings, true);
         ProcessLogOptions(&capture_settings, settings);
     }
 }
@@ -276,7 +276,7 @@ void CaptureSettings::LoadSingleOptionEnvVar(OptionsMap*        options,
     }
 }
 
-void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
+void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options, bool load_log_settings)
 {
     assert(options != nullptr);
 
@@ -287,18 +287,21 @@ void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
     LoadSingleOptionEnvVar(options, kCaptureFileFlushEnvVar, kOptionKeyCaptureFileForceFlush);
 
     // Logging environment variables
-    LoadSingleOptionEnvVar(options, kLogAllowIndentsEnvVar, kOptionKeyLogAllowIndents);
-    LoadSingleOptionEnvVar(options, kLogBreakOnErrorEnvVar, kOptionKeyLogBreakOnError);
-    LoadSingleOptionEnvVar(options, kLogDetailedEnvVar, kOptionKeyLogDetailed);
-    LoadSingleOptionEnvVar(options, kLogErrorsToStderrEnvVar, kOptionKeyLogErrorsToStderr);
-    LoadSingleOptionEnvVar(options, kLogFileNameEnvVar, kOptionKeyLogFile);
-    LoadSingleOptionEnvVar(options, kLogFileCreateNewEnvVar, kOptionKeyLogFileCreateNew);
-    LoadSingleOptionEnvVar(options, kLogFileFlushAfterWriteEnvVar, kOptionKeyLogFileFlushAfterWrite);
-    LoadSingleOptionEnvVar(options, kLogFileKeepFileOpenEnvVar, kOptionKeyLogFileKeepOpen);
-    LoadSingleOptionEnvVar(options, kLogLevelEnvVar, kOptionKeyLogLevel);
-    LoadSingleOptionEnvVar(options, kLogTimestampsEnvVar, kOptionKeyLogTimestamps);
-    LoadSingleOptionEnvVar(options, kLogOutputToConsoleEnvVar, kOptionKeyLogOutputToConsole);
-    LoadSingleOptionEnvVar(options, kLogOutputToOsDebugStringEnvVar, kOptionKeyLogOutputToOsDebugString);
+    if (load_log_settings)
+    {
+        LoadSingleOptionEnvVar(options, kLogAllowIndentsEnvVar, kOptionKeyLogAllowIndents);
+        LoadSingleOptionEnvVar(options, kLogBreakOnErrorEnvVar, kOptionKeyLogBreakOnError);
+        LoadSingleOptionEnvVar(options, kLogDetailedEnvVar, kOptionKeyLogDetailed);
+        LoadSingleOptionEnvVar(options, kLogErrorsToStderrEnvVar, kOptionKeyLogErrorsToStderr);
+        LoadSingleOptionEnvVar(options, kLogFileNameEnvVar, kOptionKeyLogFile);
+        LoadSingleOptionEnvVar(options, kLogFileCreateNewEnvVar, kOptionKeyLogFileCreateNew);
+        LoadSingleOptionEnvVar(options, kLogFileFlushAfterWriteEnvVar, kOptionKeyLogFileFlushAfterWrite);
+        LoadSingleOptionEnvVar(options, kLogFileKeepFileOpenEnvVar, kOptionKeyLogFileKeepOpen);
+        LoadSingleOptionEnvVar(options, kLogLevelEnvVar, kOptionKeyLogLevel);
+        LoadSingleOptionEnvVar(options, kLogTimestampsEnvVar, kOptionKeyLogTimestamps);
+        LoadSingleOptionEnvVar(options, kLogOutputToConsoleEnvVar, kOptionKeyLogOutputToConsole);
+        LoadSingleOptionEnvVar(options, kLogOutputToOsDebugStringEnvVar, kOptionKeyLogOutputToOsDebugString);
+    }
 
     // Memory environment variables
     LoadSingleOptionEnvVar(options, kMemoryTrackingModeEnvVar, kOptionKeyMemoryTrackingMode);
@@ -384,7 +387,7 @@ void CaptureSettings::LoadOptionsFile(OptionsMap* options)
     }
 }
 
-void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* settings)
+void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* settings, bool process_log_settings)
 {
     assert(settings != nullptr);
 
@@ -528,7 +531,10 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
     settings->trace_settings_.debug_device_lost =
         ParseBoolString(FindOption(options, kDebugDeviceLost), settings->trace_settings_.debug_device_lost);
 
-    ProcessLogOptions(options, settings);
+    if (process_log_settings)
+    {
+        ProcessLogOptions(options, settings);
+    }
 
     // Screenshot options
     settings->trace_settings_.screenshot_dir =

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -280,7 +280,7 @@ class CaptureSettings
     const util::Log::Settings& GetLogSettings() const { return log_settings_; }
 
     // Load all settings.
-    static void LoadSettings(CaptureSettings* settings);
+    static void LoadSettings(CaptureSettings* settings, bool load_log_settings);
     static void LoadRunTimeEnvVarSettings(CaptureSettings* settings);
 
     // Load only log settings.
@@ -293,11 +293,11 @@ class CaptureSettings
     static void
     LoadSingleOptionEnvVar(OptionsMap* options, const std::string& environment_variable, const std::string& option_key);
 
-    static void LoadOptionsEnvVar(OptionsMap* options);
+    static void LoadOptionsEnvVar(OptionsMap* options, bool load_log_settings);
 
     static void LoadOptionsFile(OptionsMap* options);
 
-    static void ProcessOptions(OptionsMap* options, CaptureSettings* settings);
+    static void ProcessOptions(OptionsMap* options, CaptureSettings* settings, bool process_log_settings);
 
     static void ProcessLogOptions(OptionsMap* options, CaptureSettings* settings);
 

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -218,6 +218,9 @@ int main(int argc, const char** argv)
                 gfxrecon::encode::VulkanCaptureManager::SetLayerFuncs(
                     gfxrecon::vulkan_recapture::dispatch_CreateInstance,
                     gfxrecon::vulkan_recapture::dispatch_CreateDevice);
+
+                // Logger is already initialized by replay, so inform capture manager not to initialize it again.
+                gfxrecon::encode::CommonCaptureManager::SetInitializeLog(false);
             }
 
             ApiReplayOptions  api_replay_options;

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -215,7 +215,8 @@ static void PrintUsage(const char* exe_name)
 #endif
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("Vulkan only:")
-    GFXRECON_WRITE_CONSOLE("  --capture\t\tCapture the replaying GFXR file. Capture option behavior and");
+    GFXRECON_WRITE_CONSOLE("  --capture\t\tCapture the replaying GFXR file. Capture uses the same log");
+    GFXRECON_WRITE_CONSOLE("       \t\t\toptions as replay. All other capture option behavior and");
     GFXRECON_WRITE_CONSOLE("       \t\t\tusage is the same as when capturing with the GFXR layer. The");
     GFXRECON_WRITE_CONSOLE("       \t\t\tcapture functionality is included in the `gfxrecon-replay`");
     GFXRECON_WRITE_CONSOLE("       \t\t\texecutable--no GFXR capture layer is added to the Vulkan layer");


### PR DESCRIPTION
When running `gfxrecon-replay --capture`, replay sets up the log file. The capture manager also intializes the log file, overwriting the setup from replay. This change skips the log setup in the capture manager so that logging is done based on the settings provided to replay.