### PR TITLE
Fix `CommonCaptureManager::IsCaptureModeDisabled()`

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -599,7 +599,7 @@ bool CommonCaptureManager::IsCaptureModeWrite() const
 
 bool CommonCaptureManager::IsCaptureModeDisabled() const
 {
-    return (GetCaptureMode() & kModeDisabled) == kModeDisabled;
+    return GetCaptureMode() == kModeDisabled;
 }
 
 ParameterEncoder* CommonCaptureManager::InitApiCallCapture(format::ApiCallId call_id)


### PR DESCRIPTION
The current implementation of `CommonCaptureManager::IsCaptureModeDisabled()` cannot work because `kModeDisabled` is 0. This causes the function to always return `true` no matter the value of `GetCaptureMode()`.

This causes capture to exit instantly, before any frame is captured, when `GFXRECON_QUIT_AFTER_CAPTURE_FRAMES` is set.
