### PR TITLE
Fix crash when primary cmd-buf has invalid inheritance-data

### DIFF
--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -1805,6 +1805,16 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkImportFenceFdKHR>
 };
 
 template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBeginCommandBuffer>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkBeginCommandBuffer(args...);
+    }
+};
+
+template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBeginCommandBuffer>
 {
     template <typename... Args>

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1750,24 +1750,6 @@ VkResult VulkanCaptureManager::OverrideAllocateCommandBuffers(VkDevice          
     return result;
 }
 
-VkResult VulkanCaptureManager::OverrideBeginCommandBuffer(VkCommandBuffer                 commandBuffer,
-                                                          const VkCommandBufferBeginInfo* pBeginInfo)
-{
-    auto modified_begin_info = *pBeginInfo;
-
-    const auto command_buffer_wrapper =
-        vulkan_wrappers::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
-
-    // If command buffer level is primary, pInheritanceInfo must be ignored
-    if (command_buffer_wrapper && command_buffer_wrapper->level == VK_COMMAND_BUFFER_LEVEL_PRIMARY &&
-        modified_begin_info.pInheritanceInfo != nullptr)
-    {
-        modified_begin_info.pInheritanceInfo = nullptr;
-    }
-
-    return vulkan_wrappers::GetDeviceTable(commandBuffer)->BeginCommandBuffer(commandBuffer, &modified_begin_info);
-}
-
 void VulkanCaptureManager::ProcessEnumeratePhysicalDevices(VkResult          result,
                                                            VkInstance        instance,
                                                            uint32_t          count,
@@ -3352,6 +3334,19 @@ void VulkanCaptureManager::PreProcess_vkWaitForFences(
     }
 }
 #endif
+
+void VulkanCaptureManager::PreProcess_vkBeginCommandBuffer(VkCommandBuffer                 commandBuffer,
+                                                           const VkCommandBufferBeginInfo* pBeginInfo)
+{
+    const auto* cmd_buffer_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+
+    // If command buffer level is primary, pInheritanceInfo must be ignored
+    if (cmd_buffer_wrapper != nullptr && cmd_buffer_wrapper->level == VK_COMMAND_BUFFER_LEVEL_PRIMARY)
+    {
+        // const_cast to avoid changes to code-gen
+        const_cast<VkCommandBufferBeginInfo*>(pBeginInfo)->pInheritanceInfo = nullptr;
+    }
+}
 
 void VulkanCaptureManager::PostProcess_vkCmdBindPipeline(VkCommandBuffer     commandBuffer,
                                                          VkPipelineBindPoint pipelineBindPoint,

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1753,10 +1753,7 @@ VkResult VulkanCaptureManager::OverrideAllocateCommandBuffers(VkDevice          
 VkResult VulkanCaptureManager::OverrideBeginCommandBuffer(VkCommandBuffer                 commandBuffer,
                                                           const VkCommandBufferBeginInfo* pBeginInfo)
 {
-    auto handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
-    auto pBeginInfo_unwrapped = vulkan_wrappers::UnwrapStructPtrHandles(pBeginInfo, handle_unwrap_memory);
-
-    auto modified_begin_info = (*pBeginInfo_unwrapped);
+    auto modified_begin_info = *pBeginInfo;
 
     const auto command_buffer_wrapper =
         vulkan_wrappers::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -375,7 +375,7 @@ class VulkanCaptureManager : public ApiCaptureManager
                                             const VkCommandBufferAllocateInfo* pAllocateInfo,
                                             VkCommandBuffer*                   pCommandBuffers);
 
-    VkResult OverrideBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo);
+    void PreProcess_vkBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo);
 
     void PostProcess_vkBeginCommandBuffer(VkResult                        result,
                                           VkCommandBuffer                 commandBuffer,

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -3581,7 +3581,10 @@ VKAPI_ATTR VkResult VKAPI_CALL vkBeginCommandBuffer(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBeginCommandBuffer>::Dispatch(manager, commandBuffer, pBeginInfo);
 
-    VkResult result = manager->OverrideBeginCommandBuffer(commandBuffer, pBeginInfo);
+    auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
+    const VkCommandBufferBeginInfo* pBeginInfo_unwrapped = vulkan_wrappers::UnwrapStructPtrHandles(pBeginInfo, handle_unwrap_memory);
+
+    VkResult result = vulkan_wrappers::GetDeviceTable(commandBuffer)->BeginCommandBuffer(commandBuffer, pBeginInfo_unwrapped);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkBeginCommandBuffer);
     if (encoder)

--- a/framework/generated/khronos_generators/vulkan_generators/capture_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/capture_overrides.json
@@ -17,7 +17,6 @@
         "vkCmdWriteAccelerationStructuresPropertiesKHR": "manager->OverrideCmdWriteAccelerationStructuresPropertiesKHR",
         "vkGetPhysicalDeviceProperties2": "manager->OverrideGetPhysicalDeviceProperties2",
         "vkGetPhysicalDeviceProperties2KHR": "manager->OverrideGetPhysicalDeviceProperties2",
-        "vkAllocateCommandBuffers": "manager->OverrideAllocateCommandBuffers",
-        "vkBeginCommandBuffer": "manager->OverrideBeginCommandBuffer"
+        "vkAllocateCommandBuffers": "manager->OverrideAllocateCommandBuffers"
     }
 }


### PR DESCRIPTION
- move correction from OverrideBeginCommandBuffer() to a CustomEncoderPreCall
- cleanup override, not required anymore

closes [#2349](https://github.com/LunarG/gfxreconstruct/issues/2349)