### PR TITLE
Add support for VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM

### DIFF
--- a/framework/decode/custom_vulkan_struct_handle_mappers.cpp
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.cpp
@@ -76,6 +76,7 @@ void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const CommonObjectI
             case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
             case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
             case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            case VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM:
                 if (!wrapper->pImageInfo->IsNull())
                 {
                     size_t                         len     = wrapper->pImageInfo->GetLength();

--- a/framework/encode/custom_vulkan_struct_encoders.cpp
+++ b/framework/encode/custom_vulkan_struct_encoders.cpp
@@ -134,6 +134,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value)
         case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
         case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
         case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+        case VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM:
             omit_image_data = false;
             break;
         case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:

--- a/framework/encode/custom_vulkan_struct_handle_wrappers.cpp
+++ b/framework/encode/custom_vulkan_struct_handle_wrappers.cpp
@@ -76,6 +76,7 @@ void UnwrapStructHandles(VkWriteDescriptorSet* value, HandleUnwrapMemory* unwrap
             case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
             case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
             case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            case VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM:
                 value->pImageInfo = UnwrapDescriptorImageInfoStructArrayHandles(
                     value->descriptorType, value->pImageInfo, value->descriptorCount, unwrap_memory);
                 break;

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -891,6 +891,7 @@ inline void InitializePoolObjectState(VkDevice                               par
             case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
             case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
             case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            case VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM:
                 descriptor_info.sampler_ids = std::make_unique<format::HandleId[]>(binding_info.count);
                 descriptor_info.images      = std::make_unique<VkDescriptorImageInfo[]>(binding_info.count);
                 break;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -3879,6 +3879,7 @@ void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId           
         case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
         case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
         case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+        case VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM:
             write->pImageInfo = &binding->images[write->dstArrayElement];
             break;
         case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:


### PR DESCRIPTION
This is part of VK_QCOM_image_processing, and they are just like a SAMPLED_IMAGE, but for only the new sampling opcodes.