### PR TITLE
Fix dark colors when capture uses an SRGB swapchain-format

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -58,6 +58,7 @@
 #include "generated/generated_vulkan_enum_to_string.h"
 #include "util/to_string.h"
 #include "vulkan/vulkan_core.h"
+#include "Vulkan-Utility-Libraries/vk_format_utils.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -9993,8 +9994,9 @@ VkResult VulkanReplayConsumerBase::OverrideCreateImageView(
     }
     else if (img_info->is_swapchain_image && img_info->format != modified_create_info.format)
     {
-        // for swapchain-images set image-view to actual format, avoid issues with distorted HDR-colors
-        modified_create_info.format = img_info->format;
+        // for swapchain-images set image-view to a fallback format, avoid issues with distorted HDR/SRGB colors
+        modified_create_info.format =
+            vkuFormatIsSRGB(modified_create_info.format) ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8A8_UNORM;
     }
 
     VkResult result = func(device, &modified_create_info, allocator, out_view);

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -7453,18 +7453,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
             // handle VK_KHR_swapchain_mutable_format
             if (modified_create_info.flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR)
             {
-                bool mutable_srgb = false;
                 if (auto* format_list_pnext =
                         graphics::vulkan_struct_get_pnext<VkImageFormatListCreateInfo>(&modified_create_info))
                 {
-                    for (uint32_t i = 0; i < format_list_pnext->viewFormatCount; ++i)
-                    {
-                        if (vkuFormatIsSRGB(format_list_pnext->pViewFormats[0]))
-                        {
-                            mutable_srgb = true;
-                            break;
-                        }
-                    }
+                    const auto* view_formats     = format_list_pnext->pViewFormats;
+                    const auto* view_formats_end = view_formats + format_list_pnext->viewFormatCount;
+                    bool        mutable_srgb     = std::any_of(view_formats, view_formats_end, vkuFormatIsSRGB);
 
                     // overwrite existing VkImageFormatListCreateInfo
                     format_list_create_info                  = *format_list_pnext;


### PR DESCRIPTION
follow-up to https://github.com/LunarG/gfxreconstruct/pull/2429

during replay, when we cannot support a requested swapchain VkFormat, we fall back to a 'safe' format.
later during runtime, when `VkImageView`s onto swapchain images are created,
we again have to apply corrections.
in both cases we also need to account for SRGB formats.

e.g. `VK_FORMAT_R8G8B8A8_UNORM` -> `VK_FORMAT_B8G8R8A8_UNORM`
and `VK_FORMAT_R8G8B8A8_SRGB` -> `VK_FORMAT_B8G8R8A8_SRGB`

also: 
during swapchain creation we check for usage of `VK_KHR_swapchain_mutable_format`
apply corrections, if necessary.

fixes #2414