### PR TITLE
Fix ID3D10Blob trimmed capture

### DIFF
--- a/framework/encode/dx12_state_writer.h
+++ b/framework/encode/dx12_state_writer.h
@@ -112,6 +112,17 @@ class Dx12StateWriter
     void
     WriteMethodCall(format::ApiCallId call_id, format::HandleId object_id, util::MemoryOutputStream* parameter_buffer);
 
+    bool IsCachedPSOBlob(const ID3D10Blob_Wrapper* wrapper) const;
+
+    bool IsRootSignatureBlob(const ID3D10Blob_Wrapper* wrapper) const
+    {
+        return !IsCachedPSOBlob(wrapper);
+    }
+
+    void WriteRootSignatureBlobState(const Dx12StateTable& state_table);
+
+    void WriteCachedPSOBlobState(const Dx12StateTable& state_table);
+
     void WriteHeapState(const Dx12StateTable& state_table);
 
     // Returns true if memory information was successfully retrieved and written and false otherwise.


### PR DESCRIPTION
ID3D10Blob creation commands are currently written to the trimmed file state snapshot before root signature and PSO creation. This is done to handle the case where blob objects are used to create root signatures.

There is a second use case for blobs that is not currently handled correctly. This case is for cached PSO blobs returned by PSO objects. With the current order, replay processing for these blobs will fail because they are being written to the capture file before their parent object.

This change splits blobs processing into two passes, with the first pass processing root signature blobs before root signature/PSO creation and the second pass processing cached PSO blobs after PSO creation.