### PR TITLE
Reduce busy-waiting for vkGetQueryPoolResults & vkGetEventStatus

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1490,16 +1490,16 @@ void VulkanReplayConsumerBase::CheckResult(const char*                func_name,
     if (original != replay)
     {
         // check allow-listed functions
-        bool return_code_valid = kFunctionsAllowedToReturnDifferentCodeThanCapture.contains(func_name);
+        bool accept_return_code = kFunctionsAllowedToReturnDifferentCodeThanCapture.contains(func_name);
 
         // check allow-listed capture/replay VkResult-values
         if (const auto it = kResultValuesAllowedDifferentCodeThanCapture.find(original);
             it != kResultValuesAllowedDifferentCodeThanCapture.end())
         {
-            return_code_valid = return_code_valid || replay == it->second;
+            accept_return_code = accept_return_code || replay == it->second;
         }
 
-        if (!return_code_valid)
+        if (!accept_return_code)
         {
             if (replay < 0 && replay != VK_ERROR_FORMAT_NOT_SUPPORTED)
             {


### PR DESCRIPTION
- currently we're busy-waiting for `vkGetQueryPoolResults` if `VK_SUCCESS` is expected.
-> can yield wrong result (running out of retries), doesn't match the original behavior and is inefficient
-> waiting seems more correct
- vkGetEventStatus is re-run in a loop, even if it already returned VK_EVENT_SET
-> this doesn't make sense imo and is corrected here

testing with a Unity/DXVK capture:
the PR reduces the amount of `vkGetEventStatus` by an order of magnitude (21Mio -> 2Mio)..

log-spam is reduced, not seeing this anymore:
`[gfxrecon] WARNING - API call vkGetQueryPoolResults returned value VK_NOT_READY that does not match return value from capture file: VK_SUCCESS.`

-> this could easily be seen as a bug. we go on with replay, after trying for `kMaxQueryPoolResultsRetries`
-> waiting seems like the better approach (similar to `vkGetFenceStatus`)
-> the overall replay-time/performance was not affected negatively, no significant change

~~still seeing lots of:~~
~~`[gfxrecon] WARNING - API call vkGetEventStatus returned value VK_EVENT_SET that does not match return value from capture file: VK_EVENT_RESET.`~~

~~which is true, just profoundly fills up the log and feels noisy.~~

-> this is now explicitly allowed and we will exclude warnings for `VK_EVENT_RESET` -> `VK_EVENT_SET`