### PR TITLE
Address assert releasing buffer to full pool.

### DIFF
--- a/framework/util/heap_buffer.cpp
+++ b/framework/util/heap_buffer.cpp
@@ -153,6 +153,11 @@ void HeapBufferPool::Release(Entry&& entry) noexcept
             // This is only from ~Entry so we don't have to worry about cleaning up entry
         }
     }
+    else
+    {
+        // Mark the entry as released, even if we don't take its contents back into the pool
+        entry.DisavowPool();
+    }
 }
 
 GFXRECON_END_NAMESPACE(util)


### PR DESCRIPTION
Ensure that entries are correctly released from the pool even when the pool is full. (Silences assert, and is more correct.)

Affects --preload-measurement-frames runs with debug builds