### PR TITLE
Fix gfxrecon-convert null dereference

### DIFF
--- a/framework/generated/generated_dx12_json_consumer.cpp
+++ b/framework/generated/generated_dx12_json_consumer.cpp
@@ -519,7 +519,14 @@ void Dx12JsonConsumer::Process_ID3D12Resource_GetHeapProperties(
     nlohmann::ordered_json& args = method[format::kNameArgs];
     {
         FieldToJson(args["pHeapProperties"], pHeapProperties, options);
-        FieldToJson_D3D12_HEAP_FLAGS(args["pHeapFlags"], *pHeapFlags->GetPointer(), options);
+        if (!pHeapFlags->IsNull())
+        {
+            FieldToJson_D3D12_HEAP_FLAGS(args["pHeapFlags"], *pHeapFlags->GetPointer(), options);
+        }
+        else
+        {
+            FieldToJson(args["pHeapFlags"], nullptr, options);
+        }
     }
     writer_->WriteBlockEnd();
 }
@@ -1863,7 +1870,14 @@ void Dx12JsonConsumer::Process_ID3D12CommandQueue_UpdateTileMappings(
         FieldToJson(args["pResourceRegionSizes"], pResourceRegionSizes, options);
         FieldToJson(args["pHeap"], pHeap, options);
         FieldToJson(args["NumRanges"], NumRanges, options);
-        FieldToJson_D3D12_TILE_RANGE_FLAGS(args["pRangeFlags"], *pRangeFlags->GetPointer(), options);
+        if (!pRangeFlags->IsNull())
+        {
+            FieldToJson_D3D12_TILE_RANGE_FLAGS(args["pRangeFlags"], *pRangeFlags->GetPointer(), options);
+        }
+        else
+        {
+            FieldToJson(args["pRangeFlags"], nullptr, options);
+        }
         FieldToJson(args["pHeapRangeStartOffsets"], pHeapRangeStartOffsets, options);
         FieldToJson(args["pRangeTileCounts"], pRangeTileCounts, options);
         FieldToJson_D3D12_TILE_MAPPING_FLAGS(args["Flags"], Flags, options);


### PR DESCRIPTION
Add null check for D3D12 enum pointers in gfxrecon-convert special case.