### PR TITLE
Remove obsolete warning message

### DIFF
--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -834,11 +834,6 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkFormat             
         return 0;
     }
 
-    if (mip_levels > 1 + floor(log2(std::max(std::max(extent.width, extent.height), extent.depth))))
-    {
-        GFXRECON_LOG_WARNING_ONCE("%s(): too many mip_levels for extent", __func__);
-    }
-
     if (subresource_sizes != nullptr)
     {
         subresource_sizes->clear();


### PR DESCRIPTION
GetImageResourceSizesOptimal was checking if the provided extent was in accordance with the number of the provided mip levels. When scaling is requested with VDR this could trigger this warning as the scaled down extent can have less mip levels than the original dimensions.

This should be ok and in practice desired when scaling down images and their subresources. For example dumping an image 4x4 with 3 levels at scale 0.5 should still dump 3 mip levels with dimensions (2x2), (1x1) and (1x1).

So this warning message is obsolete and is removed by this commit.