### PR TITLE
Add team responsible for reviewing PRs or assigning review of PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @LunarG/gfxreconstruct-architecture-reviewers


### PR DESCRIPTION
Add CODEOWNERS file, which has special meaning to GitHub, containing the "GFXReconstruct Architecture Reviewers" team that we have defined internally.  That team will be automatically added as a reviewer and we can at some future date if desired block merges without that review.