### PR TITLE
VDR: Remove unnnececary error message

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -1446,9 +1446,6 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
 
                             if (!IsImageDumpable(instance_table_, object_info_table_, img_info))
                             {
-                                GFXRECON_LOG_ERROR("Image %" PRIu64
-                                                   " cannot be dumped as not supported/missing features",
-                                                   img_info->capture_id);
                                 continue;
                             }
 


### PR DESCRIPTION
There was a forgotten error message related to whether an image can be dumped or not left by mistake. This error should be removed as the case it generates as an error is already treated as a warning inside IsImageDumpable.