### PR TITLE
Add maximum enum-value for format::MetaDataType

### DIFF
--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -2257,7 +2257,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
     }
     else
     {
-        if (meta_data_type >= format::MetaDataType::ADDRESS_RANGE_END ||
+        if (meta_data_type >= format::MetaDataType::kBeginExperimentalReservedRange ||
             meta_data_type == format::MetaDataType::kReserved23 || meta_data_type == format::MetaDataType::kReserved25)
         {
             // Only log a warning once if the capture file contains blocks that are a "reserved" meta data type.

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -2257,8 +2257,8 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
     }
     else
     {
-        if ((meta_data_type == format::MetaDataType::kReserved23) ||
-            (meta_data_type == format::MetaDataType::kReserved25))
+        if (meta_data_type >= format::MetaDataType::ADDRESS_RANGE_END ||
+            meta_data_type == format::MetaDataType::kReserved23 || meta_data_type == format::MetaDataType::kReserved25)
         {
             // Only log a warning once if the capture file contains blocks that are a "reserved" meta data type.
             GFXRECON_LOG_WARNING_ONCE("This capture file contains meta-data block(s) with reserved type(s) that are "

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -162,7 +162,7 @@ enum class MetaDataType : uint16_t
     kInitializeMetaCommand                              = 36,
 
     //! reserve values with highest-bit for special purposes
-    ADDRESS_RANGE_END = 1U << 15U
+    kBeginExperimentalReservedRange = 1U << 15U
 };
 
 // MetaDataId is stored in the capture file and its type must be uint32_t to avoid breaking capture file compatibility.

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -160,6 +160,9 @@ enum class MetaDataType : uint16_t
     kExecuteBlocksFromFile                              = 34,
     kCreateHardwareBufferCommand                        = 35,
     kInitializeMetaCommand                              = 36,
+
+    //! reserve values with highest-bit for special purposes
+    ADDRESS_RANGE_END = 1U << 15U
 };
 
 // MetaDataId is stored in the capture file and its type must be uint32_t to avoid breaking capture file compatibility.


### PR DESCRIPTION
 reserving high-bit for 'special purposes' (like testing, experimentation, specializations, etc.)

- the intention is to provide a vendor-neutral way to have non-conflicting custom IDs