### PR TITLE
DRY FileTransformer by converting to BlockParser

### DIFF
--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -138,7 +138,7 @@ class FileProcessor
 
     uint64_t GetNumBytesRead() const { return bytes_read_; }
 
-    BlockReadError GetErrorState() const { return error_state_; }
+    BlockIOError GetErrorState() const { return error_state_; }
 
     bool EntireFileWasProcessed() const
     {
@@ -164,7 +164,7 @@ class FileProcessor
     bool IsFrameDelimiter(format::BlockType block_type, format::MarkerType marker_type) const;
     bool IsFrameDelimiter(format::ApiCallId call_id) const;
 
-    void HandleBlockReadError(BlockReadError error_code, const char* error_message);
+    void HandleBlockReadError(BlockIOError error_code, const char* error_message);
 
     bool ProcessExecuteBlocksFromFile(const ExecuteBlocksFromFileArgs& execute_blocks_info);
     void ProcessStateBeginMarker(const StateBeginMarkerArgs& state_begin);
@@ -203,14 +203,14 @@ class FileProcessor
     uint64_t                 current_frame_number_;
     std::vector<ApiDecoder*> decoders_;
     AnnotationHandler*       annotation_handler_;
-    BlockReadError           error_state_;
+    BlockIOError             error_state_;
     uint64_t                 bytes_read_;
 
     /// @brief Incremented at the end of every block successfully processed.
     uint64_t block_index_;
 
   protected:
-    BlockReadError CheckFileStatus() const
+    BlockIOError CheckFileStatus() const
     {
         if (file_stack_.empty())
         {
@@ -423,7 +423,7 @@ class FileProcessor
 
   protected:
     BufferPool        pool_;
-    util::Compressor* compressor_;
+    std::unique_ptr<util::Compressor> compressor_;
 
     struct ActiveFileContext
     {

--- a/framework/decode/file_transformer.cpp
+++ b/framework/decode/file_transformer.cpp
@@ -32,17 +32,13 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 FileTransformer::FileTransformer() :
-    input_file_(nullptr), output_file_(nullptr), bytes_read_(0), bytes_written_(0),
-    error_state_(kErrorInvalidFileDescriptor), loading_state_(false)
+    input_file_(std::make_shared<FileInputStream>()), output_file_(nullptr), bytes_read_(0), bytes_written_(0),
+    error_state_(kErrorInvalidFileDescriptor), loading_state_(false), pool_(util::HeapBufferPool::Create())
 {}
 
 FileTransformer::~FileTransformer()
 {
-    if (input_file_ != nullptr)
-    {
-        fclose(input_file_);
-    }
-
+    // Note: input_file_ is closed by destructor
     if (output_file_ != nullptr)
     {
         fclose(output_file_);
@@ -59,11 +55,12 @@ bool FileTransformer::Initialize(const std::string& input_filename,
 
     bool success = false;
 
-    int32_t result = util::platform::FileOpen(&input_file_, input_filename.c_str(), "rb");
+    GFXRECON_ASSERT(input_file_ != nullptr);
+    bool open_input = input_file_->Open(input_filename.c_str());
 
-    if ((result == 0) && (input_file_ != nullptr))
+    if (open_input && input_file_->IsOpen())
     {
-        result = util::platform::FileOpen(&output_file_, output_filename.c_str(), "wb");
+        int32_t result = util::platform::FileOpen(&output_file_, output_filename.c_str(), "wb");
 
         if ((result == 0) && (output_file_ != nullptr))
         {
@@ -83,21 +80,35 @@ bool FileTransformer::Initialize(const std::string& input_filename,
 
     if (success)
     {
+        // We wait until after "ProcessFileHeader" as that is where compressor_ is initialized
+        auto err_handler = [this](BlockIOError err, const char* message) { HandleBlockReadError(err, message); };
+        block_parser_ =
+            std::make_unique<BlockParser>(BlockParser::ErrorHandler{ err_handler }, pool_, compressor_.get());
+        success = block_parser_ != nullptr;
+        if (success)
+        {
+            block_parser_->SetDecompressionPolicy(BlockParser::kNever);
+        }
+        else
+        {
+            error_state_ = kErrorOpeningFile;
+        }
+    }
+
+    if (success)
+    {
         error_state_ = kErrorNone;
     }
     else
     {
-        if (input_file_ != nullptr)
-        {
-            fclose(input_file_);
-            input_file_ = nullptr;
-        }
+        input_file_->Close();
 
         if (output_file_ != nullptr)
         {
             fclose(output_file_);
             output_file_ = nullptr;
         }
+        block_parser_.reset();
     }
 
     return success;
@@ -141,20 +152,52 @@ bool FileTransformer::Process()
     }
 
     block_index_ = 0;
+    BlockBuffer block_buffer;
+
     while (success)
     {
-        success = ProcessNextBlock();
-        block_index_++;
+        BlockIOError status = block_parser_->ReadBlockBuffer(input_file_, block_buffer);
+        success             = status == kErrorNone;
+        if (success)
+        {
+            // Track bytes read by the parser, since we aren't using ReadBytes here
+            bytes_read_ += block_buffer.Size();
+            block_parser_->SetBlockIndex(block_index_);
+            ParsedBlock parsed_block = block_parser_->ParseBlock(block_buffer);
+
+            // There are four states for a parsed block
+            //    kReady and kDeferredDecompress are "Visitable"
+            //    kUnknown is an unknown block type, passed through
+            //    kInvalid implies !IsValid (and thus !success)
+            success = parsed_block.IsValid();
+            if (success)
+            {
+                if (parsed_block.IsVisitable())
+                {
+                    auto visit_call = [this, &parsed_block](auto&& args) {
+                        return this->ProcessNextBlock(parsed_block, *args);
+                    };
+                    success = std::visit(visit_call, parsed_block.GetArgs());
+                }
+                else
+                {
+                    // Unknown block types are passed through unparsed
+                    GFXRECON_ASSERT(parsed_block.IsUnknown());
+                    success = WriteBytes(parsed_block);
+                }
+                block_index_++;
+            }
+        }
     }
 
     if (!success && (error_state_ == kErrorNone))
     {
         // If a failure occured, but no error code was set, check for a file error.
-        if ((input_file_ == nullptr) || (output_file_ == nullptr))
+        if ((input_file_.get() == nullptr) || !input_file_->IsOpen() || (output_file_ == nullptr))
         {
             error_state_ = kErrorInvalidFileDescriptor;
         }
-        else if (ferror(input_file_))
+        else if (input_file_->IsError())
         {
             error_state_ = kErrorReadingFile;
         }
@@ -223,117 +266,41 @@ bool FileTransformer::ProcessFileHeader()
     return success;
 }
 
-bool FileTransformer::ProcessNextBlock()
+template <typename Args>
+bool FileTransformer::ProcessNextBlock(ParsedBlock& parsed_block, const Args& /* args */)
 {
-    format::BlockHeader block_header;
-    bool                success = true;
+    // Drop the args parameter, as Decompress mutates Args, and we don't want to
+    // confuse maintainers (or the compiler) by passing a const Args& that is modified.
 
-    success = ReadBlockHeader(&block_header);
+    bool success = true;
 
-    if (success)
+    // Dispatch to appropriate processing function based on Args type
+    if constexpr (std::is_same_v<FunctionCallArgs, Args>)
     {
-        if (format::RemoveCompressedBlockBit(block_header.type) == format::BlockType::kFunctionCallBlock)
-        {
-            format::ApiCallId api_call_id = format::ApiCallId::ApiCall_Unknown;
-
-            success = ReadBytes(&api_call_id, sizeof(api_call_id));
-
-            if (success)
-            {
-                success = ProcessFunctionCall(block_header, api_call_id);
-            }
-            else
-            {
-                HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read function call block header");
-            }
-        }
-        else if (format::RemoveCompressedBlockBit(block_header.type) == format::BlockType::kMetaDataBlock)
-        {
-            format::MetaDataId meta_data_id =
-                format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_None, format::MetaDataType::kUnknownMetaDataType);
-
-            success = ReadBytes(&meta_data_id, sizeof(meta_data_id));
-
-            if (success)
-            {
-                success = ProcessMetaData(block_header, meta_data_id);
-            }
-            else
-            {
-                HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read meta-data block header");
-            }
-        }
-        else if (block_header.type == format::BlockType::kStateMarkerBlock)
-        {
-            format::MarkerType marker_type  = format::MarkerType::kUnknownMarker;
-            uint64_t           frame_number = 0;
-
-            success = ReadBytes(&marker_type, sizeof(marker_type));
-
-            if (success)
-            {
-                success = ProcessStateMarker(block_header, marker_type);
-            }
-            else
-            {
-                HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read state marker header");
-            }
-        }
-        else if (format::RemoveCompressedBlockBit(block_header.type) == format::BlockType::kMethodCallBlock)
-        {
-            format::ApiCallId api_call_id = format::ApiCallId::ApiCall_Unknown;
-
-            success = ReadBytes(&api_call_id, sizeof(api_call_id));
-
-            if (success)
-            {
-                success = ProcessMethodCall(block_header, api_call_id, block_index_);
-            }
-            else
-            {
-                HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read method call block header");
-            }
-        }
-        else
-        {
-            // Copy the block to the output file.
-            success = WriteBlockHeader(block_header);
-
-            if (success)
-            {
-                success = CopyBytes(block_header.size);
-
-                if (!success)
-                {
-                    GFXRECON_LOG_ERROR("Failed to write block data");
-                    error_state_ = kErrorWritingBlockData;
-                }
-            }
-        }
+        success = ProcessFunctionCall(parsed_block);
+    }
+    else if constexpr (std::is_same_v<MethodCallArgs, Args>)
+    {
+        success = ProcessMethodCall(parsed_block);
+    }
+    else if constexpr (std::is_same_v<StateBeginMarkerArgs, Args>)
+    {
+        success = ProcessStateBeginMarker(parsed_block);
+    }
+    else if constexpr (std::is_same_v<StateEndMarkerArgs, Args>)
+    {
+        success = ProcessStateEndMarker(parsed_block);
+    }
+    else if constexpr (DispatchTraits<Args>::kHasMetaDataId)
+    {
+        success = ProcessMetaData(parsed_block); // MetaData processing will revisit
     }
     else
     {
-        if (!feof(input_file_))
-        {
-            // If we have not hit a normal EOF condition, report an error reading the block header.
-            GFXRECON_LOG_ERROR("Failed to read block header");
-            error_state_ = kErrorReadingBlockHeader;
-        }
+        // These block types have no transformation interface defined, pass them through directly
+        success = WriteBytes(parsed_block);
     }
-
     return success;
-}
-
-bool FileTransformer::ReadBlockHeader(format::BlockHeader* block_header)
-{
-    assert(block_header != nullptr);
-
-    if (ReadBytes(block_header, sizeof(*block_header)))
-    {
-        return true;
-    }
-
-    return false;
 }
 
 bool FileTransformer::WriteBlockHeader(const format::BlockHeader& block_header)
@@ -348,52 +315,9 @@ bool FileTransformer::WriteBlockHeader(const format::BlockHeader& block_header)
     return true;
 }
 
-bool FileTransformer::ReadParameterBuffer(size_t buffer_size)
-{
-    if (buffer_size > parameter_buffer_.size())
-    {
-        parameter_buffer_.resize(buffer_size);
-    }
-
-    return ReadBytes(parameter_buffer_.data(), buffer_size);
-}
-
-bool FileTransformer::ReadCompressedParameterBuffer(size_t  compressed_buffer_size,
-                                                    size_t  expected_uncompressed_size,
-                                                    size_t* uncompressed_buffer_size)
-{
-    // This should only be null if initialization failed.
-    assert(compressor_ != nullptr);
-
-    if (compressed_buffer_size > compressed_parameter_buffer_.size())
-    {
-        compressed_parameter_buffer_.resize(compressed_buffer_size);
-    }
-
-    if (ReadBytes(compressed_parameter_buffer_.data(), compressed_buffer_size))
-    {
-        if (parameter_buffer_.size() < expected_uncompressed_size)
-        {
-            parameter_buffer_.resize(expected_uncompressed_size);
-        }
-
-        size_t uncompressed_size = compressor_->Decompress(compressed_buffer_size,
-                                                           compressed_parameter_buffer_.data(),
-                                                           expected_uncompressed_size,
-                                                           parameter_buffer_.data());
-        if ((0 < uncompressed_size) && (uncompressed_size == expected_uncompressed_size))
-        {
-            *uncompressed_buffer_size = uncompressed_size;
-            return true;
-        }
-    }
-
-    return false;
-}
-
 bool FileTransformer::ReadBytes(void* buffer, size_t buffer_size)
 {
-    if (util::platform::FileRead(buffer, buffer_size, input_file_))
+    if (input_file_->ReadBytes(buffer, buffer_size))
     {
         bytes_read_ += buffer_size;
         return true;
@@ -411,37 +335,21 @@ bool FileTransformer::WriteBytes(const void* buffer, size_t buffer_size)
     return false;
 }
 
-bool FileTransformer::SkipBytes(uint64_t skip_size)
+bool FileTransformer::WriteBytes(const ParsedBlock& parsed_block)
 {
-    bool success = util::platform::FileSeek(input_file_, skip_size, util::platform::FileSeekCurrent);
-
-    if (success)
+    const util::DataSpan& block_span = parsed_block.GetBlockData();
+    if (!WriteBytes(block_span.data(), block_span.size()))
     {
-        // These technically count as bytes read/processed.
-        bytes_read_ += skip_size;
+        HandleBlockWriteError(kErrorWritingBlockData, "Failed to write passthrough block data");
+        return false;
     }
-
-    return success;
-}
-
-bool FileTransformer::CopyBytes(uint64_t copy_size)
-{
-    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, copy_size);
-    if (ReadParameterBuffer(static_cast<size_t>(copy_size)))
-    {
-        if (WriteBytes(parameter_buffer_.data(), static_cast<size_t>(copy_size)))
-        {
-            return true;
-        }
-    }
-
-    return false;
+    return true;
 }
 
 void FileTransformer::HandleBlockReadError(Error error_code, const char* error_message)
 {
     // Report incomplete block at end of file as a warning, other I/O errors as an error.
-    if (feof(input_file_) && !ferror(input_file_))
+    if (input_file_->IsEof() && !input_file_->IsError())
     {
         GFXRECON_LOG_WARNING("Incomplete block at end of file");
     }
@@ -458,25 +366,13 @@ void FileTransformer::HandleBlockWriteError(Error error_code, const char* error_
     error_state_ = error_code;
 }
 
-void FileTransformer::HandleBlockCopyError(Error error_code, const char* error_message)
-{
-    if (ferror(output_file_))
-    {
-        HandleBlockWriteError(error_code, error_message);
-    }
-    else
-    {
-        HandleBlockReadError(error_code, error_message);
-    }
-}
-
 bool FileTransformer::CreateCompressor(format::CompressionType type, std::unique_ptr<util::Compressor>* compressor)
 {
     assert(compressor != nullptr);
 
     if (type != format::CompressionType::kNone)
     {
-        (*compressor) = std::unique_ptr<util::Compressor>(format::CreateCompressor(type));
+        compressor->reset(format::CreateCompressor(type));
 
         if ((*compressor) == nullptr)
         {
@@ -506,111 +402,35 @@ bool FileTransformer::WriteFileHeader(const format::FileHeader&                 
     return success;
 }
 
-bool FileTransformer::ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id)
+// Default Behavior for most blocks is pass-through
+bool FileTransformer::ProcessFunctionCall(ParsedBlock& parsed_block)
 {
-    // Copy block data from old file to new file.
-    if (!WriteBlockHeader(block_header))
-    {
-        return false;
-    }
-
-    if (!WriteBytes(&call_id, sizeof(call_id)))
-    {
-        HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write function call block header");
-        return false;
-    }
-
-    if (!CopyBytes(block_header.size - sizeof(call_id)))
-    {
-        HandleBlockCopyError(kErrorCopyingBlockData, "Failed to copy function call block data");
-        return false;
-    }
-
-    return true;
+    return WriteBytes(parsed_block);
 }
 
-bool FileTransformer::ProcessMethodCall(const format::BlockHeader& block_header,
-                                        format::ApiCallId          call_id,
-                                        uint64_t                   block_index)
+bool FileTransformer::ProcessMethodCall(ParsedBlock& parsed_block)
 {
-    // Copy block data from old file to new file.
-    if (!WriteBlockHeader(block_header))
-    {
-        return false;
-    }
-
-    if (!WriteBytes(&call_id, sizeof(call_id)))
-    {
-        HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write method call block header");
-        return false;
-    }
-
-    if (!CopyBytes(block_header.size - sizeof(call_id)))
-    {
-        HandleBlockCopyError(kErrorCopyingBlockData, "Failed to copy method call block data");
-        return false;
-    }
-
-    return true;
+    return WriteBytes(parsed_block);
 }
 
-bool FileTransformer::ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id)
+// Because of the numerous Args types for MetaDataBlock, any override of ProcessMetaData
+// will need to use the visitor pattern to specialize operations on the kHasMetaDataId
+// Arg type current in the DispatchArgs variant
+bool FileTransformer::ProcessMetaData(ParsedBlock& parsed_block)
 {
-    // Copy block data from old file to new file.
-    if (!WriteBlockHeader(block_header))
-    {
-        return false;
-    }
-
-    if (!WriteBytes(&meta_data_id, sizeof(meta_data_id)))
-    {
-        HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write meta-data block header");
-        return false;
-    }
-
-    if (!CopyBytes(block_header.size - sizeof(meta_data_id)))
-    {
-        HandleBlockCopyError(kErrorCopyingBlockData, "Failed to copy meta-data block data");
-        return false;
-    }
-
-    return true;
+    return WriteBytes(parsed_block);
 }
 
-bool FileTransformer::ProcessStateMarker(const format::BlockHeader& block_header, format::MarkerType marker_type)
+bool FileTransformer::ProcessStateBeginMarker(ParsedBlock& parsed_block)
 {
-    // Copy marker data from old file to new file.
-    uint64_t frame_number = 0;
+    loading_state_ = true;
+    return WriteBytes(parsed_block);
+}
 
-    if (ReadBytes(&frame_number, sizeof(frame_number)))
-    {
-        if (marker_type == format::kBeginMarker)
-        {
-            loading_state_ = true;
-        }
-        else if (marker_type == format::kEndMarker)
-        {
-            loading_state_ = false;
-        }
-
-        format::Marker marker;
-        marker.header       = block_header;
-        marker.marker_type  = marker_type;
-        marker.frame_number = frame_number;
-
-        if (!WriteBytes(&marker, sizeof(marker)))
-        {
-            HandleBlockWriteError(kErrorWritingBlockData, "Failed to write state marker data");
-            return false;
-        }
-    }
-    else
-    {
-        HandleBlockWriteError(kErrorReadingBlockData, "Failed to read state marker data");
-        return false;
-    }
-
-    return true;
+bool FileTransformer::ProcessStateEndMarker(ParsedBlock& parsed_block)
+{
+    loading_state_ = false;
+    return WriteBytes(parsed_block);
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_transformer.h
+++ b/framework/decode/file_transformer.h
@@ -23,6 +23,7 @@
 #ifndef GFXRECON_DECODE_FILE_TRANSFORMER_H
 #define GFXRECON_DECODE_FILE_TRANSFORMER_H
 
+#include "decode/block_parser.h"
 #include "format/format.h"
 #include "util/defines.h"
 #include "util/compressor.h"
@@ -37,31 +38,6 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 class FileTransformer
 {
-  public:
-    enum Error : int32_t
-    {
-        kErrorNone                         = 0,
-        kErrorInvalidFileDescriptor        = -1,
-        kErrorOpeningFile                  = -2,
-        kErrorReadingFile                  = -3,
-        kErrorReadingFileHeader            = -4,
-        kErrorReadingBlockHeader           = -5,
-        kErrorReadingCompressedBlockHeader = -6,
-        kErrorReadingBlockData             = -7,
-        kErrorReadingCompressedBlockData   = -8,
-        kErrorInvalidFourCC                = -9,
-        kErrorUnsupportedCompressionType   = -10,
-        kErrorSeekingFile                  = -11,
-        kErrorWritingFile                  = -12,
-        kErrorWritingFileHeader            = -13,
-        kErrorWritingBlockHeader           = -14,
-        kErrorWritingCompressedBlockHeader = -15,
-        kErrorWritingBlockData             = -16,
-        kErrorWritingCompressedBlockData   = -17,
-        kErrorCopyingBlockData             = -18,
-        kErrorUnsupportedBlockType         = -19
-    };
-
   public:
     FileTransformer();
 
@@ -80,16 +56,22 @@ class FileTransformer
 
     uint64_t GetNumBytesWritten() const { return bytes_written_; }
 
-    Error GetErrorState() const { return error_state_; }
+    BlockIOError GetErrorState() const { return error_state_; }
+
+    using Error = BlockIOError;
 
   protected:
+    // ProcessMetaData blocks need more than bool to report back from their visit.
+    enum VisitResult
+    {
+        kError = 0,
+        kSuccess,
+        kNeedsPassthrough,
+    };
+
     bool IsFileValid(FILE* fd) const { return ((fd != nullptr) && !feof(fd) && !ferror(fd)); }
 
     bool IsLoadingState() const { return loading_state_; }
-
-    std::vector<uint8_t>& GetParameterBuffer() { return parameter_buffer_; }
-
-    const std::vector<uint8_t>& GetParameterBuffer() const { return parameter_buffer_; }
 
     std::vector<uint8_t>& GetCompressedParameterBuffer() { return compressed_parameter_buffer_; }
 
@@ -101,64 +83,52 @@ class FileTransformer
 
     bool WriteBlockHeader(const format::BlockHeader& block_header);
 
-    bool ReadParameterBuffer(size_t buffer_size);
-
-    bool ReadCompressedParameterBuffer(size_t  compressed_buffer_size,
-                                       size_t  expected_uncompressed_size,
-                                       size_t* uncompressed_buffer_size);
-
     bool ReadBytes(void* buffer, size_t buffer_size);
 
     bool WriteBytes(const void* buffer, size_t buffer_size);
-
-    bool SkipBytes(uint64_t skip_size);
-
-    bool CopyBytes(uint64_t copy_size);
+    bool WriteBytes(const ParsedBlock& parsed_block);
 
     void HandleBlockReadError(Error error_code, const char* error_message);
 
     void HandleBlockWriteError(Error error_code, const char* error_message);
 
-    void HandleBlockCopyError(Error error_code, const char* error_message);
-
     bool CreateCompressor(format::CompressionType type, std::unique_ptr<util::Compressor>* compressor);
 
     virtual bool WriteFileHeader(const format::FileHeader& header, const std::vector<format::FileOptionPair>& options);
 
-    virtual bool ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id);
-
-    virtual bool
-    ProcessMethodCall(const format::BlockHeader& block_header, format::ApiCallId call_id, uint64_t block_index = 0);
-
-    virtual bool ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id);
-
-    virtual bool ProcessStateMarker(const format::BlockHeader& block_header, format::MarkerType marker_type);
+    virtual bool ProcessFunctionCall(ParsedBlock& parsed_block);
+    virtual bool ProcessMethodCall(ParsedBlock& parsed_block);
+    virtual bool ProcessMetaData(ParsedBlock& parsed_block);
+    virtual bool ProcessStateBeginMarker(ParsedBlock& parsed_block);
+    virtual bool ProcessStateEndMarker(ParsedBlock& parsed_block);
 
     uint64_t GetCurrentBlockIndex() { return block_index_; }
+
+    BlockParser& GetBlockParser() { return *block_parser_; }
 
   private:
     bool ProcessFileHeader();
 
-    bool ProcessNextBlock();
-
-    bool ReadBlockHeader(format::BlockHeader* block_header);
+    template <typename Args>
+    bool ProcessNextBlock(ParsedBlock& parsed_block, const Args& args);
 
   private:
-    std::string                         input_filename_;
-    std::string                         output_filename_;
-    std::string                         tool_;
-    FILE*                               input_file_;
-    FILE*                               output_file_;
-    std::vector<format::FileOptionPair> file_options_;
-    format::EnabledOptions              enabled_options_;
-    uint64_t                            bytes_read_;
-    uint64_t                            bytes_written_;
-    Error                               error_state_;
-    bool                                loading_state_;
-    std::vector<uint8_t>                parameter_buffer_;
-    std::vector<uint8_t>                compressed_parameter_buffer_;
-    std::unique_ptr<util::Compressor>   compressor_;
-    uint64_t                            block_index_{ 0 };
+    std::string                          input_filename_;
+    std::string                          output_filename_;
+    std::string                          tool_;
+    FileInputStreamPtr                   input_file_;
+    FILE*                                output_file_;
+    std::vector<format::FileOptionPair>  file_options_;
+    format::EnabledOptions               enabled_options_;
+    uint64_t                             bytes_read_;
+    uint64_t                             bytes_written_;
+    Error                                error_state_;
+    bool                                 loading_state_;
+    std::vector<uint8_t>                 compressed_parameter_buffer_;
+    std::unique_ptr<util::Compressor>    compressor_;
+    std::unique_ptr<decode::BlockParser> block_parser_;
+    uint64_t                             block_index_{ 0 };
+    BufferPool                           pool_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/preload_file_processor.cpp
+++ b/framework/decode/preload_file_processor.cpp
@@ -43,8 +43,8 @@ bool PreloadFileProcessor::PreloadBlocksOneFrame()
     BlockBuffer         block_buffer;
     bool                success = true;
 
-    auto        err_handler = [this](BlockReadError err, const char* message) { HandleBlockReadError(err, message); };
-    BlockParser block_parser(BlockParser::ErrorHandler{ err_handler }, pool_, compressor_);
+    auto        err_handler = [this](BlockIOError err, const char* message) { HandleBlockReadError(err, message); };
+    BlockParser block_parser(BlockParser::ErrorHandler{ err_handler }, pool_, compressor_.get());
     while (success)
     {
         PrintBlockInfo();

--- a/tools/compress/compression_converter.cpp
+++ b/tools/compress/compression_converter.cpp
@@ -72,201 +72,95 @@ bool CompressionConverter::WriteFileHeader(const format::FileHeader&            
     return FileTransformer::WriteFileHeader(header, output_options);
 }
 
-bool CompressionConverter::ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id)
+bool CompressionConverter::ProcessFunctionCall(decode::ParsedBlock& parsed_block)
 {
-    size_t           parameter_buffer_size = static_cast<size_t>(block_header.size) - sizeof(call_id);
-    uint64_t         uncompressed_size     = 0;
-    format::ThreadId thread_id             = 0;
-
-    bool success = ReadBytes(&thread_id, sizeof(thread_id));
+    // Decompress reports its own errors.
+    bool success = parsed_block.Decompress(GetBlockParser());
 
     if (success)
     {
-        parameter_buffer_size -= sizeof(thread_id);
-
-        if (format::IsBlockCompressed(block_header.type))
-        {
-            success = ReadBytes(&uncompressed_size, sizeof(uncompressed_size));
-
-            if (success)
-            {
-                parameter_buffer_size -= sizeof(uncompressed_size);
-
-                GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, uncompressed_size);
-
-                size_t actual_size = 0;
-                success            = ReadCompressedParameterBuffer(
-                    parameter_buffer_size, static_cast<size_t>(uncompressed_size), &actual_size);
-
-                if (success)
-                {
-                    assert(actual_size == uncompressed_size);
-                    parameter_buffer_size = static_cast<size_t>(uncompressed_size);
-                }
-                else
-                {
-                    HandleBlockReadError(kErrorReadingCompressedBlockData,
-                                         "Failed to read compressed function call block data");
-                }
-            }
-            else
-            {
-                HandleBlockReadError(kErrorReadingCompressedBlockHeader,
-                                     "Failed to read compressed function call block header");
-            }
-        }
-        else
-        {
-            success = ReadParameterBuffer(parameter_buffer_size);
-
-            if (!success)
-            {
-                HandleBlockReadError(kErrorReadingBlockData, "Failed to read function call block data");
-            }
-        }
-
-        if (success)
-        {
-            success = WriteFunctionCall(call_id, thread_id, parameter_buffer_size);
-        }
-    }
-    else
-    {
-        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read function call block header");
+        const auto& args = parsed_block.Get<decode::FunctionCallArgs>(); // Asserts if !Holds.
+        success          = WriteFunctionCall(args.call_id, args.call_info.thread_id, args.data_size, args.data);
     }
 
     return success;
 }
 
-bool CompressionConverter::ProcessMethodCall(const format::BlockHeader& block_header,
-                                             format::ApiCallId          call_id,
-                                             uint64_t                   block_index /*= 0*/)
+bool CompressionConverter::ProcessMethodCall(decode::ParsedBlock& parsed_block)
 {
-    size_t           parameter_buffer_size = static_cast<size_t>(block_header.size) - sizeof(call_id);
-    uint64_t         uncompressed_size     = 0;
-    format::HandleId object_id             = 0;
-    format::ThreadId thread_id             = 0;
-
-    bool success = ReadBytes(&object_id, sizeof(object_id));
-    success      = success && ReadBytes(&thread_id, sizeof(thread_id));
+    // Decompress reports its own errors.
+    bool success = parsed_block.Decompress(GetBlockParser());
 
     if (success)
     {
-        parameter_buffer_size -= (sizeof(object_id) + sizeof(thread_id));
-
-        if (format::IsBlockCompressed(block_header.type))
-        {
-            success = ReadBytes(&uncompressed_size, sizeof(uncompressed_size));
-
-            if (success)
-            {
-                parameter_buffer_size -= sizeof(uncompressed_size);
-
-                GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, uncompressed_size);
-
-                size_t actual_size = 0;
-                success            = ReadCompressedParameterBuffer(
-                    parameter_buffer_size, static_cast<size_t>(uncompressed_size), &actual_size);
-
-                if (success)
-                {
-                    assert(actual_size == uncompressed_size);
-                    parameter_buffer_size = static_cast<size_t>(uncompressed_size);
-                }
-                else
-                {
-                    HandleBlockReadError(kErrorReadingCompressedBlockData,
-                                         "Failed to read compressed method call block data");
-                }
-            }
-            else
-            {
-                HandleBlockReadError(kErrorReadingCompressedBlockHeader,
-                                     "Failed to read compressed method call block header");
-            }
-        }
-        else
-        {
-            success = ReadParameterBuffer(parameter_buffer_size);
-
-            if (!success)
-            {
-                HandleBlockReadError(kErrorReadingBlockData, "Failed to read method call block data");
-            }
-        }
-
-        if (success)
-        {
-            success = WriteMethodCall(call_id, object_id, thread_id, parameter_buffer_size);
-        }
-    }
-    else
-    {
-        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read method call block header");
+        const auto& args = parsed_block.Get<decode::MethodCallArgs>(); // Asserts if !Holds.
+        success = WriteMethodCall(args.call_id, args.object_id, args.call_info.thread_id, args.data_size, args.data);
     }
 
     return success;
 }
 
-bool CompressionConverter::ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id)
+bool CompressionConverter::ProcessMetaData(decode::ParsedBlock& parsed_block)
 {
-    // Only the meta data blocks that contain resource data support compression.  The rest of the meta data block types
-    // can be copied directly to the new file.
-    format::MetaDataType meta_data_type = format::GetMetaDataType(meta_data_id);
-    if (meta_data_type == format::MetaDataType::kFillMemoryCommand)
-    {
-        return WriteFillMemoryMetaData(block_header, meta_data_id);
-    }
-    else if (meta_data_type == format::MetaDataType::kInitBufferCommand)
-    {
-        return WriteInitBufferMetaData(block_header, meta_data_id);
-    }
-    else if (meta_data_type == format::MetaDataType::kInitImageCommand)
-    {
-        return WriteInitImageMetaData(block_header, meta_data_id);
-    }
-    else if (meta_data_type == format::MetaDataType::kInitSubresourceCommand)
-    {
-        return WriteInitSubresourceMetaData(block_header, meta_data_id);
-    }
-    else if (meta_data_type == format::MetaDataType::kInitDx12AccelerationStructureCommand)
-    {
-        return WriteInitDx12AccelerationStructureMetaData(block_header, meta_data_id);
-    }
-    else if (meta_data_type == format::MetaDataType::kFillMemoryResourceValueCommand)
-    {
-        return WriteFillMemoryResourceValueMetaData(block_header, meta_data_id);
-    }
-    else
-    {
-        // The current block should not be compressed.  If it is compressed, it is most likely a new block type that is
-        // not supported.
-        if (format::IsBlockCompressed(block_header.type))
-        {
-            HandleBlockWriteError(kErrorUnsupportedBlockType,
-                                  "Failed to process unrecognized compressed meta data block type.");
-            return false;
-        }
+    // We can infer format::IsBlockCompressed from NeedsDecompression as long
+    // as the DecompressionPolicy is "never".
+    auto& block_parser = GetBlockParser();
+    GFXRECON_ASSERT(block_parser.GetDecompressionPolicy() == decode::BlockParser::kNever);
+    const bool compressed_block = parsed_block.NeedsDecompression();
 
-        return FileTransformer::ProcessMetaData(block_header, meta_data_id);
+    // Unconditional decompress the metadata block wastes no time as all compressible meta_data_id have non-trivial
+    // overrides, and decompress fast returns on uncompressed blocks.
+    bool success = parsed_block.Decompress(block_parser);
+    if (success)
+    {
+        auto        visit_meta = [this](auto&& store) { return WriteMetaData(*store); };
+        VisitResult result     = std::visit(visit_meta, parsed_block.GetArgs());
+
+        if (result == kNeedsPassthrough)
+        {
+            if (!compressed_block)
+            {
+                success = FileTransformer::ProcessMetaData(parsed_block);
+            }
+            else
+            {
+                // Since this file transformer is converting compression formats, it cannot passthrough
+                // NOTE: This condition should not occur, as all compressible meta_data_id *should* have non-trivial
+                // overrides, indicating that the BlockParser recognized the block, but that the CompressionConverter
+                // does not.
+                GFXRECON_ASSERT(!compressed_block);
+                HandleBlockWriteError(decode::kErrorUnsupportedBlockType,
+                                      "Failed to process unrecognized compressed meta data block type.");
+                success = false;
+            }
+        }
+        else
+        {
+            success = result == kSuccess;
+        }
     }
+    return success;
 }
 
-bool CompressionConverter::WriteFunctionCall(format::ApiCallId call_id, format::ThreadId thread_id, size_t buffer_size)
+bool CompressionConverter::WriteFunctionCall(format::ApiCallId call_id,
+                                             format::ThreadId  thread_id,
+                                             size_t            buffer_size,
+                                             const uint8_t*    buffer)
 {
-    bool        write_uncompressed = decompressing_;
-    const auto& buffer             = GetParameterBuffer();
+    bool write_uncompressed = decompressing_;
 
     if (!write_uncompressed)
     {
-        assert(target_compressor_ != nullptr);
+        GFXRECON_ASSERT(target_compressor_ != nullptr);
 
         // Compress the buffer with the new compression format and write to the new file.
         auto&  compressed_buffer = GetCompressedParameterBuffer();
         size_t packet_size       = 0;
-        size_t compressed_size   = target_compressor_->Compress(buffer_size, buffer.data(), &compressed_buffer, 0);
+        size_t compressed_size   = target_compressor_->Compress(buffer_size, buffer, &compressed_buffer, 0);
 
-        if (0 < compressed_size && compressed_size < buffer_size)
+        // Note: we not only have to compress smaller than uncompressed, we have to include the compression overhead.
+        if ((0 < compressed_size) &&
+            ((compressed_size + sizeof(format::CompressedFunctionCallHeader::uncompressed_size)) < buffer_size))
         {
             format::CompressedFunctionCallHeader compressed_func_call_header = {};
             compressed_func_call_header.block_header.type = format::BlockType::kCompressedFunctionCallBlock;
@@ -282,14 +176,14 @@ bool CompressionConverter::WriteFunctionCall(format::ApiCallId call_id, format::
 
             if (!WriteBytes(&compressed_func_call_header, sizeof(compressed_func_call_header)))
             {
-                HandleBlockWriteError(kErrorWritingCompressedBlockHeader,
+                HandleBlockWriteError(decode::kErrorWritingCompressedBlockHeader,
                                       "Failed to write compressed function call block header");
                 return false;
             }
 
             if (!WriteBytes(compressed_buffer.data(), compressed_size))
             {
-                HandleBlockWriteError(kErrorWritingCompressedBlockData,
+                HandleBlockWriteError(decode::kErrorWritingCompressedBlockData,
                                       "Failed to write compressed function call block data");
                 return false;
             }
@@ -317,13 +211,13 @@ bool CompressionConverter::WriteFunctionCall(format::ApiCallId call_id, format::
 
         if (!WriteBytes(&func_call_header, sizeof(func_call_header)))
         {
-            HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write function call block header");
+            HandleBlockWriteError(decode::kErrorWritingBlockHeader, "Failed to write function call block header");
             return false;
         }
 
-        if (!WriteBytes(buffer.data(), buffer_size))
+        if (!WriteBytes(buffer, buffer_size))
         {
-            HandleBlockWriteError(kErrorWritingBlockData, "Failed to write function call block data");
+            HandleBlockWriteError(decode::kErrorWritingBlockData, "Failed to write function call block data");
             return false;
         }
     }
@@ -334,10 +228,10 @@ bool CompressionConverter::WriteFunctionCall(format::ApiCallId call_id, format::
 bool CompressionConverter::WriteMethodCall(format::ApiCallId call_id,
                                            format::HandleId  object_id,
                                            format::ThreadId  thread_id,
-                                           size_t            buffer_size)
+                                           size_t            buffer_size,
+                                           const uint8_t*    buffer)
 {
-    bool        write_uncompressed = decompressing_;
-    const auto& buffer             = GetParameterBuffer();
+    bool write_uncompressed = decompressing_;
 
     if (!write_uncompressed)
     {
@@ -346,9 +240,11 @@ bool CompressionConverter::WriteMethodCall(format::ApiCallId call_id,
         // Compress the buffer with the new compression format and write to the new file.
         auto&  compressed_buffer = GetCompressedParameterBuffer();
         size_t packet_size       = 0;
-        size_t compressed_size   = target_compressor_->Compress(buffer_size, buffer.data(), &compressed_buffer, 0);
+        size_t compressed_size   = target_compressor_->Compress(buffer_size, buffer, &compressed_buffer, 0);
 
-        if (0 < compressed_size && compressed_size < buffer_size)
+        // Note: we not only have to compress smaller than uncompressed, we have to include the compression overhead.
+        if ((0 < compressed_size) &&
+            ((compressed_size + sizeof(format::CompressedMethodCallHeader::uncompressed_size)) < buffer_size))
         {
             format::CompressedMethodCallHeader compressed_method_call_header = {};
             compressed_method_call_header.block_header.type = format::BlockType::kCompressedMethodCallBlock;
@@ -366,14 +262,14 @@ bool CompressionConverter::WriteMethodCall(format::ApiCallId call_id,
 
             if (!WriteBytes(&compressed_method_call_header, sizeof(compressed_method_call_header)))
             {
-                HandleBlockWriteError(kErrorWritingCompressedBlockHeader,
+                HandleBlockWriteError(decode::kErrorWritingCompressedBlockHeader,
                                       "Failed to write compressed method call block header");
                 return false;
             }
 
             if (!WriteBytes(compressed_buffer.data(), compressed_size))
             {
-                HandleBlockWriteError(kErrorWritingCompressedBlockData,
+                HandleBlockWriteError(decode::kErrorWritingCompressedBlockData,
                                       "Failed to write compressed method call block data");
                 return false;
             }
@@ -403,13 +299,13 @@ bool CompressionConverter::WriteMethodCall(format::ApiCallId call_id,
 
         if (!WriteBytes(&method_call_header, sizeof(method_call_header)))
         {
-            HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write method call block header");
+            HandleBlockWriteError(decode::kErrorWritingBlockHeader, "Failed to write method call block header");
             return false;
         }
 
-        if (!WriteBytes(buffer.data(), buffer_size))
+        if (!WriteBytes(buffer, buffer_size))
         {
-            HandleBlockWriteError(kErrorWritingBlockData, "Failed to write method call block data");
+            HandleBlockWriteError(decode::kErrorWritingBlockData, "Failed to write method call block data");
             return false;
         }
     }
@@ -417,511 +313,255 @@ bool CompressionConverter::WriteMethodCall(format::ApiCallId call_id,
     return true;
 }
 
-bool CompressionConverter::WriteFillMemoryMetaData(const format::BlockHeader& block_header,
-                                                   format::MetaDataId         meta_data_id)
+decode::FileTransformer::VisitResult CompressionConverter::WriteMetaData(const decode::FillMemoryArgs& args)
 {
-    assert(format::GetMetaDataType(meta_data_id) == format::MetaDataType::kFillMemoryCommand);
+    GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kFillMemoryCommand);
 
     format::FillMemoryCommandHeader fill_cmd;
 
-    bool success = ReadBytes(&fill_cmd.thread_id, sizeof(fill_cmd.thread_id));
-    success      = success && ReadBytes(&fill_cmd.memory_id, sizeof(fill_cmd.memory_id));
-    success      = success && ReadBytes(&fill_cmd.memory_offset, sizeof(fill_cmd.memory_offset));
-    success      = success && ReadBytes(&fill_cmd.memory_size, sizeof(fill_cmd.memory_size));
+    fill_cmd.thread_id     = args.thread_id;
+    fill_cmd.memory_id     = args.memory_id;
+    fill_cmd.memory_offset = args.offset;
+    fill_cmd.memory_size   = args.data_size;
 
-    if (success)
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, args.data_size);
+    size_t         data_size    = static_cast<size_t>(args.data_size);
+    const uint8_t* data_address = args.data;
+
+    PrepMetadataBlock(fill_cmd.meta_header, args.meta_data_id, data_address, data_size);
+
+    // Calculate size of packet with compressed or uncompressed data size.
+    fill_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(fill_cmd) + data_size;
+
+    if (!WriteBytes(&fill_cmd, sizeof(fill_cmd)))
     {
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, fill_cmd.memory_size);
-
-        size_t data_size = static_cast<size_t>(fill_cmd.memory_size);
-
-        if (format::IsBlockCompressed(block_header.type))
-        {
-            size_t uncompressed_size = 0;
-            size_t compressed_size =
-                static_cast<size_t>(block_header.size - format::GetMetaDataBlockBaseSize(fill_cmd));
-
-            if (!ReadCompressedParameterBuffer(compressed_size, data_size, &uncompressed_size))
-            {
-                HandleBlockReadError(kErrorReadingCompressedBlockData, "Failed to read fill memory meta-data block");
-                return false;
-            }
-
-            assert(uncompressed_size == data_size);
-        }
-        else
-        {
-            if (!ReadParameterBuffer(data_size))
-            {
-                HandleBlockReadError(kErrorReadingBlockData, "Failed to read fill memory meta-data block");
-                return false;
-            }
-        }
-
-        const auto&    buffer       = GetParameterBuffer();
-        const uint8_t* data_address = buffer.data();
-
-        PrepMetadataBlock(fill_cmd.meta_header, meta_data_id, data_address, data_size);
-
-        // Calculate size of packet with compressed or uncompressed data size.
-        fill_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(fill_cmd) + data_size;
-
-        if (!WriteBytes(&fill_cmd, sizeof(fill_cmd)))
-        {
-            HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write fill memory meta-data block header");
-            return false;
-        }
-
-        if (!WriteBytes(data_address, data_size))
-        {
-            HandleBlockWriteError(kErrorWritingBlockData, "Failed to write fill memory meta-data block");
-            return false;
-        }
-    }
-    else
-    {
-        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read fill memory meta-data block header");
-        return false;
+        HandleBlockWriteError(decode::kErrorWritingBlockHeader, "Failed to write fill memory meta-data block header");
+        return kError;
     }
 
-    return true;
+    if (!WriteBytes(data_address, data_size))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockData, "Failed to write fill memory meta-data block");
+        return kError;
+    }
+
+    return kSuccess;
 }
 
-bool CompressionConverter::WriteInitBufferMetaData(const format::BlockHeader& block_header,
-                                                   format::MetaDataId         meta_data_id)
+decode::FileTransformer::VisitResult CompressionConverter::WriteMetaData(const decode::InitBufferArgs& args)
 {
-    assert(format::GetMetaDataType(meta_data_id) == format::MetaDataType::kInitBufferCommand);
+    GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitBufferCommand);
 
     format::InitBufferCommandHeader init_cmd;
 
-    bool success = ReadBytes(&init_cmd.thread_id, sizeof(init_cmd.thread_id));
-    success      = success && ReadBytes(&init_cmd.device_id, sizeof(init_cmd.device_id));
-    success      = success && ReadBytes(&init_cmd.buffer_id, sizeof(init_cmd.buffer_id));
-    success      = success && ReadBytes(&init_cmd.data_size, sizeof(init_cmd.data_size));
+    init_cmd.thread_id = args.thread_id;
+    init_cmd.device_id = args.device_id;
+    init_cmd.buffer_id = args.buffer_id;
+    init_cmd.data_size = args.data_size;
 
-    if (success)
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.data_size);
+    size_t         data_size    = static_cast<size_t>(init_cmd.data_size);
+    const uint8_t* data_address = args.data;
+
+    PrepMetadataBlock(init_cmd.meta_header, args.meta_data_id, data_address, data_size);
+
+    // Calculate size of packet with compressed or uncompressed data size.
+    init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + data_size;
+
+    if (!WriteBytes(&init_cmd, sizeof(init_cmd)))
     {
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.data_size);
-
-        size_t data_size = static_cast<size_t>(init_cmd.data_size);
-
-        if (format::IsBlockCompressed(block_header.type))
-        {
-            size_t uncompressed_size = 0;
-            size_t compressed_size =
-                static_cast<size_t>(block_header.size - format::GetMetaDataBlockBaseSize(init_cmd));
-
-            if (!ReadCompressedParameterBuffer(compressed_size, data_size, &uncompressed_size))
-            {
-                HandleBlockReadError(kErrorReadingCompressedBlockData, "Failed to read init buffer meta-data block");
-                return false;
-            }
-
-            assert(uncompressed_size == data_size);
-        }
-        else
-        {
-            if (!ReadParameterBuffer(data_size))
-            {
-                HandleBlockReadError(kErrorReadingBlockData, "Failed to read init buffer meta-data block");
-                return false;
-            }
-        }
-
-        const auto&    buffer       = GetParameterBuffer();
-        const uint8_t* data_address = buffer.data();
-
-        PrepMetadataBlock(init_cmd.meta_header, meta_data_id, data_address, data_size);
-
-        // Calculate size of packet with compressed or uncompressed data size.
-        init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + data_size;
-
-        if (!WriteBytes(&init_cmd, sizeof(init_cmd)))
-        {
-            HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write init buffer meta-data block header");
-            return false;
-        }
-
-        if (!WriteBytes(data_address, data_size))
-        {
-            HandleBlockWriteError(kErrorWritingBlockData, "Failed to write init buffer meta-data block");
-            return false;
-        }
-    }
-    else
-    {
-        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read init buffer meta-data block header");
-        return false;
+        HandleBlockWriteError(decode::kErrorWritingBlockHeader, "Failed to write init buffer meta-data block header");
+        return kError;
     }
 
-    return true;
+    if (!WriteBytes(data_address, data_size))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockData, "Failed to write init buffer meta-data block");
+        return kError;
+    }
+
+    return kSuccess;
 }
 
-bool CompressionConverter::WriteInitImageMetaData(const format::BlockHeader& block_header,
-                                                  format::MetaDataId         meta_data_id)
+decode::FileTransformer::VisitResult CompressionConverter::WriteMetaData(const decode::InitImageArgs& args)
 {
-    assert(format::GetMetaDataType(meta_data_id) == format::MetaDataType::kInitImageCommand);
+    GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitImageCommand);
 
     format::InitImageCommandHeader init_cmd;
     std::vector<uint64_t>          level_sizes;
     size_t                         levels_size = 0;
 
-    bool success = ReadBytes(&init_cmd.thread_id, sizeof(init_cmd.thread_id));
-    success      = success && ReadBytes(&init_cmd.device_id, sizeof(init_cmd.device_id));
-    success      = success && ReadBytes(&init_cmd.image_id, sizeof(init_cmd.image_id));
-    success      = success && ReadBytes(&init_cmd.data_size, sizeof(init_cmd.data_size));
-    success      = success && ReadBytes(&init_cmd.aspect, sizeof(init_cmd.aspect));
-    success      = success && ReadBytes(&init_cmd.layout, sizeof(init_cmd.layout));
-    success      = success && ReadBytes(&init_cmd.level_count, sizeof(init_cmd.level_count));
+    init_cmd.thread_id   = args.thread_id;
+    init_cmd.device_id   = args.device_id;
+    init_cmd.image_id    = args.image_id;
+    init_cmd.data_size   = args.data_size;
+    init_cmd.aspect      = args.aspect;
+    init_cmd.layout      = args.layout;
+    init_cmd.level_count = args.level_sizes.size();
 
-    if (success && (init_cmd.level_count > 0))
+    if (init_cmd.level_count > 0)
     {
-        level_sizes.resize(init_cmd.level_count);
+        level_sizes = args.level_sizes;
         levels_size = init_cmd.level_count * sizeof(level_sizes[0]);
-        success     = ReadBytes(level_sizes.data(), levels_size);
     }
 
-    if (success)
-    {
-        // Packet size without the resource data.
-        init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd);
-        init_cmd.meta_header.block_header.type = format::kMetaDataBlock;
-        init_cmd.meta_header.meta_data_id      = meta_data_id;
+    // Packet size without the resource data.
+    init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd);
+    init_cmd.meta_header.block_header.type = format::kMetaDataBlock;
+    init_cmd.meta_header.meta_data_id      = args.meta_data_id;
 
-        if (init_cmd.data_size > 0)
-        {
-            assert(init_cmd.data_size == std::accumulate(level_sizes.begin(), level_sizes.end(), 0ull));
-            GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.data_size);
-
-            size_t data_size = static_cast<size_t>(init_cmd.data_size);
-
-            if (format::IsBlockCompressed(block_header.type))
-            {
-                size_t uncompressed_size = 0;
-                size_t compressed_size =
-                    static_cast<size_t>(block_header.size - format::GetMetaDataBlockBaseSize(init_cmd)) - levels_size;
-
-                if (!ReadCompressedParameterBuffer(compressed_size, data_size, &uncompressed_size))
-                {
-                    HandleBlockReadError(kErrorReadingCompressedBlockData, "Failed to read init image meta-data block");
-                    return false;
-                }
-
-                assert(uncompressed_size == data_size);
-            }
-            else
-            {
-                if (!ReadParameterBuffer(data_size))
-                {
-                    HandleBlockReadError(kErrorReadingBlockData, "Failed to read init image meta-data block");
-                    return false;
-                }
-            }
-
-            const auto&    buffer       = GetParameterBuffer();
-            const uint8_t* data_address = buffer.data();
-
-            PrepMetadataBlock(init_cmd.meta_header, meta_data_id, data_address, data_size);
-
-            // Calculate size of packet with compressed or uncompressed data size.
-            init_cmd.meta_header.block_header.size =
-                format::GetMetaDataBlockBaseSize(init_cmd) + levels_size + data_size;
-
-            if (!WriteBytes(&init_cmd, sizeof(init_cmd)))
-            {
-                HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write init image meta-data block header");
-                return false;
-            }
-
-            if (!WriteBytes(level_sizes.data(), levels_size))
-            {
-                HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write init image meta-data block");
-                return false;
-            }
-
-            if (!WriteBytes(data_address, data_size))
-            {
-                HandleBlockWriteError(kErrorWritingBlockData, "Failed to write init image meta-data block");
-                return false;
-            }
-        }
-        else
-        {
-            // Write a packet without resource data; replay must still perform a layout transition at image
-            // initialization.
-            init_cmd.data_size   = 0;
-            init_cmd.level_count = 0;
-
-            if (!WriteBytes(&init_cmd, sizeof(init_cmd)))
-            {
-                HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write init image meta-data block header");
-                return false;
-            }
-        }
-    }
-    else
-    {
-        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read init image meta-data block header");
-        return false;
-    }
-
-    return true;
-}
-
-bool CompressionConverter::WriteInitSubresourceMetaData(const format::BlockHeader& block_header,
-                                                        format::MetaDataId         meta_data_id)
-{
-    assert(format::GetMetaDataType(meta_data_id) == format::MetaDataType::kInitSubresourceCommand);
-
-    format::InitSubresourceCommandHeader init_cmd;
-
-    bool success = ReadBytes(&init_cmd.thread_id, sizeof(init_cmd.thread_id));
-    success      = success && ReadBytes(&init_cmd.device_id, sizeof(init_cmd.device_id));
-    success      = success && ReadBytes(&init_cmd.resource_id, sizeof(init_cmd.resource_id));
-    success      = success && ReadBytes(&init_cmd.subresource, sizeof(init_cmd.subresource));
-    success      = success && ReadBytes(&init_cmd.initial_state, sizeof(init_cmd.initial_state));
-    success      = success && ReadBytes(&init_cmd.resource_state, sizeof(init_cmd.resource_state));
-    success      = success && ReadBytes(&init_cmd.barrier_flags, sizeof(init_cmd.barrier_flags));
-    success      = success && ReadBytes(&init_cmd.data_size, sizeof(init_cmd.data_size));
-
-    if (success)
+    if (init_cmd.data_size > 0)
     {
         GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.data_size);
-
         size_t data_size = static_cast<size_t>(init_cmd.data_size);
+        const uint8_t* data_address = args.data;
 
-        if (format::IsBlockCompressed(block_header.type))
-        {
-            size_t uncompressed_size = 0;
-            size_t compressed_size =
-                static_cast<size_t>(block_header.size - format::GetMetaDataBlockBaseSize(init_cmd));
-
-            if (!ReadCompressedParameterBuffer(compressed_size, data_size, &uncompressed_size))
-            {
-                HandleBlockReadError(kErrorReadingCompressedBlockData,
-                                     "Failed to read init subresource meta-data block");
-                return false;
-            }
-
-            assert(uncompressed_size == data_size);
-        }
-        else
-        {
-            if (!ReadParameterBuffer(data_size))
-            {
-                HandleBlockReadError(kErrorReadingBlockData, "Failed to read init subresource meta-data block");
-                return false;
-            }
-        }
-
-        const auto&    buffer       = GetParameterBuffer();
-        const uint8_t* data_address = buffer.data();
-
-        PrepMetadataBlock(init_cmd.meta_header, meta_data_id, data_address, data_size);
+        PrepMetadataBlock(init_cmd.meta_header, args.meta_data_id, data_address, data_size);
 
         // Calculate size of packet with compressed or uncompressed data size.
-        init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + data_size;
+        init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + levels_size + data_size;
 
         if (!WriteBytes(&init_cmd, sizeof(init_cmd)))
         {
-            HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write init subresource meta-data block header");
-            return false;
+            HandleBlockWriteError(decode::kErrorWritingBlockHeader,
+                                  "Failed to write init image meta-data block header");
+            return kError;
+        }
+
+        if (!WriteBytes(level_sizes.data(), levels_size))
+        {
+            HandleBlockWriteError(decode::kErrorWritingBlockHeader, "Failed to write init image meta-data block");
+            return kError;
         }
 
         if (!WriteBytes(data_address, data_size))
         {
-            HandleBlockWriteError(kErrorWritingBlockData, "Failed to write init subresource meta-data block");
-            return false;
+            HandleBlockWriteError(decode::kErrorWritingBlockData, "Failed to write init image meta-data block");
+            return kError;
         }
     }
     else
     {
-        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read init subresource meta-data block header");
-        return false;
-    }
-
-    return true;
-}
-
-bool CompressionConverter::WriteInitDx12AccelerationStructureMetaData(const format::BlockHeader& block_header,
-                                                                      format::MetaDataId         meta_data_id)
-{
-    assert(format::GetMetaDataType(meta_data_id) == format::MetaDataType::kInitDx12AccelerationStructureCommand);
-
-    format::InitDx12AccelerationStructureCommandHeader init_cmd;
-    bool success = ReadBytes(&init_cmd.thread_id, sizeof(init_cmd.thread_id));
-    success      = success &&
-              ReadBytes(&init_cmd.dest_acceleration_structure_data, sizeof(init_cmd.dest_acceleration_structure_data));
-    success = success && ReadBytes(&init_cmd.copy_source_gpu_va, sizeof(init_cmd.copy_source_gpu_va));
-    success = success && ReadBytes(&init_cmd.copy_mode, sizeof(init_cmd.copy_mode));
-    success = success && ReadBytes(&init_cmd.inputs_type, sizeof(init_cmd.inputs_type));
-    success = success && ReadBytes(&init_cmd.inputs_flags, sizeof(init_cmd.inputs_flags));
-    success = success && ReadBytes(&init_cmd.inputs_num_instance_descs, sizeof(init_cmd.inputs_num_instance_descs));
-    success = success && ReadBytes(&init_cmd.inputs_num_geometry_descs, sizeof(init_cmd.inputs_num_geometry_descs));
-    success = success && ReadBytes(&init_cmd.inputs_data_size, sizeof(init_cmd.inputs_data_size));
-
-    // Parse geometry descs.
-
-    std::vector<format::InitDx12AccelerationStructureGeometryDesc> geom_descs;
-    if (success)
-    {
-        for (uint32_t i = 0; i < init_cmd.inputs_num_geometry_descs; ++i)
-        {
-            format::InitDx12AccelerationStructureGeometryDesc geom_desc;
-            success = success && ReadBytes(&geom_desc.geometry_type, sizeof(geom_desc.geometry_type));
-            success = success && ReadBytes(&geom_desc.geometry_flags, sizeof(geom_desc.geometry_flags));
-            success = success && ReadBytes(&geom_desc.aabbs_count, sizeof(geom_desc.aabbs_count));
-            success = success && ReadBytes(&geom_desc.aabbs_stride, sizeof(geom_desc.aabbs_stride));
-            success =
-                success && ReadBytes(&geom_desc.triangles_has_transform, sizeof(geom_desc.triangles_has_transform));
-            success = success && ReadBytes(&geom_desc.triangles_index_format, sizeof(geom_desc.triangles_index_format));
-            success =
-                success && ReadBytes(&geom_desc.triangles_vertex_format, sizeof(geom_desc.triangles_vertex_format));
-            success = success && ReadBytes(&geom_desc.triangles_index_count, sizeof(geom_desc.triangles_index_count));
-            success = success && ReadBytes(&geom_desc.triangles_vertex_count, sizeof(geom_desc.triangles_vertex_count));
-            success =
-                success && ReadBytes(&geom_desc.triangles_vertex_stride, sizeof(geom_desc.triangles_vertex_stride));
-            geom_descs.push_back(geom_desc);
-        }
-    }
-
-    if (success)
-    {
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.inputs_data_size);
-
-        size_t data_size = static_cast<size_t>(init_cmd.inputs_data_size);
-
-        if (format::IsBlockCompressed(block_header.type))
-        {
-            size_t uncompressed_size = 0;
-            size_t compressed_size =
-                static_cast<size_t>(block_header.size) -
-                (sizeof(init_cmd) - sizeof(init_cmd.meta_header.block_header)) -
-                (sizeof(format::InitDx12AccelerationStructureGeometryDesc) * init_cmd.inputs_num_geometry_descs);
-
-            if (!ReadCompressedParameterBuffer(compressed_size, data_size, &uncompressed_size))
-            {
-                HandleBlockReadError(kErrorReadingCompressedBlockData,
-                                     "Failed to read init DX12 acceleration structure meta-data block");
-                return false;
-            }
-
-            assert(uncompressed_size == data_size);
-        }
-        else
-        {
-            if (!ReadParameterBuffer(data_size))
-            {
-                HandleBlockReadError(kErrorReadingBlockData,
-                                     "Failed to read init DX12 acceleration structure meta-data block");
-                return false;
-            }
-        }
-
-        const auto&    buffer       = GetParameterBuffer();
-        const uint8_t* data_address = buffer.data();
-
-        PrepMetadataBlock(init_cmd.meta_header, meta_data_id, data_address, data_size);
-
-        // Calculate size of packet with compressed or uncompressed data size.
-        init_cmd.meta_header.block_header.size =
-            format::GetMetaDataBlockBaseSize(init_cmd) + data_size +
-            (sizeof(format::InitDx12AccelerationStructureGeometryDesc) * init_cmd.inputs_num_geometry_descs);
+        // Write a packet without resource data; replay must still perform a layout transition at image
+        // initialization.
+        init_cmd.data_size   = 0;
+        init_cmd.level_count = 0;
 
         if (!WriteBytes(&init_cmd, sizeof(init_cmd)))
         {
-            HandleBlockWriteError(kErrorWritingBlockHeader,
-                                  "Failed to write init DX12 acceleration structure meta-data block header");
-            return false;
+            HandleBlockWriteError(decode::kErrorWritingBlockHeader,
+                                  "Failed to write init image meta-data block header");
+            return kError;
         }
-        if (!WriteBytes(geom_descs.data(),
-                        sizeof(format::InitDx12AccelerationStructureGeometryDesc) * geom_descs.size()))
-        {
-            HandleBlockWriteError(kErrorWritingBlockHeader,
-                                  "Failed to write init DX12 acceleration structure geometry block");
-            return false;
-        }
-        if (!WriteBytes(data_address, data_size))
-        {
-            HandleBlockWriteError(kErrorWritingBlockData,
-                                  "Failed to write init DX12 acceleration structure meta-data block");
-            return false;
-        }
-    }
-    else
-    {
-        HandleBlockReadError(kErrorReadingBlockHeader,
-                             "Failed to read init DX12 acceleration structure meta-data block header");
     }
 
-    return true;
+    return kSuccess;
 }
 
-bool CompressionConverter::WriteFillMemoryResourceValueMetaData(const format::BlockHeader& block_header,
-                                                                format::MetaDataId         meta_data_id)
+decode::FileTransformer::VisitResult CompressionConverter::WriteMetaData(const decode::InitSubresourceArgs& args)
 {
-    format::FillMemoryResourceValueCommandHeader rv_cmd;
-    bool                                         success = ReadBytes(&rv_cmd.thread_id, sizeof(rv_cmd.thread_id));
+    GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitSubresourceCommand);
 
-    success = success && ReadBytes(&rv_cmd.resource_value_count, sizeof(rv_cmd.resource_value_count));
+    // The header needs to be a copy as we are rewriting it below
+    format::InitSubresourceCommandHeader init_cmd = args.command_header;
 
-    if (success)
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.data_size);
+    size_t         data_size    = static_cast<size_t>(init_cmd.data_size);
+    const uint8_t* data_address = args.data;
+
+    PrepMetadataBlock(init_cmd.meta_header, args.meta_data_id, data_address, data_size);
+
+    // Calculate size of packet with compressed or uncompressed data size.
+    init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + data_size;
+
+    if (!WriteBytes(&init_cmd, sizeof(init_cmd)))
     {
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, rv_cmd.resource_value_count);
-        size_t data_size =
-            static_cast<size_t>(rv_cmd.resource_value_count * (sizeof(format::ResourceValueType) + sizeof(uint64_t)));
-
-        if (format::IsBlockCompressed(block_header.type))
-        {
-            size_t uncompressed_size = 0;
-            size_t compressed_size = static_cast<size_t>(block_header.size - format::GetMetaDataBlockBaseSize(rv_cmd));
-
-            if (!ReadCompressedParameterBuffer(compressed_size, data_size, &uncompressed_size))
-            {
-                HandleBlockReadError(kErrorReadingCompressedBlockData,
-                                     "Failed to read fill memory resource value meta-data block");
-                return false;
-            }
-
-            assert(uncompressed_size == data_size);
-        }
-        else
-        {
-            if (!ReadParameterBuffer(data_size))
-            {
-                HandleBlockReadError(kErrorReadingBlockData,
-                                     "Failed to read fill memory resource value meta-data block");
-                return false;
-            }
-        }
-
-        const auto&    buffer       = GetParameterBuffer();
-        const uint8_t* data_address = buffer.data();
-
-        PrepMetadataBlock(rv_cmd.meta_header, meta_data_id, data_address, data_size);
-
-        // Calculate size of packet with compressed or uncompressed data size.
-        rv_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(rv_cmd) + data_size;
-
-        if (!WriteBytes(&rv_cmd, sizeof(rv_cmd)))
-        {
-            HandleBlockWriteError(kErrorWritingBlockHeader, "Failed to write fill memory meta-data block header");
-            return false;
-        }
-
-        if (!WriteBytes(data_address, data_size))
-        {
-            HandleBlockWriteError(kErrorWritingBlockData, "Failed to read fill memory resource value meta-data block");
-            return false;
-        }
-    }
-    else
-    {
-        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to write fill memory resource value meta-data block");
-        return false;
+        HandleBlockWriteError(decode::kErrorWritingBlockHeader,
+                              "Failed to write init subresource meta-data block header");
+        return kError;
     }
 
-    return true;
+    if (!WriteBytes(data_address, data_size))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockData, "Failed to write init subresource meta-data block");
+        return kError;
+    }
+
+    return kSuccess;
+}
+
+decode::FileTransformer::VisitResult
+CompressionConverter::WriteMetaData(const decode::InitDx12AccelerationStructureArgs& args)
+{
+    GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) ==
+                    format::MetaDataType::kInitDx12AccelerationStructureCommand);
+
+    // The header needs to be a copy as we are rewriting it below
+    format::InitDx12AccelerationStructureCommandHeader                    init_cmd   = args.command_header;
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geom_descs = args.geometry_descs;
+    GFXRECON_ASSERT(args.geometry_descs.size() == init_cmd.inputs_num_geometry_descs);
+
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.inputs_data_size);
+    size_t         data_size    = static_cast<size_t>(init_cmd.inputs_data_size);
+    const uint8_t* data_address = args.data;
+
+    PrepMetadataBlock(init_cmd.meta_header, args.meta_data_id, data_address, data_size);
+
+    // Calculate size of packet with compressed or uncompressed data size.
+    init_cmd.meta_header.block_header.size =
+        format::GetMetaDataBlockBaseSize(init_cmd) + data_size +
+        (sizeof(format::InitDx12AccelerationStructureGeometryDesc) * init_cmd.inputs_num_geometry_descs);
+
+    if (!WriteBytes(&init_cmd, sizeof(init_cmd)))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockHeader,
+                              "Failed to write init DX12 acceleration structure meta-data block header");
+        return kError;
+    }
+    if (!WriteBytes(geom_descs.data(), sizeof(format::InitDx12AccelerationStructureGeometryDesc) * geom_descs.size()))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockHeader,
+                              "Failed to write init DX12 acceleration structure geometry block");
+        return kError;
+    }
+    if (!WriteBytes(data_address, data_size))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockData,
+                              "Failed to write init DX12 acceleration structure meta-data block");
+        return kError;
+    }
+
+    return kSuccess;
+}
+
+decode::FileTransformer::VisitResult
+CompressionConverter::WriteMetaData(const decode::FillMemoryResourceValueArgs& args)
+{
+    // The header needs to be a copy as we are rewriting it below
+    format::FillMemoryResourceValueCommandHeader rv_cmd = args.command_header;
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, args.data_size);
+    size_t         data_size    = static_cast<size_t>(args.data_size);
+    const uint8_t* data_address = args.data;
+
+    PrepMetadataBlock(rv_cmd.meta_header, args.meta_data_id, data_address, data_size);
+
+    // Calculate size of packet with compressed or uncompressed data size.
+    rv_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(rv_cmd) + data_size;
+
+    if (!WriteBytes(&rv_cmd, sizeof(rv_cmd)))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockHeader, "Failed to write fill memory meta-data block header");
+        return kError;
+    }
+
+    if (!WriteBytes(data_address, data_size))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockData,
+                              "Failed to read fill memory resource value meta-data block");
+        return kError;
+    }
+
+    return kSuccess;
 }
 
 void CompressionConverter::PrepMetadataBlock(format::MetaDataHeader& meta_data_header,
@@ -934,11 +574,13 @@ void CompressionConverter::PrepMetadataBlock(format::MetaDataHeader& meta_data_h
 
     if (!decompressing_)
     {
-        assert(target_compressor_ != nullptr);
+        GFXRECON_ASSERT(target_compressor_ != nullptr);
 
         auto&  compressed_buffer = GetCompressedParameterBuffer();
         size_t compressed_size   = target_compressor_->Compress(data_size, data_address, &compressed_buffer, 0);
 
+        // Note: With MetaDataBlocks the uncompressed size is encoded (or computable from) other fields in the
+        //       block, s.t. there is no data size overhead for using compressed_data
         if ((compressed_size > 0) && (compressed_size < data_size))
         {
             meta_data_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;

--- a/tools/compress/compression_converter.h
+++ b/tools/compress/compression_converter.h
@@ -46,36 +46,36 @@ class CompressionConverter : public decode::FileTransformer
                     format::CompressionType target_compression_type);
 
   protected:
-    virtual bool WriteFileHeader(const format::FileHeader&                  header,
-                                 const std::vector<format::FileOptionPair>& options) override;
+    bool WriteFileHeader(const format::FileHeader& header, const std::vector<format::FileOptionPair>& options) override;
 
-    virtual bool ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id) override;
+    bool ProcessFunctionCall(decode::ParsedBlock& parsed_block) override;
+    bool ProcessMethodCall(decode::ParsedBlock& parsed_block) override;
 
-    virtual bool
-    ProcessMethodCall(const format::BlockHeader& block_header, format::ApiCallId call_id, uint64_t block_index = 0) override;
-
-    virtual bool ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id) override;
+    bool ProcessMetaData(decode::ParsedBlock& parsed_block) override;
 
   private:
-    bool WriteFunctionCall(format::ApiCallId call_id, format::ThreadId thread_id, size_t buffer_size);
+    bool
+    WriteFunctionCall(format::ApiCallId call_id, format::ThreadId thread_id, size_t buffer_size, const uint8_t* buffer);
 
     bool WriteMethodCall(format::ApiCallId call_id,
                          format::HandleId  object_id,
                          format::ThreadId  thread_id,
-                         size_t            buffer_size);
+                         size_t            buffer_size,
+                         const uint8_t*    buffer);
 
-    bool WriteFillMemoryMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id);
+    // Specialists called by the vistor in ProcessMetaData
+    VisitResult WriteMetaData(const decode::FillMemoryArgs& args);
+    VisitResult WriteMetaData(const decode::InitBufferArgs& args);
+    VisitResult WriteMetaData(const decode::InitImageArgs& args);
+    VisitResult WriteMetaData(const decode::InitSubresourceArgs& args);
+    VisitResult WriteMetaData(const decode::InitDx12AccelerationStructureArgs& args);
+    VisitResult WriteMetaData(const decode::FillMemoryResourceValueArgs& args);
 
-    bool WriteInitBufferMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id);
-
-    bool WriteInitImageMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id);
-
-    bool WriteInitSubresourceMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id);
-
-    bool WriteInitDx12AccelerationStructureMetaData(const format::BlockHeader& block_header,
-                                                    format::MetaDataId         meta_data_id);
-
-    bool WriteFillMemoryResourceValueMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id);
+    template <typename Args>
+    VisitResult WriteMetaData(Args&)
+    {
+        return kNeedsPassthrough;
+    }
 
     void PrepMetadataBlock(format::MetaDataHeader& meta_data_header,
                            format::MetaDataId      meta_data_id,

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -481,7 +481,7 @@ int main(int argc, const char** argv)
                 out_file_handle = nullptr;
             }
 
-            if (file_processor.GetErrorState() != gfxrecon::decode::BlockReadError::kErrorNone)
+            if (file_processor.GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
             {
                 GFXRECON_LOG_ERROR("Failed to process trace.");
                 ret_code = 1;

--- a/tools/extract/main.cpp
+++ b/tools/extract/main.cpp
@@ -321,7 +321,7 @@ int main(int argc, const char** argv)
         file_processor.AddDecoder(&decoder);
         file_processor.ProcessAllFrames();
 
-        if (file_processor.GetErrorState() != gfxrecon::decode::BlockReadError::kErrorNone)
+        if (file_processor.GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
         {
             GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
             gfxrecon::util::Log::Release();

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -122,7 +122,7 @@ struct ApiAgnosticStats
     gfxrecon::format::CompressionType compression_type;
     uint32_t                          trim_start_frame;
     uint32_t                          frame_count;
-    gfxrecon::decode::BlockReadError  error_state;
+    gfxrecon::decode::BlockIOError    error_state;
     bool                              uses_frame_markers;
 };
 
@@ -467,7 +467,7 @@ void PrintVulkanStats(const gfxrecon::decode::FileProcessor&       file_processo
                       const ApiAgnosticStats&                      api_agnostic_stats,
                       const AnnotationRecorder&                    annotation_recoder)
 {
-    if (api_agnostic_stats.error_state == gfxrecon::decode::BlockReadError::kErrorNone)
+    if (api_agnostic_stats.error_state == gfxrecon::decode::BlockIOError::kErrorNone)
     {
         GFXRECON_WRITE_CONSOLE("");
         GFXRECON_WRITE_CONSOLE("File info:");
@@ -606,7 +606,7 @@ void PrintVulkanStats(const gfxrecon::decode::FileProcessor&       file_processo
             GFXRECON_WRITE_CONSOLE("\nFile did not contain any frames");
         }
     }
-    else if (api_agnostic_stats.error_state != gfxrecon::decode::BlockReadError::kErrorNone)
+    else if (api_agnostic_stats.error_state != gfxrecon::decode::BlockIOError::kErrorNone)
     {
         GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
         gfxrecon::util::Log::Release();
@@ -757,7 +757,7 @@ void PrintD3D12Stats(gfxrecon::decode::FileProcessor&     file_processor,
                      gfxrecon::decode::InfoConsumer&      info_consumer,
                      const AnnotationRecorder&            annotation_recoder)
 {
-    if (api_agnostic_stats.error_state == gfxrecon::decode::BlockReadError::kErrorNone)
+    if (api_agnostic_stats.error_state == gfxrecon::decode::BlockIOError::kErrorNone)
     {
         GFXRECON_WRITE_CONSOLE("");
         GFXRECON_WRITE_CONSOLE("File info:");
@@ -808,7 +808,7 @@ void PrintD3D12Stats(gfxrecon::decode::FileProcessor&     file_processor,
 
         PrintDxrEiInfo(dx12_consumer);
     }
-    else if (api_agnostic_stats.error_state != gfxrecon::decode::BlockReadError::kErrorNone)
+    else if (api_agnostic_stats.error_state != gfxrecon::decode::BlockIOError::kErrorNone)
     {
         GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
         gfxrecon::util::Log::Release();
@@ -885,7 +885,7 @@ void GatherAndPrintEnvVars(const std::string& input_filename)
         info_decoder.AddConsumer(&info_consumer);
         file_processor.AddDecoder(&info_decoder);
         file_processor.ProcessAllFrames();
-        if (file_processor.GetErrorState() == gfxrecon::decode::BlockReadError::kErrorNone)
+        if (file_processor.GetErrorState() == gfxrecon::decode::BlockIOError::kErrorNone)
         {
             PrintEnvironmentVariableInfo(info_consumer);
         }
@@ -942,7 +942,7 @@ void GatherAndPrintAllInfo(const std::string& input_filename)
 #endif
 
         file_processor.ProcessAllFrames();
-        if (file_processor.GetErrorState() == gfxrecon::decode::BlockReadError::kErrorNone)
+        if (file_processor.GetErrorState() == gfxrecon::decode::BlockIOError::kErrorNone)
         {
             ApiAgnosticStats api_agnostic_stats = {};
             GatherApiAgnosticStats(api_agnostic_stats, file_processor, stat_consumer);

--- a/tools/optimize/dx12_file_optimizer.h
+++ b/tools/optimize/dx12_file_optimizer.h
@@ -43,9 +43,11 @@ class Dx12FileOptimizer : public FileOptimizer
     uint64_t GetNumOptimizedFillCommands() { return num_optimized_fill_commands_; }
 
   private:
-    bool AddFillMemoryResourceValueCommand(const format::BlockHeader& block_header, format::MetaDataId meta_data_id);
+    bool AddFillMemoryResourceValueCommand();
 
-    virtual bool ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id) override;
+    template <typename Args>
+    decode::FileTransformer::VisitResult         VisitMetaData(const Args& args);
+    bool                                         ProcessMetaData(decode::ParsedBlock& parsed_block) override;
 
     const decode::Dx12FillCommandResourceValueMap*          fill_command_resource_values_;
     decode::Dx12FillCommandResourceValueMap::const_iterator resource_values_iter_;

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -93,7 +93,7 @@ bool FileProcessorSucceeded(const decode::FileProcessor& processor)
         GFXRECON_WRITE_CONSOLE("Did not detect any frames in the capture.");
     }
 
-    if ((processor.GetErrorState() == gfxrecon::decode::BlockReadError::kErrorNone) == false)
+    if ((processor.GetErrorState() == gfxrecon::decode::BlockIOError::kErrorNone) == false)
     {
         GFXRECON_WRITE_CONSOLE("Encountered error while reading the capture.");
     }
@@ -104,7 +104,7 @@ bool FileProcessorSucceeded(const decode::FileProcessor& processor)
     }
 
     return (processor.GetCurrentFrameNumber() > 0) &&
-           (processor.GetErrorState() == gfxrecon::decode::BlockReadError::kErrorNone) &&
+           (processor.GetErrorState() == gfxrecon::decode::BlockIOError::kErrorNone) &&
            processor.EntireFileWasProcessed();
 }
 
@@ -160,7 +160,7 @@ bool GetPsoOptimizationInfo(const std::string&               input_filename,
                 options.optimize_resource_values = false;
             }
         }
-        else if (pso_pass_file_processor.GetErrorState() != gfxrecon::decode::BlockReadError::kErrorNone)
+        else if (pso_pass_file_processor.GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
         {
             GFXRECON_WRITE_CONSOLE("A failure has occurred during scanning capture file for unreferenced PSOs");
         }
@@ -262,7 +262,7 @@ bool GetDxrOptimizationInfo(const std::string&               input_filename,
 
             dxr_scan_result = true;
         }
-        else if (dxr_pass_file_processor.GetErrorState() != gfxrecon::decode::BlockReadError::kErrorNone)
+        else if (dxr_pass_file_processor.GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
         {
             GFXRECON_WRITE_CONSOLE("A failure has occurred during capture processing for DXR/EI optimization");
         }
@@ -397,7 +397,7 @@ bool ApplyDx12OptimizationInfo(const std::string&                     input_file
 
             file_optimizer.Process();
 
-            if (file_optimizer.GetErrorState() != gfxrecon::FileOptimizer::kErrorNone)
+            if (file_optimizer.GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
             {
                 GFXRECON_WRITE_CONSOLE("A failure has occurred during capture processing (error=%d). If it was "
                                        "created, the output file may be invalid.",

--- a/tools/optimize/file_optimizer.cpp
+++ b/tools/optimize/file_optimizer.cpp
@@ -50,226 +50,121 @@ uint64_t FileOptimizer::GetUnreferencedBlocksSize()
     return unreferenced_blocks_.size();
 }
 
-bool FileOptimizer::ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id)
+bool FileOptimizer::ProcessMetaData(decode::ParsedBlock& parsed_block)
 {
-    format::MetaDataType meta_data_type = format::GetMetaDataType(meta_data_id);
-    if (meta_data_type == format::MetaDataType::kInitBufferCommand)
+    auto filter_visitor = [this](const auto& store) { return FilterMetaData(*store); };
+
+    VisitResult result = std::visit(filter_visitor, parsed_block.GetArgs());
+
+    if (result == kNeedsPassthrough)
     {
-        return FilterInitBufferMetaData(block_header, meta_data_id);
+        return FileTransformer::ProcessMetaData(parsed_block);
     }
-    else if (meta_data_type == format::MetaDataType::kInitImageCommand)
-    {
-        return FilterInitImageMetaData(block_header, meta_data_id);
-    }
-    else
-    {
-        // Copy the meta data block, if it was not filtered.
-        return FileTransformer::ProcessMetaData(block_header, meta_data_id);
-    }
+    return result == kSuccess;
 }
 
-bool FileOptimizer::ProcessMethodCall(const format::BlockHeader& block_header,
-                                      format::ApiCallId          api_call_id,
-                                      uint64_t                   block_index)
+bool FileOptimizer::ProcessMethodCall(decode::ParsedBlock& parsed_block)
 {
+    const auto& args       = parsed_block.Get<decode::MethodCallArgs>();
+    bool        filter_out = FilterMethodCall(args);
+
+    if (!filter_out)
+    {
+        // Copy the method call block, if it was not filtered.
+        return FileTransformer::ProcessMethodCall(parsed_block);
+    }
+    return true; // Successful filtering no passthrough write.
+}
+
+decode::FileTransformer::VisitResult FileOptimizer::FilterMetaData(const decode::InitBufferArgs& args)
+{
+    GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitBufferCommand);
+
+    // If the buffer is in the unused list, omit its initialization data from the file.
+    if (unreferenced_ids_.find(args.buffer_id) != unreferenced_ids_.end())
+    {
+        // In its place insert a dummy annotation meta command. This should keep the block index when
+        // replaying an optimized trimmed capture in in alignment with the block index calculated
+        // at capture time
+        const char*       label = format::kAnnotationLabelRemovedResource;
+        const std::string data  = "Removed buffer " + std::to_string(args.buffer_id);
+
+        const size_t label_length = util::platform::StringLength(label);
+        const size_t data_length  = data.length();
+
+        format::AnnotationHeader annotation;
+        annotation.block_header.size = format::GetAnnotationBlockBaseSize() + label_length + data_length;
+        annotation.block_header.type = format::BlockType::kAnnotation;
+        annotation.annotation_type   = format::kText;
+        annotation.label_length      = static_cast<uint32_t>(label_length);
+        annotation.data_length       = static_cast<uint64_t>(data.length());
+
+        if (!WriteBytes(&annotation, sizeof(annotation)) || !WriteBytes(label, label_length) ||
+            !WriteBytes(data.c_str(), data_length))
+        {
+            HandleBlockWriteError(decode::kErrorWritingBlockData, "Failed to write annotation meta-data block");
+            return kError;
+        }
+        return kSuccess;
+    }
+
+    return kNeedsPassthrough;
+}
+
+decode::FileTransformer::VisitResult FileOptimizer::FilterMetaData(const decode::InitImageArgs& args)
+{
+    GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitImageCommand);
+
+    // If the image is in the unused list, omit its initialization data from the file.
+    if (unreferenced_ids_.find(args.image_id) != unreferenced_ids_.end())
+    {
+        // In its place insert a dummy annotation meta command. This should keep the block index when
+        // replaying an optimized trimmed capture in in alignment with the block index calculated
+        // at capture time
+        const char*       label = format::kAnnotationLabelRemovedResource;
+        const std::string data  = "Removed subresource from image " + std::to_string(args.image_id);
+
+        const size_t label_length = util::platform::StringLength(label);
+        const size_t data_length  = data.length();
+
+        format::AnnotationHeader annotation;
+        annotation.block_header.size = format::GetAnnotationBlockBaseSize() + label_length + data_length;
+        annotation.block_header.type = format::BlockType::kAnnotation;
+        annotation.annotation_type   = format::kText;
+        annotation.label_length      = static_cast<uint32_t>(label_length);
+        annotation.data_length       = static_cast<uint64_t>(data.length());
+
+        if (!WriteBytes(&annotation, sizeof(annotation)) || !WriteBytes(label, label_length) ||
+            !WriteBytes(data.c_str(), data_length))
+        {
+            HandleBlockWriteError(decode::kErrorWritingBlockData, "Failed to write annotation meta-data block");
+            return kError;
+        }
+
+        return kSuccess;
+    }
+
+    return kNeedsPassthrough;
+}
+
+// Returns whether or not to filter this MethodCall block or not
+bool FileOptimizer::FilterMethodCall(const decode::MethodCallArgs& args)
+{
+    const format::ApiCallId api_call_id = args.call_id;
+    const uint64_t          block_index = args.call_info.index;
+    bool                    filter_out  = false;
+
+    // Only a subset of blocks can be filtered out...
     if (api_call_id == format::ApiCallId::ApiCall_ID3D12Device_CreateGraphicsPipelineState ||
         api_call_id == format::ApiCallId::ApiCall_ID3D12Device_CreateComputePipelineState ||
         api_call_id == format::ApiCallId::ApiCall_ID3D12PipelineLibrary_StorePipeline)
     {
-        return FilterMethodCall(block_header, api_call_id, block_index);
+
+        // If the buffer is in the unused list, omit the call block from the file.
+        // NOTE: Erase returns number of items erased, so only > 0 if the block_index is found
+        filter_out = (unreferenced_blocks_.erase(block_index) > 0);
     }
-    else
-    {
-        // Copy the method call block, if it was not filtered.
-        return FileTransformer::ProcessMethodCall(block_header, api_call_id);
-    }
-}
-
-bool FileOptimizer::FilterInitBufferMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id)
-{
-    GFXRECON_ASSERT(format::GetMetaDataType(meta_data_id) == format::MetaDataType::kInitBufferCommand);
-
-    format::InitBufferCommandHeader header;
-
-    bool success = ReadBytes(&header.thread_id, sizeof(header.thread_id));
-    success      = success && ReadBytes(&header.device_id, sizeof(header.device_id));
-    success      = success && ReadBytes(&header.buffer_id, sizeof(header.buffer_id));
-    success      = success && ReadBytes(&header.data_size, sizeof(header.data_size));
-
-    if (success)
-    {
-        // Total number of bytes remaining to be read for the current block.
-        uint64_t unread_bytes = block_header.size - (sizeof(header) - sizeof(block_header));
-
-        // If the buffer is in the unused list, omit its initialization data from the file.
-        if (unreferenced_ids_.find(header.buffer_id) != unreferenced_ids_.end())
-        {
-            // In its place insert a dummy annotation meta command. This should keep the block index when
-            // replaying an optimized trimmed capture in in alignment with the block index calculated
-            // at capture time
-            const char*       label = format::kAnnotationLabelRemovedResource;
-            const std::string data  = "Removed buffer " + std::to_string(header.buffer_id);
-
-            const size_t label_length = util::platform::StringLength(label);
-            const size_t data_length  = data.length();
-
-            format::AnnotationHeader annotation;
-            annotation.block_header.size = format::GetAnnotationBlockBaseSize() + label_length + data_length;
-            annotation.block_header.type = format::BlockType::kAnnotation;
-            annotation.annotation_type   = format::kText;
-            annotation.label_length      = static_cast<uint32_t>(label_length);
-            annotation.data_length       = static_cast<uint64_t>(data.length());
-
-            if (!WriteBytes(&annotation, sizeof(annotation)) || !WriteBytes(label, label_length) ||
-                !WriteBytes(data.c_str(), data_length))
-            {
-                HandleBlockWriteError(kErrorReadingBlockHeader, "Failed to write annotation meta-data block");
-                return false;
-            }
-
-            if (!SkipBytes(unread_bytes))
-            {
-                HandleBlockReadError(kErrorSeekingFile, "Failed to skip init buffer data meta-data block data");
-                return false;
-            }
-        }
-        else
-        {
-            // Copy the block from the input file to the output file.
-            header.meta_header.block_header = block_header;
-            header.meta_header.meta_data_id = meta_data_id;
-
-            if (!WriteBytes(&header, sizeof(header)))
-            {
-                HandleBlockWriteError(kErrorReadingBlockHeader,
-                                      "Failed to write init buffer data meta-data block header");
-                return false;
-            }
-
-            if (!CopyBytes(unread_bytes))
-            {
-                HandleBlockCopyError(kErrorCopyingBlockData, "Failed to copy init buffer data meta-data block data");
-                return false;
-            }
-        }
-    }
-    else
-    {
-        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read init buffer data meta-data block header");
-        return false;
-    }
-
-    return true;
-}
-
-bool FileOptimizer::FilterInitImageMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id)
-{
-    GFXRECON_ASSERT(format::GetMetaDataType(meta_data_id) == format::MetaDataType::kInitImageCommand);
-
-    format::InitImageCommandHeader header;
-    std::vector<uint64_t>          level_sizes;
-
-    bool success = ReadBytes(&header.thread_id, sizeof(header.thread_id));
-    success      = success && ReadBytes(&header.device_id, sizeof(header.device_id));
-    success      = success && ReadBytes(&header.image_id, sizeof(header.image_id));
-    success      = success && ReadBytes(&header.data_size, sizeof(header.data_size));
-    success      = success && ReadBytes(&header.aspect, sizeof(header.aspect));
-    success      = success && ReadBytes(&header.layout, sizeof(header.layout));
-    success      = success && ReadBytes(&header.level_count, sizeof(header.level_count));
-
-    if (success)
-    {
-        // Total number of bytes remaining to be read for the current block.
-        uint64_t unread_bytes = block_header.size - (sizeof(header) - sizeof(block_header));
-
-        // If the image is in the unused list, omit its initialization data from the file.
-        if (unreferenced_ids_.find(header.image_id) != unreferenced_ids_.end())
-        {
-            // In its place insert a dummy annotation meta command. This should keep the block index when
-            // replaying an optimized trimmed capture in in alignment with the block index calculated
-            // at capture time
-            const char*       label = format::kAnnotationLabelRemovedResource;
-            const std::string data  = "Removed subresource from image " + std::to_string(header.image_id);
-
-            const size_t label_length = util::platform::StringLength(label);
-            const size_t data_length  = data.length();
-
-            format::AnnotationHeader annotation;
-            annotation.block_header.size = format::GetAnnotationBlockBaseSize() + label_length + data_length;
-            annotation.block_header.type = format::BlockType::kAnnotation;
-            annotation.annotation_type   = format::kText;
-            annotation.label_length      = static_cast<uint32_t>(label_length);
-            annotation.data_length       = static_cast<uint64_t>(data.length());
-
-            if (!WriteBytes(&annotation, sizeof(annotation)) || !WriteBytes(label, label_length) ||
-                !WriteBytes(data.c_str(), data_length))
-            {
-                HandleBlockWriteError(kErrorReadingBlockHeader, "Failed to write annotation meta-data block");
-                return false;
-            }
-
-            if (!SkipBytes(unread_bytes))
-            {
-                HandleBlockReadError(kErrorSeekingFile, "Failed to skip init image data meta-data block data");
-                return false;
-            }
-        }
-        else
-        {
-            // Copy the block from the input file to the output file.
-            header.meta_header.block_header = block_header;
-            header.meta_header.meta_data_id = meta_data_id;
-
-            if (!WriteBytes(&header, sizeof(header)))
-            {
-                HandleBlockWriteError(kErrorReadingBlockHeader,
-                                      "Failed to write init image data meta-data block header");
-                return false;
-            }
-
-            if (!CopyBytes(unread_bytes))
-            {
-                HandleBlockCopyError(kErrorCopyingBlockData, "Failed to copy init image data meta-data block data");
-                return false;
-            }
-        }
-    }
-    else
-    {
-        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read init image data meta-data block header");
-        return false;
-    }
-
-    return true;
-}
-
-bool FileOptimizer::FilterMethodCall(const format::BlockHeader& block_header,
-                                     format::ApiCallId          api_call_id,
-                                     uint64_t                   block_index)
-{
-    GFXRECON_ASSERT(api_call_id == format::ApiCallId::ApiCall_ID3D12Device_CreateGraphicsPipelineState ||
-                    api_call_id == format::ApiCallId::ApiCall_ID3D12Device_CreateComputePipelineState ||
-                    api_call_id == format::ApiCallId::ApiCall_ID3D12PipelineLibrary_StorePipeline);
-
-    // Total number of bytes remaining to be read for the current block.
-    uint64_t unread_bytes = block_header.size - sizeof(format::ApiCallId);
-
-    // If the buffer is in the unused list, omit the call block from the file.
-    if (unreferenced_blocks_.find(block_index) != unreferenced_blocks_.end())
-    {
-        unreferenced_blocks_.erase(block_index);
-        if (!SkipBytes(unread_bytes))
-        {
-            HandleBlockReadError(kErrorSeekingFile, "Failed to skip method call block data");
-            return false;
-        }
-    }
-    else
-    {
-        return FileTransformer::ProcessMethodCall(block_header, api_call_id);
-    }
-
-    return true;
+    return filter_out;
 }
 
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/tools/optimize/file_optimizer.h
+++ b/tools/optimize/file_optimizer.h
@@ -44,18 +44,19 @@ class FileOptimizer : public decode::FileTransformer
     uint64_t GetUnreferencedBlocksSize();
 
   protected:
-    virtual bool ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id) override;
-
-    virtual bool ProcessMethodCall(const format::BlockHeader& block_header,
-                                   format::ApiCallId          call_id,
-                                   uint64_t                   block_index = 0) override;
+    bool ProcessMethodCall(decode::ParsedBlock& parsed_block) override;
+    bool ProcessMetaData(decode::ParsedBlock& parsed_block) override;
 
   private:
-    bool FilterInitBufferMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id);
+    VisitResult FilterMetaData(const decode::InitBufferArgs& args);
+    VisitResult FilterMetaData(const decode::InitImageArgs& args);
+    template <typename Args>
+    VisitResult FilterMetaData(const Args& args)
+    {
+        return kNeedsPassthrough;
+    }
 
-    bool FilterInitImageMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id);
-
-    bool FilterMethodCall(const format::BlockHeader& block_header, format::ApiCallId api_call_id, uint64_t block_index);
+    bool FilterMethodCall(const decode::MethodCallArgs& args);
 
   private:
     std::unordered_set<format::HandleId> unreferenced_ids_;

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -136,12 +136,12 @@ void GetUnreferencedResources(const std::string&                              in
             exit(65);
         }
         else if ((file_processor.GetCurrentFrameNumber() > 0) &&
-                 (file_processor.GetErrorState() == gfxrecon::decode::BlockReadError::kErrorNone))
+                 (file_processor.GetErrorState() == gfxrecon::decode::BlockIOError::kErrorNone))
         {
             // Get the list of resources that were included in a command buffer submission during replay.
             resref_consumer.GetReferencedResourceIds(nullptr, unreferenced_ids);
         }
-        else if (file_processor.GetErrorState() != gfxrecon::decode::BlockReadError::kErrorNone)
+        else if (file_processor.GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
         {
             GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
             gfxrecon::util::Log::Release();
@@ -165,7 +165,7 @@ void FilterUnreferencedResources(const std::string&                             
     {
         file_processor.Process();
 
-        if (file_processor.GetErrorState() != gfxrecon::FileOptimizer::kErrorNone)
+        if (file_processor.GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
         {
             GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
             gfxrecon::util::Log::Release();

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -256,7 +256,7 @@ void android_main(struct android_app* app)
                 fps_info.EndFile(file_processor->GetCurrentFrameNumber() + 1);
 
                 if ((file_processor->GetCurrentFrameNumber() > 0) &&
-                    (file_processor->GetErrorState() == gfxrecon::decode::BlockReadError::kErrorNone))
+                    (file_processor->GetErrorState() == gfxrecon::decode::BlockIOError::kErrorNone))
                 {
                     if (file_processor->GetCurrentFrameNumber() < measurement_start_frame)
                     {
@@ -271,7 +271,7 @@ void android_main(struct android_app* app)
                         fps_info.LogMeasurements();
                     }
                 }
-                else if (file_processor->GetErrorState() != gfxrecon::decode::BlockReadError::kErrorNone)
+                else if (file_processor->GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
                 {
                     GFXRECON_WRITE_CONSOLE("A failure has occurred during replay");
                 }

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -323,7 +323,7 @@ int main(int argc, const char** argv)
             fps_info.EndFile(file_processor->GetCurrentFrameNumber() + 1);
 
             if ((file_processor->GetCurrentFrameNumber() > 0) &&
-                (file_processor->GetErrorState() == gfxrecon::decode::BlockReadError::kErrorNone))
+                (file_processor->GetErrorState() == gfxrecon::decode::BlockIOError::kErrorNone))
             {
                 if (file_processor->GetCurrentFrameNumber() < measurement_start_frame)
                 {
@@ -351,7 +351,7 @@ int main(int argc, const char** argv)
                     fps_info.LogMeasurements();
                 }
             }
-            else if (file_processor->GetErrorState() != gfxrecon::decode::BlockReadError::kErrorNone)
+            else if (file_processor->GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
             {
                 GFXRECON_WRITE_CONSOLE("A failure has occurred during replay");
                 return_code = -1;

--- a/tools/tocpp/main.cpp
+++ b/tools/tocpp/main.cpp
@@ -370,7 +370,7 @@ bool ProcessCapture(gfxrecon::decode::VulkanCppConsumer&      cpp_consumer,
     } while (success && file_processor.GetCurrentFrameNumber() <= frame_limit);
     printf("\nDone processing file\n");
 
-    return (file_processor.GetErrorState() == gfxrecon::decode::BlockReadError::kErrorNone);
+    return (file_processor.GetErrorState() == gfxrecon::decode::BlockIOError::kErrorNone);
 }
 
 int main(int argc, const char** argv)


### PR DESCRIPTION
Removed all duplicate block parsing code and convert to visitor style processing of the ParsedBlock Args variant.

Based on Block parser housekeeping #2508
