### PR TITLE
Fix in ahb shader copy path

### DIFF
--- a/framework/encode/vulkan_capture_common.cpp
+++ b/framework/encode/vulkan_capture_common.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "vulkan_capture_common.h"
+#include "Vulkan-Utility-Libraries/vk_format_utils.h"
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 #include <android/hardware_buffer.h>
@@ -126,6 +127,20 @@ static void CommonWriteFillMemoryCmd(format::HandleId      memory_id,
     else
     {
         vulkan_state_writer->WriteFillMemoryCmd(memory_id, 0u, size, data);
+    }
+}
+
+// Wrap vkuFormatRequiresYcbcrConversion so that we handle VK_FORMAT_UNDEFINED as a YCbCr format which applies for AHB
+// external formats
+static bool ExternalFormatRequiresYcbcrConversion(VkFormat format)
+{
+    if (format == VK_FORMAT_UNDEFINED)
+    {
+        return true;
+    }
+    else
+    {
+        return vkuFormatRequiresYcbcrConversion(format);
     }
 }
 
@@ -405,8 +420,9 @@ void CommonProcessHardwareBuffer(format::ThreadId                      thread_id
         auto ahb_image_aspect_mask = graphics::GetFormatAspects(format_properties.format);
 
         VkImageViewCreateInfo image_view_create_info;
-        image_view_create_info.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-        image_view_create_info.pNext                           = &sampler_ycbcr_conversion_info;
+        image_view_create_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        image_view_create_info.pNext =
+            ExternalFormatRequiresYcbcrConversion(format_properties.format) ? &sampler_ycbcr_conversion_info : nullptr;
         image_view_create_info.flags                           = 0u;
         image_view_create_info.image                           = ahb_image;
         image_view_create_info.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
@@ -426,8 +442,9 @@ void CommonProcessHardwareBuffer(format::ThreadId                      thread_id
             vk_result = device_table->CreateImageView(device, &image_view_create_info, nullptr, &image_view);
 
         VkSamplerCreateInfo sampler_create_info;
-        sampler_create_info.sType                   = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-        sampler_create_info.pNext                   = &sampler_ycbcr_conversion_info;
+        sampler_create_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        sampler_create_info.pNext =
+            ExternalFormatRequiresYcbcrConversion(format_properties.format) ? &sampler_ycbcr_conversion_info : nullptr;
         sampler_create_info.flags                   = 0u;
         sampler_create_info.magFilter               = VK_FILTER_LINEAR;
         sampler_create_info.minFilter               = VK_FILTER_LINEAR;


### PR DESCRIPTION
The shader copy code path that copies the content of AHB buffers via a
compute shader uses a ycbcr sampler without checking the format of the
AHB. This can cause glitches when an AHB is not a yuv format. This
commits fixes the issue.