### PR TITLE
Multi CopyBufferRegion over to same DXR buffer

### DIFF
--- a/framework/decode/dx12_resource_value_mapper.h
+++ b/framework/decode/dx12_resource_value_mapper.h
@@ -174,6 +174,8 @@ class Dx12ResourceValueMapper
 
     void ProcessResourceMappings(ProcessResourceMappingsArgs args);
 
+    void SourceCopyResources(std::vector<ResourceCopyInfo>& copy_infos, ResourceValueInfoMap& resource_value_info_map);
+
     bool MapValue(const ResourceValueInfo& value_info,
                   std::vector<uint8_t>&    result_data,
                   format::HandleId         resource_id,


### PR DESCRIPTION
Game updated same DXR buffer data from one stagging buffer but different offset. If there were a few of ExecuteIndirect(DispatchRays) calls within one commandlist, GFXR only tracked the latest CopyBufferRegion 
and made the latest stagging buffer resource as DXR buffer source.
For example,

// Copy buffer1 offset 100 data over to EI_DispatchRays offset_0 
CL::CopyBufferRegion(EI_DispatchRays, offset_0, buffer1, offset_100) CL::SetStateObject1( SO_0)
CL::ExecuteIndirect(EI_DispatchRays, offset_0)

// Copy buffer1 offset 200 data over to EI_DispatchRays offset_0 
CL::CopyBufferRegion(EI_DispatchRays, offset_0, buffer1, offset_200) CL::SetStateObject1( SO_0)
CL::ExecuteIndirect(EI_DispatchRays, offset_0)

// Copy buffer1 data offset 300 over to EI_DispatchRays offset_0 
CL::CopyBufferRegion(EI_DispatchRays, offset_0, buffer1, offset_300) CL::SetStateObject1( SO_1)
CL::ExecuteIndirect(EI_DispatchRays, offset_0)
CL::Close()

// GFXR inject ResourceValueMap()
CQ::ExecuteCommandList(CL)

We have to track correct stagging buffer and its offset for each EI(), BuildAS() and DisptachRays() calls.