### PR TITLE
VDR: Dump more formats as srgb

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -106,7 +106,7 @@ static VkFormat ChooseDestinationImageFormat(VkFormat format)
 {
     VkFormat dst_format;
 
-    if (vkuFormatIsSRGB(format))
+    if (vkuFormatIsSRGB(format) || vkuFormatIsSFLOAT(format) || vkuFormatIsSNORM(format))
     {
         dst_format = vkuFormatHasAlpha(format) ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8_SRGB;
     }


### PR DESCRIPTION
SFLOAT and SNORM formats should also be converted into srgb when dumping images in bmps/pngs