### PR TITLE
fix typo in fixEtensions

### DIFF
--- a/framework/generated/khronos_generators/openxr_generators/gencode.py
+++ b/framework/generated/khronos_generators/openxr_generators/gencode.py
@@ -764,7 +764,7 @@ def gen_target(args):
                 file=sys.stderr
             )
             write(
-                '* options.emitEtensions    =',
+                '* options.emitExtensions    =',
                 options.emitExtensions,
                 file=sys.stderr
             )

--- a/framework/generated/khronos_generators/vulkan_generators/gencode.py
+++ b/framework/generated/khronos_generators/vulkan_generators/gencode.py
@@ -980,7 +980,7 @@ def gen_target(args):
                 file=sys.stderr
             )
             write(
-                '* options.emitEtensions    =',
+                '* options.emitExtensions    =',
                 options.emitExtensions,
                 file=sys.stderr
             )


### PR DESCRIPTION
Fix spelling of "emitExtensions" in a debug print.  This doesn't impact our compiled code, but still helpful to prevent confusion