### PR TITLE
VDR: Small amends for 2330

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources_delegate.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.cpp
@@ -343,7 +343,7 @@ bool DefaultVulkanDumpResourcesDelegate::DumpImageToFile(const VulkanDelegateDum
 
             if (output_image_format == kFormatBMP)
             {
-                if (options_.dump_resources_dump_all_image_subresources)
+                if (options_.dump_resources_dump_separate_alpha)
                 {
                     util::imagewriter::WriteBmpImageSeparateAlpha(
                         filename,

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -242,7 +242,7 @@ void VulkanReplayDumpResourcesJson::InsertBufferInfo(nlohmann::ordered_json& jso
 
     if (dumped_buffer.compressed_size)
     {
-        json_entry["compressedSize"] = dumped_buffer.size;
+        json_entry["compressedSize"] = dumped_buffer.compressed_size;
     }
 }
 


### PR DESCRIPTION
- When compressing raw dumped binaries the json output would report the uncompressed size where the compressed size should be reported
- Dumping the images' alpha channel separately is being falsly enabled when dumping all image subresources has been requested.