### PR TITLE
Add sccache to reuse intermediates across ci runs

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -38,6 +38,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Install build dependencies
       run: |
         sudo apt-get update
@@ -58,6 +60,10 @@ jobs:
         else
           python3 scripts/build.py --config ${{ matrix.config.type }} --skip-check-code-style --parallel 0 --test-apps
         fi
+      env:
+        SCCACHE_GHA_ENABLED: on
+        CMAKE_C_COMPILER_LAUNCHER: sccache
+        CMAKE_CXX_COMPILER_LAUNCHER: sccache
     - name: Run test app test cases
       id: test_apps
       run: |
@@ -192,6 +198,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Cache dependencies
       id: cache-deps
       uses: actions/cache@v3
@@ -204,6 +212,12 @@ jobs:
     - name: Run build script
       run: |
         python3 scripts/build.py --skip-check-code-style --config ${{ matrix.config.type }} --cmake-extra "CMAKE_PREFIX_PATH=$HOME/deps" --cmake-extra CMAKE_OSX_DEPLOYMENT_TARGET=11.0 --parallel 0 --test-apps
+      env:
+        SCCACHE_GHA_ENABLED: on
+        SCCACHE_CACHE_MULTIARCH: on
+        SCCACHE_IDLE_TIMEOUT: 0
+        CMAKE_C_COMPILER_LAUNCHER: sccache
+        CMAKE_CXX_COMPILER_LAUNCHER: sccache
     - name: Run test app test cases
       id: test_apps
       run: |
@@ -278,9 +292,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - name: Update submodules
-        run: |
-          git submodule update --init
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Set up Java
         uses: "actions/setup-java@v4"
         with:
@@ -295,6 +308,10 @@ jobs:
           else
             sh gradlew assembleDebug -Parm64-v8a
           fi
+        env:
+          SCCACHE_GHA_ENABLED: on
+          CMAKE_C_COMPILER_LAUNCHER: sccache
+          CMAKE_CXX_COMPILER_LAUNCHER: sccache
       - name: Prepare artifacts
         run: |
           mkdir gfxreconstruct-dev


### PR DESCRIPTION
This is an experiment to test using [sccache](https://github.com/mozilla/sccache) to speed up GitHub CI builds by caching intermediate build artifacts.

This change adds sccache to the Linux, Android, and macOS builds. It should be possible to add Windows in the future, but it will likely require extra steps ([example: MSVC debug format](https://deepwiki.com/mozilla/sccache/1.2-installation-and-setup#msvc-specific-configuration)).