### PR TITLE
VDR: Filter semaphores on same submission

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -1978,8 +1978,12 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(const std::vector<VkSubmitIn
             if (dr_context != nullptr)
             {
                 assert(cmd_buf_begin_map_.find(command_buffer_handles[o]) != cmd_buf_begin_map_.end());
-                res = dr_context->DumpDispatchTraceRays(
-                    queue, index, cmd_buf_begin_map_[command_buffer_handles[o]], modified_submit_infos[s], fence);
+                res = dr_context->DumpDispatchTraceRays(queue,
+                                                        index,
+                                                        cmd_buf_begin_map_[command_buffer_handles[o]],
+                                                        modified_submit_infos[s],
+                                                        fence,
+                                                        !submitted);
                 if (res != VK_SUCCESS)
                 {
                     Release();

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -1042,19 +1042,23 @@ void DispatchTraceRaysDumpingContext::ReleaseIndirectParams()
     }
 }
 
-VkResult DispatchTraceRaysDumpingContext::DumpDispatchTraceRays(
-    VkQueue queue, uint64_t qs_index, uint64_t bcb_index, const VkSubmitInfo& submit_info, VkFence fence)
+VkResult DispatchTraceRaysDumpingContext::DumpDispatchTraceRays(VkQueue             queue,
+                                                                uint64_t            qs_index,
+                                                                uint64_t            bcb_index,
+                                                                const VkSubmitInfo& submit_info,
+                                                                VkFence             fence,
+                                                                bool                use_semaphores)
 {
     VkSubmitInfo si;
     si.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     si.pNext                = nullptr;
-    si.waitSemaphoreCount   = submit_info.waitSemaphoreCount;
-    si.pWaitSemaphores      = submit_info.pWaitSemaphores;
-    si.pWaitDstStageMask    = submit_info.pWaitDstStageMask;
+    si.waitSemaphoreCount   = use_semaphores ? submit_info.waitSemaphoreCount : 0;
+    si.pWaitSemaphores      = use_semaphores ? submit_info.pWaitSemaphores : nullptr;
+    si.pWaitDstStageMask    = use_semaphores ? submit_info.pWaitDstStageMask : nullptr;
     si.commandBufferCount   = 1;
     si.pCommandBuffers      = &DR_command_buffer_;
-    si.signalSemaphoreCount = submit_info.signalSemaphoreCount;
-    si.pSignalSemaphores    = submit_info.pSignalSemaphores;
+    si.signalSemaphoreCount = use_semaphores ? submit_info.signalSemaphoreCount : 0;
+    si.pSignalSemaphores    = use_semaphores ? submit_info.pSignalSemaphores : nullptr;
 
     const VulkanDeviceInfo* device_info = object_info_table_.GetVkDeviceInfo(original_command_buffer_info_->parent_id);
     assert(device_info);

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
@@ -75,8 +75,12 @@ class DispatchTraceRaysDumpingContext
                             uint32_t                                           dynamicOffsetCount,
                             const uint32_t*                                    pDynamicOffsets);
 
-    VkResult DumpDispatchTraceRays(
-        VkQueue queue, uint64_t qs_index, uint64_t bcb_index, const VkSubmitInfo& submit_info, VkFence fence);
+    VkResult DumpDispatchTraceRays(VkQueue             queue,
+                                   uint64_t            qs_index,
+                                   uint64_t            bcb_index,
+                                   const VkSubmitInfo& submit_info,
+                                   VkFence             fence,
+                                   bool                use_semaphores);
 
     VkResult DumpMutableResources(uint64_t bcb_index, uint64_t qs_index, uint64_t cmd_index, bool is_dispatch);
 


### PR DESCRIPTION
When dumping both draw calls and dispatch/trace rays from the same queue submit draw calls are dumped first. If wait semaphores are used in the submission then the first submission (draw calls) will sucessfully wait for the semaphore while the second submission (dispatch) will hang.