### PR TITLE
VDR: Filter image subresource ranges from input json

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -476,7 +476,7 @@ VkResult DumpImage(DumpedImage&                         dumped_image,
     dumped_image.dumped_format  = dst_format;
 
     const VkImageSubresourceRange modified_subresource_range =
-        ConvertRemainingToSpecificNumber(subresource_range, image_info);
+        FilterImageSubresourceRange(subresource_range, image_info);
 
     std::vector<VkImageAspectFlagBits> aspects;
     graphics::AspectFlagsToFlagBits(modified_subresource_range.aspectMask, aspects);


### PR DESCRIPTION
Previously it was assumed that the image subresource ranges provided in the input json to cull dumped descriptor was correct but this is not always the case as the ranges provided can be wrong.

The ranges are now filtered based on the dumped image