### PR TITLE
Correct read errors with preload enabled

### DIFF
--- a/framework/decode/preload_file_processor.cpp
+++ b/framework/decode/preload_file_processor.cpp
@@ -327,18 +327,17 @@ bool PreloadFileProcessor::ReadBytes(void* buffer, size_t buffer_size)
     if (status_ == PreloadStatus::kReplay)
     {
         bytes_read = preload_buffer_.Read(buffer, buffer_size);
+        bytes_read_ += bytes_read;
         if (preload_buffer_.ReplayFinished())
         {
             status_ = PreloadStatus::kInactive;
         }
+        return bytes_read == buffer_size;
     }
     else
     {
-        bytes_read = util::platform::FileRead(buffer, buffer_size, GetFileDescriptor());
+        return Base::ReadBytes(buffer, buffer_size);
     }
-
-    bytes_read_ += bytes_read;
-    return bytes_read == buffer_size;
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/preload_file_processor.h
+++ b/framework/decode/preload_file_processor.h
@@ -33,6 +33,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class PreloadFileProcessor : public FileProcessor
 {
   public:
+    using Base = FileProcessor;
     PreloadFileProcessor();
 
     // Preloads *count* frames to continuous, expandable memory buffer


### PR DESCRIPTION
Fixes regression to preload caused by file processor IO cleanup.