### PR TITLE
Use replace JSON error handler instead of strict

### DIFF
--- a/framework/decode/json_writer.cpp
+++ b/framework/decode/json_writer.cpp
@@ -113,7 +113,10 @@ void JsonWriter::WriteBlockEnd()
     /// while the main thread gets on with building the tree for the next block.
     // Dominates profiling (2/2):
     const std::string block =
-        json_data_.dump(json_options_.format == util::JsonFormat::JSONL ? -1 : util::kJsonIndentWidth);
+        json_data_.dump(json_options_.format == util::JsonFormat::JSONL ? -1 : util::kJsonIndentWidth,
+                        ' ',
+                        false,
+                        nlohmann::json::error_handler_t::replace);
     Write(*os_, block);
     os_->Flush();
 }


### PR DESCRIPTION
JsonWriter::WriteBlockEnd() calls the json dump() function without specifying an error handler. This leaves it with the strict handler, which throws an exception at any invalid UTF-8 char, like a trademark char, and terminates gfxrecon-convert early. Using the replace handler allows the conversion to complete, in these cases.