### PR TITLE
Reuse memory to reduce memory usage for rebind

### DIFF
--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -1818,12 +1818,12 @@ void VulkanRebindAllocator::WriteBoundResource(ResourceAllocInfo* resource_alloc
     }
 }
 
-bool VulkanRebindAllocator::TranslateMemoryRange(const VmaMemoryInfo*     bound_memory_info,
-                                                 VkDeviceSize             original_start,
-                                                 VkDeviceSize             original_end,
-                                                 VkDeviceSize*            src_offset,
-                                                 VkDeviceSize*            dst_offset,
-                                                 VkDeviceSize*            data_size)
+bool VulkanRebindAllocator::TranslateMemoryRange(const VmaMemoryInfo* bound_memory_info,
+                                                 VkDeviceSize         original_start,
+                                                 VkDeviceSize         original_end,
+                                                 VkDeviceSize*        src_offset,
+                                                 VkDeviceSize*        dst_offset,
+                                                 VkDeviceSize*        data_size)
 {
     assert((src_offset != nullptr) && (dst_offset != nullptr) && (data_size));
 
@@ -1900,9 +1900,9 @@ void VulkanRebindAllocator::UpdateBoundResource(ResourceAllocInfo* resource_allo
 }
 
 VkResult VulkanRebindAllocator::UpdateMappedMemoryRange(
-    VmaMemoryInfo*     bound_memory_info,
-    VkDeviceSize       original_start,
-    VkDeviceSize       original_end,
+    VmaMemoryInfo* bound_memory_info,
+    VkDeviceSize   original_start,
+    VkDeviceSize   original_end,
     VkResult (*update_func)(VmaAllocator, VmaAllocation, VkDeviceSize, VkDeviceSize))
 {
     VkResult     result     = VK_SUCCESS;
@@ -2981,7 +2981,6 @@ uint64_t VulkanRebindAllocator::GetDeviceMemoryOpaqueCaptureAddress(const VkDevi
     }
 
     uint64_t result = 0;
-
 
     for (const auto& mem_info : memory_alloc_info->vma_mem_infos)
     {

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -508,7 +508,7 @@ VulkanRebindAllocator::GetVideoSessionMemoryRequirementsKHR(VkVideoSessionKHR vi
         auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
 
         resource_alloc_info->capture_mem_reqs.resize(*memory_requirements_count);
-        
+
         for (uint32_t i = 0; i < *memory_requirements_count; ++i)
         {
             resource_alloc_info->capture_mem_reqs[i] = memory_requirements[i].memoryRequirements;

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -2900,7 +2900,7 @@ VkResult VulkanRebindAllocator::QueueBindSparse(VkQueue                 queue,
                         VkMemoryRequirements requirements;
                         functions_.get_buffer_memory_requirements(device_, bind.buffer, &requirements);
 
-                        requirements.size = mem_alloc_info->allocation_size;
+                        requirements.size = bind.pBinds[m_i].size;
 
                         auto usage = GetBufferMemoryUsage(
                             res_alloc_info->usage,
@@ -2959,7 +2959,7 @@ VkResult VulkanRebindAllocator::QueueBindSparse(VkQueue                 queue,
                         VkMemoryRequirements requirements;
                         functions_.get_image_memory_requirements(device_, bind.image, &requirements);
 
-                        requirements.size = mem_alloc_info->allocation_size;
+                        requirements.size = bind.pBinds[m_i].size;
 
                         auto usage = GetImageMemoryUsage(
                             res_alloc_info->usage,
@@ -3018,7 +3018,9 @@ VkResult VulkanRebindAllocator::QueueBindSparse(VkQueue                 queue,
                         VkMemoryRequirements requirements;
                         functions_.get_image_memory_requirements(device_, bind.image, &requirements);
 
-                        requirements.size = mem_alloc_info->allocation_size;
+                        // TODO: Set the exact size in requirements.size for allocating sparse image memory.
+                        requirements.size = std::min(requirements.size,
+                                                     mem_alloc_info->allocation_size - bind.pBinds[m_i].memoryOffset);
 
                         auto usage = GetImageMemoryUsage(
                             res_alloc_info->usage,

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -644,7 +644,9 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                           uint32_t                  object_bind_index,
                                           uint32_t                  memory_bind_index,
                                           std::vector<VkSemaphore>& semaphores,
-                                          const VmaMemoryInfo*      vma_mem_info);
+                                          ResourceData              allocator_data,
+                                          MemoryData                allocator_mem_data,
+                                          VkMemoryPropertyFlags     mem_properties);
 
   private:
     VkDevice                         device_ = VK_NULL_HANDLE;

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -447,8 +447,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                  (create_info.requiredFlags == alc_create_info.requiredFlags) &&
                  (create_info.preferredFlags == alc_create_info.preferredFlags) &&
                  (create_info.memoryTypeBits == alc_create_info.memoryTypeBits) &&
-                 (create_info.pool == alc_create_info.pool) && (create_info.pUserData == alc_create_info.pUserData) &&
-                 (create_info.priority == alc_create_info.priority)))
+                 (create_info.pool == alc_create_info.pool) && (create_info.priority == alc_create_info.priority)))
             {
                 return true;
             }

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -457,7 +457,13 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                 (create_info.pool == alc_create_info.pool) && (create_info.priority == alc_create_info.priority) &&
                 !requires_dedicated_allocation && !prefers_dedicated_allocation)
             {
-                return true;
+                // GetRebindOffsetFromOriginalDeviceMemory
+                auto offset_from_device_memory = offset - offset_from_original_device_memory + allocation_info.offset;
+                // memoryOffset is must be an integer multiple of the VkMemoryRequirements::alignment
+                if (offset_from_device_memory % req.alignment == 0)
+                {
+                    return true;
+                }
             }
             return false;
         }

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -428,6 +428,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         VkMemoryRequirements    mem_req{};
         VmaAllocationCreateInfo alc_create_info{};
         VkDeviceSize            offset_from_original_device_memory{ 0 };
+        uint64_t                reference_count{ 0 };
 
         VmaAllocation     allocation{ VK_NULL_HANDLE };
         VmaAllocationInfo allocation_info{};

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -424,9 +424,9 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     // Create a new allocation for a binding memory case.
     struct VmaMemoryInfo
     {
-        MemoryAllocInfo*        memory_info{ nullptr };
-        VkMemoryRequirements    capture_mem_req{};
-        VkMemoryRequirements    replay_mem_req{};
+        MemoryAllocInfo*     memory_info{ nullptr };
+        VkMemoryRequirements capture_mem_req{};
+        VkMemoryRequirements replay_mem_req{};
 
         // If requires_dedicated_allocation or prefers_dedicated_allocation is true, the object should have an its own
         // memory, not shared.
@@ -449,8 +449,8 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                          const VmaAllocationCreateInfo& create_info) const
         {
             // If capture_req.size is 0, it means the memory requirement is not recorded in the capture file.
-            // It didn't call vkGetImageMemoryRequirements or vkGetBufferMemoryRequirements before, like swapchain images. 
-            // We can't be sure it's compatible.
+            // It didn't call vkGetImageMemoryRequirements or vkGetBufferMemoryRequirements before, like swapchain
+            // images. We can't be sure it's compatible.
             if (caputre_req.size == 0)
             {
                 return false;
@@ -487,12 +487,12 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         std::vector<VmaMemoryInfo*>       bound_memory_infos; // VideoSeesion and sparse could be multiple bindings.
         std::vector<VkMemoryRequirements> capture_mem_reqs{};
 
-        VkObjectType                object_type{ VK_OBJECT_TYPE_UNKNOWN };
-        VkFlags                     usage{ 0 };
-        VkImageTiling               tiling{};
-        uint32_t                    height{ 0 };
-        bool                        uses_extensions{ false };
-        VkFormat                    format{ VK_FORMAT_UNDEFINED };
+        VkObjectType  object_type{ VK_OBJECT_TYPE_UNKNOWN };
+        VkFlags       usage{ 0 };
+        VkImageTiling tiling{};
+        uint32_t      height{ 0 };
+        bool          uses_extensions{ false };
+        VkFormat      format{ VK_FORMAT_UNDEFINED };
 
         std::string          debug_utils_name;
         std::vector<uint8_t> debug_utils_tag;

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -421,12 +421,10 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         kVideoSession // array: video_session
     };
 
-    // Create a new allocation for a binding memory case. The binding offset is allocation_info's offset, instead of
-    // original offset.
+    // Create a new allocation for a binding memory case.
     struct VmaMemoryInfo
     {
-        MemoryAllocInfo* memory_info{ nullptr }; // If memory_info is nullptr, the memory could be free.
-
+        MemoryAllocInfo*        memory_info{ nullptr };
         VkMemoryRequirements    mem_req{};
         VmaAllocationCreateInfo alc_create_info{};
         VkDeviceSize            offset_from_original_device_memory{ 0 };
@@ -436,9 +434,6 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
 
         bool             is_host_visible{ false };
         void*            mapped_pointer{ nullptr };
-        VkDeviceSize     rebind_offset{ 0 };
-        VkDeviceSize     original_size{ 0 };
-        VkDeviceSize     rebind_size{ 0 };
 
         bool is_compatible(VkDeviceSize                   offset,
                            const VkMemoryRequirements&    req,
@@ -464,8 +459,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     struct ResourceAllocInfo
     {
         MemoryInfoType              memory_info_type;
-        std::vector<VmaMemoryInfo*> bound_memory_infos;
-        std::vector<VkDeviceSize>   original_sizes; // video_session is array, the others are single.
+        std::vector<VmaMemoryInfo*> bound_memory_infos; // VideoSeesion and sparse could be multiple bindings.
         VkObjectType                object_type{ VK_OBJECT_TYPE_UNKNOWN };
         VkFlags                     usage{ 0 };
         VkImageTiling               tiling{};

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -520,6 +520,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         std::string          debug_utils_name;
         std::vector<uint8_t> debug_utils_tag;
         uint64_t             debug_utils_tag_name;
+        bool                 is_free{ false };
     };
 
   private:
@@ -650,6 +651,8 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                   bool                           prefers_dedicated_allocation,
                                   const VmaAllocationCreateInfo& alc_create_info,
                                   VmaMemoryInfo**                vma_mem_info);
+
+    void RemoveVmaMemoryInfo(ResourceAllocInfo& resource_alloc_info, uint64_t object_handle);
 
     void UpdateAllocInfo(ResourceAllocInfo&     resource_alloc_info,
                          uint64_t               object_handle,


### PR DESCRIPTION
For rebind, it allocated memory when a object was bound to a memory. It could allocate duplicated memory when two objects were bound to the same memory to cause OUT_OF_MEMORY. In order to reduce memory usage, it attempts to find a compatible existing `VmaMemoryInfo` before allocating new memory. Plus, it needs to consider offset for binding because the memory could not be specifically allocated to an object.