### PR TITLE
Set extension properties of physical_device_info

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -172,6 +172,13 @@ struct VulkanReplayDeviceInfo
     std::optional<VkPhysicalDeviceDriverProperties>                   driver_properties;
     std::optional<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>    raytracing_properties;
     std::optional<VkPhysicalDeviceAccelerationStructurePropertiesKHR> acceleration_structure_properties;
+
+    bool IsPropertiesNull()
+    {
+        // Not include memory properties.
+        return properties == std::nullopt || driver_properties == std::nullopt ||
+               raytracing_properties == std::nullopt || acceleration_structure_properties == std::nullopt;
+    }
 };
 
 template <typename T>

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1635,9 +1635,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                      const VkPhysicalDeviceProperties* capture_properties,
                                      const VkPhysicalDeviceProperties* replay_properties);
 
-    void SetPhysicalDeviceProperties(VulkanPhysicalDeviceInfo*          physical_device_info,
-                                     const VkPhysicalDeviceProperties2* capture_properties,
-                                     const VkPhysicalDeviceProperties2* replay_properties);
+    void SetPhysicalDeviceProperties2(VulkanPhysicalDeviceInfo*          physical_device_info,
+                                      const VkPhysicalDeviceProperties2* capture_properties,
+                                      const VkPhysicalDeviceProperties2* replay_properties);
 
     void SetPhysicalDeviceMemoryProperties(VulkanPhysicalDeviceInfo*               physical_device_info,
                                            const VkPhysicalDeviceMemoryProperties* capture_properties,

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -344,6 +344,7 @@ void VulkanDeviceUtil::GetReplayDeviceProperties(const VulkanInstanceUtilInfo&  
 
     if (instance_info.api_version >= VK_MAKE_VERSION(1, 1, 0))
     {
+        // properties needs to match VulkanReplayConsumerBase::SetPhysicalDeviceProperties2.
         // pNext-chaining
         VkPhysicalDeviceDriverProperties driver_properties = {};
         driver_properties.sType                            = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
@@ -351,12 +352,17 @@ void VulkanDeviceUtil::GetReplayDeviceProperties(const VulkanInstanceUtilInfo&  
         VkPhysicalDeviceRayTracingPipelinePropertiesKHR raytracing_properties = {};
         raytracing_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
 
+        VkPhysicalDeviceAccelerationStructurePropertiesKHR acc_str_properties = {};
+        acc_str_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR;
+
+        driver_properties.pNext     = &acc_str_properties;
         raytracing_properties.pNext = &driver_properties;
         device_properties2.pNext    = &raytracing_properties;
 
         instance_table->GetPhysicalDeviceProperties2(physical_device, &device_properties2);
-        replay_device_info->raytracing_properties = raytracing_properties;
-        replay_device_info->driver_properties     = driver_properties;
+        replay_device_info->raytracing_properties             = raytracing_properties;
+        replay_device_info->driver_properties                 = driver_properties;
+        replay_device_info->acceleration_structure_properties = acc_str_properties;
     }
     else
     {


### PR DESCRIPTION
A crash occurred in `VulkanReplayConsumerBase::OverrideGetRayTracingShaderGroupHandlesKHR` because `physical_device_info->replay_device_info->raytracing_properties` was null. 

The reason was the system had two GPUs, A and B, and the device used GPU B, but when the capture replayed `vkGetPhysicalDeviceProperties2`, it retrieved GPU A's properties instead. As a result, GPU B's properties were never set. In this case, GPU B's properties should have been set in `VulkanDeviceUtil::GetReplayDeviceProperties`.

It should run `VulkanDeviceUtil::GetReplayDeviceProperties` when any property in `replay_device_info` is null , not just when the main `properties` is null.