### PR TITLE
Bug fix in resource initializer

### DIFF
--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -365,7 +365,12 @@ VkResult VulkanResourceInitializer::TransitionImage(uint32_t              queue_
                                           1,
                                           &memory_barrier);
 
-        result = FlushCommandBuffer(queue_family_index);
+        // Check if there are pending commands from InitializeImage by checking the staging buffer's offset.
+        // If there are then don't submit the command buffer as there is still room left to init more resources
+        if (!staging_buffer_offset_)
+        {
+            result = FlushCommandBuffer(queue_family_index);
+        }
     }
 
     return result;


### PR DESCRIPTION
Under some conditions resource initializer can attempt to record vulkan commands to command buffer which is not in the recording state causing a crash.

This patch should address this issue