### PR TITLE
android: Fix screenshot command logging

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -1054,8 +1054,8 @@ adb shell am force-stop com.lunarg.gfxreconstruct.replay
 adb shell am start -n "com.lunarg.gfxreconstruct.replay/android.app.NativeActivity" \
                    -a android.intent.action.MAIN \
                    -c android.intent.category.LAUNCHER \
-                   --es "args" \
-                   "<arg-list>"
+                   --es args \
+                   '"<arg-list>"'
 ```
 
 If `gfxrecon-replay` was built with Vulkan Validation Layer support,

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -420,8 +420,8 @@ def ReplayCommon(replay_args, activity):
 
         adb_start = 'adb shell am start -n {} -a {} -c {}'.format(activity, app_action, app_category)
 
-        cmd = ' '.join([adb_start, '--es', '"args"', '"{}"'.format(extras)])
-        print('Executing:', cmd)
+        print(f'Executing: {adb_start} --es args \'"{extras}"\'')
+        cmd = ' '.join([adb_start, '--es', 'args', '"{}"'.format(extras)])
 
         # Specify posix=False to prevent removal of quotes from adb extras.
         subprocess.check_call(shlex.split(cmd, posix=False))


### PR DESCRIPTION
Previous log was wrong. Copy pasting it for running again did not work. The value after args should be escaped twice.