### PR TITLE
Const clean decoder and consumer interfaces

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -83,9 +83,9 @@ class ApiDecoder
 
     virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) = 0;
 
-    virtual void DispatchDriverInfo(format::ThreadId thread_id, format::DriverInfoBlock& info) = 0;
+    virtual void DispatchDriverInfo(format::ThreadId thread_id, const format::DriverInfoBlock& info) = 0;
 
-    virtual void DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info) = 0;
+    virtual void DispatchExeFileInfo(format::ThreadId thread_id, const format::ExeFileInfoBlock& info) = 0;
 
     virtual void DispatchFillMemoryCommand(
         format::ThreadId thread_id, uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) = 0;
@@ -184,9 +184,9 @@ class ApiDecoder
                                                 const uint8_t*                              data) = 0;
 
     virtual void DispatchInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data) = 0;
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data) = 0;
 
     virtual void DispatchGetDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header){};
 
@@ -207,8 +207,8 @@ class ApiDecoder
     virtual void DispatchSetTlasToBlasDependencyCommand(format::HandleId                     tlas,
                                                         const std::vector<format::HandleId>& blases){};
 
-    virtual void DispatchSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                        const char*                             env_string){};
+    virtual void DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                        const char*                                   env_string){};
 
     virtual void DispatchVulkanAccelerationStructuresBuildMetaCommand(const uint8_t* parameter_buffer,
                                                                       size_t         buffer_size){};
@@ -219,10 +219,11 @@ class ApiDecoder
     virtual void DispatchVulkanAccelerationStructuresWritePropertiesMetaCommand(const uint8_t* parameter_buffer,
                                                                                 size_t         buffer_size){};
 
-    virtual void DispatchViewRelativeLocation(format::ThreadId thread_id, format::ViewRelativeLocation& location){};
+    virtual void DispatchViewRelativeLocation(format::ThreadId                    thread_id,
+                                              const format::ViewRelativeLocation& location){};
 
-    virtual void DispatchInitializeMetaCommand(format::InitializeMetaCommand& header,
-                                               const uint8_t*                 initialization_parameters_data){};
+    virtual void DispatchInitializeMetaCommand(const format::InitializeMetaCommand& header,
+                                               const uint8_t*                       initialization_parameters_data){};
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/common_consumer_base.h
+++ b/framework/decode/common_consumer_base.h
@@ -54,8 +54,8 @@ class CommonConsumerBase : public MetadataConsumerBase, public MarkerConsumerBas
 
     virtual void SetCurrentFrameNumber(uint64_t frame_number) { frame_number_ = frame_number; }
 
-    virtual void ProcessSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                       const char*                             env_string)
+    virtual void ProcessSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                       const char*                                   env_string)
     {}
 
   protected:

--- a/framework/decode/custom_ags_decoder.h
+++ b/framework/decode/custom_ags_decoder.h
@@ -53,9 +53,9 @@ class AgsDecoder : public ApiDecoder
 
     virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) override {}
 
-    virtual void DispatchDriverInfo(format::ThreadId thread_id, format::DriverInfoBlock& info) override {}
+    virtual void DispatchDriverInfo(format::ThreadId thread_id, const format::DriverInfoBlock& info) override {}
 
-    virtual void DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info) override {}
+    virtual void DispatchExeFileInfo(format::ThreadId thread_id, const format::ExeFileInfoBlock& info) override {}
 
     virtual void DispatchFillMemoryCommand(
         format::ThreadId thread_id, uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) override
@@ -182,9 +182,9 @@ class AgsDecoder : public ApiDecoder
     {}
 
     virtual void DispatchInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data) override
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data) override
     {}
 
   protected:

--- a/framework/decode/dx12_consumer_base.h
+++ b/framework/decode/dx12_consumer_base.h
@@ -49,9 +49,9 @@ class Dx12ConsumerBase : public MetadataConsumerBase, public MarkerConsumerBase
     virtual bool IsComplete(uint64_t block_index) { return false; }
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data)
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data)
     {}
 
     virtual void ProcessDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header) {}
@@ -83,8 +83,8 @@ class Dx12ConsumerBase : public MetadataConsumerBase, public MarkerConsumerBase
                                                            UINT                                     SrcDepthPitch)
     {}
 
-    virtual void ProcessSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                       const char*                             env_string) {};
+    virtual void ProcessSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                       const char*                                   env_string){};
 
     virtual void ProcessInitializeMetaCommand(const format::InitializeMetaCommand& command_header,
                                               const uint8_t*                       parameters_data)

--- a/framework/decode/dx12_decoder_base.cpp
+++ b/framework/decode/dx12_decoder_base.cpp
@@ -296,9 +296,9 @@ void Dx12DecoderBase::DispatchInitSubresourceCommand(const format::InitSubresour
 }
 
 void Dx12DecoderBase::DispatchInitDx12AccelerationStructureCommand(
-    const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-    std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-    const uint8_t*                                                  build_inputs_data)
+    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+    const uint8_t*                                                        build_inputs_data)
 {
     for (auto consumer : consumers_)
     {
@@ -322,8 +322,8 @@ void Dx12DecoderBase::DispatchGetDx12RuntimeInfo(const format::Dx12RuntimeInfoCo
     }
 }
 
-void Dx12DecoderBase::DispatchInitializeMetaCommand(format::InitializeMetaCommand& header,
-                                                    const uint8_t*                 initialization_parameters_data)
+void Dx12DecoderBase::DispatchInitializeMetaCommand(const format::InitializeMetaCommand& header,
+                                                    const uint8_t*                       initialization_parameters_data)
 {
     for (auto consumer : consumers_)
     {
@@ -331,8 +331,8 @@ void Dx12DecoderBase::DispatchInitializeMetaCommand(format::InitializeMetaComman
     }
 }
 
-void Dx12DecoderBase::DispatchSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                             const char*                             env_string)
+void Dx12DecoderBase::DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                             const char*                                   env_string)
 {
     for (auto consumer : consumers_)
     {

--- a/framework/decode/dx12_decoder_base.h
+++ b/framework/decode/dx12_decoder_base.h
@@ -90,7 +90,7 @@ class Dx12DecoderBase : public ApiDecoder
 
     virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) override;
 
-    virtual void DispatchDriverInfo(format::ThreadId thread_id, format::DriverInfoBlock& info)
+    virtual void DispatchDriverInfo(format::ThreadId thread_id, const format::DriverInfoBlock& info)
     {
         for (auto consumer : consumers_)
         {
@@ -98,7 +98,7 @@ class Dx12DecoderBase : public ApiDecoder
         }
     }
 
-    virtual void DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info)
+    virtual void DispatchExeFileInfo(format::ThreadId thread_id, const format::ExeFileInfoBlock& info)
     {
         for (auto consumer : consumers_)
         {
@@ -203,24 +203,24 @@ class Dx12DecoderBase : public ApiDecoder
                                                 const uint8_t*                              data) override;
 
     virtual void DispatchInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data) override;
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data) override;
 
     virtual void DispatchGetDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header) override;
 
     virtual void
     DispatchGetDx12RuntimeInfo(const format::Dx12RuntimeInfoCommandHeader& dx12_runtime_info_header) override;
 
-    virtual void DispatchSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                        const char*                             env_string) override;
+    virtual void DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                        const char* env_string) override;
 
     virtual void SetCurrentBlockIndex(uint64_t block_index) override;
 
     virtual void SetCurrentApiCallId(format::ApiCallId api_call_id) override;
 
-    virtual void DispatchInitializeMetaCommand(format::InitializeMetaCommand& header,
-                                               const uint8_t*                 initialization_parameters_data) override;
+    virtual void DispatchInitializeMetaCommand(const format::InitializeMetaCommand& header,
+                                               const uint8_t* initialization_parameters_data) override;
 
   protected:
     const std::vector<Dx12Consumer*>& GetConsumers() const { return consumers_; }

--- a/framework/decode/dx12_json_consumer_base.cpp
+++ b/framework/decode/dx12_json_consumer_base.cpp
@@ -89,9 +89,9 @@ void Dx12JsonConsumerBase::ProcessInitSubresourceCommand(const format::InitSubre
 /// captures as part of establishing the GPU memory state at the start of the trimmed
 /// range.
 void Dx12JsonConsumerBase::ProcessInitDx12AccelerationStructureCommand(
-    const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-    std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-    const uint8_t*                                                  build_inputs_data)
+    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+    const uint8_t*                                                        build_inputs_data)
 {
     const util::JsonOptions& json_options = writer_->GetOptions();
     auto&                    jdata        = writer_->WriteMetaCommandStart("InitDx12AccelerationStructureCommand");

--- a/framework/decode/dx12_json_consumer_base.h
+++ b/framework/decode/dx12_json_consumer_base.h
@@ -51,9 +51,9 @@ class Dx12JsonConsumerBase : public Dx12Consumer
     virtual void ProcessInitSubresourceCommand(const format::InitSubresourceCommandHeader& command_header,
                                                const uint8_t*                              data) override;
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data) override;
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data) override;
     virtual void
     ProcessFillMemoryResourceValueCommand(const format::FillMemoryResourceValueCommandHeader& command_header,
                                           const uint8_t*                                      data) override;

--- a/framework/decode/dx12_object_scanning_consumer.cpp
+++ b/framework/decode/dx12_object_scanning_consumer.cpp
@@ -156,9 +156,9 @@ void Dx12ObjectScanningConsumer::ProcessFillMemoryResourceValueCommand(
 }
 
 void Dx12ObjectScanningConsumer::ProcessInitDx12AccelerationStructureCommand(
-    const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-    std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-    const uint8_t*                                                  build_inputs_data)
+    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+    const uint8_t*                                                        build_inputs_data)
 {
     dxr_workload_ = true;
 }

--- a/framework/decode/dx12_object_scanning_consumer.h
+++ b/framework/decode/dx12_object_scanning_consumer.h
@@ -113,9 +113,9 @@ class Dx12ObjectScanningConsumer : public Dx12ObjectScanningConsumerBase
                                           const uint8_t*                                      data);
 
     virtual void Dx12ObjectScanningConsumer::ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data);
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data);
 
     virtual void
     Dx12ObjectScanningConsumer::Process_ID3D12GraphicsCommandList_ExecuteIndirect(const ApiCallInfo& call_info,

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -732,9 +732,9 @@ void Dx12ReplayConsumerBase::ProcessInitializeMetaCommand(const format::Initiali
 }
 
 void Dx12ReplayConsumerBase::ProcessInitDx12AccelerationStructureCommand(
-    const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-    std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-    const uint8_t*                                                  build_inputs_data)
+    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+    const uint8_t*                                                        build_inputs_data)
 {
     if (!accel_struct_builder_)
     {

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -64,7 +64,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     virtual ~Dx12ReplayConsumerBase() override;
 
-    virtual void Process_ExeFileInfo(util::filepath::FileInfo& info_record)
+    virtual void Process_ExeFileInfo(const util::filepath::FileInfo& info_record)
     {
         gfxrecon::util::filepath::CheckReplayerName(info_record.AppName);
     }
@@ -110,9 +110,9 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                const uint8_t*                              data) override;
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data) override;
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data) override;
 
     virtual void ProcessInitializeMetaCommand(const format::InitializeMetaCommand& command_header,
                                               const uint8_t*                       parameters_data) override;

--- a/framework/decode/dx12_stats_consumer.h
+++ b/framework/decode/dx12_stats_consumer.h
@@ -256,9 +256,9 @@ class Dx12StatsConsumer : public Dx12Consumer
     }
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data)
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data)
     {
         dxr_workload_ = true;
     }

--- a/framework/decode/info_consumer.h
+++ b/framework/decode/info_consumer.h
@@ -46,7 +46,7 @@ class InfoConsumer
     const char*       GetProductVersion() const { return exe_info.ProductVersion; }
     const std::vector<std::string>& GetEnvironmentVariables() const { return env_vars; }
 
-    void Process_ExeFileInfo(gfxrecon::util::filepath::FileInfo& info)
+    void Process_ExeFileInfo(const gfxrecon::util::filepath::FileInfo& info)
     {
         exe_info        = info;
         found_exe_info_ = true;
@@ -75,7 +75,8 @@ class InfoConsumer
         }
     }
 
-    void Process_SetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header, const char* env_string)
+    void Process_SetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                const char*                                   env_string)
     {
         env_vars = util::strings::SplitString(std::string_view(env_string), format::kEnvironmentStringDelimeter);
     }

--- a/framework/decode/info_decoder.cpp
+++ b/framework/decode/info_decoder.cpp
@@ -32,7 +32,7 @@ bool InfoDecoder::IsComplete(uint64_t block_index)
     return decode::IsComplete<InfoConsumer*>(consumers_, block_index);
 }
 
-void InfoDecoder::DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info)
+void InfoDecoder::DispatchExeFileInfo(format::ThreadId thread_id, const format::ExeFileInfoBlock& info)
 {
     GFXRECON_UNREFERENCED_PARAMETER(thread_id);
 
@@ -42,7 +42,7 @@ void InfoDecoder::DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFil
     }
 }
 
-void InfoDecoder::DispatchDriverInfo(format::ThreadId thread_id, format::DriverInfoBlock& info)
+void InfoDecoder::DispatchDriverInfo(format::ThreadId thread_id, const format::DriverInfoBlock& info)
 {
     GFXRECON_UNREFERENCED_PARAMETER(thread_id);
 
@@ -52,8 +52,8 @@ void InfoDecoder::DispatchDriverInfo(format::ThreadId thread_id, format::DriverI
     }
 }
 
-void InfoDecoder::DispatchSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                         const char*                             env_string)
+void InfoDecoder::DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                         const char*                                   env_string)
 {
     for (auto consumer : consumers_)
     {

--- a/framework/decode/info_decoder.h
+++ b/framework/decode/info_decoder.h
@@ -45,9 +45,9 @@ class InfoDecoder : public ApiDecoder
 
     virtual void WaitIdle() override{};
 
-    virtual void DispatchDriverInfo(format::ThreadId thread_id, format::DriverInfoBlock& info) override;
+    virtual void DispatchDriverInfo(format::ThreadId thread_id, const format::DriverInfoBlock& info) override;
 
-    virtual void DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info) override;
+    virtual void DispatchExeFileInfo(format::ThreadId thread_id, const format::ExeFileInfoBlock& info) override;
 
     void AddConsumer(InfoConsumer* consumer) { consumers_.push_back(consumer); }
 
@@ -188,13 +188,13 @@ class InfoDecoder : public ApiDecoder
     {}
 
     virtual void DispatchInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data) override
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data) override
     {}
 
-    virtual void DispatchSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                        const char*                             env_string) override;
+    virtual void DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                        const char* env_string) override;
 
   private:
     std::vector<InfoConsumer*> consumers_;

--- a/framework/decode/metadata_consumer_base.h
+++ b/framework/decode/metadata_consumer_base.h
@@ -37,7 +37,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class MetadataConsumerBase
 {
   public:
-    virtual void Process_ExeFileInfo(util::filepath::FileInfo& info_record) {}
+    virtual void Process_ExeFileInfo(const util::filepath::FileInfo& info_record) {}
     virtual void ProcessDisplayMessageCommand(const std::string& message) {}
     virtual void ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) {}
     virtual void
@@ -126,7 +126,8 @@ class MetadataConsumerBase
         format::HandleId device_id, VkQueryType query_type, format::HandleId acceleration_structure_id)
     {}
 
-    virtual void ProcessViewRelativeLocation(format::ThreadId thread_id, format::ViewRelativeLocation& location){};
+    virtual void ProcessViewRelativeLocation(format::ThreadId                    thread_id,
+                                             const format::ViewRelativeLocation& location){};
 
     virtual void ProcessInitializeMetaCommand(const format::InitializeMetaCommand& command_header,
                                               const uint8_t*                       parameters_data)

--- a/framework/decode/metadata_json_consumer.h
+++ b/framework/decode/metadata_json_consumer.h
@@ -80,7 +80,7 @@ class MetadataJsonConsumer : public Base
         WriteBlockEnd();
     }
 
-    virtual void Process_ExeFileInfo(gfxrecon::util::filepath::FileInfo& info) override
+    virtual void Process_ExeFileInfo(const gfxrecon::util::filepath::FileInfo& info) override
     {
         const util::JsonOptions& json_options = GetOptions();
         auto&                    jdata        = WriteMetaCommandStart("ExeFileInfo");
@@ -283,8 +283,8 @@ class MetadataJsonConsumer : public Base
         WriteBlockEnd();
     }
 
-    virtual void ProcessSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                       const char*                             env_string) override
+    virtual void ProcessSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                       const char* env_string) override
     {
         const JsonOptions& json_options = GetJsonOptions();
         auto&              json_data    = WriteMetaCommandStart("SetEnvironmentVariablesCommand");

--- a/framework/decode/openxr_decoder_base.cpp
+++ b/framework/decode/openxr_decoder_base.cpp
@@ -82,7 +82,8 @@ void OpenXrDecoderBase::SetCurrentBlockIndex(uint64_t block_index)
     }
 }
 
-void OpenXrDecoderBase::DispatchViewRelativeLocation(format::ThreadId thread_id, format::ViewRelativeLocation& location)
+void OpenXrDecoderBase::DispatchViewRelativeLocation(format::ThreadId                    thread_id,
+                                                     const format::ViewRelativeLocation& location)
 {
     for (auto consumer : consumers_)
     {

--- a/framework/decode/openxr_decoder_base.h
+++ b/framework/decode/openxr_decoder_base.h
@@ -86,8 +86,8 @@ class OpenXrDecoderBase : public ApiDecoder
 
     virtual void SetCurrentBlockIndex(uint64_t block_index) override;
 
-    virtual void DispatchViewRelativeLocation(format::ThreadId              thread_id,
-                                              format::ViewRelativeLocation& location) override;
+    virtual void DispatchViewRelativeLocation(format::ThreadId                    thread_id,
+                                              const format::ViewRelativeLocation& location) override;
 
     // Unused stubs
     virtual void DecodeFunctionCall(format::ApiCallId  call_id,
@@ -95,8 +95,8 @@ class OpenXrDecoderBase : public ApiDecoder
                                     const uint8_t*     parameter_buffer,
                                     size_t             buffer_size) override
     {}
-    virtual void DispatchDriverInfo(format::ThreadId thread_id, format::DriverInfoBlock& info) override {}
-    virtual void DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info) override {}
+    virtual void DispatchDriverInfo(format::ThreadId thread_id, const format::DriverInfoBlock& info) override {}
+    virtual void DispatchExeFileInfo(format::ThreadId thread_id, const format::ExeFileInfoBlock& info) override {}
     virtual void DispatchFillMemoryCommand(
         format::ThreadId thread_id, uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) override
     {}
@@ -192,9 +192,9 @@ class OpenXrDecoderBase : public ApiDecoder
                                                 const uint8_t*                              data) override
     {}
     virtual void DispatchInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data) override
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data) override
     {}
 
   protected:

--- a/framework/decode/openxr_json_consumer_base.cpp
+++ b/framework/decode/openxr_json_consumer_base.cpp
@@ -325,8 +325,8 @@ void OpenXrExportJsonConsumerBase::Process_xrPollEvent(const ApiCallInfo&       
     WriteBlockEnd();
 }
 
-void OpenXrExportJsonConsumerBase::ProcessViewRelativeLocation(format::ThreadId              thread_id,
-                                                               format::ViewRelativeLocation& location)
+void OpenXrExportJsonConsumerBase::ProcessViewRelativeLocation(format::ThreadId                    thread_id,
+                                                               const format::ViewRelativeLocation& location)
 {
     const util::JsonOptions& json_options = writer_->GetOptions();
     // TODO: Fold this into a override for WriteMetaCommandStart if we add many more meta data blocks

--- a/framework/decode/openxr_json_consumer_base.h
+++ b/framework/decode/openxr_json_consumer_base.h
@@ -128,7 +128,7 @@ class OpenXrExportJsonConsumerBase : public OpenXrConsumer
                              XrResult                                         returnValue,
                              format::HandleId                                 instance,
                              StructPointerDecoder<Decoded_XrEventDataBuffer>* eventData) override;
-    void ProcessViewRelativeLocation(format::ThreadId thread_id, format::ViewRelativeLocation& location) override;
+    void ProcessViewRelativeLocation(format::ThreadId thread_id, const format::ViewRelativeLocation& location) override;
 
     uint32_t submit_index_{ 0 }; // index of submissions across the trace
 

--- a/framework/decode/openxr_replay_consumer_base.cpp
+++ b/framework/decode/openxr_replay_consumer_base.cpp
@@ -1502,8 +1502,8 @@ void OpenXrReplayConsumerBase::Process_xrReleaseSwapchainImage(
     CheckResult("xrReleaseSwapchainImage", returnValue, replay_result, call_info);
 }
 
-void OpenXrReplayConsumerBase::ProcessViewRelativeLocation(format::ThreadId              thread_id,
-                                                           format::ViewRelativeLocation& location)
+void OpenXrReplayConsumerBase::ProcessViewRelativeLocation(format::ThreadId                    thread_id,
+                                                           const format::ViewRelativeLocation& location)
 {
     // Create a proxy space for a given space_id at a view relative location
     XrSession replay_session =

--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -161,7 +161,7 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
                                     format::HandleId                                           swapchain,
                                     StructPointerDecoder<Decoded_XrSwapchainImageReleaseInfo>* releaseInfo) override;
 
-    void ProcessViewRelativeLocation(format::ThreadId thread_id, format::ViewRelativeLocation& location) override;
+    void ProcessViewRelativeLocation(format::ThreadId thread_id, const format::ViewRelativeLocation& location) override;
 
     virtual void Process_xrEndFrame(const ApiCallInfo&                            call_info,
                                     XrResult                                      returnValue,

--- a/framework/decode/stat_decoder_base.h
+++ b/framework/decode/stat_decoder_base.h
@@ -45,9 +45,9 @@ class StatDecoderBase : public ApiDecoder
 
     virtual void WaitIdle() override{};
 
-    virtual void DispatchDriverInfo(format::ThreadId thread_id, format::DriverInfoBlock& info) override {}
+    virtual void DispatchDriverInfo(format::ThreadId thread_id, const format::DriverInfoBlock& info) override {}
 
-    virtual void DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info) override {}
+    virtual void DispatchExeFileInfo(format::ThreadId thread_id, const format::ExeFileInfoBlock& info) override {}
 
     void AddConsumer(StatConsumerBase* consumer) { consumers_.push_back(consumer); }
 
@@ -188,9 +188,9 @@ class StatDecoderBase : public ApiDecoder
     {}
 
     virtual void DispatchInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data) override
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data) override
     {}
 
   private:

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -83,7 +83,7 @@ void VulkanDecoderBase::DispatchFillMemoryCommand(
     }
 }
 
-void VulkanDecoderBase::DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info)
+void VulkanDecoderBase::DispatchExeFileInfo(format::ThreadId thread_id, const format::ExeFileInfoBlock& info)
 {
     for (auto consumer : consumers_)
     {
@@ -552,8 +552,8 @@ void VulkanDecoderBase::DispatchSetTlasToBlasDependencyCommand(format::HandleId 
     }
 }
 
-void VulkanDecoderBase::DispatchSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                               const char*                             env_string)
+void VulkanDecoderBase::DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                               const char*                                   env_string)
 {
     for (auto consumer : consumers_)
     {

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -187,17 +187,17 @@ class VulkanDecoderBase : public ApiDecoder
                                                         const std::vector<format::HandleId>& blases) override;
 
     virtual void DispatchInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data) override
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data) override
     {}
 
-    virtual void DispatchDriverInfo(format::ThreadId thread_id, format::DriverInfoBlock& info) override {}
+    virtual void DispatchDriverInfo(format::ThreadId thread_id, const format::DriverInfoBlock& info) override {}
 
-    virtual void DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info) override;
+    virtual void DispatchExeFileInfo(format::ThreadId thread_id, const format::ExeFileInfoBlock& info) override;
 
-    virtual void DispatchSetEnvironmentVariablesCommand(format::SetEnvironmentVariablesCommand& header,
-                                                        const char*                             env_string) override;
+    virtual void DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                        const char* env_string) override;
 
     virtual void SetCurrentBlockIndex(uint64_t block_index) override;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -92,7 +92,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         get_instance_proc_addr_ = get_instance_proc_addr;
     }
 
-    void Process_ExeFileInfo(util::filepath::FileInfo& info_record) override
+    void Process_ExeFileInfo(const util::filepath::FileInfo& info_record) override
     {
         gfxrecon::util::filepath::CheckReplayerName(info_record.AppName);
     }

--- a/tools/optimize/dx12_resource_value_tracking_consumer.cpp
+++ b/tools/optimize/dx12_resource_value_tracking_consumer.cpp
@@ -81,9 +81,9 @@ void Dx12ResourceValueTrackingConsumer::Process_ID3D12GraphicsCommandList4_CopyR
 }
 
 void Dx12ResourceValueTrackingConsumer::ProcessInitDx12AccelerationStructureCommand(
-    const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-    std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-    const uint8_t*                                                  build_inputs_data)
+    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+    const uint8_t*                                                        build_inputs_data)
 {
     dxr_workload_ = true;
 

--- a/tools/optimize/dx12_resource_value_tracking_consumer.h
+++ b/tools/optimize/dx12_resource_value_tracking_consumer.h
@@ -56,9 +56,9 @@ class Dx12ResourceValueTrackingConsumer : public Dx12ReplayConsumer
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE Mode) override;
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data) override;
+        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const uint8_t*                                                        build_inputs_data) override;
 
     virtual void OverrideExecuteIndirect(DxObjectInfo* command_list_object_info,
                                          DxObjectInfo* command_signature_object_info,


### PR DESCRIPTION
Prevent decoders and consumers from modifying data passed down from the parser.