### PR TITLE
Fix `VulkanRebindAllocator::AllocateAHBMemory`

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2199,6 +2199,7 @@ void VulkanReplayConsumerBase::InitializeResourceAllocator(const VulkanPhysicalD
     functions.get_physical_device_queue_family_properties = instance_table->GetPhysicalDeviceQueueFamilyProperties;
     functions.set_debug_utils_object_name                 = instance_table->SetDebugUtilsObjectNameEXT;
     functions.set_debug_utils_object_tag                  = instance_table->SetDebugUtilsObjectTagEXT;
+    functions.get_android_hardware_buffer_properties      = device_table->GetAndroidHardwareBufferPropertiesANDROID;
 
     if (physical_device_info->parent_info.api_version >= VK_MAKE_VERSION(1, 1, 0))
     {

--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -107,6 +107,7 @@ class VulkanResourceAllocator
         PFN_vkCreateSemaphore                              create_semaphore{ nullptr };
         PFN_vkDestroySemaphore                             destroy_semaphore{ nullptr };
         PFN_vkWaitForFences                                wait_for_fences{ nullptr };
+        PFN_vkGetAndroidHardwareBufferPropertiesANDROID    get_android_hardware_buffer_properties{ nullptr };
     };
 
   public:


### PR DESCRIPTION
According to the Vulkan specification:

(VUID-VkMemoryAllocateInfo-allocationSize-02383)
If the parameters define an import operation and the external handle type is `VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID`, `allocationSize` must be the size returned by
`vkGetAndroidHardwareBufferPropertiesANDROID` for the Android hardware buffer.

As per the current state of the code, this function can only be reached if `memory_alloc_info->ahb` is not `nullptr`, so this applies. Thus `allocationSize` must neither be the one returned by `vkGetImageMemoryRequirements` nor the capture time allocation size.

I also added a `GFXRECON_ASSERT` to make sure that `memory_alloc_info->ahb` cannot be `nullptr`.