### PR TITLE
Add `--present-mode` option

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -779,8 +779,8 @@ usage: gfxrecon.py replay [-h] [-p LOCAL_FILE] [--version] [--log-level LEVEL]
                           [--flush-measurement-range]
                           [--flush-inside-measurement-range] [--sgfs STATUS]
                           [--sgfr FRAME-RANGES] [--wait-before-present]
-                          [-m MODE] [--swapchain MODE] [--vssb]
-                          [--use-captured-swapchain-indices]
+                          [-m MODE] [--swapchain MODE] [--present-mode MODE]
+                          [--vssb] [--use-captured-swapchain-indices]
                           [--dump-resources DUMP_RESOURCES]
                           [--dump-resources-before-draw]
                           [--dump-resources-image-format FORMAT]
@@ -965,6 +965,9 @@ options:
   --swapchain MODE      Choose a swapchain mode to replay. Available modes
                         are: virtual, captured, offscreen (forwarded to replay
                         tool)
+  --present-mode MODE   Set swapchain's VkPresentModeKHR. Available modes are:
+                        capture, immediate, mailbox, fifo, fifo_relaxed
+                        (forwarded to replay tool)
   --vssb, --virtual-swapchain-skip-blit
                         Skip blit to real swapchain to gain performance during
                         replay.

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -621,6 +621,7 @@ gfxrecon-replay         [-h | --help] [--version] [--cpu-mask <binary-mask>] [--
                         [-m <mode> | --memory-translation <mode>]
                         [--fwo <x,y> | --force-windowed-origin <x,y>]
                         [--swapchain MODE] [--use-captured-swapchain-indices]
+                        [--present-mode <mode>]
                         [--mfr|--measurement-frame-range <start-frame>-<end-frame>]
                         [--measurement-file <file>] [--quit-after-measurement-range]
                         [--flush-measurement-range]
@@ -783,6 +784,13 @@ Optional arguments:
                                         capture directly on the swapchain setup for replay.
                             offscreen   Disable creating swapchains, surfaces
                                         and windows. To see rendering, add the --screenshots option.
+  --present-mode <mode> Set swapchain's VkPresentModeKHR.
+                        Available modes are:
+                            capture: Present mode used at capture time.
+                            immediate: VK_PRESENT_MODE_IMMEDIATE_KHR
+                            mailbox: VK_PRESENT_MODE_MAILBOX_KHR
+                            fifo: VK_PRESENT_MODE_FIFO_KHR
+                            fifo_relaxed: VK_PRESENT_MODE_FIFO_RELAXED_KHR
   --vssb
                         Skip blit to real swapchain to gain performance during replay.
   --use-captured-swapchain-indices

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -128,6 +128,7 @@ def CreateReplayParser():
     parser.add_argument('--wait-before-present', action='store_true', default=False, help='Force wait on completion of queue operations for all queues before calling Present. This is needed for accurate acquisition of instrumentation data on some platforms.')
     parser.add_argument('-m', '--memory-translation', metavar='MODE', choices=['none', 'remap', 'realign', 'rebind'], help='Enable memory translation for replay on GPUs with memory types that are not compatible with the capture GPU\'s memory types.  Available modes are: none, remap, realign, rebind (forwarded to replay tool)')
     parser.add_argument('--swapchain', metavar='MODE', choices=['virtual', 'captured', 'offscreen'], help='Choose a swapchain mode to replay. Available modes are: virtual, captured, offscreen (forwarded to replay tool)')
+    parser.add_argument('--present-mode', metavar='MODE', choices=['capture', 'immediate', 'mailbox', 'fifo', 'fifo_relaxed'], help='Set swapchain\'s VkPresentModeKHR. Available modes are: auto, immediate, mailbox, fifo, fifo_relaxed (forwarded to replay tool)')
     parser.add_argument('--vssb', '--virtual-swapchain-skip-blit', action='store_true', default=False, help='Skip blit to real swapchain to gain performance during replay.')
     parser.add_argument('--use-captured-swapchain-indices', action='store_true', default=False, help='Same as "--swapchain captured". Ignored if the "--swapchain" option is used.')
     parser.add_argument('file', nargs='?', help='File on device to play (forwarded to replay tool)')
@@ -270,6 +271,10 @@ def MakeExtrasString(args):
     if args.swapchain:
         arg_list.append('--swapchain')
         arg_list.append('{}'.format(args.swapchain))
+
+    if args.present_mode:
+        arg_list.append('--present-mode')
+        arg_list.append('{}'.format(args.present_mode))
 
     if args.offscreen_swapchain_frame_boundary:
         arg_list.append('--offscreen-swapchain-frame-boundary')

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -7520,9 +7520,6 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
                     break;
             }
 
-            VulkanPhysicalDeviceInfo* physical_device_info =
-                object_info_table_->GetVkPhysicalDeviceInfo(device_info->parent_id);
-
             auto instance_table = GetInstanceTable(physical_device_info->parent);
 
             uint32_t present_mode_count;
@@ -7535,15 +7532,9 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
                                                                     &present_mode_count,
                                                                     supported_present_modes.data());
 
-            bool is_supported = false;
-            for (VkPresentModeKHR supported_present_mode : supported_present_modes)
-            {
-                if (supported_present_mode == present_mode)
-                {
-                    is_supported = true;
-                    break;
-                }
-            }
+            bool is_supported =
+                std::find(supported_present_modes.begin(), supported_present_modes.end(), present_mode) !=
+                supported_present_modes.end();
 
             if (is_supported)
             {

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -7497,6 +7497,65 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
             }
         }
 
+        if (options_.present_mode_option != util::PresentModeOption::kCapture)
+        {
+            VkPresentModeKHR present_mode = modified_create_info.presentMode;
+
+            switch (options_.present_mode_option)
+            {
+                case util::PresentModeOption::kImmediate:
+                    present_mode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+                    break;
+                case util::PresentModeOption::kMailbox:
+                    present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+                    break;
+                case util::PresentModeOption::kFifo:
+                    present_mode = VK_PRESENT_MODE_FIFO_KHR;
+                    break;
+                case util::PresentModeOption::kFifoRelaxed:
+                    present_mode = VK_PRESENT_MODE_FIFO_RELAXED_KHR;
+                    break;
+                default:
+                    // If something else, just leave it untouched.
+                    break;
+            }
+
+            VulkanPhysicalDeviceInfo* physical_device_info =
+                object_info_table_->GetVkPhysicalDeviceInfo(device_info->parent_id);
+
+            auto instance_table = GetInstanceTable(physical_device_info->parent);
+
+            uint32_t present_mode_count;
+            instance_table->GetPhysicalDeviceSurfacePresentModesKHR(
+                physical_device_info->handle, modified_create_info.surface, &present_mode_count, nullptr);
+
+            std::vector<VkPresentModeKHR> supported_present_modes(present_mode_count);
+            instance_table->GetPhysicalDeviceSurfacePresentModesKHR(physical_device_info->handle,
+                                                                    modified_create_info.surface,
+                                                                    &present_mode_count,
+                                                                    supported_present_modes.data());
+
+            bool is_supported = false;
+            for (VkPresentModeKHR supported_present_mode : supported_present_modes)
+            {
+                if (supported_present_mode == present_mode)
+                {
+                    is_supported = true;
+                    break;
+                }
+            }
+
+            if (is_supported)
+            {
+                modified_create_info.presentMode = present_mode;
+            }
+            else
+            {
+                GFXRECON_LOG_ERROR("Swapchain present mode '%s' is requested but not supported",
+                                   util::ToString<VkPresentModeKHR>(present_mode).c_str())
+            }
+        }
+
         result = swapchain_->CreateSwapchainKHR(original_result,
                                                 func,
                                                 device_info,

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -73,6 +73,7 @@ struct VulkanReplayOptions : public ReplayOptions
     bool                         use_colorspace_fallback{ false };
     bool                         offscreen_swapchain_frame_boundary{ false };
     util::SwapchainOption        swapchain_option{ util::SwapchainOption::kVirtual };
+    util::PresentModeOption      present_mode_option{ util::PresentModeOption::kCapture };
     bool                         virtual_swapchain_skip_blit{ false };
     int32_t                      override_gpu_group_index{ -1 };
     int32_t                      surface_index{ -1 };

--- a/framework/util/options.h
+++ b/framework/util/options.h
@@ -55,6 +55,15 @@ enum class SwapchainOption : uint32_t
     kOffscreen = 2,
 };
 
+enum class PresentModeOption : uint32_t
+{
+    kCapture     = 0,
+    kImmediate   = 1,
+    kMailbox     = 2,
+    kFifo        = 3,
+    kFifoRelaxed = 4,
+};
+
 //----------------------------------------------------------------------------
 /// Read a boolean value out of a string
 /// \param  value_string Input string

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -48,7 +48,7 @@ const char kArguments[] =
     "skip-get-fence-ranges,--dump-resources,--dump-resources-scale,--dump-resources-"
     "image-format,--dump-resources-dir,--dump-resources-binary-file-compression-type,"
     "--dump-resources-dump-color-attachment-index,--pbis,--pcj|--pipeline-creation-jobs,--save-pipeline-cache,--load-"
-    "pipeline-cache,--quit-after-frame";
+    "pipeline-cache,--quit-after-frame,--present-mode";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -76,7 +76,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--remove-unsupported] [--validate]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--onhb | --omit-null-hardware-buffers]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[-m <mode> | --memory-translation <mode>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--swapchain <mode>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--swapchain <mode>] [--present-mode <mode>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--vssb | --virtual-swapchain-skip-blit]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-captured-swapchain-indices]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-colorspace-fallback]");
@@ -268,6 +268,13 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\t         \tcapture directly on the swapchain setup for replay.");
     GFXRECON_WRITE_CONSOLE("          \t\t    %s\tDisable creating swapchains, surfaces", kSwapchainOffscreen);
     GFXRECON_WRITE_CONSOLE("          \t\t         \tand windows. To see rendering, add the --screenshots option.");
+    GFXRECON_WRITE_CONSOLE("  --present-mode <mode>\tSet swapchain's VkPresentModeKHR.");
+    GFXRECON_WRITE_CONSOLE("          \t\tAvailable modes are:");
+    GFXRECON_WRITE_CONSOLE("          \t\t\t%s: Present mode used at capture time.", kPresentModeCapture);
+    GFXRECON_WRITE_CONSOLE("          \t\t\t%s: VK_PRESENT_MODE_IMMEDIATE_KHR", kPresentModeImmediate);
+    GFXRECON_WRITE_CONSOLE("          \t\t\t%s: VK_PRESENT_MODE_MAILBOX_KHR", kPresentModeMailbox);
+    GFXRECON_WRITE_CONSOLE("          \t\t\t%s: VK_PRESENT_MODE_FIFO_KHR", kPresentModeFifo);
+    GFXRECON_WRITE_CONSOLE("          \t\t\t%s: VK_PRESENT_MODE_FIFO_RELAXED_KHR", kPresentModeFifoRelaxed);
     GFXRECON_WRITE_CONSOLE("  --vssb");
     GFXRECON_WRITE_CONSOLE("          \t\tSkip blit to real swapchain to gain performance during replay.");
     GFXRECON_WRITE_CONSOLE("  --use-captured-swapchain-indices");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -124,6 +124,7 @@ const char kQuitAfterFrameArgument[]             = "--quit-after-frame";
 const char kFlushMeasurementRangeOption[]        = "--flush-measurement-range";
 const char kFlushInsideMeasurementRangeOption[]  = "--flush-inside-measurement-range";
 const char kSwapchainOption[]                    = "--swapchain";
+const char kPresentModeOption[]                  = "--present-mode";
 const char kEnableUseCapturedSwapchainIndices[] =
     "--use-captured-swapchain-indices"; // The same: util::SwapchainOption::kCaptured
 const char kVirtualSwapchainSkipBlitShortOption[] = "--vssb";
@@ -202,6 +203,12 @@ const char kMemoryTranslationRebind[]  = "rebind";
 const char kSwapchainVirtual[]   = "virtual";
 const char kSwapchainCaptured[]  = "captured";
 const char kSwapchainOffscreen[] = "offscreen";
+
+const char kPresentModeCapture[]     = "capture";
+const char kPresentModeImmediate[]   = "immediate";
+const char kPresentModeMailbox[]     = "mailbox";
+const char kPresentModeFifo[]        = "fifo";
+const char kPresentModeFifoRelaxed[] = "fifo_relaxed";
 
 const char kScreenshotFormatBmp[] = "bmp";
 const char kScreenshotFormatPng[] = "png";
@@ -1134,6 +1141,32 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
         {
             GFXRECON_LOG_WARNING("Ignoring unrecognized \"--swapchain\" option: %s", swapchain_option.c_str());
         }
+    }
+
+    auto present_mode_option = arg_parser.GetArgumentValue(kPresentModeOption);
+    if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeCapture, present_mode_option.c_str()) == 0)
+    {
+        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kCapture;
+    }
+    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeImmediate, present_mode_option.c_str()) == 0)
+    {
+        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kImmediate;
+    }
+    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeMailbox, present_mode_option.c_str()) == 0)
+    {
+        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kMailbox;
+    }
+    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeFifo, present_mode_option.c_str()) == 0)
+    {
+        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kFifo;
+    }
+    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeFifoRelaxed, present_mode_option.c_str()) == 0)
+    {
+        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kFifoRelaxed;
+    }
+    else if (!present_mode_option.empty())
+    {
+        GFXRECON_LOG_WARNING("Ignoring unrecognized \"--present-mode\" option: %s", present_mode_option.c_str());
     }
 
     if (arg_parser.IsOptionSet(kColorspaceFallback))


### PR DESCRIPTION
Add an option to adjust the swapchain's present mode used at replay time.

Present mode may need to be modified for performance measurement reasons or for portability reasons.
This commit allows to set a particular present mode to use.
