### PR TITLE
Zero file handle pointer after close

### DIFF
--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -340,6 +340,7 @@ void VulkanCppConsumerBase::PrintOutGlobalVar()
         }
 
         util::platform::FileClose(global_file_);
+        global_file_ = nullptr;
     }
     else
     {
@@ -461,6 +462,7 @@ void VulkanCppConsumerBase::Destroy()
         {
             WriteMainFooter();
             util::platform::FileClose(main_file_);
+            main_file_ = nullptr;
             if (platform_ != GfxToCppPlatform::PLATFORM_ANDROID)
             {
                 PrintOutCMakeFile();

--- a/framework/util/logging.cpp
+++ b/framework/util/logging.cpp
@@ -93,6 +93,7 @@ void Log::Init(Severity    min_severity,
             if (!settings_.leave_file_open)
             {
                 platform::FileClose(settings_.file_pointer);
+                settings_.file_pointer = nullptr;
             }
         }
     }
@@ -127,6 +128,7 @@ void Log::Init(const util::Log::Settings& settings)
             if (!settings_.leave_file_open)
             {
                 platform::FileClose(settings_.file_pointer);
+                settings_.file_pointer = nullptr;
             }
         }
     }

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -472,11 +472,13 @@ int main(int argc, const char** argv)
             if (tmp_file_handle != nullptr)
             {
                 gfxrecon::util::platform::FileClose(tmp_file_handle);
+                tmp_file_handle = nullptr;
             }
 
             if (!output_to_stdout)
             {
                 gfxrecon::util::platform::FileClose(out_file_handle);
+                out_file_handle = nullptr;
             }
 
             if (file_processor.GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)


### PR DESCRIPTION
Having introduced a double-close (double-free) with a non-null'd FILE * after close accidentally, I searched the codebase and found the following locations that have persistent FILE * variables or members after file close and thus *could* be subject to a double-close.