### PR TITLE
VDR: Different descriptor same buffer

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -1525,8 +1525,9 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
                                 continue;
                             }
 
-                            auto&       new_dumped_image   = std::get<DumpedImage>(new_dumped_desc.dumped_resource);
-                            const auto& dumped_descs_entry = dumped_descriptors.image_descriptors.find(img_info);
+                            auto& new_dumped_image         = std::get<DumpedImage>(new_dumped_desc.dumped_resource);
+                            const DescriptorLocation loc   = { desc_set_index, desc_binding_index, array_index };
+                            const auto& dumped_descs_entry = dumped_descriptors.image_descriptors.find(loc);
                             if (dumped_descs_entry == dumped_descriptors.image_descriptors.end())
                             {
                                 VulkanDelegateDumpResourceContext res_info = res_info_base;
@@ -1557,7 +1558,7 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
 
                                 delegate_.DumpResource(res_info);
 
-                                dumped_descriptors.image_descriptors.emplace(img_info, new_dumped_image);
+                                dumped_descriptors.image_descriptors.emplace(loc, new_dumped_image);
                             }
                             else
                             {
@@ -1604,7 +1605,8 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
                             size,
                             resource_type);
 
-                        const auto& dumped_desc_entry = dumped_descriptors.buffer_descriptors.find(buffer_info);
+                        const DescriptorLocation loc = { desc_set_index, desc_binding_index, array_index };
+                        const auto&              dumped_desc_entry = dumped_descriptors.buffer_descriptors.find(loc);
                         if (dumped_desc_entry == dumped_descriptors.buffer_descriptors.end())
                         {
                             const auto& new_dumped_buffer = std::get<DumpedBuffer>(new_dumped_desc.dumped_resource);
@@ -1632,7 +1634,7 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
 
                             delegate_.DumpResource(res_info);
 
-                            dumped_descriptors.buffer_descriptors.emplace(buffer_info, new_dumped_buffer);
+                            dumped_descriptors.buffer_descriptors.emplace(loc, new_dumped_buffer);
                         }
                         else
                         {
@@ -1680,7 +1682,8 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
                             size,
                             resource_type);
 
-                        const auto dumped_desc_entry = dumped_descriptors.buffer_descriptors.find(buffer_info);
+                        const DescriptorLocation loc = { desc_set_index, desc_binding_index, array_index };
+                        const auto               dumped_desc_entry = dumped_descriptors.buffer_descriptors.find(loc);
                         if (dumped_desc_entry == dumped_descriptors.buffer_descriptors.end())
                         {
                             const auto& new_dumped_buffer = std::get<DumpedBuffer>(new_dumped_desc.dumped_resource);
@@ -1708,7 +1711,7 @@ VkResult DispatchTraceRaysDumpingContext::DumpDescriptors(uint64_t qs_index,
 
                             delegate_.DumpResource(res_info);
 
-                            dumped_descriptors.buffer_descriptors.emplace(buffer_info, new_dumped_buffer);
+                            dumped_descriptors.buffer_descriptors.emplace(loc, new_dumped_buffer);
                         }
                         else
                         {

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.h
@@ -461,8 +461,8 @@ class DispatchTraceRaysDumpingContext
     // multiple times
     struct DumpedDescriptors
     {
-        std::unordered_map<const VulkanImageInfo*, const DumpedImage&>   image_descriptors;
-        std::unordered_map<const VulkanBufferInfo*, const DumpedBuffer&> buffer_descriptors;
+        std::map<DescriptorLocation, const DumpedImage&>  image_descriptors;
+        std::map<DescriptorLocation, const DumpedBuffer&> buffer_descriptors;
     };
 
     DumpedDescriptors dispatch_dumped_descriptors_;

--- a/framework/decode/vulkan_replay_dump_resources_delegate.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.cpp
@@ -555,7 +555,8 @@ DefaultVulkanDumpResourcesDelegate::GenerateGraphicsBufferDescriptorFilename(con
 
     filename << capture_filename_ << "_"
              << "buffer_" << buffer_info->capture_id << "_qs_" << dumped_desc.qs_index << "_bcb_"
-             << dumped_desc.bcb_index << "_rp_" << dumped_desc.render_pass << ".bin";
+             << dumped_desc.bcb_index << "_rp_" << dumped_desc.render_pass << "_set_" << dumped_desc.set << "_binding_"
+             << dumped_desc.binding << "_ai_" << dumped_desc.array_index << ".bin";
 
     std::filesystem::path filedirname(options_.dump_resources_output_dir);
     std::filesystem::path filebasename(filename.str());
@@ -571,8 +572,9 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateGraphicsInlineUniformBuf
 
     std::stringstream filename;
     filename << capture_filename_ << "_"
-             << "inlineUniformBlock_set_" << buffer_desc_info.set << "_binding_" << buffer_desc_info.binding << "_qs_"
-             << buffer_desc_info.qs_index << "_bcb_" << buffer_desc_info.bcb_index << ".bin";
+             << "inlineUniformBlock_set_" << buffer_desc_info.set << "_binding_" << buffer_desc_info.binding << "_ai_"
+             << buffer_desc_info.array_index << "_qs_" << buffer_desc_info.qs_index << "_bcb_"
+             << buffer_desc_info.bcb_index << ".bin";
 
     std::filesystem::path filedirname(options_.dump_resources_output_dir);
     std::filesystem::path filebasename(filename.str());
@@ -1139,8 +1141,9 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysBufferD
     GFXRECON_ASSERT(buffer_info != nullptr);
 
     std::stringstream filename;
-    filename << capture_filename_ << "_buffer_" << buffer_info->capture_id << "_qs_" << buffer_desc_info.qs_index
-             << "_bcb_" << buffer_desc_info.bcb_index << ".bin";
+    filename << capture_filename_ << "_buffer_" << buffer_info->capture_id << "_set_" << buffer_desc_info.set
+             << "_binding_" << buffer_desc_info.binding << "_ai_" << buffer_desc_info.array_index << "_qs_"
+             << buffer_desc_info.qs_index << "_bcb_" << buffer_desc_info.bcb_index << ".bin";
 
     std::filesystem::path filedirname(options_.dump_resources_output_dir);
     std::filesystem::path filebasename(filename.str());
@@ -1156,8 +1159,8 @@ std::string DefaultVulkanDumpResourcesDelegate::GenerateDispatchTraceRaysInlineU
 
     std::stringstream filename;
     filename << capture_filename_ << '_' << "inlineUniformBlock_set_" << buffer_desc_info.set << "_binding_"
-             << buffer_desc_info.binding << "_qs_" << buffer_desc_info.qs_index << "_bcb_" << buffer_desc_info.bcb_index
-             << ".bin";
+             << buffer_desc_info.binding << "_ai_" << buffer_desc_info.array_index << "_qs_"
+             << buffer_desc_info.qs_index << "_bcb_" << buffer_desc_info.bcb_index << ".bin";
 
     std::filesystem::path filedirname(options_.dump_resources_output_dir);
     std::filesystem::path filebasename(filename.str());

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -1346,9 +1346,10 @@ VkResult DrawCallsDumpingContext::DumpDescriptors(uint64_t qs_index, uint64_t bc
                                 continue;
                             }
 
-                            auto&      new_dumped_image = std::get<DumpedImage>(new_dumped_desc.dumped_resource);
-                            const auto dumped_desc_entry =
-                                render_pass_dumped_descriptors_[rp].image_descriptors.find(image_info);
+                            auto& new_dumped_image       = std::get<DumpedImage>(new_dumped_desc.dumped_resource);
+                            const DescriptorLocation loc = { desc_set_index, desc_binding_index, array_index };
+                            const auto               dumped_desc_entry =
+                                render_pass_dumped_descriptors_[rp].image_descriptors.find(loc);
                             if (dumped_desc_entry == render_pass_dumped_descriptors_[rp].image_descriptors.end())
                             {
                                 VulkanDelegateDumpResourceContext res_info = res_info_base;
@@ -1391,8 +1392,7 @@ VkResult DrawCallsDumpingContext::DumpDescriptors(uint64_t qs_index, uint64_t bc
 
                                 delegate_.DumpResource(res_info);
 
-                                render_pass_dumped_descriptors_[rp].image_descriptors.emplace(image_info,
-                                                                                              new_dumped_image);
+                                render_pass_dumped_descriptors_[rp].image_descriptors.emplace(loc, new_dumped_image);
                             }
                             else
                             {
@@ -1444,8 +1444,9 @@ VkResult DrawCallsDumpingContext::DumpDescriptors(uint64_t qs_index, uint64_t bc
                             size,
                             DumpResourcesCommandType::kGraphics);
 
-                        const auto& dumped_desc_entry =
-                            render_pass_dumped_descriptors_[rp].buffer_descriptors.find(buffer_info);
+                        const DescriptorLocation loc = { desc_set_index, desc_binding_index, array_index };
+                        const auto&              dumped_desc_entry =
+                            render_pass_dumped_descriptors_[rp].buffer_descriptors.find(loc);
                         if (dumped_desc_entry == render_pass_dumped_descriptors_[rp].buffer_descriptors.end())
                         {
                             const auto& new_dumped_buffer = std::get<DumpedBuffer>(new_dumped_desc.dumped_resource);
@@ -1473,8 +1474,7 @@ VkResult DrawCallsDumpingContext::DumpDescriptors(uint64_t qs_index, uint64_t bc
 
                             delegate_.DumpResource(res_info);
 
-                            render_pass_dumped_descriptors_[rp].buffer_descriptors.emplace(buffer_info,
-                                                                                           new_dumped_buffer);
+                            render_pass_dumped_descriptors_[rp].buffer_descriptors.emplace(loc, new_dumped_buffer);
                         }
                         else
                         {
@@ -1526,8 +1526,9 @@ VkResult DrawCallsDumpingContext::DumpDescriptors(uint64_t qs_index, uint64_t bc
                             size,
                             DumpResourcesCommandType::kGraphics);
 
-                        const auto& dumped_desc_entry =
-                            render_pass_dumped_descriptors_[rp].buffer_descriptors.find(buffer_info);
+                        const DescriptorLocation loc = { desc_set_index, desc_binding_index, array_index };
+                        const auto&              dumped_desc_entry =
+                            render_pass_dumped_descriptors_[rp].buffer_descriptors.find(loc);
                         if (dumped_desc_entry == render_pass_dumped_descriptors_[rp].buffer_descriptors.end())
                         {
                             const auto& new_dumped_buffer = std::get<DumpedBuffer>(new_dumped_desc.dumped_resource);
@@ -1555,8 +1556,7 @@ VkResult DrawCallsDumpingContext::DumpDescriptors(uint64_t qs_index, uint64_t bc
 
                             delegate_.DumpResource(res_info);
 
-                            render_pass_dumped_descriptors_[rp].buffer_descriptors.emplace(buffer_info,
-                                                                                           new_dumped_buffer);
+                            render_pass_dumped_descriptors_[rp].buffer_descriptors.emplace(loc, new_dumped_buffer);
                         }
                         else
                         {

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -688,8 +688,8 @@ class DrawCallsDumpingContext
     // multiple times
     struct RenderPassDumpedDescriptors
     {
-        std::unordered_map<const VulkanImageInfo*, const DumpedImage&>   image_descriptors;
-        std::unordered_map<const VulkanBufferInfo*, const DumpedBuffer&> buffer_descriptors;
+        std::map<DescriptorLocation, const DumpedImage&>  image_descriptors;
+        std::map<DescriptorLocation, const DumpedBuffer&> buffer_descriptors;
     };
 
     std::vector<RenderPassDumpedDescriptors> render_pass_dumped_descriptors_;


### PR DESCRIPTION
The case where different descriptors were referencing the same buffer was not being handled correctly dumping only one of descriptors. This should be fixed now.