### PR TITLE
VDR: Two small fixes

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -108,7 +108,7 @@ static VkFormat ChooseDestinationImageFormat(VkFormat format)
 
     if (vkuFormatIsSRGB(format))
     {
-        dst_format = vkuFormatHasAlpha(format) ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8_SRGB;
+        dst_format = VK_FORMAT_B8G8R8A8_SRGB;
     }
     else if (vkuFormatIsDepthOrStencil(format))
     {
@@ -118,7 +118,7 @@ static VkFormat ChooseDestinationImageFormat(VkFormat format)
     }
     else
     {
-        dst_format = vkuFormatHasAlpha(format) ? VK_FORMAT_B8G8R8A8_UNORM : VK_FORMAT_B8G8R8_UNORM;
+        dst_format = VK_FORMAT_B8G8R8A8_UNORM;
     }
 
     return dst_format;

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -2379,9 +2379,12 @@ bool VulkanResourcesUtil::IsBlitSupported(VkFormat       src_format,
                                           VkFormat       dst_format,
                                           VkImageTiling* dst_image_tiling) const
 {
-    // Integer formats must match
-    if ((vkuFormatIsSINT(src_format) != vkuFormatIsSINT(dst_format)) ||
-        (vkuFormatIsUINT(src_format) != vkuFormatIsUINT(dst_format)))
+    // According to spec: "Integer formats can only be converted to other integer formats with the same signedness."
+    const bool is_src_sint = vkuFormatIsSINT(src_format) || vkuFormatIsSSCALED(src_format);
+    const bool is_src_uint = vkuFormatIsUINT(src_format) || vkuFormatIsUSCALED(src_format);
+    const bool is_dst_sint = vkuFormatIsSINT(dst_format) || vkuFormatIsSSCALED(dst_format);
+    const bool is_dst_uint = vkuFormatIsUINT(dst_format) || vkuFormatIsUSCALED(dst_format);
+    if ((is_src_sint != is_dst_sint) || (is_src_uint != is_dst_uint))
     {
         return false;
     }


### PR DESCRIPTION
1. Fixed logic in IsBlitSupported() regarding integer formats
signedness. Also added missing [S|U]SCALED.
2. Formats B8G8R8_SRGB and B8G8R8_UNORM are removed from the logic that
decides which format to use when dumping images into bmp/png as they
might not be supported. Instead we stick to VK_FORMAT_B8G8R8A8_UNORM and
VK_FORMAT_B8G8R8A8_SRGB which are mandatory from the spec.