### PR TITLE
Check before dereferencing file processor

### DIFF
--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -77,12 +77,26 @@ extern "C"
 {
     uint64_t MainGetCurrentBlockIndex()
     {
-        return file_processor->GetCurrentBlockIndex();
+        if (file_processor != nullptr)
+        {
+            return file_processor->GetCurrentBlockIndex();
+        }
+        else
+        {
+            return 0;
+        }
     }
 
     bool MainGetLoadingTrimmedState()
     {
-        return file_processor->GetLoadingTrimmedState();
+        if (file_processor != nullptr)
+        {
+            return file_processor->GetLoadingTrimmedState();
+        }
+        else
+        {
+            return false;
+        }
     }
 }
 


### PR DESCRIPTION
MainGetCurrentBlockIndex() and MainGetLoadingTrimmedState() are intended to be called by external libraries. It is possible that a call can be made soon enough that the file processor has not be initialized yet causing a null pointer dereferencing.