### PR TITLE
Zulauf mmap patch

### DIFF
--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -49,7 +49,16 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+// WIP WIP WIP Enable memory mapped file support on Windows platforms.
+// TODO: Test and enable on POSIX platforms.
+#ifdef WIN32
+// Currently, memory mapped file support is only tested Windows platforms.
+// A POSIX implementation has been sketched, but not even compile tested.
+using FileInputStream = util::MappedFileInputStream;
+#else
 using FileInputStream    = util::FStreamFileInputStream;
+#endif
+
 using FileInputStreamPtr = std::shared_ptr<FileInputStream>;
 
 class FileProcessor;

--- a/framework/util/file_input_stream.cpp
+++ b/framework/util/file_input_stream.cpp
@@ -29,11 +29,184 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
+#if !defined(WIN32)
+#include <sys/mman.h>
+#endif
+
 #include "util/file_input_stream.h"
 #include "util/logging.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
+
+#if defined(WIN32)
+MappedFileOpsWindows::MappedFileOpsWindows()
+{
+    SYSTEM_INFO sys_info;
+    GetSystemInfo(&sys_info);
+    offset_alignment_ = static_cast<int64_t>(sys_info.dwAllocationGranularity);
+}
+
+MappedFileOpsWindows::~MappedFileOpsWindows()
+{
+    Close();
+}
+
+bool MappedFileOpsWindows::Open(const std::string& filename)
+{
+    // Don't double open is in the contract
+    GFXRECON_ASSERT(!IsValid());
+
+    // Create a file handle for the file to map
+    HANDLE file_handle =
+        CreateFileA(filename.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, 0, nullptr);
+
+    if (file_handle == INVALID_HANDLE_VALUE)
+    {
+        return false;
+    }
+
+    // Get the file size
+    LARGE_INTEGER file_size;
+    if (!GetFileSizeEx(file_handle, &file_size))
+    {
+        CloseHandle(file_handle);
+        return false;
+    }
+    GFXRECON_ASSERT(file_size.QuadPart > 0);
+    file_size_ = static_cast<uint64_t>(file_size.QuadPart);
+
+    // Create a mapping handle, from which views can be created
+    mapping_handle_ = CreateFileMapping(file_handle, nullptr, PAGE_READONLY, 0, 0, nullptr);
+    CloseHandle(file_handle);
+    return (mapping_handle_ != nullptr);
+}
+
+void MappedFileOpsWindows::Close()
+{
+    if (IsValid())
+    {
+        CloseHandle(mapping_handle_);
+        mapping_handle_ = nullptr;
+    }
+}
+
+const char* MappedFileOpsWindows::MapView(int64_t offset, size_t size)
+{
+    if (!IsValid())
+    {
+        return nullptr;
+    }
+
+    LARGE_INTEGER offset_arg;
+    offset_arg.QuadPart = offset;
+    const char* view    = static_cast<const char*>(
+        MapViewOfFile(mapping_handle_, FILE_MAP_READ, offset_arg.HighPart, offset_arg.LowPart, size));
+
+#define MAPPEDFILE_ENABLE_PREFETCH 0
+#if MAPPEDFILE_ENABLE_PREFETCH
+    // NOTE: A quick experiment to see if prefetching helps, didn't show any positive effect on my test system
+    // TODO: Some page prefetching experiments including
+    // 1) Checking if this command is sufficient
+    // 2) Page-faulting worker thread could prefault all this into the page tables and TLB's
+    // 3) See if prefetch is sufficient just on the current view or if an (overlapping) predictive "next" view
+    //    is needed. Offline analysis showed that for 32MB views and from CI traces, a 1MB overlap is optimal
+    //    to avoid remapping the predicted "next" range. (the few, large accesses dominate the remapping)
+    //
+    if (view)
+    {
+        WIN32_MEMORY_RANGE_ENTRY prefetch_range = { (PVOID)view, (SIZE_T)size };
+        PrefetchVirtualMemory(GetCurrentProcess(), 1, &prefetch_range, 0);
+    }
+#endif
+
+    return view;
+}
+
+void MappedFileOpsWindows::UnmapView(const char* view, size_t)
+{
+    // Size argument not needed on Windows
+    if (IsValid() && view)
+    {
+        UnmapViewOfFile(view);
+    }
+}
+
+#else // ie. !WIN32
+
+MappedFileOpsPosix::MappedFileOpsPosix()
+{
+    offset_alignment_ = sysconf(_SC_PAGE_SIZE);
+}
+
+MappedFileOpsPosix::~MappedFileOpsPosix()
+{
+    Close();
+}
+
+bool MappedFileOpsPosix::Open(const std::string& filename)
+{
+    // Don't double open is in the contract
+    GFXRECON_ASSERT(!IsValid());
+
+    // Create a file descriptor for the file to be mappped
+    fd_ = open(filename.c_str(), O_RDONLY);
+    if (fd_ == -1)
+    {
+        return false;
+    }
+
+    // Get the file size
+    struct stat file_stat_info;
+    if (fstat(fd_, &file_stat_info) == -1)
+    {
+        // Hmmm... can't stat it... somethings wrong.  Give up.
+        close(fd_);
+        fd_ = -1;
+        return false;
+    }
+    file_size_ = file_stat_info.st_size;
+
+    return true;
+}
+
+void MappedFileOpsPosix::Close()
+{
+    if (IsValid())
+    {
+        close(fd_);
+        fd_ = -1;
+    }
+}
+
+const char* MappedFileOpsPosix::MapView(int64_t offset, size_t size)
+{
+    if (!IsValid())
+    {
+        return nullptr;
+    }
+
+    // Get virtual address of mapped view
+    void* view = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd_, offset);
+
+    if (view == MAP_FAILED)
+    {
+        return nullptr;
+    }
+
+    return static_cast<const char*>(view);
+}
+
+void MappedFileOpsPosix::UnmapView(const char* view, size_t size)
+{
+    if (IsValid() && view)
+    {
+        // Unmap the viewed virtual address
+        munmap(static_cast<void*>(const_cast<char*>(view)), size);
+    }
+}
+
+#endif // WIN32
 
 bool DataRange::Contains(int64_t access_offset) const
 {
@@ -57,6 +230,304 @@ bool DataRange::Contains(const DataRange& range) const
     }
 
     return true;
+}
+
+// Only call this if in range
+const char* MappedView::GetDataAbsolute(int64_t absolute_offset) const
+{
+    GFXRECON_ASSERT(Contains(absolute_offset));
+    return data_ + RelativeOffset(absolute_offset);
+}
+
+// Only call this if in range
+void MappedView::CopyDataAbsolute(void* buffer, const DataRange& absolute_range) const
+{
+    GFXRECON_ASSERT(Contains(absolute_range));
+    memcpy(buffer, GetDataAbsolute(absolute_range.offset), absolute_range.size);
+}
+
+// Mapped Views can only be moved not copied
+MappedView::MappedView(MappedView&& other) noexcept :
+    mapped_file_(std::move(other.mapped_file_)), data_(other.data_), range_(other.range_)
+{
+    // Mark other as invalid, other.mapped_file_ is already null'd by the move
+    other.data_ = nullptr;
+}
+
+// Mapped Views can only be moved not copied
+MappedView& MappedView::operator=(MappedView&& other) noexcept
+{
+    if (this == &other)
+    {
+        // If they're the same we're done
+        return *this;
+    }
+
+    if (IsValid())
+    {
+        // We currently own a view, deal with it
+        // The IsValid check is actually redundant, as Reset *also* checks current, but
+        // it's clearer and less fragile this way and the compiler is going to optimize it away, anyhow
+        Reset();
+    }
+    // Reset should have cleared these
+    GFXRECON_ASSERT(!mapped_file_);
+    GFXRECON_ASSERT(!data_);
+
+    mapped_file_ = std::move(other.mapped_file_);
+    data_        = other.data_;
+    range_       = other.range_;
+
+    // Mark other as invalid, other.mapped_file_ is already null'd by the move
+    // Do not Reset() other as that would close the view we are moving
+    other.data_ = nullptr;
+
+    return *this;
+}
+
+MappedView::~MappedView()
+{
+    Reset();
+}
+
+// access_offset is from beginning of file
+bool MappedView::Contains(int64_t access_offset) const
+{
+    return IsValid() && range_.Contains(access_offset);
+}
+
+MappedFilePtr MappedFile::Open(const std::string& filename)
+{
+    MappedFilePtr mapped_file = MappedFilePtr(new MappedFile(filename));
+    bool          success     = mapped_file->Open();
+    if (!success)
+    {
+        mapped_file.reset();
+    }
+
+    return mapped_file;
+}
+
+MappedViewPtr MappedFile::MapView(const DataRange& range)
+{
+    if (!IsValid() || ((range.offset % GetOffsetAlignment()) != 0) || ((range.offset + range.size > GetFileSize())))
+    {
+        return MappedViewPtr();
+    }
+
+    const char* data = Base::MapView(range.offset, range.size);
+    if (data != nullptr)
+    {
+        return MappedViewPtr(new MappedView(shared_from_this(), data, range));
+    }
+    return MappedViewPtr();
+}
+
+// Find an aligned range at least as big as the size hint that includes the given range
+// It is possible that the resulting range will not include the input range IFF
+// the input range exceeds the file bounds.  Callers should check.
+DataRange MappedFile::ComputeContainingRange(const DataRange& range, size_t size_hint)
+{
+    // Alignment is much, much less than uint32_t max
+    const int64_t  alignment = GetOffsetAlignment();
+    const uint64_t file_size = GetFileSize();
+
+    // Limit legal size to include padding effects
+    constexpr size_t size_type_max = std::numeric_limits<size_t>::max();
+    GFXRECON_ASSERT(alignment < (size_type_max >> 2)); // alignment small relative to size_t
+    const size_t size_max = size_type_max - 2 * alignment;
+
+    if ((range.offset < 0) || (range.offset >= file_size) || (range.size > size_max))
+    {
+        // No possible view
+        return DataRange{};
+    }
+
+    // Limit size hint
+    size_hint = std::min(size_max, size_hint);
+
+    // Find a suitable starting offset, floored to the near multiple of alignment
+    // less than input range (noting alignent less than size_type_max
+    size_t  prepad         = range.offset % alignment;
+    int64_t aligned_offset = range.offset - prepad;
+
+    // Guaranteed not to overflow because of size_max check above and prepad < alignment
+    size_t padded_size = range.size + static_cast<size_t>(prepad);
+
+    size_t reqd_size = std::max<size_t>(size_hint, padded_size);
+
+    size_t post_pad = alignment - (reqd_size % alignment);
+    if (post_pad == alignment)
+    {
+        post_pad = 0;
+    }
+
+    size_t aligned_size = reqd_size + post_pad;
+    aligned_size        = std::min<uint64_t>(aligned_size, (file_size - aligned_offset));
+
+    return DataRange{ aligned_offset, aligned_size };
+}
+
+// Utility MapViewFactory for creating views that contain a given access range, but
+// that are also suitably sizes for subsequent accesses.
+//
+// If no containing range exists, return an empty view pointer
+MappedViewPtr MappedFile::MapContainingView(const DataRange& range, size_t size_hint)
+{
+    DataRange containing_range = ComputeContainingRange(range, size_hint);
+    if (containing_range.Contains(range))
+    {
+        return MapView(containing_range);
+    }
+    return MappedViewPtr();
+}
+
+void MappedView::Reset()
+{
+    if (mapped_file_ && data_)
+    {
+#if MAPPEDFILE_ASYNC_UNMAP
+        MappedFile::UnmapViewAsync(std::move(mapped_file_), data_, range_.size);
+#else
+        mapped_file_->UnmapView(data_, range_.size);
+        mapped_file_.reset();
+#endif
+        data_ = nullptr;
+    }
+}
+
+const std::string MappedFileInputStream::kInvalidFilename("INVALID_FILE_NAME");
+
+bool MappedFileInputStream::Open(const std::string& filename)
+{
+    if (IsOpen())
+    {
+        Close();
+    }
+
+    mapped_file_ = MappedFile::Open(filename);
+    read_pos_    = 0;
+
+    return IsOpen();
+}
+
+void MappedFileInputStream::Close()
+{
+    mapped_file_.reset();
+}
+
+// Unlike FStream negative new locations are truncated to [0, file_size] (yes you can seek to eof)
+bool MappedFileInputStream::FileSeek(int64_t offset, util::platform::FileSeekOrigin origin)
+{
+    if (!IsOpen())
+        return false;
+
+    const int64_t file_size = mapped_file_->GetFileSize();
+    // Determine where we want to set readpos_ to
+    int64_t new_pos;
+    switch (origin)
+    {
+        case platform::FileSeekOrigin::FileSeekCurrent:
+            new_pos = read_pos_ + offset;
+            break;
+        case platform::FileSeekOrigin::FileSeekSet:
+            new_pos = offset;
+            break;
+        case platform::FileSeekOrigin::FileSeekEnd:
+            // Note that offset from end of file are correctly negative.
+            // 0 puts one at EOF
+            new_pos = offset + file_size;
+            break;
+        default:
+            new_pos = read_pos_;
+    }
+
+    // Bound new pos to [0, file_size]
+    read_pos_ = std::max<int64_t>(0, std::min<int64_t>(new_pos, file_size));
+
+    return true;
+}
+
+bool MappedFileInputStream::ReadBytes(void* buffer, size_t bytes)
+{
+
+    bool success = PeekBytes(buffer, bytes);
+    if (success)
+    {
+        read_pos_ += bytes;
+    }
+
+    return success;
+}
+
+bool MappedFileInputStream::PeekBytes(void* buffer, size_t bytes)
+{
+    if (bytes == 0)
+        return true;
+
+    DataRange read_range = SetupForRead(bytes);
+    // Empty ranges means setup for read failed.
+    if (read_range.size != bytes)
+        return false;
+
+    // The read range is now in the current view
+    current_view_->CopyDataAbsolute(buffer, read_range);
+    return true;
+}
+
+util::DataSpan MappedFileInputStream::ReadSpan(const size_t bytes)
+{
+    DataRange read_range = SetupForRead(bytes);
+    if (read_range.IsEmpty())
+    {
+        return DataSpan();
+    }
+
+    // Read range is in current view create the managed span and return it
+    read_pos_ += read_range.size;
+    return DataSpan(current_view_, read_range);
+}
+
+DataRange MappedFileInputStream::SetupForRead(size_t bytes)
+{
+    // NOTE: Don't do Open, Error or Eof checks here, as the constituent parts do the
+    // right thing in those cases.  Invalid file, EOF, or bogus read_pos_ will all result
+    // in an empty DataRange being returned.
+
+    DataRange read_range{ read_pos_, bytes };
+    if (!InCurrentView(read_range))
+    {
+        // We need a new view for this range
+        // Note that read_pos_ might be in current view, but since we're going to need
+        // create a new view to complete the access, might as well do it, and not have
+        // to managed "straddle logic"
+        UpdateCurrentView(read_range);
+        if (!InCurrentView(read_range))
+        {
+            // The requested read cannot be mapped, likely EOF
+            return DataRange(); // Cannot map requested byte range
+        }
+    }
+    return read_range;
+}
+
+// This will update the current_view_ to include the access_offset
+// *ONLY* call it if !InCurrentView
+void MappedFileInputStream::UpdateCurrentView(const DataRange& range)
+{
+    // There are several reasons this can fail.
+    GFXRECON_ASSERT(IsOpen());
+    current_view_ = mapped_file_->MapContainingView(range, kViewSize);
+
+    if (!current_view_)
+    {
+        // Failed to map a view containing the requested range
+        if ((range.offset + range.size) > mapped_file_->GetFileSize())
+        {
+            // We're trying to read past the end of the file, set read_pos_ to EOF
+            read_pos_ = mapped_file_->GetFileSize();
+        }
+    }
 }
 
 bool FStreamFileInputStream::Open(const std::string& filename)
@@ -226,6 +697,20 @@ DataSpan FStreamFileInputStream::ReadSpan(const size_t bytes)
         return DataSpan(std::move(pool_entry), bytes);
     }
     return DataSpan();
+}
+
+DataSpan::DataSpan(const MappedViewPtr& copy_view, const DataRange& range) :
+    size_(copy_view && copy_view->Contains(range) ? range.size : 0),
+    data_(size_ ? copy_view->GetDataAbsolute(range.offset) : nullptr)
+{
+    if (size_)
+    {
+        store_.emplace<MappedViewPtr>(copy_view);
+    }
+    else
+    {
+        store_.emplace<std::monostate>();
+    }
 }
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/file_input_stream.h
+++ b/framework/util/file_input_stream.h
@@ -22,15 +22,77 @@
 #ifndef GFXRECON_UTIL_FILE_INPUT_STREAM_H
 #define GFXRECON_UTIL_FILE_INPUT_STREAM_H
 
+#if !defined(WIN32)
+#include <fcntl.h>
+#endif
+
+// Control the use of async unmap of mapped views.
+#define MAPPEDFILE_ASYNC_UNMAP 1
+
 #include "util/heap_buffer.h"
 #include "util/logging.h"
 #include "util/platform.h"
+#if MAPPEDFILE_ASYNC_UNMAP
+#include "util/threadpool.h"
+#endif
 
 #include <type_traits>
 #include <variant>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
+
+#if defined(WIN32)
+class MappedFileOpsWindows
+{
+  public:
+    int64_t  GetOffsetAlignment() const { return offset_alignment_; }
+    bool     IsValid() const { return mapping_handle_ != nullptr; }
+    uint64_t GetFileSize() const { return file_size_; }
+
+  protected:
+    MappedFileOpsWindows();
+    ~MappedFileOpsWindows();
+    bool        Open(const std::string& filename);
+    void        Close();
+    const char* MapView(int64_t offset, size_t size);
+    void        UnmapView(const char* view, size_t);
+
+  private:
+    uint64_t file_size_      = 0;
+    HANDLE   mapping_handle_ = nullptr;
+    int64_t  offset_alignment_;
+};
+using MappedFileOps = MappedFileOpsWindows;
+#else
+class MappedFileOpsPosix
+{
+  public:
+    int64_t  GetOffsetAlignment() const { return offset_alignment_; }
+    bool     IsValid() const { return fd_ != -1; }
+    uint64_t GetFileSize() const { return file_size_; }
+
+  protected:
+    MappedFileOpsPosix();
+    ~MappedFileOpsPosix();
+    bool        Open(const std::string& filename);
+    void        Close();
+    const char* MapView(int64_t offset, size_t size);
+    void        UnmapView(const char* view, size_t size);
+
+  private:
+    uint64_t file_size_ = 0;
+    int      fd_        = -1;
+    int64_t  offset_alignment_;
+};
+
+using MappedFileOps = MappedFileOpsPosix;
+
+#endif
+
+// The Platform Independent interface for memory mapped file management
+class MappedFile;
+using MappedFilePtr = std::shared_ptr<MappedFile>;
 
 // DataSpan supporting code
 struct DataRange
@@ -44,10 +106,14 @@ struct DataRange
     bool    Contains(const DataRange& range) const;
 };
 
+class MappedView;
+using MappedViewPtr = std::shared_ptr<MappedView>;
+
 // An type anonymous union that can represent a data span from one of three sources:
 // 1) A heap allocated buffer owned by this object
 // 2) An entry from a heap buffer pool
 // 3) A borrowed data pointer, not owned by this object
+// 4) A memory mapped file span, shared ownership of the MappedView with the file mapping object
 //
 // NOTE: Access is designed to be read-only
 // NOTE: Only one of the available sources will be active at any time.
@@ -76,7 +142,7 @@ class DataSpan
         // const size_type capacity;
     };
 
-    using Storage = std::variant<std::monostate, HeapBuffer, PoolEntry, BorrowedBuffer>;
+    using Storage = std::variant<std::monostate, HeapBuffer, PoolEntry, MappedViewPtr, BorrowedBuffer>;
     // NOTE: When adding supported types
     //     * they must be move-assignable
     //     * they noexcept move-constructible
@@ -146,6 +212,8 @@ class DataSpan
         data_ = std::get<PoolEntry>(store_).Get();
     }
 
+    DataSpan(const MappedViewPtr& copy_view, const DataRange& range);
+
     void Reset() noexcept
     {
         data_ = nullptr;
@@ -190,6 +258,150 @@ class DataSpan
     const_pointer data_{ nullptr };
 
     Storage store_;
+};
+
+// MappedView acts a unique pointer to a view.  It can only be created by a MappedFile object
+// The shared_ptr are used to ensure views cannot outlive the file mapping
+class MappedView
+{
+  public:
+    const char* GetData() const { return data_; }
+
+    // Only call these only if in range
+    const char* GetDataAbsolute(int64_t absolute_offset) const;
+    void        CopyDataAbsolute(void* buffer, const DataRange& absolute_range) const;
+
+    const DataRange& GetRange() const { return range_; }
+    explicit         operator bool() const { return data_ != nullptr && mapped_file_; }
+    bool             IsValid() const { return static_cast<bool>(*this); }
+
+    // Alternate STL style interface...
+    const char* data() const { return data_; }
+    size_t      size() const { return range_.size; }
+    int64_t     offset() const { return range_.offset; }
+    bool        has_value() const { return static_cast<bool>(*this); }
+
+    // Mapped Views can only be moved not copied
+    MappedView(MappedView&& other) noexcept;
+
+    // Mapped Views can only be moved not copied
+    MappedView& operator=(MappedView&& other) noexcept;
+    void        Reset();
+
+    MappedView()                             = delete;
+    MappedView(const MappedView&)            = delete;
+    MappedView& operator=(const MappedView&) = delete;
+
+    ~MappedView();
+    ; // May need to tell mapped_file_ to clean up the view
+
+    friend MappedFile;
+
+    // access_offset and access.offset are from beginning of file
+    bool Contains(int64_t access_offset) const;
+    bool Contains(const DataRange& access) const { return IsValid() && range_.Contains(access); }
+
+  private:
+    MappedView(const MappedFilePtr& mapped_file, const char* data, const DataRange& range) :
+        mapped_file_(mapped_file), data_(data), range_(range)
+    {}
+
+    // access_offset is from beginning of file
+    int64_t RelativeOffset(int64_t absolute_offset) const { return range_.RelativeOffset(absolute_offset); }
+
+    MappedFilePtr mapped_file_;
+    const char*   data_  = nullptr;
+    DataRange     range_ = { 0, 0 };
+};
+
+// MappedFile is the plaform independent implementation of the memory mapped (read-only) file access
+class MappedFile : public MappedFileOps, public std::enable_shared_from_this<MappedFile>
+{
+  public:
+    using Base = MappedFileOps;
+
+    static MappedFilePtr Open(const std::string& filename);
+    MappedViewPtr        MapView(const DataRange& range);
+    DataRange            ComputeContainingRange(const DataRange& range, size_t size_hint);
+
+    // Utility MapViewFactory for creating views that contain a given access range, but
+    // that are also suitably sizes for subsequent accesses.
+    //
+    // If no containing range exists, return an empty view pointer
+    MappedViewPtr MapContainingView(const DataRange& range, size_t size_hint);
+
+    const std::string& GetFilename() const { return filename_; }
+
+    friend MappedView;
+
+  protected:
+#if MAPPEDFILE_ASYNC_UNMAP
+    static void UnmapViewAsync(MappedFilePtr&& view_owner, const char* data, size_t size)
+    {
+        // Offload the unmap to a thread pool to avoid blocking the main thread
+
+        // Note: Since the lambda construction will null out view_owner, we need to get a reference to the
+        //       thread pool before the move happens
+        ThreadPool& unmap_pool_ref = view_owner->unmap_pool_;
+        unmap_pool_ref.post([view_owner = std::move(view_owner), data, size]() { view_owner->UnmapView(data, size); });
+    }
+    MappedFile(const std::string& filename) : filename_(filename), unmap_pool_(2) {}
+#else
+    MappedFile(const std::string& filename) : filename_(filename) {}
+#endif
+    void UnmapView(const char* data, size_t size)
+    {
+        Base::UnmapView(data, size);
+    }
+    bool Open()
+    {
+        return Base::Open(filename_);
+    }
+
+    const std::string filename_;
+#if MAPPEDFILE_ASYNC_UNMAP
+    ThreadPool unmap_pool_;
+#endif
+};
+
+class MappedFileInputStream
+{
+  public:
+    const std::string& GetFilename() const
+    {
+        GFXRECON_ASSERT(mapped_file_);
+        return mapped_file_ ? mapped_file_->GetFilename() : kInvalidFilename;
+    }
+
+    bool IsOpen() const { return mapped_file_ && mapped_file_->IsValid(); }
+    bool IsEof() const { return IsOpen() && (read_pos_ == mapped_file_->GetFileSize()); }
+    bool IsError() const { return IsOpen() && ((read_pos_ < 0) || (read_pos_ > mapped_file_->GetFileSize())); }
+    bool IsReady() const { return IsOpen() && !IsEof() && !IsError(); }
+
+    bool Open(const std::string& filename);
+    void Close();
+
+    // Unlike FStream negative new locations are truncated to [0, file_size] (yes you can seek to eof)
+    bool     FileSeek(int64_t offset, util::platform::FileSeekOrigin origin);
+    bool     ReadBytes(void* buffer, size_t bytes);
+    bool     PeekBytes(void* buffer, size_t bytes);
+    DataSpan ReadSpan(const size_t bytes);
+
+    explicit operator bool() const { return IsOpen(); }
+
+  protected:
+    static const std::string kInvalidFilename;
+    bool      InCurrentView(const DataRange& range) { return current_view_.get() && current_view_->Contains(range); }
+    DataRange SetupForRead(size_t bytes);
+    // This will update the current_view_ to include the access_offset
+    // *ONLY* call it if !InCurrentView
+    void UpdateCurrentView(const DataRange& range);
+
+    MappedFilePtr           mapped_file_;
+    MappedViewPtr           current_view_;
+    int64_t                 read_pos_;
+    static constexpr size_t kMib      = 1u << 20;
+    static constexpr size_t kViewSize = 32 * kMib;
 };
 
 class FStreamFileInputStream


### PR DESCRIPTION
Add memory mapped IO with zero copy support for BlockRead, preload, and parameter block input.

Enabled and tested on Windows only.  DRAFT support for POSIX (mmap) enabled but untested.

