### PR TITLE
Document the process for debugging the Android capture layer

### DIFF
--- a/DEBUG_android.md
+++ b/DEBUG_android.md
@@ -17,19 +17,20 @@ on Android using lldb-server.***
 ## Index
 
 1. [Problem](#problem)
-2. [Setting up lldb-server](#lldb-server-setup)
+2. [Setting up lldb-server](#setting-up-lldb-server)
 3. [Client setup](#client-setup)
    1. [VSCode](#vscode)
    2. [CLI](#cli)
+4. [Waiting for debugger](#waiting-for-debugger)
 
 ## Problem
 
 Android apps under development can be debugged easily through Android Studio. However, the GFXR capture layer is
 a shared object file that is loaded by the, typically non-debug, application. This document illustrates a 
-method by which the `lldb-server` binary included with the Android SDK can be used for debugging
+method by which the `lldb-server` binary included with the Android NDK can be used for debugging
 a .so built in debug mode with any Android app.
 
-## lldb-server setup
+## Setting up lldb-server
 
 The first step is to locate and copy the lldb-server binary to a location on the Android device,
 making sure to give it execute permissions as well.
@@ -67,7 +68,7 @@ List of devices attached
 We document two methods for attaching a client debugger to lldb-server: VScode, and CLI
 
 ### VScode
-To setup VScode to be the client debugger, you need to set up your
+To enable VScode to be the client debugger, you need to set up your
 `launch.json` to be like the following:
 ```
 {
@@ -119,12 +120,12 @@ settings append target.exec-search-paths $PWD/android/layer/build/intermediates/
 attach $(adb shell pidof <apk name e.g. com.example.VkCube>)
 ```
 
-Then (assuming lldb is in $PATH) launch `lldb` with `lldb -s /tmp/lldbinit`
-From here `lldb` will connect, and 
+Then (assuming `lldb` is in $PATH) launch `lldb` with `lldb -s ./lldbinit`
+From here `lldb` will connect, and present you with the typical `lldb` CLI.
 
 
 
-## Wait for debugger
+## Waiting for debugger
 
 It is often desired to be able to attach the debugger to the app as soon as it launches.
 
@@ -132,15 +133,18 @@ Unfortunately, since we only have control over the layer, the best we can do is 
 an arbitrary spinlock in `VulkanCaptureManager::OverrideCreateInstance()` that we release
 once the debugger has attached.
 
-At the start of `VulkanCaptureManager::OverrideCreateInstance`
+At the start of `VulkanCaptureManager::OverrideCreateInstance`, add:
 ```
 while (util::platform::GetEnv("debug.gfxrecon.debug_wait") == "1") {
     usleep(100000);
 }
 ```
+So you can use `adb shell setprop debug.gfxrecon.debug_wait 1` to enable the spinlock,
+and `adb shell setprop debug.gfxrecon.debug_wait 0` to disable it.
 
 This enables the following workflow:
-  1. yeah
-  2. bruh
-  3. i mean
-  4. dude
+  1. Start `lldb-server`
+  2. Start the app with `debug.gfxrecon.debug_wait` set to `1`
+  3. Launch the `lldb` client and wait for the connection, set breakpoints, etc.
+  4. Set `debug.gfxrecon.debug_wait` to `0` to break the spinlock
+  5. Use the debugger as normal

--- a/DEBUG_android.md
+++ b/DEBUG_android.md
@@ -1,0 +1,63 @@
+<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable MD041 -->
+<p align="left"><img src="https://vulkan.lunarg.com/img/NewLunarGLogoBlack.png" alt="LunarG" width=263 height=113 /></p>
+
+[![Creative Commons][1]][2]
+
+[1]: https://i.creativecommons.org/l/by-nd/4.0/88x31.png "Creative Commons License"
+[2]: https://creativecommons.org/licenses/by-nd/4.0/
+
+Copyright &copy; 2018-2025 LunarG, Inc.
+
+# GFXReconstruct API Capture and Replay - Android
+
+***This document describes how to debug the GFXReconstruct capture layer
+on Android using lldbserver.***
+
+## Index
+
+1. [Concept](#concept)
+
+1. [Capturing API Calls](#capturing-api-calls)
+    1. [Before Use](#before-use)
+    2. [Enabling the Capture Layer](#enabling-the-capture-layer)
+    3. [Capture Options](#capture-options)
+    4. [Capture Files](#capture-files)
+    6. [Capture Limitations](#capture-limitations)
+    7. [Troubleshooting Capturing of Applications](#troubleshooting-capturing-of-applications)
+2. [Replaying API Calls](#replaying-api-calls)
+    1. [Launch Script](#launch-script)
+    2. [Install APK Command](#install-apk-command)
+    3. [Replay Command](#replay-command)
+    4. [Touch Controls](#touch-controls)
+    5. [Key Controls](#key-controls)
+    6. [Limitations of Replay On Android](#limitations-of-replay-on-android)
+    7. [Troubleshooting Replay of Applications](#troubleshooting-replay-of-applications)
+    8. [Dumping resources](#dumping-resources)
+3. [Android Detailed Examples](#android-detailed-examples)
+
+
+## Concept
+
+Ordinary Android apps can be debugged easily through Android Studio. However, the GFXR capture layer is
+a shared object file that is loaded by the, often non-debug, application. This document illustrates a 
+method by which the `lldb-server` binary included with the Android SDK can be used for debugging
+a .so built in debug mode with any Android app.
+
+bash```
+adb root
+adb push $(find $ANDROID_NDK_HOME -path "*/aarch64/lldb-server") /data/local/tmp
+adb shell /data/local/tmp/lldb-server platform --server --listen localhost:9999
+```
+
+
+
+
+
+
+
+
+
+## Wait for debugger
+
+Yeah

--- a/DEBUG_android.md
+++ b/DEBUG_android.md
@@ -12,7 +12,7 @@ Copyright &copy; 2018-2025 LunarG, Inc.
 # GFXReconstruct Capture layer debugging - Android
 
 ***This document describes how to debug the GFXReconstruct capture layer
-on Android using lldbserver.***
+on Android using lldb-server.***
 
 ## Index
 
@@ -24,7 +24,7 @@ on Android using lldbserver.***
 
 ## Problem
 
-Ordinary Android apps can be debugged easily through Android Studio. However, the GFXR capture layer is
+Android apps under development can be debugged easily through Android Studio. However, the GFXR capture layer is
 a shared object file that is loaded by the, typically non-debug, application. This document illustrates a 
 method by which the `lldb-server` binary included with the Android SDK can be used for debugging
 a .so built in debug mode with any Android app.
@@ -52,6 +52,17 @@ On the client side, we need to launch `lldb` with options to do the following:
   1. Disable breaking on signals we don't care about (e.g. SIGSEGV)
   2. Load the capture layer's debug symbols
   3. Attach to the remote debugger on the phone
+
+You need two pieces of information before continuing:
+  1. Your device's ID
+  2. The path to the directory containing the compiled Android layer e.g. `android/layer/build/intermediates/cxx/Debug/3m4on72q/obj/arm64-v8a/`
+
+You can obtain your device's id with the `adb devices` command:
+```
+> adb devices
+List of devices attached
+44021FDJH00229  device
+```
 
 We document two methods for attaching a client debugger to lldb-server: VScode, and CLI
 
@@ -91,25 +102,45 @@ To setup VScode to be the client debugger, you need to set up your
 }
 ```
 When you go to Start Debugging, the `adb shell pidof` command will run, and present you with an
-option whose content is the PID of the target process. Selecting this will begin the process of
-automatically attaching to the remote debugger.
-
-You can obtain your device's id with the `adb devices` command:
-```
-> adb devices
-List of devices attached
-44021FDJH00229  device
-```
+option whose content is the PID of the target process. Selecting this will launch lldb, and will
+begin the process of automatically attaching to the remote debugger.
 
 ### CLI
 
+If you prefer CLI-based debugging, then create an `lldbinit` file at the root of the repo with the following contents:
+```
+platform select remote-android
+platform connect connect://<your-device-id here>:9999
+process handle -p true -s false -n false SIGSEGV
+process handle -p true -s false -n false SIGPWR
+process handle -p true -s false -n false SIGXCPU
+process handle -p true -s false -n false SIGBUS
+settings append target.exec-search-paths $PWD/android/layer/build/intermediates/cxx/Debug/<some numbers such as '3m4on72q'>/obj/<target device architecture e.g. arm64-v8a>/
+attach $(adb shell pidof <apk name e.g. com.example.VkCube>)
+```
 
-
-
-
+Then (assuming lldb is in $PATH) launch `lldb` with `lldb -s /tmp/lldbinit`
+From here `lldb` will connect, and 
 
 
 
 ## Wait for debugger
 
-Yeah
+It is often desired to be able to attach the debugger to the app as soon as it launches.
+
+Unfortunately, since we only have control over the layer, the best we can do is construct
+an arbitrary spinlock in `VulkanCaptureManager::OverrideCreateInstance()` that we release
+once the debugger has attached.
+
+At the start of `VulkanCaptureManager::OverrideCreateInstance`
+```
+while (util::platform::GetEnv("debug.gfxrecon.debug_wait") == "1") {
+    usleep(100000);
+}
+```
+
+This enables the following workflow:
+  1. yeah
+  2. bruh
+  3. i mean
+  4. dude

--- a/DEBUG_android.md
+++ b/DEBUG_android.md
@@ -18,24 +18,90 @@ on Android using lldbserver.***
 
 1. [Problem](#problem)
 2. [Setting up lldb-server](#lldb-server-setup)
+3. [Client setup](#client-setup)
+   1. [VSCode](#vscode)
+   2. [CLI](#cli)
 
 ## Problem
 
 Ordinary Android apps can be debugged easily through Android Studio. However, the GFXR capture layer is
-a shared object file that is loaded by the, often non-debug, application. This document illustrates a 
+a shared object file that is loaded by the, typically non-debug, application. This document illustrates a 
 method by which the `lldb-server` binary included with the Android SDK can be used for debugging
 a .so built in debug mode with any Android app.
 
 ## lldb-server setup
 
-The first step is to locate and copy the lldb-server binary to a location on the Android device.
+The first step is to locate and copy the lldb-server binary to a location on the Android device,
+making sure to give it execute permissions as well.
 ```
 adb root
 adb push $(find $ANDROID_NDK_HOME -path "*/aarch64/lldb-server") /data/local/tmp
 adb shell chmod +x /data/local/tmp/lldb-server
+```
+
+Then, run the following command to start the server listening on port 9999
+```
 adb shell /data/local/tmp/lldb-server platform --server --listen localhost:9999
 ```
 
+lldb-server is now ready to accept connections from a client debugger.
+
+## Client setup
+
+On the client side, we need to launch `lldb` with options to do the following:
+  1. Disable breaking on signals we don't care about (e.g. SIGSEGV)
+  2. Load the capture layer's debug symbols
+  3. Attach to the remote debugger on the phone
+
+We document two methods for attaching a client debugger to lldb-server: VScode, and CLI
+
+### VScode
+To setup VScode to be the client debugger, you need to set up your
+`launch.json` to be like the following:
+```
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Android",
+            "type": "lldb",
+            "request": "attach",
+            "pid": "${input:android_pid}",
+            "initCommands": [
+                "platform select remote-android",
+                "platform connect connect://<your-device-id here>:9999",
+                "process handle -p true -s false -n false SIGSEGV",
+                "process handle -p true -s false -n false SIGBUS",
+                "process handle -p true -s false -n false SIGPWR",
+                "process handle -p true -s false -n false SIGXCPU",
+                "settings append target.exec-search-paths ${workspaceFolder}/android/layer/build/intermediates/cxx/Debug/<some numbers such as '3m4on72q'>/obj/<target device architecture e.g. arm64-v8a>/"
+            ]
+        }
+    ],
+    "inputs": [
+        {
+            "id": "android_pid",
+            "type": "command",
+            "command": "shellCommand.execute",
+            "args": {
+                "command": "adb shell pidof <apk name e.g. com.example.VkCube>"
+            }
+        }
+    ]
+}
+```
+When you go to Start Debugging, the `adb shell pidof` command will run, and present you with an
+option whose content is the PID of the target process. Selecting this will begin the process of
+automatically attaching to the remote debugger.
+
+You can obtain your device's id with the `adb devices` command:
+```
+> adb devices
+List of devices attached
+44021FDJH00229  device
+```
+
+### CLI
 
 
 

--- a/DEBUG_android.md
+++ b/DEBUG_android.md
@@ -9,44 +9,30 @@
 
 Copyright &copy; 2018-2025 LunarG, Inc.
 
-# GFXReconstruct API Capture and Replay - Android
+# GFXReconstruct Capture layer debugging - Android
 
 ***This document describes how to debug the GFXReconstruct capture layer
 on Android using lldbserver.***
 
 ## Index
 
-1. [Concept](#concept)
+1. [Problem](#problem)
+2. [Setting up lldb-server](#lldb-server-setup)
 
-1. [Capturing API Calls](#capturing-api-calls)
-    1. [Before Use](#before-use)
-    2. [Enabling the Capture Layer](#enabling-the-capture-layer)
-    3. [Capture Options](#capture-options)
-    4. [Capture Files](#capture-files)
-    6. [Capture Limitations](#capture-limitations)
-    7. [Troubleshooting Capturing of Applications](#troubleshooting-capturing-of-applications)
-2. [Replaying API Calls](#replaying-api-calls)
-    1. [Launch Script](#launch-script)
-    2. [Install APK Command](#install-apk-command)
-    3. [Replay Command](#replay-command)
-    4. [Touch Controls](#touch-controls)
-    5. [Key Controls](#key-controls)
-    6. [Limitations of Replay On Android](#limitations-of-replay-on-android)
-    7. [Troubleshooting Replay of Applications](#troubleshooting-replay-of-applications)
-    8. [Dumping resources](#dumping-resources)
-3. [Android Detailed Examples](#android-detailed-examples)
-
-
-## Concept
+## Problem
 
 Ordinary Android apps can be debugged easily through Android Studio. However, the GFXR capture layer is
 a shared object file that is loaded by the, often non-debug, application. This document illustrates a 
 method by which the `lldb-server` binary included with the Android SDK can be used for debugging
 a .so built in debug mode with any Android app.
 
-bash```
+## lldb-server setup
+
+The first step is to locate and copy the lldb-server binary to a location on the Android device.
+```
 adb root
 adb push $(find $ANDROID_NDK_HOME -path "*/aarch64/lldb-server") /data/local/tmp
+adb shell chmod +x /data/local/tmp/lldb-server
 adb shell /data/local/tmp/lldb-server platform --server --listen localhost:9999
 ```
 

--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -21,7 +21,7 @@ to one of these other documents:
 
 If you are looking for how to debug the Android capture layer, please
 refer to this document:
- * [GFXReconstruct Capture layer debugging - Android](./DEBUG_android.md)
+ * [GFXReconstruct Capture layer debugging - Android](./docs/DEBUG_android.md)
 
 ## Index
 

--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -19,6 +19,10 @@ to one of these other documents:
  * [GFXReconstruct for Desktop Vulkan](./USAGE_desktop_Vulkan.md)
  * [GFXReconstruct for Desktop D3D12](./USAGE_desktop_D3D12.md)
 
+If you are looking for how to debug the Android capture layer, please
+refer to this document:
+ * [GFXReconstruct Capture layer debugging - Android](./DEBUG_android.md)
+
 ## Index
 
 1. [Capturing API Calls](#capturing-api-calls)

--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -19,8 +19,7 @@ to one of these other documents:
  * [GFXReconstruct for Desktop Vulkan](./USAGE_desktop_Vulkan.md)
  * [GFXReconstruct for Desktop D3D12](./USAGE_desktop_D3D12.md)
 
-If you are looking for how to debug the Android capture layer, please
-refer to this document:
+Additional instructions for debugging the GFXReconstruct capture layer on Android can be found here:
  * [GFXReconstruct Capture layer debugging - Android](./docs/DEBUG_android.md)
 
 ## Index

--- a/docs/DEBUG_android.md
+++ b/docs/DEBUG_android.md
@@ -107,6 +107,9 @@ When you go to Start Debugging, the `adb shell pidof` command will run, and pres
 option whose content is the PID of the target process. Selecting this will launch lldb, and will
 begin the process of automatically attaching to the remote debugger.
 
+Please note that the ability to allow shell output to be the input to VScode tasks
+is provided by the [Tasks Shell Input](https://marketplace.visualstudio.com/items?itemName=augustocdias.tasks-shell-input) extension.
+
 ### CLI
 
 If you prefer CLI-based debugging, then create an `lldbinit` file at the root of the repo with the following contents:
@@ -117,7 +120,7 @@ process handle -p true -s false -n false SIGSEGV
 process handle -p true -s false -n false SIGPWR
 process handle -p true -s false -n false SIGXCPU
 process handle -p true -s false -n false SIGBUS
-settings append target.exec-search-paths $PWD/android/layer/build/intermediates/cxx/Debug/<some numbers such as '3m4on72q'>/obj/<target device architecture e.g. arm64-v8a>/
+settings append target.exec-search-paths android/layer/build/intermediates/cxx/Debug/<some numbers such as '3m4on72q'>/obj/<target device architecture e.g. arm64-v8a>/
 attach $(adb shell pidof <apk name e.g. com.example.VkCube>)
 ```
 

--- a/docs/DEBUG_android.md
+++ b/docs/DEBUG_android.md
@@ -26,8 +26,9 @@ on Android using lldb-server.***
 ## Problem
 
 Android apps under development can be debugged easily through Android Studio. However, the GFXR capture layer is
-a shared object file that is loaded by the, typically non-debug, application. This document illustrates a 
-method by which the `lldb-server` binary included with the Android NDK can be used for debugging
+a shared object file, not an individual app that can be debugged the easy way.
+
+This document illustrates a method by which the `lldb-server` binary included with the Android NDK can be used for debugging
 a .so built in debug mode with any Android app.
 
 ## Setting up lldb-server

--- a/docs/DEBUG_android.md
+++ b/docs/DEBUG_android.md
@@ -121,7 +121,7 @@ process handle -p true -s false -n false SIGPWR
 process handle -p true -s false -n false SIGXCPU
 process handle -p true -s false -n false SIGBUS
 settings append target.exec-search-paths android/layer/build/intermediates/cxx/Debug/<some numbers such as '3m4on72q'>/obj/<target device architecture e.g. arm64-v8a>/
-attach $(adb shell pidof <apk name e.g. com.example.VkCube>)
+attach <pid of running app>
 ```
 
 Then (assuming `lldb` is in $PATH) launch `lldb` with `lldb -s ./lldbinit`

--- a/docs/DEBUG_android.md
+++ b/docs/DEBUG_android.md
@@ -7,7 +7,7 @@
 [1]: https://i.creativecommons.org/l/by-nd/4.0/88x31.png "Creative Commons License"
 [2]: https://creativecommons.org/licenses/by-nd/4.0/
 
-Copyright &copy; 2018-2025 LunarG, Inc.
+Copyright &copy; 2025 LunarG, Inc.
 
 # GFXReconstruct Capture layer debugging - Android
 


### PR DESCRIPTION
This PR adds `DEBUG_android.md`, a document detailing how to use `lldb` to debug the capture layer on Android devices.