### PR TITLE
codegen: Enforce NULL pNext for VU-mandated structs

### DIFF
--- a/framework/encode/struct_pointer_encoder.h
+++ b/framework/encode/struct_pointer_encoder.h
@@ -110,6 +110,35 @@ typename std::enable_if<!std::is_integral<SizeT>::value>::type EncodeStructArray
     }
 }
 
+/// For some structs, spec mandates that `pNext` must be `NULL`.
+/// On the other hand, vendor extensions may add structures to the pNext chain.
+/// To handle this, we encode the pNext chain if it is valid, otherwise we encode a null pNext pointer.
+inline void EncodePNextStructIfValid(ParameterEncoder* encoder, const void* pNext)
+{
+    if (util::platform::PointerIsValid(pNext))
+    {
+        EncodePNextStruct(encoder, pNext);
+    }
+    else
+    {
+        encoder->EncodeStructPtrPreamble(nullptr);
+    }
+}
+
+#if ENABLE_OPENXR_SUPPORT
+inline void EncodeNextStructIfValid(ParameterEncoder* encoder, const void* value)
+{
+    if (util::platform::PointerIsValid(value))
+    {
+        EncodeNextStruct(encoder, value);
+    }
+    else
+    {
+        encoder->EncodeStructPtrPreamble(nullptr);
+    }
+}
+#endif
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/generated/generated_openxr_struct_encoders.cpp
+++ b/framework/generated/generated_openxr_struct_encoders.cpp
@@ -59,7 +59,7 @@ void EncodeStruct(ParameterEncoder* encoder, const LUID& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrApiLayerProperties& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeString(value.layerName);
     encoder->EncodeUInt64Value(value.specVersion);
     encoder->EncodeUInt32Value(value.layerVersion);
@@ -69,7 +69,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrApiLayerProperties& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrExtensionProperties& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeString(value.extensionName);
     encoder->EncodeUInt32Value(value.extensionVersion);
 }
@@ -98,7 +98,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrInstanceCreateInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrInstanceProperties& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt64Value(value.runtimeVersion);
     encoder->EncodeString(value.runtimeName);
 }
@@ -106,7 +106,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrInstanceProperties& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrSystemGetInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.formFactor);
 }
 
@@ -175,7 +175,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPosef& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrReferenceSpaceCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.referenceSpaceType);
     EncodeStruct(encoder, value.poseInReferenceSpace);
 }
@@ -189,7 +189,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrExtent2Df& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrActionSpaceCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::ActionWrapper>(value.action);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::PathWrapper>(value.subactionPath);
     EncodeStruct(encoder, value.poseInActionSpace);
@@ -206,7 +206,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceLocation& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrViewConfigurationProperties& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.viewConfigurationType);
     encoder->EncodeUInt32Value(value.fovMutable);
 }
@@ -324,20 +324,20 @@ void EncodeStructArrayLoop<XrSwapchainImageBaseHeader>(ParameterEncoder* encoder
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainImageAcquireInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainImageWaitInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeInt64Value(value.timeout);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainImageReleaseInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrSessionBeginInfo& value)
@@ -350,7 +350,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSessionBeginInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrFrameWaitInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrFrameState& value)
@@ -365,7 +365,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrFrameState& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrFrameBeginInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerBaseHeader& value)
@@ -506,7 +506,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrViewLocateInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrViewState& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.viewStateFlags);
 }
 
@@ -521,7 +521,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrFovf& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrView& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStruct(encoder, value.pose);
     EncodeStruct(encoder, value.fov);
 }
@@ -529,7 +529,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrView& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrActionSetCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeString(value.actionSetName);
     encoder->EncodeString(value.localizedActionSetName);
     encoder->EncodeUInt32Value(value.priority);
@@ -538,7 +538,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrActionSetCreateInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrActionCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeString(value.actionName);
     encoder->EncodeEnumValue(value.actionType);
     encoder->EncodeUInt32Value(value.countSubactionPaths);
@@ -564,7 +564,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrInteractionProfileSuggested
 void EncodeStruct(ParameterEncoder* encoder, const XrSessionActionSetsAttachInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.countActionSets);
     encoder->EncodeOpenXrHandleArray<openxr_wrappers::ActionSetWrapper>(value.actionSets, value.countActionSets);
 }
@@ -572,14 +572,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSessionActionSetsAttachInfo
 void EncodeStruct(ParameterEncoder* encoder, const XrInteractionProfileState& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::PathWrapper>(value.interactionProfile);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrActionStateGetInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::ActionWrapper>(value.action);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::PathWrapper>(value.subactionPath);
 }
@@ -587,7 +587,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrActionStateGetInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrActionStateBoolean& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.currentState);
     encoder->EncodeUInt32Value(value.changedSinceLastSync);
     encoder->EncodeXrTimeValue(value.lastChangeTime);
@@ -597,7 +597,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrActionStateBoolean& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrActionStateFloat& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFloatValue(value.currentState);
     encoder->EncodeUInt32Value(value.changedSinceLastSync);
     encoder->EncodeXrTimeValue(value.lastChangeTime);
@@ -613,7 +613,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVector2f& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrActionStateVector2f& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStruct(encoder, value.currentState);
     encoder->EncodeUInt32Value(value.changedSinceLastSync);
     encoder->EncodeXrTimeValue(value.lastChangeTime);
@@ -623,7 +623,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrActionStateVector2f& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrActionStatePose& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.isActive);
 }
 
@@ -644,14 +644,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrActionsSyncInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrBoundSourcesForActionEnumerateInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::ActionWrapper>(value.action);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrInputSourceLocalizedNameGetInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::PathWrapper>(value.sourcePath);
     encoder->EncodeFlags64Value(value.whichComponents);
 }
@@ -659,7 +659,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrInputSourceLocalizedNameGet
 void EncodeStruct(ParameterEncoder* encoder, const XrHapticActionInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::ActionWrapper>(value.action);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::PathWrapper>(value.subactionPath);
 }
@@ -772,7 +772,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerProjection&
 void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerQuad& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.layerFlags);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     encoder->EncodeEnumValue(value.eyeVisibility);
@@ -1054,21 +1054,21 @@ void EncodeStructArrayLoop<XrEventDataBaseHeader>(ParameterEncoder* encoder, con
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataEventsLost& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.lostEventCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataInstanceLossPending& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeXrTimeValue(value.lossTime);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSessionStateChanged& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SessionWrapper>(value.session);
     encoder->EncodeEnumValue(value.state);
     encoder->EncodeXrTimeValue(value.time);
@@ -1077,7 +1077,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSessionStateChange
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataReferenceSpaceChangePending& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SessionWrapper>(value.session);
     encoder->EncodeEnumValue(value.referenceSpaceType);
     encoder->EncodeXrTimeValue(value.changeTime);
@@ -1088,14 +1088,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataReferenceSpaceChan
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataInteractionProfileChanged& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SessionWrapper>(value.session);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrHapticVibration& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeInt64Value(value.duration);
     encoder->EncodeFloatValue(value.frequency);
     encoder->EncodeFloatValue(value.amplitude);
@@ -1203,7 +1203,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrUuid& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrSpacesLocateInfo& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.baseSpace);
     encoder->EncodeXrTimeValue(value.time);
     encoder->EncodeUInt32Value(value.spaceCount);
@@ -1242,7 +1242,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceVelocities& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerCubeKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.layerFlags);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     encoder->EncodeEnumValue(value.eyeVisibility);
@@ -1273,7 +1273,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerDepthInfoKH
 void EncodeStruct(ParameterEncoder* encoder, const XrVulkanSwapchainFormatListCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.viewFormatCount);
     encoder->EncodeEnumArray(value.viewFormats, value.viewFormatCount);
 }
@@ -1281,7 +1281,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVulkanSwapchainFormatListCr
 void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerCylinderKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.layerFlags);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     encoder->EncodeEnumValue(value.eyeVisibility);
@@ -1295,7 +1295,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerCylinderKHR
 void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerEquirectKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.layerFlags);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     encoder->EncodeEnumValue(value.eyeVisibility);
@@ -1347,14 +1347,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsBindingOpenGLWaylan
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainImageOpenGLKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.image);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsRequirementsOpenGLKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt64Value(value.minApiVersionSupported);
     encoder->EncodeUInt64Value(value.maxApiVersionSupported);
 }
@@ -1371,14 +1371,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsBindingOpenGLESAndr
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainImageOpenGLESKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.image);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsRequirementsOpenGLESKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt64Value(value.minApiVersionSupported);
     encoder->EncodeUInt64Value(value.maxApiVersionSupported);
 }
@@ -1404,7 +1404,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainImageVulkanKHR& va
 void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsRequirementsVulkanKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt64Value(value.minApiVersionSupported);
     encoder->EncodeUInt64Value(value.maxApiVersionSupported);
 }
@@ -1419,14 +1419,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsBindingD3D11KHR& va
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainImageD3D11KHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeVoidPtr(value.texture);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsRequirementsD3D11KHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeLUIDValue(value.adapterLuid);
     encoder->EncodeD3D_FEATURE_LEVELValue(value.minFeatureLevel);
 }
@@ -1442,14 +1442,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsBindingD3D12KHR& va
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainImageD3D12KHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeVoidPtr(value.texture);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsRequirementsD3D12KHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeLUIDValue(value.adapterLuid);
     encoder->EncodeD3D_FEATURE_LEVELValue(value.minFeatureLevel);
 }
@@ -1464,21 +1464,21 @@ void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsBindingMetalKHR& va
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainImageMetalKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeVoidPtr(value.texture);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsRequirementsMetalKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeVoidPtr(value.metalDevice);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrVisibilityMaskKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.vertexCapacityInput);
     encoder->EncodeUInt32Value(value.vertexCountOutput);
     EncodeStructArray(encoder, value.vertices, value.vertexCapacityInput);
@@ -1490,7 +1490,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVisibilityMaskKHR& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataVisibilityMaskChangedKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SessionWrapper>(value.session);
     encoder->EncodeEnumValue(value.viewConfigurationType);
     encoder->EncodeUInt32Value(value.viewIndex);
@@ -1546,7 +1546,7 @@ void EncodeStructArrayLoop<XrLoaderInitInfoBaseHeaderKHR>(ParameterEncoder* enco
 void EncodeStruct(ParameterEncoder* encoder, const XrLoaderInitInfoAndroidKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeVoidPtr(value.applicationVM);
     encoder->EncodeVoidPtr(value.applicationContext);
 }
@@ -1554,7 +1554,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrLoaderInitInfoAndroidKHR& v
 void EncodeStruct(ParameterEncoder* encoder, const XrVulkanGraphicsDeviceGetInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::SystemIdWrapper>(value.systemId);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::InstanceWrapper>(value.vulkanInstance);
 }
@@ -1562,7 +1562,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVulkanGraphicsDeviceGetInfo
 void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerEquirect2KHR& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.layerFlags);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     encoder->EncodeEnumValue(value.eyeVisibility);
@@ -1635,7 +1635,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrBindingModificationsKHR& va
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataPerfSettingsEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.domain);
     encoder->EncodeEnumValue(value.subDomain);
     encoder->EncodeEnumValue(value.fromLevel);
@@ -1645,7 +1645,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataPerfSettingsEXT& v
 void EncodeStruct(ParameterEncoder* encoder, const XrDebugUtilsObjectNameInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.objectType);
     encoder->EncodeUInt64Value(value.objectHandle);
     encoder->EncodeString(value.objectName);
@@ -1654,14 +1654,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrDebugUtilsObjectNameInfoEXT
 void EncodeStruct(ParameterEncoder* encoder, const XrDebugUtilsLabelEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeString(value.labelName);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrDebugUtilsMessengerCallbackDataEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeString(value.messageId);
     encoder->EncodeString(value.functionName);
     encoder->EncodeString(value.message);
@@ -1706,7 +1706,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSessionCreateInfoOverlayEXT
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataMainSessionVisibilityChangedEXTX& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.visible);
     encoder->EncodeFlags64Value(value.flags);
 }
@@ -1714,7 +1714,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataMainSessionVisibil
 void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorCreateInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     EncodeStruct(encoder, value.pose);
     encoder->EncodeXrTimeValue(value.time);
@@ -1723,7 +1723,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorCreateInfoMSFT
 void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorSpaceCreateInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpatialAnchorMSFTWrapper>(value.anchor);
     EncodeStruct(encoder, value.poseInAnchorSpace);
 }
@@ -1768,7 +1768,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrGraphicsBindingEGLMNDX& val
 void EncodeStruct(ParameterEncoder* encoder, const XrSpatialGraphNodeSpaceCreateInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.nodeType);
     encoder->EncodeUInt8Array(value.nodeId, XR_GUID_SIZE_MSFT);
     EncodeStruct(encoder, value.pose);
@@ -1777,7 +1777,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpatialGraphNodeSpaceCreate
 void EncodeStruct(ParameterEncoder* encoder, const XrSpatialGraphStaticNodeBindingCreateInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     EncodeStruct(encoder, value.poseInSpace);
     encoder->EncodeXrTimeValue(value.time);
@@ -1786,13 +1786,13 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpatialGraphStaticNodeBindi
 void EncodeStruct(ParameterEncoder* encoder, const XrSpatialGraphNodeBindingPropertiesGetInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrSpatialGraphNodeBindingPropertiesMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt8Array(value.nodeId, XR_GUID_SIZE_MSFT);
     EncodeStruct(encoder, value.poseInNodeSpace);
 }
@@ -1863,7 +1863,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemHandTrackingMeshPrope
 void EncodeStruct(ParameterEncoder* encoder, const XrHandMeshSpaceCreateInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.handPoseType);
     EncodeStruct(encoder, value.poseInHandMeshSpace);
 }
@@ -1871,7 +1871,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrHandMeshSpaceCreateInfoMSFT
 void EncodeStruct(ParameterEncoder* encoder, const XrHandMeshUpdateInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeXrTimeValue(value.time);
     encoder->EncodeEnumValue(value.handPoseType);
 }
@@ -1901,7 +1901,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrHandMeshVertexBufferMSFT& v
 void EncodeStruct(ParameterEncoder* encoder, const XrHandMeshMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.isActive);
     encoder->EncodeUInt32Value(value.indexBufferChanged);
     encoder->EncodeUInt32Value(value.vertexBufferChanged);
@@ -1927,7 +1927,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSecondaryViewConfigurationS
 void EncodeStruct(ParameterEncoder* encoder, const XrSecondaryViewConfigurationStateMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.viewConfigurationType);
     encoder->EncodeUInt32Value(value.active);
 }
@@ -1943,7 +1943,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSecondaryViewConfigurationF
 void EncodeStruct(ParameterEncoder* encoder, const XrSecondaryViewConfigurationLayerInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.viewConfigurationType);
     encoder->EncodeEnumValue(value.environmentBlendMode);
     encoder->EncodeUInt32Value(value.layerCount);
@@ -1968,14 +1968,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSecondaryViewConfigurationS
 void EncodeStruct(ParameterEncoder* encoder, const XrControllerModelKeyStateMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::ControllerModelKeyMSFTWrapper>(value.modelKey);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrControllerModelNodePropertiesMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeString(value.parentNodeName);
     encoder->EncodeString(value.nodeName);
 }
@@ -1983,7 +1983,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrControllerModelNodeProperti
 void EncodeStruct(ParameterEncoder* encoder, const XrControllerModelPropertiesMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.nodeCapacityInput);
     encoder->EncodeUInt32Value(value.nodeCountOutput);
     EncodeStructArray(encoder, value.nodeProperties, value.nodeCapacityInput);
@@ -1992,14 +1992,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrControllerModelPropertiesMS
 void EncodeStruct(ParameterEncoder* encoder, const XrControllerModelNodeStateMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStruct(encoder, value.nodePose);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrControllerModelStateMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.nodeCapacityInput);
     encoder->EncodeUInt32Value(value.nodeCountOutput);
     EncodeStructArray(encoder, value.nodeStates, value.nodeCapacityInput);
@@ -2139,7 +2139,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemBodyTrackingPropertie
 void EncodeStruct(ParameterEncoder* encoder, const XrBodyTrackerCreateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.bodyJointSet);
 }
 
@@ -2153,7 +2153,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrBodySkeletonJointFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrBodySkeletonFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.jointCount);
     EncodeStructArray(encoder, value.joints, value.jointCount);
 }
@@ -2161,7 +2161,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrBodySkeletonFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrBodyJointsLocateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.baseSpace);
     encoder->EncodeXrTimeValue(value.time);
 }
@@ -2169,7 +2169,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrBodyJointsLocateInfoFB& val
 void EncodeStruct(ParameterEncoder* encoder, const XrBodyJointLocationsFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.isActive);
     encoder->EncodeFloatValue(value.confidence);
     encoder->EncodeUInt32Value(value.jointCount);
@@ -2181,7 +2181,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrBodyJointLocationsFB& value
 void EncodeStruct(ParameterEncoder* encoder, const XrInteractionProfileDpadBindingEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::PathWrapper>(value.binding);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::ActionSetWrapper>(value.actionSet);
     encoder->EncodeFloatValue(value.forceThreshold);
@@ -2196,7 +2196,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrInteractionProfileDpadBindi
 void EncodeStruct(ParameterEncoder* encoder, const XrInteractionProfileAnalogThresholdVALVE& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::ActionWrapper>(value.action);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::PathWrapper>(value.binding);
     encoder->EncodeFloatValue(value.onThreshold);
@@ -2220,13 +2220,13 @@ void EncodeStruct(ParameterEncoder* encoder, const XrUuidMSFT& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneObserverCreateInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneCreateInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneSphereBoundMSFT& value)
@@ -2310,7 +2310,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSceneComponentLocationMSFT&
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneComponentLocationsMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.locationCount);
     EncodeStructArray(encoder, value.locations, value.locationCount);
 }
@@ -2318,7 +2318,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSceneComponentLocationsMSFT
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneComponentsLocateInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.baseSpace);
     encoder->EncodeXrTimeValue(value.time);
     encoder->EncodeUInt32Value(value.componentIdCount);
@@ -2394,20 +2394,20 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSceneMeshesMSFT& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneMeshBuffersGetInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt64Value(value.meshBufferId);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneMeshBuffersMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneMeshVertexBufferMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.vertexCapacityInput);
     encoder->EncodeUInt32Value(value.vertexCountOutput);
     EncodeStructArray(encoder, value.vertices, value.vertexCapacityInput);
@@ -2416,7 +2416,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSceneMeshVertexBufferMSFT& 
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneMeshIndicesUint32MSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.indexCapacityInput);
     encoder->EncodeUInt32Value(value.indexCountOutput);
     encoder->EncodeUInt32Array(value.indices, value.indexCapacityInput);
@@ -2425,7 +2425,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSceneMeshIndicesUint32MSFT&
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneMeshIndicesUint16MSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.indexCapacityInput);
     encoder->EncodeUInt32Value(value.indexCountOutput);
     encoder->EncodeUInt16Array(value.indices, value.indexCapacityInput);
@@ -2434,7 +2434,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSceneMeshIndicesUint16MSFT&
 void EncodeStruct(ParameterEncoder* encoder, const XrSerializedSceneFragmentDataGetInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStruct(encoder, value.sceneFragmentId);
 }
 
@@ -2447,7 +2447,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrDeserializeSceneFragmentMSF
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneDeserializeInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.fragmentCount);
     EncodeStructArray(encoder, value.fragments, value.fragmentCount);
 }
@@ -2455,7 +2455,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSceneDeserializeInfoMSFT& v
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataDisplayRefreshRateChangedFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFloatValue(value.fromDisplayRefreshRate);
     encoder->EncodeFloatValue(value.toDisplayRefreshRate);
 }
@@ -2463,7 +2463,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataDisplayRefreshRate
 void EncodeStruct(ParameterEncoder* encoder, const XrViveTrackerPathsHTCX& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::PathWrapper>(value.persistentPath);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::PathWrapper>(value.rolePath);
 }
@@ -2471,7 +2471,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrViveTrackerPathsHTCX& value
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataViveTrackerConnectedHTCX& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStructPtr(encoder, value.paths);
 }
 
@@ -2486,7 +2486,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemFacialTrackingPropert
 void EncodeStruct(ParameterEncoder* encoder, const XrFacialExpressionsHTC& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.isActive);
     encoder->EncodeXrTimeValue(value.sampleTime);
     encoder->EncodeUInt32Value(value.expressionCount);
@@ -2496,7 +2496,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrFacialExpressionsHTC& value
 void EncodeStruct(ParameterEncoder* encoder, const XrFacialTrackerCreateInfoHTC& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.facialTrackingType);
 }
 
@@ -2518,7 +2518,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVector4sFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrHandTrackingMeshFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.jointCapacityInput);
     encoder->EncodeUInt32Value(value.jointCountOutput);
     EncodeStructArray(encoder, value.jointBindPoses, value.jointCapacityInput);
@@ -2582,7 +2582,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemSpatialEntityProperti
 void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorCreateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     EncodeStruct(encoder, value.poseInSpace);
     encoder->EncodeXrTimeValue(value.time);
@@ -2591,7 +2591,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorCreateInfoFB& 
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceComponentStatusSetInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.componentType);
     encoder->EncodeUInt32Value(value.enabled);
     encoder->EncodeInt64Value(value.timeout);
@@ -2600,7 +2600,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceComponentStatusSetInfo
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceComponentStatusFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.enabled);
     encoder->EncodeUInt32Value(value.changePending);
 }
@@ -2608,7 +2608,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceComponentStatusFB& val
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpatialAnchorCreateCompleteFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::AsyncRequestIdFBWrapper>(value.requestId);
     encoder->EncodeEnumValue(value.result);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
@@ -2618,7 +2618,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpatialAnchorCreat
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpaceSetStatusCompleteFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::AsyncRequestIdFBWrapper>(value.requestId);
     encoder->EncodeEnumValue(value.result);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
@@ -2643,7 +2643,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainCreateInfoFoveatio
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainStateFoveationFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.flags);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::FoveationProfileFBWrapper>(value.profile);
 }
@@ -2675,21 +2675,21 @@ void EncodeStruct(ParameterEncoder* encoder, const XrKeyboardTrackingDescription
 void EncodeStruct(ParameterEncoder* encoder, const XrKeyboardSpaceCreateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt64Value(value.trackedKeyboardId);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrKeyboardTrackingQueryFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.flags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrTriangleMeshCreateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.flags);
     encoder->EncodeEnumValue(value.windingOrder);
     encoder->EncodeUInt32Value(value.vertexCount);
@@ -2715,14 +2715,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemPassthroughProperties
 void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughCreateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.flags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughLayerCreateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::PassthroughFBWrapper>(value.passthrough);
     encoder->EncodeFlags64Value(value.flags);
     encoder->EncodeEnumValue(value.purpose);
@@ -2731,7 +2731,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughLayerCreateInfoF
 void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerPassthroughFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.flags);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::PassthroughLayerFBWrapper>(value.layerHandle);
@@ -2740,7 +2740,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerPassthrough
 void EncodeStruct(ParameterEncoder* encoder, const XrGeometryInstanceCreateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::PassthroughLayerFBWrapper>(value.layer);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::TriangleMeshFBWrapper>(value.mesh);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.baseSpace);
@@ -2751,7 +2751,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrGeometryInstanceCreateInfoF
 void EncodeStruct(ParameterEncoder* encoder, const XrGeometryInstanceTransformFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.baseSpace);
     encoder->EncodeXrTimeValue(value.time);
     EncodeStruct(encoder, value.pose);
@@ -2792,14 +2792,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughBrightnessContra
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataPassthroughStateChangedFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.flags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrRenderModelPathInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::PathWrapper>(value.path);
 }
 
@@ -2817,7 +2817,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrRenderModelPropertiesFB& va
 void EncodeStruct(ParameterEncoder* encoder, const XrRenderModelBufferFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.bufferCapacityInput);
     encoder->EncodeUInt32Value(value.bufferCountOutput);
     encoder->EncodeUInt8Array(value.buffer, value.bufferCapacityInput);
@@ -2826,7 +2826,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrRenderModelBufferFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrRenderModelLoadInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::RenderModelKeyFBWrapper>(value.modelKey);
 }
 
@@ -2883,7 +2883,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemMarkerTrackingPropert
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataMarkerTrackingUpdateVARJO& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt64Value(value.markerId);
     encoder->EncodeUInt32Value(value.isActive);
     encoder->EncodeUInt32Value(value.isPredicted);
@@ -2893,7 +2893,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataMarkerTrackingUpda
 void EncodeStruct(ParameterEncoder* encoder, const XrMarkerSpaceCreateInfoVARJO& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt64Value(value.markerId);
     EncodeStruct(encoder, value.poseInMarkerSpace);
 }
@@ -2917,7 +2917,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrGlobalDimmerFrameEndInfoML&
 void EncodeStruct(ParameterEncoder* encoder, const XrCoordinateSpaceCreateInfoML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeMLCoordinateFrameUIDValue(value.cfuid);
     EncodeStruct(encoder, value.poseInCoordinateSpace);
 }
@@ -2973,20 +2973,20 @@ void EncodeStruct(ParameterEncoder* encoder, const XrMarkerDetectorCustomProfile
 void EncodeStruct(ParameterEncoder* encoder, const XrMarkerDetectorSnapshotInfoML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrMarkerDetectorStateML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.state);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrMarkerSpaceCreateInfoML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::MarkerDetectorMLWrapper>(value.markerDetector);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::MarkerMLWrapper>(value.marker);
     EncodeStruct(encoder, value.poseInMarkerSpace);
@@ -2995,7 +2995,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrMarkerSpaceCreateInfoML& va
 void EncodeStruct(ParameterEncoder* encoder, const XrLocalizationMapML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeString(value.name);
     EncodeStruct(encoder, value.mapUuid);
     encoder->EncodeEnumValue(value.mapType);
@@ -3004,7 +3004,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrLocalizationMapML& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataLocalizationChangedML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SessionWrapper>(value.session);
     encoder->EncodeEnumValue(value.state);
     EncodeStruct(encoder, value.map);
@@ -3015,20 +3015,20 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataLocalizationChange
 void EncodeStruct(ParameterEncoder* encoder, const XrLocalizationMapQueryInfoBaseHeaderML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrMapLocalizationRequestInfoML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStruct(encoder, value.mapUuid);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrLocalizationMapImportInfoML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.size);
     encoder->EncodeString(value.data);
 }
@@ -3036,7 +3036,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrLocalizationMapImportInfoML
 void EncodeStruct(ParameterEncoder* encoder, const XrLocalizationEnableEventsInfoML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.enabled);
 }
 
@@ -3048,7 +3048,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorPersistenceNam
 void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorPersistenceInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStruct(encoder, value.spatialAnchorPersistenceName);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpatialAnchorMSFTWrapper>(value.spatialAnchor);
 }
@@ -3056,7 +3056,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorPersistenceInf
 void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorFromPersistedAnchorCreateInfoMSFT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpatialAnchorStoreConnectionMSFTWrapper>(value.spatialAnchorStore);
     EncodeStruct(encoder, value.spatialAnchorPersistenceName);
 }
@@ -3191,7 +3191,7 @@ void EncodeStructArrayLoop<XrSpaceFilterInfoBaseHeaderFB>(ParameterEncoder* enco
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceQueryInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.queryAction);
     encoder->EncodeUInt32Value(value.maxResultCount);
     encoder->EncodeInt64Value(value.timeout);
@@ -3209,7 +3209,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceStorageLocationFilterI
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceUuidFilterInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.uuidCount);
     EncodeStructArray(encoder, value.uuids, value.uuidCount);
 }
@@ -3217,7 +3217,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceUuidFilterInfoFB& valu
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceComponentFilterInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.componentType);
 }
 
@@ -3230,7 +3230,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceQueryResultFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceQueryResultsFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.resultCapacityInput);
     encoder->EncodeUInt32Value(value.resultCountOutput);
     EncodeStructArray(encoder, value.results, value.resultCapacityInput);
@@ -3239,14 +3239,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceQueryResultsFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpaceQueryResultsAvailableFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::AsyncRequestIdFBWrapper>(value.requestId);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpaceQueryCompleteFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::AsyncRequestIdFBWrapper>(value.requestId);
     encoder->EncodeEnumValue(value.result);
 }
@@ -3254,7 +3254,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpaceQueryComplete
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceSaveInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     encoder->EncodeEnumValue(value.location);
     encoder->EncodeEnumValue(value.persistenceMode);
@@ -3263,7 +3263,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceSaveInfoFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceEraseInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     encoder->EncodeEnumValue(value.location);
 }
@@ -3271,7 +3271,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceEraseInfoFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpaceSaveCompleteFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::AsyncRequestIdFBWrapper>(value.requestId);
     encoder->EncodeEnumValue(value.result);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
@@ -3282,7 +3282,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpaceSaveCompleteF
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpaceEraseCompleteFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::AsyncRequestIdFBWrapper>(value.requestId);
     encoder->EncodeEnumValue(value.result);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
@@ -3302,7 +3302,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainImageFoveationVulk
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainStateAndroidSurfaceDimensionsFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.width);
     encoder->EncodeUInt32Value(value.height);
 }
@@ -3310,7 +3310,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainStateAndroidSurfac
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainStateSamplerOpenGLESFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.minFilter);
     encoder->EncodeUInt32Value(value.magFilter);
     encoder->EncodeUInt32Value(value.wrapModeS);
@@ -3326,7 +3326,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainStateSamplerOpenGL
 void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainStateSamplerVulkanFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.minFilter);
     encoder->EncodeEnumValue(value.magFilter);
     encoder->EncodeEnumValue(value.mipmapMode);
@@ -3343,7 +3343,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSwapchainStateSamplerVulkan
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceShareInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.spaceCount);
     encoder->EncodeOpenXrHandleArray<openxr_wrappers::SpaceWrapper>(value.spaces, value.spaceCount);
     encoder->EncodeUInt32Value(value.userCount);
@@ -3353,7 +3353,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceShareInfoFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpaceShareCompleteFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::AsyncRequestIdFBWrapper>(value.requestId);
     encoder->EncodeEnumValue(value.result);
 }
@@ -3383,7 +3383,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemSpaceWarpPropertiesFB
 void EncodeStruct(ParameterEncoder* encoder, const XrHapticAmplitudeEnvelopeVibrationFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeInt64Value(value.duration);
     encoder->EncodeUInt32Value(value.amplitudeCount);
     encoder->EncodeFloatArray(value.amplitudes, value.amplitudeCount);
@@ -3405,7 +3405,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrRect3DfFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrSemanticLabelsFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.bufferCapacityInput);
     encoder->EncodeUInt32Value(value.bufferCountOutput);
     encoder->EncodeString(value.buffer);
@@ -3414,7 +3414,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSemanticLabelsFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrRoomLayoutFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStruct(encoder, value.floorUuid);
     EncodeStruct(encoder, value.ceilingUuid);
     encoder->EncodeUInt32Value(value.wallUuidCapacityInput);
@@ -3425,7 +3425,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrRoomLayoutFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrBoundary2DFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.vertexCapacityInput);
     encoder->EncodeUInt32Value(value.vertexCountOutput);
     EncodeStructArray(encoder, value.vertices, value.vertexCapacityInput);
@@ -3434,7 +3434,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrBoundary2DFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrSemanticLabelsSupportInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.flags);
     encoder->EncodeString(value.recognizedLabels);
 }
@@ -3442,14 +3442,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSemanticLabelsSupportInfoFB
 void EncodeStruct(ParameterEncoder* encoder, const XrDigitalLensControlALMALENCE& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.flags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSceneCaptureCompleteFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::AsyncRequestIdFBWrapper>(value.requestId);
     encoder->EncodeEnumValue(value.result);
 }
@@ -3457,7 +3457,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSceneCaptureComple
 void EncodeStruct(ParameterEncoder* encoder, const XrSceneCaptureRequestInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.requestByteCount);
     encoder->EncodeString(value.request);
 }
@@ -3465,7 +3465,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSceneCaptureRequestInfoFB& 
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceContainerFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.uuidCapacityInput);
     encoder->EncodeUInt32Value(value.uuidCountOutput);
     EncodeStructArray(encoder, value.uuids, value.uuidCapacityInput);
@@ -3481,7 +3481,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrFoveationEyeTrackedProfileC
 void EncodeStruct(ParameterEncoder* encoder, const XrFoveationEyeTrackedStateMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStructArray(encoder, value.foveationCenter, XR_FOVEATION_CENTER_SIZE_META);
     encoder->EncodeFlags64Value(value.flags);
 }
@@ -3503,14 +3503,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemFaceTrackingPropertie
 void EncodeStruct(ParameterEncoder* encoder, const XrFaceTrackerCreateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.faceExpressionSet);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrFaceExpressionInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeXrTimeValue(value.time);
 }
 
@@ -3523,7 +3523,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrFaceExpressionStatusFB& val
 void EncodeStruct(ParameterEncoder* encoder, const XrFaceExpressionWeightsFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.weightCount);
     encoder->EncodeFloatArray(value.weights, value.weightCount);
     encoder->EncodeUInt32Value(value.confidenceCount);
@@ -3542,13 +3542,13 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEyeGazeFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrEyeTrackerCreateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEyeGazesInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.baseSpace);
     encoder->EncodeXrTimeValue(value.time);
 }
@@ -3563,7 +3563,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemEyeTrackingProperties
 void EncodeStruct(ParameterEncoder* encoder, const XrEyeGazesFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStructArray(encoder, value.gaze, XR_EYE_POSITION_COUNT_FB);
     encoder->EncodeXrTimeValue(value.time);
 }
@@ -3571,7 +3571,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEyeGazesFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughKeyboardHandsIntensityFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFloatValue(value.leftHandIntensity);
     encoder->EncodeFloatValue(value.rightHandIntensity);
 }
@@ -3586,7 +3586,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrCompositionLayerSettingsFB&
 void EncodeStruct(ParameterEncoder* encoder, const XrHapticPcmVibrationFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.bufferSize);
     encoder->EncodeFloatArray(value.buffer, value.bufferSize);
     encoder->EncodeFloatValue(value.sampleRate);
@@ -3597,7 +3597,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrHapticPcmVibrationFB& value
 void EncodeStruct(ParameterEncoder* encoder, const XrDevicePcmSampleRateStateFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFloatValue(value.sampleRate);
 }
 
@@ -3619,7 +3619,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrLocalDimmingFrameEndInfoMET
 void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughPreferencesMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.flags);
 }
 
@@ -3633,13 +3633,13 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemVirtualKeyboardProper
 void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardCreateInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardSpaceCreateInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.locationType);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     EncodeStruct(encoder, value.poseInSpace);
@@ -3648,7 +3648,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardSpaceCreateI
 void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardLocationInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.locationType);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     EncodeStruct(encoder, value.poseInSpace);
@@ -3658,14 +3658,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardLocationInfo
 void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardModelVisibilitySetInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.visible);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardAnimationStateMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeInt32Value(value.animationIndex);
     encoder->EncodeFloatValue(value.fraction);
 }
@@ -3673,7 +3673,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardAnimationSta
 void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardModelAnimationStatesMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.stateCapacityInput);
     encoder->EncodeUInt32Value(value.stateCountOutput);
     EncodeStructArray(encoder, value.states, value.stateCapacityInput);
@@ -3682,7 +3682,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardModelAnimati
 void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardTextureDataMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.textureWidth);
     encoder->EncodeUInt32Value(value.textureHeight);
     encoder->EncodeUInt32Value(value.bufferCapacityInput);
@@ -3693,7 +3693,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardTextureDataM
 void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardInputInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.inputSource);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.inputSpace);
     EncodeStruct(encoder, value.inputPoseInSpace);
@@ -3703,14 +3703,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardInputInfoMET
 void EncodeStruct(ParameterEncoder* encoder, const XrVirtualKeyboardTextContextChangeInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeString(value.textContext);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataVirtualKeyboardCommitTextMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::VirtualKeyboardMETAWrapper>(value.keyboard);
     encoder->EncodeString(value.text);
 }
@@ -3718,28 +3718,28 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataVirtualKeyboardCom
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataVirtualKeyboardBackspaceMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::VirtualKeyboardMETAWrapper>(value.keyboard);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataVirtualKeyboardEnterMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::VirtualKeyboardMETAWrapper>(value.keyboard);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataVirtualKeyboardShownMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::VirtualKeyboardMETAWrapper>(value.keyboard);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataVirtualKeyboardHiddenMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::VirtualKeyboardMETAWrapper>(value.keyboard);
 }
 
@@ -3763,7 +3763,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrExternalCameraExtrinsicsOCU
 void EncodeStruct(ParameterEncoder* encoder, const XrExternalCameraOCULUS& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeString(value.name);
     EncodeStruct(encoder, value.intrinsics);
     EncodeStruct(encoder, value.extrinsics);
@@ -3780,14 +3780,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrVulkanSwapchainCreateInfoME
 void EncodeStruct(ParameterEncoder* encoder, const XrPerformanceMetricsStateMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.enabled);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrPerformanceMetricsCounterMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.counterFlags);
     encoder->EncodeEnumValue(value.counterUnit);
     encoder->EncodeUInt32Value(value.uintValue);
@@ -3797,7 +3797,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPerformanceMetricsCounterME
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceListSaveInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.spaceCount);
     encoder->EncodeOpenXrHandleArray<openxr_wrappers::SpaceWrapper>(value.spaces, value.spaceCount);
     encoder->EncodeEnumValue(value.location);
@@ -3806,7 +3806,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpaceListSaveInfoFB& value)
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpaceListSaveCompleteFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrAtomValue<openxr_wrappers::AsyncRequestIdFBWrapper>(value.requestId);
     encoder->EncodeEnumValue(value.result);
 }
@@ -3814,7 +3814,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataSpaceListSaveCompl
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceUserCreateInfoFB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt64Value(value.userId);
 }
 
@@ -3828,7 +3828,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemHeadsetIdPropertiesME
 void EncodeStruct(ParameterEncoder* encoder, const XrRecommendedLayerResolutionMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStruct(encoder, value.recommendedImageDimensions);
     encoder->EncodeUInt32Value(value.isValid);
 }
@@ -3836,7 +3836,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrRecommendedLayerResolutionM
 void EncodeStruct(ParameterEncoder* encoder, const XrRecommendedLayerResolutionGetInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStructPtr(encoder, value.layer);
     encoder->EncodeXrTimeValue(value.predictedDisplayTime);
 }
@@ -3850,7 +3850,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughColorLutDataMETA
 void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughColorLutCreateInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.channels);
     encoder->EncodeUInt32Value(value.resolution);
     EncodeStruct(encoder, value.data);
@@ -3859,7 +3859,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughColorLutCreateIn
 void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughColorLutUpdateInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStruct(encoder, value.data);
 }
 
@@ -3890,13 +3890,13 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemPassthroughColorLutPr
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceTriangleMeshGetInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrSpaceTriangleMeshMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.vertexCapacityInput);
     encoder->EncodeUInt32Value(value.vertexCountOutput);
     EncodeStructArray(encoder, value.vertices, value.vertexCapacityInput);
@@ -3916,7 +3916,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemFaceTrackingPropertie
 void EncodeStruct(ParameterEncoder* encoder, const XrFaceTrackerCreateInfo2FB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.faceExpressionSet);
     encoder->EncodeUInt32Value(value.requestedDataSourceCount);
     encoder->EncodeEnumArray(value.requestedDataSources, value.requestedDataSourceCount);
@@ -3925,14 +3925,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrFaceTrackerCreateInfo2FB& v
 void EncodeStruct(ParameterEncoder* encoder, const XrFaceExpressionInfo2FB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeXrTimeValue(value.time);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrFaceExpressionWeights2FB& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.weightCount);
     encoder->EncodeFloatArray(value.weights, value.weightCount);
     encoder->EncodeUInt32Value(value.confidenceCount);
@@ -3946,21 +3946,21 @@ void EncodeStruct(ParameterEncoder* encoder, const XrFaceExpressionWeights2FB& v
 void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthProviderCreateInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.createFlags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthSwapchainCreateInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.createFlags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthSwapchainStateMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.width);
     encoder->EncodeUInt32Value(value.height);
 }
@@ -3968,7 +3968,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthSwapchainSt
 void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthImageAcquireInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     encoder->EncodeXrTimeValue(value.displayTime);
 }
@@ -3976,7 +3976,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthImageAcquir
 void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthImageViewMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     EncodeStruct(encoder, value.fov);
     EncodeStruct(encoder, value.pose);
 }
@@ -3984,7 +3984,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthImageViewME
 void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthImageMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.swapchainIndex);
     encoder->EncodeFloatValue(value.nearZ);
     encoder->EncodeFloatValue(value.farZ);
@@ -3994,7 +3994,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthImageMETA& 
 void EncodeStruct(ParameterEncoder* encoder, const XrEnvironmentDepthHandRemovalSetInfoMETA& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.enabled);
 }
 
@@ -4009,14 +4009,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemEnvironmentDepthPrope
 void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughCreateInfoHTC& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.form);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrPassthroughColorHTC& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFloatValue(value.alpha);
 }
 
@@ -4090,7 +4090,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorNameHTC& value
 void EncodeStruct(ParameterEncoder* encoder, const XrSpatialAnchorCreateInfoHTC& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.space);
     EncodeStruct(encoder, value.poseInSpace);
     EncodeStruct(encoder, value.name);
@@ -4126,7 +4126,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrForceFeedbackCurlApplyLocat
 void EncodeStruct(ParameterEncoder* encoder, const XrForceFeedbackCurlApplyLocationsMNDX& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.locationCount);
     EncodeStructArray(encoder, value.locations, value.locationCount);
 }
@@ -4157,14 +4157,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemPlaneDetectionPropert
 void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeFlags64Value(value.flags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorBeginInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.baseSpace);
     encoder->EncodeXrTimeValue(value.time);
     encoder->EncodeUInt32Value(value.orientationCount);
@@ -4180,7 +4180,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorBeginInfoEXT& 
 void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorGetInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SpaceWrapper>(value.baseSpace);
     encoder->EncodeXrTimeValue(value.time);
 }
@@ -4188,7 +4188,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorGetInfoEXT& va
 void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorLocationEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt64Value(value.planeId);
     encoder->EncodeFlags64Value(value.locationFlags);
     EncodeStruct(encoder, value.pose);
@@ -4201,7 +4201,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorLocationEXT& v
 void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorLocationsEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.planeLocationCapacityInput);
     encoder->EncodeUInt32Value(value.planeLocationCountOutput);
     EncodeStructArray(encoder, value.planeLocations, value.planeLocationCapacityInput);
@@ -4210,7 +4210,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorLocationsEXT& 
 void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorPolygonBufferEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.vertexCapacityInput);
     encoder->EncodeUInt32Value(value.vertexCountOutput);
     EncodeStructArray(encoder, value.vertices, value.vertexCapacityInput);
@@ -4219,14 +4219,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrPlaneDetectorPolygonBufferE
 void EncodeStruct(ParameterEncoder* encoder, const XrFutureCancelInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrOpaqueValue<openxr_wrappers::FutureEXTWrapper>(value.future);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrFuturePollInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrOpaqueValue<openxr_wrappers::FutureEXTWrapper>(value.future);
 }
 
@@ -4272,21 +4272,21 @@ void EncodeStructArrayLoop<XrFutureCompletionBaseHeaderEXT>(ParameterEncoder* en
 void EncodeStruct(ParameterEncoder* encoder, const XrFutureCompletionEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.futureResult);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrFuturePollResultEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.state);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataUserPresenceChangedEXT& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeOpenXrHandleValue<openxr_wrappers::SessionWrapper>(value.session);
     encoder->EncodeUInt32Value(value.isUserPresent);
 }
@@ -4301,7 +4301,7 @@ void EncodeStruct(ParameterEncoder* encoder, const XrSystemUserPresencePropertie
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataHeadsetFitChangedML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.status);
     encoder->EncodeXrTimeValue(value.time);
 }
@@ -4309,14 +4309,14 @@ void EncodeStruct(ParameterEncoder* encoder, const XrEventDataHeadsetFitChangedM
 void EncodeStruct(ParameterEncoder* encoder, const XrEventDataEyeCalibrationChangedML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeEnumValue(value.status);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const XrUserCalibrationEnableEventsInfoML& value)
 {
     encoder->EncodeEnumValue(value.type);
-    EncodeNextStruct(encoder, value.next);
+    EncodeNextStructIfValid(encoder, value.next);
     encoder->EncodeUInt32Value(value.enabled);
 }
 

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -922,7 +922,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryBarrier& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryBarrier& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.srcAccessMask);
     encoder->EncodeFlagsValue(value.dstAccessMask);
 }
@@ -949,7 +949,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAllocationCallbacks& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkApplicationInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeString(value.pApplicationName);
     encoder->EncodeUInt32Value(value.applicationVersion);
     encoder->EncodeString(value.pEngineName);
@@ -1258,7 +1258,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSubmitInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkMappedMemoryRange& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeUInt64Value(value.offset);
     encoder->EncodeUInt64Value(value.size);
@@ -1375,7 +1375,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreCreateInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkEventCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
 }
 
@@ -1472,7 +1472,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkShaderModuleCreateInfo& val
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCacheCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeSizeTValue(value.initialDataSize);
     encoder->EncodeVoidArray(value.pInitialData, value.initialDataSize);
@@ -1544,7 +1544,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineVertexInputStateCre
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineInputAssemblyStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.topology);
     encoder->EncodeUInt32Value(value.primitiveRestartEnable);
@@ -1623,7 +1623,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkStencilOpState& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineDepthStencilStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.depthTestEnable);
     encoder->EncodeUInt32Value(value.depthWriteEnable);
@@ -1663,7 +1663,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineColorBlendStateCrea
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineDynamicStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.dynamicStateCount);
     encoder->EncodeEnumArray(value.pDynamicStates, value.dynamicStateCount);
@@ -1735,7 +1735,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSamplerCreateInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyDescriptorSet& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DescriptorSetWrapper>(value.srcSet);
     encoder->EncodeUInt32Value(value.srcBinding);
     encoder->EncodeUInt32Value(value.srcArrayElement);
@@ -1868,7 +1868,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassCreateInfo& value
 void EncodeStruct(ParameterEncoder* encoder, const VkCommandPoolCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.queueFamilyIndex);
 }
@@ -1876,7 +1876,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCommandPoolCreateInfo& valu
 void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferAllocateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::CommandPoolWrapper>(value.commandPool);
     encoder->EncodeEnumValue(value.level);
     encoder->EncodeUInt32Value(value.commandBufferCount);
@@ -2103,7 +2103,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemoryDeviceGroupI
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceGroupProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.physicalDeviceCount);
     encoder->EncodeVulkanHandleArray<vulkan_wrappers::PhysicalDeviceWrapper>(value.physicalDevices, value.physicalDeviceCount);
     encoder->EncodeUInt32Value(value.subsetAllocation);
@@ -2120,7 +2120,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupDeviceCreateInfo
 void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
 }
 
@@ -2134,7 +2134,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryRequirementsInfo
 void EncodeStruct(ParameterEncoder* encoder, const VkImageSparseMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
 }
 
@@ -2148,7 +2148,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryRequirements2& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryRequirements2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.memoryRequirements);
 }
 
@@ -2208,14 +2208,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryPropert
 void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageFormatProperties2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.properties);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseImageFormatInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.format);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeEnumValue(value.samples);
@@ -2313,7 +2313,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceProtectedMemo
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceQueueInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.queueFamilyIndex);
     encoder->EncodeUInt32Value(value.queueIndex);
@@ -2388,7 +2388,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateEnt
 void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.descriptorUpdateEntryCount);
     EncodeStructArray(encoder, value.pDescriptorUpdateEntries, value.descriptorUpdateEntryCount);
@@ -2432,7 +2432,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalBuffe
 void EncodeStruct(ParameterEncoder* encoder, const VkExternalBufferProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.externalMemoryProperties);
 }
 
@@ -2471,14 +2471,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfo& v
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalFenceInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.handleType);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkExternalFenceProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.exportFromImportedHandleTypes);
     encoder->EncodeFlagsValue(value.compatibleHandleTypes);
     encoder->EncodeFlagsValue(value.externalFenceFeatures);
@@ -2508,7 +2508,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalSemap
 void EncodeStruct(ParameterEncoder* encoder, const VkExternalSemaphoreProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.exportFromImportedHandleTypes);
     encoder->EncodeFlagsValue(value.compatibleHandleTypes);
     encoder->EncodeFlagsValue(value.externalSemaphoreFeatures);
@@ -2775,7 +2775,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassCreateInfo2& valu
 void EncodeStruct(ParameterEncoder* encoder, const VkSubpassBeginInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.contents);
 }
 
@@ -2988,7 +2988,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceImagelessFram
 void EncodeStruct(ParameterEncoder* encoder, const VkFramebufferAttachmentImageInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeFlagsValue(value.usage);
     encoder->EncodeUInt32Value(value.width);
@@ -3092,7 +3092,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkTimelineSemaphoreSubmitInfo
 void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreWaitInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.semaphoreCount);
     encoder->EncodeVulkanHandleArray<vulkan_wrappers::SemaphoreWrapper>(value.pSemaphores, value.semaphoreCount);
@@ -3102,7 +3102,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreWaitInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreSignalInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeUInt64Value(value.value);
 }
@@ -3119,7 +3119,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceBufferDeviceA
 void EncodeStruct(ParameterEncoder* encoder, const VkBufferDeviceAddressInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
 }
 
@@ -3140,7 +3140,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryOpaqueCaptureAddressA
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceMemoryOpaqueCaptureAddressInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
 }
 
@@ -3241,7 +3241,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderTermina
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceToolProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeString(value.name);
     encoder->EncodeString(value.version);
     encoder->EncodeFlagsValue(value.purposes);
@@ -3273,7 +3273,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDevicePrivateDataCreateInfo
 void EncodeStruct(ParameterEncoder* encoder, const VkPrivateDataSlotCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
 }
 
@@ -3328,7 +3328,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryBarrier2& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkDependencyInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.dependencyFlags);
     encoder->EncodeUInt32Value(value.memoryBarrierCount);
     EncodeStructArray(encoder, value.pMemoryBarriers, value.memoryBarrierCount);
@@ -3341,7 +3341,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDependencyInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreSubmitInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeUInt64Value(value.value);
     encoder->EncodeFlags64Value(value.stageMask);
@@ -3393,7 +3393,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceImageRobustne
 void EncodeStruct(ParameterEncoder* encoder, const VkBufferCopy2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.srcOffset);
     encoder->EncodeUInt64Value(value.dstOffset);
     encoder->EncodeUInt64Value(value.size);
@@ -3402,7 +3402,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferCopy2& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyBufferInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::BufferWrapper>(value.srcBuffer);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::BufferWrapper>(value.dstBuffer);
     encoder->EncodeUInt32Value(value.regionCount);
@@ -3412,7 +3412,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyBufferInfo2& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkImageCopy2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.srcSubresource);
     EncodeStruct(encoder, value.srcOffset);
     EncodeStruct(encoder, value.dstSubresource);
@@ -3423,7 +3423,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageCopy2& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ImageWrapper>(value.dstImage);
@@ -3447,7 +3447,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferImageCopy2& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyBufferToImageInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::BufferWrapper>(value.srcBuffer);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
@@ -3458,7 +3458,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyBufferToImageInfo2& val
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageToBufferInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::BufferWrapper>(value.dstBuffer);
@@ -3492,7 +3492,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBlitImageInfo2& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkImageResolve2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.srcSubresource);
     EncodeStruct(encoder, value.srcOffset);
     EncodeStruct(encoder, value.dstSubresource);
@@ -3503,7 +3503,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageResolve2& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkResolveImageInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ImageWrapper>(value.dstImage);
@@ -3716,14 +3716,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMaintenance4P
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceBufferMemoryRequirements& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStructPtr(encoder, value.pCreateInfo);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceImageMemoryRequirements& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStructPtr(encoder, value.pCreateInfo);
     encoder->EncodeEnumValue(value.planeAspect);
 }
@@ -3909,7 +3909,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryMapInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryUnmapInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
 }
@@ -3936,7 +3936,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMaintenance5P
 void EncodeStruct(ParameterEncoder* encoder, const VkRenderingAreaInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.viewMask);
     encoder->EncodeUInt32Value(value.colorAttachmentCount);
     encoder->EncodeEnumArray(value.pColorAttachmentFormats, value.colorAttachmentCount);
@@ -3947,14 +3947,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderingAreaInfo& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkImageSubresource2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.imageSubresource);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceImageSubresourceInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStructPtr(encoder, value.pCreateInfo);
     EncodeStructPtr(encoder, value.pSubresource);
 }
@@ -4126,7 +4126,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceHostImageCopy
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageToImageInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
@@ -4139,7 +4139,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageToImageInfo& value
 void EncodeStruct(ParameterEncoder* encoder, const VkHostImageLayoutTransitionInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
     encoder->EncodeEnumValue(value.oldLayout);
     encoder->EncodeEnumValue(value.newLayout);
@@ -4233,7 +4233,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemorySwapchainInf
 void EncodeStruct(ParameterEncoder* encoder, const VkAcquireNextImageInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(value.swapchain);
     encoder->EncodeUInt64Value(value.timeout);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
@@ -4244,7 +4244,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAcquireNextImageInfoKHR& va
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupPresentCapabilitiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Array(value.presentMask, VK_MAX_DEVICE_GROUP_SIZE);
     encoder->EncodeFlagsValue(value.modes);
 }
@@ -4274,7 +4274,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeParametersKHR& v
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     EncodeStruct(encoder, value.parameters);
 }
@@ -4341,7 +4341,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPresentInfoKHR& valu
 void EncodeStruct(ParameterEncoder* encoder, const VkXlibSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.dpy);
     encoder->EncodeSizeTValue(value.window);
@@ -4350,7 +4350,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkXlibSurfaceCreateInfoKHR& v
 void EncodeStruct(ParameterEncoder* encoder, const VkXcbSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.connection);
     encoder->EncodeUInt32Value(value.window);
@@ -4359,7 +4359,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkXcbSurfaceCreateInfoKHR& va
 void EncodeStruct(ParameterEncoder* encoder, const VkWaylandSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.display);
     encoder->EncodeVoidPtr(value.surface);
@@ -4368,7 +4368,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWaylandSurfaceCreateInfoKHR
 void EncodeStruct(ParameterEncoder* encoder, const VkAndroidSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.window);
 }
@@ -4376,7 +4376,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAndroidSurfaceCreateInfoKHR
 void EncodeStruct(ParameterEncoder* encoder, const VkWin32SurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.hinstance);
     encoder->EncodeVoidPtr(value.hwnd);
@@ -4451,7 +4451,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoFormatPropertiesKHR& v
 void EncodeStruct(ParameterEncoder* encoder, const VkVideoPictureResourceInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.codedOffset);
     EncodeStruct(encoder, value.codedExtent);
     encoder->EncodeUInt32Value(value.baseArrayLayer);
@@ -4469,7 +4469,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoReferenceSlotInfoKHR& 
 void EncodeStruct(ParameterEncoder* encoder, const VkVideoSessionMemoryRequirementsKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryBindIndex);
     EncodeStruct(encoder, value.memoryRequirements);
 }
@@ -4477,7 +4477,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoSessionMemoryRequireme
 void EncodeStruct(ParameterEncoder* encoder, const VkBindVideoSessionMemoryInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryBindIndex);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeUInt64Value(value.memoryOffset);
@@ -4529,7 +4529,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoBeginCodingInfoKHR& va
 void EncodeStruct(ParameterEncoder* encoder, const VkVideoEndCodingInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
 }
 
@@ -4657,7 +4657,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoEncodeH264SessionParam
 void EncodeStruct(ParameterEncoder* encoder, const VkVideoEncodeH264NaluSliceInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeInt32Value(value.constantQp);
     EncodeStructPtr(encoder, value.pStdSliceHeader);
 }
@@ -4798,14 +4798,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfo
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryWin32HandlePropertiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryTypeBits);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
@@ -4821,14 +4821,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryFdInfoKHR& valu
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryFdPropertiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryTypeBits);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
@@ -4849,7 +4849,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireRelea
 void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
@@ -4879,7 +4879,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkD3D12FenceSubmitInfoKHR& va
 void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
@@ -4887,7 +4887,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetWin32HandleInfo
 void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
@@ -4897,7 +4897,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreFdInfoKHR& v
 void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
@@ -4933,7 +4933,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSharedPresentSurfaceCapabil
 void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::FenceWrapper>(value.fence);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
@@ -4953,7 +4953,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkExportFenceWin32HandleInfoK
 void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::FenceWrapper>(value.fence);
     encoder->EncodeEnumValue(value.handleType);
 }
@@ -4961,7 +4961,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetWin32HandleInfoKHR&
 void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::FenceWrapper>(value.fence);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
@@ -4971,7 +4971,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceFdInfoKHR& value
 void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::FenceWrapper>(value.fence);
     encoder->EncodeEnumValue(value.handleType);
 }
@@ -4994,7 +4994,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevicePerformanceQu
 void EncodeStruct(ParameterEncoder* encoder, const VkPerformanceCounterKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.unit);
     encoder->EncodeEnumValue(value.scope);
     encoder->EncodeEnumValue(value.storage);
@@ -5004,7 +5004,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPerformanceCounterKHR& valu
 void EncodeStruct(ParameterEncoder* encoder, const VkPerformanceCounterDescriptionKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeString(value.name);
     encoder->EncodeString(value.category);
@@ -5023,7 +5023,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkQueryPoolPerformanceCreateI
 void EncodeStruct(ParameterEncoder* encoder, const VkAcquireProfilingLockInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt64Value(value.timeout);
 }
@@ -5059,14 +5059,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceFormat2KHR& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayProperties2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.displayProperties);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneProperties2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.displayPlaneProperties);
 }
 
@@ -5080,7 +5080,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeProperties2KHR& 
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneInfo2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DisplayModeKHRWrapper>(value.mode);
     encoder->EncodeUInt32Value(value.planeIndex);
 }
@@ -5088,7 +5088,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneInfo2KHR& value
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilities2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.capabilities);
 }
 
@@ -5188,7 +5188,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentShadi
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentShadingRateKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.sampleCounts);
     EncodeStruct(encoder, value.fragmentSize);
 }
@@ -5233,14 +5233,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevicePipelineExecu
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutablePropertiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.stages);
     encoder->EncodeString(value.name);
     encoder->EncodeString(value.description);
@@ -5250,7 +5250,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutablePropertie
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutableInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
     encoder->EncodeUInt32Value(value.executableIndex);
 }
@@ -5258,7 +5258,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutableInfoKHR& 
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutableStatisticKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeString(value.name);
     encoder->EncodeString(value.description);
     encoder->EncodeEnumValue(value.format);
@@ -5268,7 +5268,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutableStatistic
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutableInternalRepresentationKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeString(value.name);
     encoder->EncodeString(value.description);
     encoder->EncodeUInt32Value(value.isText);
@@ -5368,7 +5368,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoEncodeRateControlInfoK
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStructPtr(encoder, value.pVideoProfile);
     encoder->EncodeUInt32Value(value.qualityLevel);
 }
@@ -5512,7 +5512,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevicePresentWait2F
 void EncodeStruct(ParameterEncoder* encoder, const VkPresentWait2InfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.presentId);
     encoder->EncodeUInt64Value(value.timeout);
 }
@@ -5552,7 +5552,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDevicePipelineBinaryInterna
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryKeyKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.keySize);
     encoder->EncodeUInt8Array(value.key, VK_MAX_PIPELINE_BINARY_KEY_SIZE_KHR);
 }
@@ -5573,13 +5573,13 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryKeysAndDataKH
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStructPtr(encoder, value.pKeysAndDataInfo);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
     EncodeStructPtr(encoder, value.pPipelineCreateInfo);
@@ -5596,21 +5596,21 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryInfoKHR& valu
 void EncodeStruct(ParameterEncoder* encoder, const VkReleaseCapturedPipelineDataInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryDataInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineBinaryKHRWrapper>(value.pipelineBinary);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryHandlesInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.pipelineBinaryCount);
     encoder->EncodeVulkanHandleArray<vulkan_wrappers::PipelineBinaryKHRWrapper>(value.pPipelineBinaries, value.pipelineBinaryCount);
 }
@@ -5684,7 +5684,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainPresentScalingCrea
 void EncodeStruct(ParameterEncoder* encoder, const VkReleaseSwapchainImagesInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(value.swapchain);
     encoder->EncodeUInt32Value(value.imageIndexCount);
     encoder->EncodeUInt32Array(value.pImageIndices, value.imageIndexCount);
@@ -5693,7 +5693,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkReleaseSwapchainImagesInfoK
 void EncodeStruct(ParameterEncoder* encoder, const VkCooperativeMatrixPropertiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.MSize);
     encoder->EncodeUInt32Value(value.NSize);
     encoder->EncodeUInt32Value(value.KSize);
@@ -5992,7 +5992,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentFeedbackLoopInfoE
 void EncodeStruct(ParameterEncoder* encoder, const VkCalibratedTimestampInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.timeDomain);
 }
 
@@ -6034,7 +6034,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryIndirectCommandKH
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryIndirectInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.srcCopyFlags);
     encoder->EncodeFlagsValue(value.dstCopyFlags);
     encoder->EncodeUInt32Value(value.copyCount);
@@ -6054,7 +6054,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToImageIndirectCo
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToImageIndirectInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.srcCopyFlags);
     encoder->EncodeUInt32Value(value.copyCount);
     EncodeStruct(encoder, value.copyAddressRange);
@@ -6332,7 +6332,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationStateR
 void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectNameInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
     encoder->EncodeUInt64Value(vulkan_wrappers::GetWrappedId(value.object, value.objectType));
     encoder->EncodeString(value.pObjectName);
@@ -6341,7 +6341,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectNameInfoEX
 void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectTagInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
     encoder->EncodeUInt64Value(vulkan_wrappers::GetWrappedId(value.object, value.objectType));
     encoder->EncodeUInt64Value(value.tagName);
@@ -6352,7 +6352,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectTagInfoEXT
 void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerMarkerInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeString(value.pMarkerName);
     encoder->EncodeFloatArray(value.color, 4);
 }
@@ -6414,7 +6414,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationStateS
 void EncodeStruct(ParameterEncoder* encoder, const VkImageViewHandleInfoNVX& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ImageViewWrapper>(value.imageView);
     encoder->EncodeEnumValue(value.descriptorType);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SamplerWrapper>(value.sampler);
@@ -6423,7 +6423,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageViewHandleInfoNVX& val
 void EncodeStruct(ParameterEncoder* encoder, const VkImageViewAddressPropertiesNVX& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.deviceAddress);
     encoder->EncodeUInt64Value(value.size);
 }
@@ -6458,7 +6458,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkShaderStatisticsInfoAMD& va
 void EncodeStruct(ParameterEncoder* encoder, const VkStreamDescriptorSurfaceCreateInfoGGP& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt64Value(value.streamDescriptor);
 }
@@ -6532,7 +6532,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkValidationFlagsEXT& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkViSurfaceCreateInfoNN& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.window);
 }
@@ -6554,7 +6554,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceASTCDecodeFea
 void EncodeStruct(ParameterEncoder* encoder, const VkConditionalRenderingBeginInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeUInt64Value(value.offset);
     encoder->EncodeFlagsValue(value.flags);
@@ -6593,7 +6593,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportWScalingSta
 void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceCapabilities2EXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.minImageCount);
     encoder->EncodeUInt32Value(value.maxImageCount);
     EncodeStruct(encoder, value.currentExtent);
@@ -6610,21 +6610,21 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceCapabilities2EXT& va
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPowerInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.powerState);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceEventInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.deviceEvent);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayEventInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.displayEvent);
 }
 
@@ -6781,7 +6781,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRelaxedLineRa
 void EncodeStruct(ParameterEncoder* encoder, const VkIOSSurfaceCreateInfoMVK& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.pView);
 }
@@ -6789,7 +6789,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkIOSSurfaceCreateInfoMVK& va
 void EncodeStruct(ParameterEncoder* encoder, const VkMacOSSurfaceCreateInfoMVK& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.pView);
 }
@@ -6797,7 +6797,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMacOSSurfaceCreateInfoMVK& 
 void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsLabelEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeString(value.pLabelName);
     encoder->EncodeFloatArray(value.color, 4);
 }
@@ -6841,7 +6841,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCreateIn
 void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsObjectTagInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
     encoder->EncodeUInt64Value(vulkan_wrappers::GetWrappedId(value.objectHandle, value.objectType));
     encoder->EncodeUInt64Value(value.tagName);
@@ -6888,7 +6888,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportAndroidHardwareBuffer
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetAndroidHardwareBufferInfoANDROID& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
 }
 
@@ -6982,7 +6982,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSampleLocatio
 void EncodeStruct(ParameterEncoder* encoder, const VkMultisamplePropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.maxSampleLocationGridSize);
 }
 
@@ -7094,7 +7094,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageDrmFormatModifierExpli
 void EncodeStruct(ParameterEncoder* encoder, const VkImageDrmFormatModifierPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.drmFormatModifier);
 }
 
@@ -7116,7 +7116,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDrmFormatModifierProperties
 void EncodeStruct(ParameterEncoder* encoder, const VkValidationCacheCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeSizeTValue(value.initialDataSize);
     encoder->EncodeVoidArray(value.pInitialData, value.initialDataSize);
@@ -7188,7 +7188,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportCoarseSampl
 void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingShaderGroupCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeUInt32Value(value.generalShader);
     encoder->EncodeUInt32Value(value.closestHitShader);
@@ -7214,7 +7214,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingPipelineCreateInf
 void EncodeStruct(ParameterEncoder* encoder, const VkGeometryTrianglesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::BufferWrapper>(value.vertexData);
     encoder->EncodeUInt64Value(value.vertexOffset);
     encoder->EncodeUInt32Value(value.vertexCount);
@@ -7231,7 +7231,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeometryTrianglesNV& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkGeometryAABBNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::BufferWrapper>(value.aabbData);
     encoder->EncodeUInt32Value(value.numAABBs);
     encoder->EncodeUInt32Value(value.stride);
@@ -7247,7 +7247,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeometryDataNV& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkGeometryNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.geometryType);
     EncodeStruct(encoder, value.geometry);
     encoder->EncodeFlagsValue(value.flags);
@@ -7256,7 +7256,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeometryNV& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.instanceCount);
@@ -7267,7 +7267,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureInfoNV
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.compactedSize);
     EncodeStruct(encoder, value.info);
 }
@@ -7275,7 +7275,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureCreate
 void EncodeStruct(ParameterEncoder* encoder, const VkBindAccelerationStructureMemoryInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::AccelerationStructureNVWrapper>(value.accelerationStructure);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeUInt64Value(value.memoryOffset);
@@ -7294,7 +7294,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSetAccelerat
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureMemoryRequirementsInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::AccelerationStructureNVWrapper>(value.accelerationStructure);
 }
@@ -7378,7 +7378,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryHostPointerInfo
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryHostPointerPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryTypeBits);
 }
 
@@ -7502,7 +7502,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkQueueFamilyCheckpointProper
 void EncodeStruct(ParameterEncoder* encoder, const VkCheckpointDataNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.stage);
     encoder->EncodeVoidPtr(value.pCheckpointMarker);
 }
@@ -7517,7 +7517,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkQueueFamilyCheckpointProper
 void EncodeStruct(ParameterEncoder* encoder, const VkCheckpointData2NV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlags64Value(value.stage);
     encoder->EncodeVoidPtr(value.pCheckpointMarker);
 }
@@ -7532,7 +7532,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderInteger
 void EncodeStruct(ParameterEncoder* encoder, const VkInitializePerformanceApiInfoINTEL& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVoidPtr(value.pUserData);
 }
 
@@ -7546,21 +7546,21 @@ void EncodeStruct(ParameterEncoder* encoder, const VkQueryPoolPerformanceQueryCr
 void EncodeStruct(ParameterEncoder* encoder, const VkPerformanceMarkerInfoINTEL& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.marker);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPerformanceStreamMarkerInfoINTEL& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.marker);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPerformanceOverrideInfoINTEL& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeUInt32Value(value.enable);
     encoder->EncodeUInt64Value(value.parameter);
@@ -7569,7 +7569,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPerformanceOverrideInfoINTE
 void EncodeStruct(ParameterEncoder* encoder, const VkPerformanceConfigurationAcquireInfoINTEL& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
 }
 
@@ -7600,7 +7600,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainDisplayNativeHdrCr
 void EncodeStruct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfoFUCHSIA& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.imagePipeHandle);
 }
@@ -7608,7 +7608,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfoF
 void EncodeStruct(ParameterEncoder* encoder, const VkMetalSurfaceCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.pLayer);
 }
@@ -7727,7 +7727,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkValidationFeaturesEXT& valu
 void EncodeStruct(ParameterEncoder* encoder, const VkCooperativeMatrixPropertiesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.MSize);
     encoder->EncodeUInt32Value(value.NSize);
     encoder->EncodeUInt32Value(value.KSize);
@@ -7771,7 +7771,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCoverageReductionSt
 void EncodeStruct(ParameterEncoder* encoder, const VkFramebufferMixedSamplesCombinationNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.coverageReductionMode);
     encoder->EncodeEnumValue(value.rasterizationSamples);
     encoder->EncodeFlagsValue(value.depthStencilSamples);
@@ -7841,7 +7841,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceFullScreenExclusiveW
 void EncodeStruct(ParameterEncoder* encoder, const VkHeadlessSurfaceCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
 }
 
@@ -7936,7 +7936,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDeviceGenerat
 void EncodeStruct(ParameterEncoder* encoder, const VkGraphicsShaderGroupCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.stageCount);
     EncodeStructArray(encoder, value.pStages, value.stageCount);
     EncodeStructPtr(encoder, value.pVertexInputState);
@@ -7986,7 +7986,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsStreamNV& v
 void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutTokenNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.tokenType);
     encoder->EncodeUInt32Value(value.stream);
     encoder->EncodeUInt32Value(value.offset);
@@ -8005,7 +8005,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutToken
 void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
     encoder->EncodeUInt32Value(value.tokenCount);
@@ -8017,7 +8017,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutCreat
 void EncodeStruct(ParameterEncoder* encoder, const VkGeneratedCommandsInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(value.indirectCommandsLayout);
@@ -8036,7 +8036,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeneratedCommandsInfoNV& va
 void EncodeStruct(ParameterEncoder* encoder, const VkGeneratedCommandsMemoryRequirementsInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(value.indirectCommandsLayout);
@@ -8118,7 +8118,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDeviceMemoryR
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceMemoryReportCallbackDataEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeUInt64Value(value.memoryObjectId);
@@ -8236,19 +8236,19 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassTileShadingCreate
 void EncodeStruct(ParameterEncoder* encoder, const VkPerTileBeginInfoQCOM& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPerTileEndInfoQCOM& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDispatchTileInfoQCOM& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkQueryLowLatencySupportNV& value)
@@ -8458,7 +8458,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFaultFeatures
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceFaultCountsEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.addressInfoCount);
     encoder->EncodeUInt32Value(value.vendorInfoCount);
     encoder->EncodeUInt64Value(value.vendorBinarySize);
@@ -8481,7 +8481,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDeviceFaultVendorInfoEXT& v
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceFaultInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeString(value.description);
     EncodeStructPtr(encoder, value.pAddressInfos);
     EncodeStructPtr(encoder, value.pVendorInfos);
@@ -8522,7 +8522,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRGBA10X6Forma
 void EncodeStruct(ParameterEncoder* encoder, const VkDirectFBSurfaceCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.dfb);
     encoder->EncodeVoidPtr(value.surface);
@@ -8559,7 +8559,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVertexInputDy
 void EncodeStruct(ParameterEncoder* encoder, const VkVertexInputBindingDescription2EXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.binding);
     encoder->EncodeUInt32Value(value.stride);
     encoder->EncodeEnumValue(value.inputRate);
@@ -8569,7 +8569,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVertexInputBindingDescripti
 void EncodeStruct(ParameterEncoder* encoder, const VkVertexInputAttributeDescription2EXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.location);
     encoder->EncodeUInt32Value(value.binding);
     encoder->EncodeEnumValue(value.format);
@@ -8638,14 +8638,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryZirconHandleInf
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryZirconHandlePropertiesFUCHSIA& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryTypeBits);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetZirconHandleInfoFUCHSIA& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
@@ -8653,7 +8653,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetZirconHandleInfoFU
 void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreZirconHandleInfoFUCHSIA& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
@@ -8663,7 +8663,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreZirconHandle
 void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetZirconHandleInfoFUCHSIA& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
@@ -8678,7 +8678,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceInvocationMas
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetRemoteAddressInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
@@ -8746,7 +8746,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExtendedDynam
 void EncodeStruct(ParameterEncoder* encoder, const VkScreenSurfaceCreateInfoQNX& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.context);
     encoder->EncodeVoidPtr(value.window);
@@ -8887,7 +8887,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMicromapUsageEXT& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkMicromapBuildInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.mode);
@@ -8904,7 +8904,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMicromapBuildInfoEXT& value
 void EncodeStruct(ParameterEncoder* encoder, const VkMicromapCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.createFlags);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeUInt64Value(value.offset);
@@ -8933,14 +8933,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceOpacityMicrom
 void EncodeStruct(ParameterEncoder* encoder, const VkMicromapVersionInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt8Array(value.pVersionData, 2*VK_UUID_SIZE);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyMicromapToMemoryInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.src);
     EncodeStruct(encoder, value.dst);
     encoder->EncodeEnumValue(value.mode);
@@ -8949,7 +8949,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMicromapToMemoryInfoEXT
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToMicromapInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.src);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
@@ -8958,7 +8958,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToMicromapInfoEXT
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyMicromapInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.src);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
@@ -8967,7 +8967,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMicromapInfoEXT& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkMicromapBuildSizesInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.micromapSize);
     encoder->EncodeUInt64Value(value.buildScratchSize);
     encoder->EncodeUInt32Value(value.discardable);
@@ -9133,7 +9133,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorSet
 void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetBindingReferenceVALVE& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DescriptorSetLayoutWrapper>(value.descriptorSetLayout);
     encoder->EncodeUInt32Value(value.binding);
 }
@@ -9141,7 +9141,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetBindingReferen
 void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutHostMappingInfoVALVE& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeSizeTValue(value.descriptorOffset);
     encoder->EncodeUInt32Value(value.descriptorSize);
 }
@@ -9171,7 +9171,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRenderPassStr
 void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassStripeInfoARM& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.stripeArea);
 }
 
@@ -9234,7 +9234,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkComputePipelineIndirectBuff
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineIndirectDeviceAddressInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
 }
@@ -9455,7 +9455,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassSubpassFeedbackCr
 void EncodeStruct(ParameterEncoder* encoder, const VkDirectDriverLoadingInfoLUNARG& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeFunctionPtr(value.pfnGetInstanceProcAddr);
 }
@@ -9494,7 +9494,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineShaderStageModuleId
 void EncodeStruct(ParameterEncoder* encoder, const VkShaderModuleIdentifierEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.identifierSize);
     encoder->EncodeUInt8Array(value.identifier, VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT);
 }
@@ -9533,7 +9533,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkOpticalFlowImageFormatInfoN
 void EncodeStruct(ParameterEncoder* encoder, const VkOpticalFlowImageFormatPropertiesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.format);
 }
 
@@ -9564,7 +9564,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkOpticalFlowSessionCreatePri
 void EncodeStruct(ParameterEncoder* encoder, const VkOpticalFlowExecuteInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -9610,7 +9610,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceAntiLagFeatur
 void EncodeStruct(ParameterEncoder* encoder, const VkAntiLagPresentationInfoAMD& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.stage);
     encoder->EncodeUInt64Value(value.frameIndex);
 }
@@ -9618,7 +9618,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAntiLagPresentationInfoAMD&
 void EncodeStruct(ParameterEncoder* encoder, const VkAntiLagDataAMD& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.mode);
     encoder->EncodeUInt32Value(value.maxFPS);
     EncodeStructPtr(encoder, value.pPresentationInfo);
@@ -9673,7 +9673,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceTilePropertie
 void EncodeStruct(ParameterEncoder* encoder, const VkTilePropertiesQCOM& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.tileSize);
     EncodeStruct(encoder, value.apronSize);
     EncodeStruct(encoder, value.origin);
@@ -9736,7 +9736,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceCooperativeVe
 void EncodeStruct(ParameterEncoder* encoder, const VkCooperativeVectorPropertiesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.inputType);
     encoder->EncodeEnumValue(value.inputInterpretation);
     encoder->EncodeEnumValue(value.matrixInterpretation);
@@ -9748,7 +9748,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCooperativeVectorProperties
 void EncodeStruct(ParameterEncoder* encoder, const VkConvertCooperativeVectorMatrixInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeSizeTValue(value.srcSize);
     EncodeStruct(encoder, value.srcData);
     encoder->EncodeSizeTPtr(value.pDstSize);
@@ -9843,7 +9843,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDynamicRender
 void EncodeStruct(ParameterEncoder* encoder, const VkLatencySleepModeInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.lowLatencyMode);
     encoder->EncodeUInt32Value(value.lowLatencyBoost);
     encoder->EncodeUInt32Value(value.minimumIntervalUs);
@@ -9852,7 +9852,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkLatencySleepModeInfoNV& val
 void EncodeStruct(ParameterEncoder* encoder, const VkLatencySleepInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.signalSemaphore);
     encoder->EncodeUInt64Value(value.value);
 }
@@ -9860,7 +9860,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkLatencySleepInfoNV& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkSetLatencyMarkerInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.presentID);
     encoder->EncodeEnumValue(value.marker);
 }
@@ -9868,7 +9868,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSetLatencyMarkerInfoNV& val
 void EncodeStruct(ParameterEncoder* encoder, const VkLatencyTimingsFrameReportNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.presentID);
     encoder->EncodeUInt64Value(value.inputSampleTimeUs);
     encoder->EncodeUInt64Value(value.simStartTimeUs);
@@ -9888,7 +9888,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkLatencyTimingsFrameReportNV
 void EncodeStruct(ParameterEncoder* encoder, const VkGetLatencyMarkerInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.timingCount);
     EncodeStructArray(encoder, value.pTimings, value.timingCount);
 }
@@ -9910,7 +9910,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainLatencyCreateInfoN
 void EncodeStruct(ParameterEncoder* encoder, const VkOutOfBandQueueTypeInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.queueType);
 }
 
@@ -10207,7 +10207,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPartitionedAccelerationStru
 void EncodeStruct(ParameterEncoder* encoder, const VkBuildPartitionedAccelerationStructureInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.input);
     encoder->EncodeUInt64Value(value.srcAccelerationStructureData);
     encoder->EncodeUInt64Value(value.dstAccelerationStructureData);
@@ -10219,7 +10219,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBuildPartitionedAcceleratio
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureBuildSizesInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.accelerationStructureSize);
     encoder->EncodeUInt64Value(value.updateScratchSize);
     encoder->EncodeUInt64Value(value.buildScratchSize);
@@ -10264,7 +10264,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeneratedCommandsMemoryRequ
 void EncodeStruct(ParameterEncoder* encoder, const VkIndirectExecutionSetPipelineInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineWrapper>(value.initialPipeline);
     encoder->EncodeUInt32Value(value.maxPipelineCount);
 }
@@ -10272,7 +10272,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkIndirectExecutionSetPipelin
 void EncodeStruct(ParameterEncoder* encoder, const VkIndirectExecutionSetShaderLayoutInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.setLayoutCount);
     encoder->EncodeVulkanHandleArray<vulkan_wrappers::DescriptorSetLayoutWrapper>(value.pSetLayouts, value.setLayoutCount);
 }
@@ -10280,7 +10280,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkIndirectExecutionSetShaderL
 void EncodeStruct(ParameterEncoder* encoder, const VkIndirectExecutionSetShaderInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.shaderCount);
     encoder->EncodeVulkanHandleArray<vulkan_wrappers::ShaderEXTWrapper>(value.pInitialShaders, value.shaderCount);
     EncodeStructArray(encoder, value.pSetLayoutInfos, value.shaderCount);
@@ -10308,7 +10308,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeneratedCommandsInfoEXT& v
 void EncodeStruct(ParameterEncoder* encoder, const VkWriteIndirectExecutionSetPipelineEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.index);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
 }
@@ -10385,7 +10385,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeneratedCommandsShaderInfo
 void EncodeStruct(ParameterEncoder* encoder, const VkWriteIndirectExecutionSetShaderEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.index);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::ShaderEXTWrapper>(value.shader);
 }
@@ -10444,7 +10444,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkHdrVividDynamicMetadataHUAW
 void EncodeStruct(ParameterEncoder* encoder, const VkCooperativeMatrixFlexibleDimensionsPropertiesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.MGranularity);
     encoder->EncodeUInt32Value(value.NGranularity);
     encoder->EncodeUInt32Value(value.KGranularity);
@@ -10497,14 +10497,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryMetalHandleInfo
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryMetalHandlePropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryTypeBits);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetMetalHandleInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
@@ -10603,7 +10603,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureGeomet
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureGeometryAabbsDataKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.data);
     encoder->EncodeUInt64Value(value.stride);
 }
@@ -10611,7 +10611,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureGeomet
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureGeometryInstancesDataKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.arrayOfPointers);
     EncodeStruct(encoder, value.data);
 }
@@ -10619,7 +10619,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureGeomet
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureBuildGeometryInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.mode);
@@ -10679,21 +10679,21 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceAccelerationS
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureDeviceAddressInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.accelerationStructure);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureVersionInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt8Array(value.pVersionData, 2*VK_UUID_SIZE);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyAccelerationStructureToMemoryInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.src);
     EncodeStruct(encoder, value.dst);
     encoder->EncodeEnumValue(value.mode);
@@ -10702,7 +10702,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyAccelerationStructureTo
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToAccelerationStructureInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     EncodeStruct(encoder, value.src);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
@@ -10711,7 +10711,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToAccelerationStr
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyAccelerationStructureInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.src);
     encoder->EncodeVulkanHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
@@ -10720,7 +10720,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyAccelerationStructureIn
 void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingShaderGroupCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeUInt32Value(value.generalShader);
     encoder->EncodeUInt32Value(value.closestHitShader);
@@ -10732,7 +10732,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingShaderGroupCreate
 void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingPipelineInterfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
+    EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxPipelineRayPayloadSize);
     encoder->EncodeUInt32Value(value.maxPipelineRayHitAttributeSize);
 }

--- a/framework/generated/khronos_generators/khronos_struct_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_encoders_body_generator.py
@@ -33,6 +33,10 @@ class KhronosStructEncodersBodyGenerator():
         """Override as needed"""
         return False
 
+    def must_extended_struct_be_null(self, struct_type):
+        """Override as needed"""
+        return False
+
     def write_encoder_content(self):
         api_data = self.get_api_data()
         for struct in self.get_all_filtered_struct_names():
@@ -118,9 +122,14 @@ class KhronosStructEncodersBodyGenerator():
         for value in values:
             # pNext fields require special treatment and are not processed by typename
             if self.is_extended_struct_definition(value):
-                body += '    Encode{}Struct(encoder, {});\n'.format(
-                    api_data.extended_struct_func_prefix, prefix + value.name
-                )
+                if self.must_extended_struct_be_null(name):
+                    body += '    Encode{}StructIfValid(encoder, {});\n'.format(
+                        api_data.extended_struct_func_prefix, prefix + value.name
+                    )
+                else:
+                    body += '    Encode{}Struct(encoder, {});\n'.format(
+                        api_data.extended_struct_func_prefix, prefix + value.name
+                    )
             else:
                 method_call = self.make_encoder_method_call(
                     name, value, values, prefix

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_encoders_body_generator.py
@@ -85,3 +85,9 @@ class VulkanStructEncodersBodyGenerator(VulkanBaseGenerator, KhronosStructEncode
 
         # Finish processing in superclass
         VulkanBaseGenerator.endFile(self)
+
+    def need_feature_generation(self):
+        """Indicates that the current feature has C++ code to generate."""
+        if self.feature_struct_members:
+            return True
+        return False

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -223,6 +223,7 @@ if (${RUN_TESTS})
             ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
             ${CMAKE_CURRENT_LIST_DIR}/test/test_linear_hashmap.cpp
             ${CMAKE_CURRENT_LIST_DIR}/test/test_spirv_parsing_util.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/test/test_valid_pointer.cpp
             ${CMAKE_CURRENT_LIST_DIR}/../../tools/platform_debug_helper.cpp
             $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/test/dx_pointers.h>
             $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/test/dx12_utils.cpp>

--- a/framework/util/platform.h
+++ b/framework/util/platform.h
@@ -811,6 +811,78 @@ inline uint64_t SizeTtoUint64(size_t value)
 #endif
 }
 
+/// @brief Get the start address of the memory page containing the given pointer.
+/// @param ptr Pointer to the memory location.
+/// @return The start address of the memory page containing the pointer.
+inline uintptr_t GetPageStartAddress(const void* ptr)
+{
+    static size_t page_size = GetSystemPageSize();
+    return (reinterpret_cast<uintptr_t>(ptr) / page_size) * page_size;
+}
+
+#if defined(WIN32)
+
+/// @brief Heuristically determine whether a pointer likely refers to readable
+///        memory in the current process on Windows.
+/// @param ptr Pointer to the memory location to check.
+/// @return `true` if the pointer is valid, `false` otherwise.
+/// @note This is a best-effort probe only; it cannot guarantee safety.
+///       Even if this returns true, dereferencing the pointer can still fault.
+/// @note This implementation is adapted from the LLVM compiler-rt project:
+///       `llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp`
+/// @copyright License notice for the original source: https://llvm.org/LICENSE.txt
+///            Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+inline bool PointerIsValid(const void* ptr)
+{
+    if (ptr == nullptr)
+    {
+        return false;
+    }
+
+    uintptr_t page = GetPageStartAddress(ptr);
+
+    MEMORY_BASIC_INFORMATION info;
+    if (VirtualQuery(reinterpret_cast<LPCVOID>(page), &info, sizeof(info)) != sizeof(info))
+    {
+        return false;
+    }
+
+    if (info.Protect == 0 || info.Protect == PAGE_NOACCESS || info.Protect == PAGE_EXECUTE)
+    {
+        // The page is not accessible.
+        return false;
+    }
+
+    if (info.RegionSize == 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+#else  // (WIN32)
+
+/// @brief This implementation probes whether the page containing ptr is currently mapped in this process,
+///        to guess whether the pointer might be valid.
+/// @param ptr Pointer to the memory location to check.
+/// @return `true` if the pointer is valid, `false` otherwise.
+/// @note This is not a safety/readability guarantee. A mapped page may still be unreadable (e.g., `PROT_NONE`),
+///       so dereferencing ptr can still fault even if this returns `true`.
+inline bool PointerIsValid(const void* ptr)
+{
+    if (ptr == nullptr)
+    {
+        return false;
+    }
+
+    uintptr_t     page_start = GetPageStartAddress(ptr);
+    static size_t page_size  = GetSystemPageSize();
+    // Returns -1 with errno=ENOMEM if the indicated memory (or part of it) was not mapped.
+    return msync(reinterpret_cast<void*>(page_start), page_size, MS_ASYNC) == 0;
+}
+#endif // !WIN32
+
 GFXRECON_END_NAMESPACE(platform)
 GFXRECON_END_NAMESPACE(util)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/test/test_valid_pointer.cpp
+++ b/framework/util/test/test_valid_pointer.cpp
@@ -1,0 +1,53 @@
+/*
+** Copyright (c) 2025 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch.hpp>
+#include "util/platform.h"
+
+using namespace gfxrecon::util::platform;
+
+TEST_CASE("valid_pointer - stack", "[]")
+{
+    int   ans = 42;
+    void* p   = &ans;
+    REQUIRE(PointerIsValid(p));
+}
+
+TEST_CASE("valid_pointer - null", "[]")
+{
+    void* p = nullptr;
+    REQUIRE_FALSE(PointerIsValid(p));
+}
+
+TEST_CASE("valid_pointer - invalid", "[]")
+{
+    // This is an address that is very likely to be invalid in any process.
+    void* p = reinterpret_cast<void*>(0x123);
+    REQUIRE_FALSE(PointerIsValid(p));
+}
+
+TEST_CASE("valid_pointer - heap", "[]")
+{
+    int* p = new int(42);
+    REQUIRE(PointerIsValid(p));
+    delete p;
+}


### PR DESCRIPTION
This commit aligns encoding with Vulkan valid-usage requirements, preventing serializing non-null pNext where forbidden.

A `generate_null_pnexts.py` is run to generate `null_pnexts.json` based on pNext-nullable structs from Vulka-Headers validusage.json.

`NULL_PNEXTS` are loaded in `KhronosBaseGenerator` and the method `must_extended_struct_be_null` is exposed, overriden in Vulkan generator.

The `KhronosStructEncodersBodyGenerator` is updated to emit `EncodeStructPtrPreamble(nullptr)` when `pNext` must be `NULL`.