### PR TITLE
Fix issues with -m rebind, correction to use capture-time memory-indices

### DIFF
--- a/framework/decode/vulkan_address_replacer.h
+++ b/framework/decode/vulkan_address_replacer.h
@@ -441,9 +441,9 @@ class VulkanAddressReplacer
     bool swap_acceleration_structure_handle(VkAccelerationStructureKHR&               handle,
                                             const decode::VulkanDeviceAddressTracker& address_tracker);
 
-    const graphics::VulkanDeviceTable*                             device_table_      = nullptr;
-    decode::CommonObjectInfoTable*                                 object_table_      = nullptr;
-    VkPhysicalDeviceMemoryProperties                               memory_properties_ = {};
+    const graphics::VulkanDeviceTable*                             device_table_              = nullptr;
+    decode::CommonObjectInfoTable*                                 object_table_              = nullptr;
+    VkPhysicalDeviceMemoryProperties                               capture_memory_properties_ = {};
     std::optional<VkPhysicalDeviceRayTracingPipelinePropertiesKHR> capture_ray_properties_{}, replay_ray_properties_{};
     std::optional<VkPhysicalDeviceAccelerationStructurePropertiesKHR> replay_acceleration_structure_properties_{};
     bool                                                              valid_sbt_alignment_ = true;


### PR DESCRIPTION
While testing various `-m rebind` scenarios (capture on X, replay on Y)
and ran into some weird issues when trying to map internal host-memory.
Reason was basically wrong usage of VulkanRebindAllocator,
feeding wrong memory-properties (we provided replay-time, but needs to be capture-time)
for internal memory-allocations.
The PR corrects this bug.