### PR TITLE
Fix tracking of deleted AS input-buffers during capture

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -996,7 +996,7 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
 
     if (device_info != nullptr)
     {
-        assert(device_info->handle != VK_NULL_HANDLE);
+        GFXRECON_ASSERT(device_info->handle != VK_NULL_HANDLE);
 
         VkResult       result = VK_SUCCESS;
         VkDevice       device = device_info->handle;
@@ -1004,19 +1004,21 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
         VkDeviceMemory memory = VK_NULL_HANDLE;
 
         auto allocator = device_info->allocator.get();
-        assert(allocator != nullptr);
+        GFXRECON_ASSERT(allocator != nullptr);
 
         auto table = GetDeviceTable(device);
-        assert(table != nullptr);
+        GFXRECON_ASSERT(table != nullptr);
 
         VkPhysicalDevice physical_device = device_info->parent;
-        assert(physical_device != VK_NULL_HANDLE);
+        GFXRECON_ASSERT(physical_device != VK_NULL_HANDLE);
 
-        VkPhysicalDeviceMemoryProperties properties;
+        VkPhysicalDeviceProperties       properties;
+        VkPhysicalDeviceMemoryProperties memory_properties;
         auto                             instance_table = GetInstanceTable(physical_device);
-        assert(instance_table != nullptr);
+        GFXRECON_ASSERT(instance_table != nullptr);
 
-        instance_table->GetPhysicalDeviceMemoryProperties(physical_device, &properties);
+        instance_table->GetPhysicalDeviceProperties(physical_device, &properties);
+        instance_table->GetPhysicalDeviceMemoryProperties(physical_device, &memory_properties);
 
         const auto& available_extensions      = device_info->extensions;
         bool        have_shader_stencil_write = false;
@@ -1029,7 +1031,7 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
         }
 
         device_info->resource_initializer = std::make_shared<VulkanResourceInitializer>(
-            device_info, max_copy_size, properties, have_shader_stencil_write, allocator, table);
+            device_info, max_copy_size, properties, memory_properties, have_shader_stencil_write, allocator, table);
     }
 }
 

--- a/framework/decode/vulkan_resource_initializer.h
+++ b/framework/decode/vulkan_resource_initializer.h
@@ -42,6 +42,7 @@ class VulkanResourceInitializer
   public:
     VulkanResourceInitializer(const VulkanDeviceInfo*                 device_info,
                               VkDeviceSize                            max_copy_size,
+                              const VkPhysicalDeviceProperties&       physical_device_properties,
                               const VkPhysicalDeviceMemoryProperties& memory_properties,
                               bool                                    have_shader_stencil_write,
                               VulkanResourceAllocator*                resource_allocator,
@@ -188,6 +189,7 @@ class VulkanResourceInitializer
     VkBuffer                              staging_buffer_;
     VulkanResourceAllocator::ResourceData staging_buffer_data_;
     size_t                                staging_buffer_offset_;
+    size_t                                staging_buffer_alignment_;
     uint8_t*                              staging_buffer_mapped_ptr_;
     VkSampler                             draw_sampler_;
     VkDescriptorPool                      draw_pool_;

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -493,7 +493,7 @@ void VulkanStateTracker::TrackAccelerationStructureBuildCommand(
                     encode::AccelerationStructureInputBuffer& buffer =
                         dst_command.input_buffers[target_buffer_wrapper->handle_id];
 
-                    buffer.capture_address    = address;
+                    buffer.capture_address    = target_buffer_wrapper->address;
                     buffer.handle             = target_buffer_wrapper->handle;
                     buffer.handle_id          = target_buffer_wrapper->handle_id;
                     buffer.bind_device        = target_buffer_wrapper->bind_device;

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -487,7 +487,8 @@ void VulkanStateTracker::TrackAccelerationStructureBuildCommand(
                     device_address_trackers_[device_wrapper->handle].GetBufferByDeviceAddress(address));
 
                 GFXRECON_ASSERT(target_buffer_wrapper != nullptr);
-                if (target_buffer_wrapper != nullptr)
+                if (target_buffer_wrapper != nullptr &&
+                    dst_command.input_buffers.find(target_buffer_wrapper->handle_id) == dst_command.input_buffers.end())
                 {
                     encode::AccelerationStructureInputBuffer& buffer =
                         dst_command.input_buffers[target_buffer_wrapper->handle_id];
@@ -2056,38 +2057,39 @@ void VulkanStateTracker::DestroyState(vulkan_wrappers::DeviceMemoryWrapper* wrap
     // If the memory gets destroyed before the asset(s) it's bound to, dump the AS as we would in the DestroyBuffer call
     for (const auto& bound_asset : wrapper->bound_assets)
     {
-        state_table_.VisitWrappers([&bound_asset, this](vulkan_wrappers::AccelerationStructureKHRWrapper* acc_wrapper) {
-            GFXRECON_ASSERT(acc_wrapper != nullptr && acc_wrapper->buffer != nullptr);
-            auto build_state_it = acc_wrapper->buffer->acceleration_structures.find(acc_wrapper->address);
+        // This works even if the bound asset is not a buffer, as they all derive from HandleWrapper and
+        // handle_id will contain a valid value
+        auto* buffer_wrapper = static_cast<vulkan_wrappers::BufferWrapper*>(bound_asset);
 
-            if (build_state_it != acc_wrapper->buffer->acceleration_structures.end() &&
-                build_state_it->second.latest_build_command)
-            {
-                auto& command = *build_state_it->second.latest_build_command;
+        state_table_.VisitWrappers(
+            [buffer_wrapper, this](vulkan_wrappers::AccelerationStructureKHRWrapper* acc_wrapper) {
+                GFXRECON_ASSERT(acc_wrapper != nullptr && acc_wrapper->buffer != nullptr);
+                auto build_state_it = acc_wrapper->buffer->acceleration_structures.find(acc_wrapper->address);
 
-                // This works even if the bound asset is not a buffer, as they all derive from HandleWrapper and
-                // handle_id will contain a valid value
-                auto buffer_wrapper = static_cast<vulkan_wrappers::BufferWrapper*>(bound_asset);
-
-                auto it = command.input_buffers.find(buffer_wrapper->handle_id);
-                if (it != command.input_buffers.end())
+                if (build_state_it != acc_wrapper->buffer->acceleration_structures.end() &&
+                    build_state_it->second.latest_build_command)
                 {
-                    encode::AccelerationStructureInputBuffer& buffer = it->second;
-                    buffer.destroyed                                 = true;
-                    auto [resource_util, created]                    = resource_utils_.try_emplace(
-                        buffer.bind_device->handle,
-                        graphics::VulkanResourcesUtil(buffer.bind_device->handle,
-                                                      buffer.bind_device->physical_device->handle,
-                                                      buffer.bind_device->layer_table,
-                                                      *buffer.bind_device->physical_device->layer_table_ref,
-                                                      buffer.bind_device->physical_device->memory_properties));
-                    buffer.bind_device->layer_table.GetBufferMemoryRequirements(
-                        buffer.bind_device->handle, buffer.handle, &buffer.memory_requirements);
-                    resource_util->second.ReadFromBufferResource(
-                        buffer.handle, buffer.created_size, 0, buffer.queue_family_index, buffer.bytes);
+                    auto& command = *build_state_it->second.latest_build_command;
+
+                    auto it = command.input_buffers.find(buffer_wrapper->handle_id);
+                    if (it != command.input_buffers.end())
+                    {
+                        encode::AccelerationStructureInputBuffer& buffer = it->second;
+                        buffer.destroyed                                 = true;
+                        auto [resource_util, created]                    = resource_utils_.try_emplace(
+                            buffer.bind_device->handle,
+                            graphics::VulkanResourcesUtil(buffer.bind_device->handle,
+                                                          buffer.bind_device->physical_device->handle,
+                                                          buffer.bind_device->layer_table,
+                                                          *buffer.bind_device->physical_device->layer_table_ref,
+                                                          buffer.bind_device->physical_device->memory_properties));
+                        buffer.bind_device->layer_table.GetBufferMemoryRequirements(
+                            buffer.bind_device->handle, buffer.handle, &buffer.memory_requirements);
+                        resource_util->second.ReadFromBufferResource(
+                            buffer.handle, buffer.created_size, 0, buffer.queue_family_index, buffer.bytes);
+                    }
                 }
-            }
-        });
+            });
     }
 
     wrapper->asset_map_lock.unlock();
@@ -2099,27 +2101,25 @@ void VulkanStateTracker::DestroyState(vulkan_wrappers::DeviceMemoryWrapper* wrap
     }
 }
 
-void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferWrapper* wrapper)
+void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferWrapper* buffer_wrapper)
 {
-    GFXRECON_ASSERT(wrapper != nullptr && wrapper->device != nullptr);
-    wrapper->create_parameters = nullptr;
+    GFXRECON_ASSERT(buffer_wrapper != nullptr && buffer_wrapper->device != nullptr);
+    buffer_wrapper->create_parameters = nullptr;
 
-    if (wrapper != nullptr && wrapper->device != nullptr)
+    if (buffer_wrapper != nullptr && buffer_wrapper->device != nullptr)
     {
-        device_address_trackers_[wrapper->device].RemoveBuffer(wrapper);
+        device_address_trackers_[buffer_wrapper->device].RemoveBuffer(buffer_wrapper);
     }
 
-    vulkan_wrappers::DeviceMemoryWrapper* mem_wrapper =
-        state_table_.GetVulkanDeviceMemoryWrapper(wrapper->bind_memory_id);
+    state_table_.VisitWrappers([this, buffer_wrapper](vulkan_wrappers::AccelerationStructureKHRWrapper* acc_wrapper) {
+        GFXRECON_ASSERT(acc_wrapper != nullptr && acc_wrapper->buffer != nullptr);
+        auto build_state_it = acc_wrapper->buffer->acceleration_structures.find(acc_wrapper->address);
 
-    for (auto& [as_address, build_state] : wrapper->acceleration_structures)
-    {
-        // If the memory bound to this resource has already been destroyed, skip reading the buffer data.
-        if (build_state.latest_build_command && mem_wrapper != nullptr)
+        if (build_state_it != acc_wrapper->buffer->acceleration_structures.end() &&
+            build_state_it->second.latest_build_command)
         {
-            auto& command = *build_state.latest_build_command;
-
-            auto it = command.input_buffers.find(wrapper->handle_id);
+            auto& command = *build_state_it->second.latest_build_command;
+            auto  it      = command.input_buffers.find(buffer_wrapper->handle_id);
             if (it != command.input_buffers.end())
             {
                 encode::AccelerationStructureInputBuffer& buffer = it->second;
@@ -2137,26 +2137,31 @@ void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferW
                     buffer.handle, buffer.created_size, 0, buffer.queue_family_index, buffer.bytes);
             }
         }
-    }
+    });
 
-    if (wrapper->bind_memory_id != format::kNullHandleId && mem_wrapper != nullptr)
+    if (buffer_wrapper->bind_memory_id != format::kNullHandleId)
     {
+        vulkan_wrappers::DeviceMemoryWrapper* mem_wrapper =
+            state_table_.GetVulkanDeviceMemoryWrapper(buffer_wrapper->bind_memory_id);
 
-        mem_wrapper->asset_map_lock.lock();
-        auto bind_entry = mem_wrapper->bound_assets.find(wrapper);
-        if (bind_entry != mem_wrapper->bound_assets.end())
+        if (mem_wrapper != nullptr)
         {
-            mem_wrapper->bound_assets.erase(bind_entry);
+            mem_wrapper->asset_map_lock.lock();
+            auto bind_entry = mem_wrapper->bound_assets.find(buffer_wrapper);
+            if (bind_entry != mem_wrapper->bound_assets.end())
+            {
+                mem_wrapper->bound_assets.erase(bind_entry);
+            }
+            mem_wrapper->asset_map_lock.unlock();
         }
-        mem_wrapper->asset_map_lock.unlock();
     }
 
-    for (auto entry : wrapper->descriptor_sets_bound_to)
+    for (auto* desc_set_wrapper : buffer_wrapper->descriptor_sets_bound_to)
     {
-        entry->dirty = true;
+        desc_set_wrapper->dirty = true;
     }
 
-    for (vulkan_wrappers::BufferViewWrapper* view_wrapper : wrapper->buffer_views)
+    for (vulkan_wrappers::BufferViewWrapper* view_wrapper : buffer_wrapper->buffer_views)
     {
         view_wrapper->buffer    = nullptr;
         view_wrapper->buffer_id = format::kNullHandleId;

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -820,7 +820,7 @@ class VulkanStateTracker
 
     void DestroyState(vulkan_wrappers::DeviceMemoryWrapper* wrapper);
 
-    void DestroyState(vulkan_wrappers::BufferWrapper* wrapper);
+    void DestroyState(vulkan_wrappers::BufferWrapper* buffer_wrapper);
 
     void DestroyState(vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper);
 

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -393,6 +393,9 @@ class VulkanStateWriter
 
     void WriteAccelerationStructureStateMetaCommands(const VulkanStateTable& state_table);
 
+    void WriteAccelerationStructureResourceInit(const gfxrecon::format::HandleId&                 device,
+                                                encode::AccelerationStructureKHRBuildCommandData& command);
+
     void WriteAccelerationStructureBuildState(const gfxrecon::format::HandleId&                 device,
                                               encode::AccelerationStructureKHRBuildCommandData& command);
 


### PR DESCRIPTION
two different things are corrected in this PR. both are related to trimming and deleted buffers
used for AS-builds.

1) tracking/recreation of deleted AS input-buffers during capture had a regression after recent rework

2) a longer standing issue we didn't notice caused errors/crashes during replay for trimmed raytracing-captures 
(when using default-allocator, `-m rebind` was fine)

-> this was since an optimization of `decode::VulkanResourceInitializer` which deferred copying of data until destruction.
->  the symptom was attempted buffer-copies, but the temporary buffer was already deleted again.
-> fixed by splitting AS state-init into resource-upload / build+cleanup

also:
- Fix validation-error in `decode::VulkanResourceInitializer`
-> query `VkPhysicalDeviceLimits::nonCoherentAtomSize`, align sizes and flush-ranges 