### PR TITLE
Capture in replay: preserve struct Handle IDs

### DIFF
--- a/framework/decode/common_consumer_base.h
+++ b/framework/decode/common_consumer_base.h
@@ -61,6 +61,7 @@ class CommonConsumerBase : public MetadataConsumerBase, public MarkerConsumerBas
     virtual void PushRecaptureHandleId(const format::HandleId* id) {}
     virtual void PushRecaptureHandleIds(const format::HandleId* id_array, uint64_t id_count) {}
     virtual void ClearRecaptureHandleIds() {}
+    virtual bool IsRecapture() { return false; }
 
   protected:
     uint64_t frame_number_{ 0 };

--- a/framework/decode/common_struct_handle_mappers.h
+++ b/framework/decode/common_struct_handle_mappers.h
@@ -23,6 +23,8 @@
 #ifndef GFXRECON_DECODE_COMMON_HANDLE_MAPPERS_H
 #define GFXRECON_DECODE_COMMON_HANDLE_MAPPERS_H
 
+#include "decode/common_consumer_base.h"
+
 template <typename T>
 void MapStructArrayHandles(T* structs, size_t len, const CommonObjectInfoTable& object_info_table)
 {
@@ -62,6 +64,19 @@ void AddStructArrayHandles(format::HandleId               parent_id,
         for (size_t i = 0; i < len; ++i)
         {
             AddStructHandles(parent_id, &id_wrappers[i], &handle_structs[i], object_info_table);
+        }
+    }
+}
+
+template <typename T>
+void PushRecaptureStructArrayHandleIds(const T* id_wrappers, size_t id_len, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrappers != nullptr)
+    {
+        for (size_t i = 0; i < id_len; ++i)
+        {
+            PushRecaptureStructHandleIds(&id_wrappers[i], consumer);
         }
     }
 }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1628,6 +1628,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     virtual void PushRecaptureHandleId(const format::HandleId* id) override;
     virtual void PushRecaptureHandleIds(const format::HandleId* id_array, uint64_t id_count) override;
     virtual void ClearRecaptureHandleIds() override;
+    virtual bool IsRecapture() override { return options_.capture; }
 
     //// End recapture members
 

--- a/framework/generated/generated_openxr_replay_consumer.cpp
+++ b/framework/generated/generated_openxr_replay_consumer.cpp
@@ -141,8 +141,10 @@ void OpenXrReplayConsumer::Process_xrGetSystemProperties(
     XrSystemProperties* out_properties = properties->IsNull() ? nullptr : properties->AllocateOutputData(1, { XR_TYPE_SYSTEM_PROPERTIES, nullptr });
     InitializeOutputStructNext(properties);
 
+    PushRecaptureStructHandleIds(properties->GetMetaStructPointer(), this);
     XrResult replay_result = GetInstanceTable(in_instance)->GetSystemProperties(in_instance, in_systemId, out_properties);
     CheckResult("xrGetSystemProperties", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     AddStructHandles(instance, properties->GetMetaStructPointer(), out_properties, &GetObjectInfoTable());
     CustomProcess<format::ApiCallId::ApiCall_xrGetSystemProperties>::UpdateState(this, call_info, returnValue, instance, systemId, properties, replay_result);
@@ -676,8 +678,10 @@ void OpenXrReplayConsumer::Process_xrGetCurrentInteractionProfile(
     XrInteractionProfileState* out_interactionProfile = interactionProfile->IsNull() ? nullptr : interactionProfile->AllocateOutputData(1, { XR_TYPE_INTERACTION_PROFILE_STATE, nullptr });
     InitializeOutputStructNext(interactionProfile);
 
+    PushRecaptureStructHandleIds(interactionProfile->GetMetaStructPointer(), this);
     XrResult replay_result = GetInstanceTable(in_session)->GetCurrentInteractionProfile(in_session, in_topLevelUserPath, out_interactionProfile);
     CheckResult("xrGetCurrentInteractionProfile", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     AddStructHandles(session, interactionProfile->GetMetaStructPointer(), out_interactionProfile, &GetObjectInfoTable());
     CustomProcess<format::ApiCallId::ApiCall_xrGetCurrentInteractionProfile>::UpdateState(this, call_info, returnValue, session, topLevelUserPath, interactionProfile, replay_result);
@@ -1615,8 +1619,10 @@ void OpenXrReplayConsumer::Process_xrGetControllerModelKeyMSFT(
     XrControllerModelKeyStateMSFT* out_controllerModelKeyState = controllerModelKeyState->IsNull() ? nullptr : controllerModelKeyState->AllocateOutputData(1, { XR_TYPE_CONTROLLER_MODEL_KEY_STATE_MSFT, nullptr });
     InitializeOutputStructNext(controllerModelKeyState);
 
+    PushRecaptureStructHandleIds(controllerModelKeyState->GetMetaStructPointer(), this);
     XrResult replay_result = GetInstanceTable(in_session)->GetControllerModelKeyMSFT(in_session, in_topLevelUserPath, out_controllerModelKeyState);
     CheckResult("xrGetControllerModelKeyMSFT", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     AddStructHandles(session, controllerModelKeyState->GetMetaStructPointer(), out_controllerModelKeyState, &GetObjectInfoTable());
     CustomProcess<format::ApiCallId::ApiCall_xrGetControllerModelKeyMSFT>::UpdateState(this, call_info, returnValue, session, topLevelUserPath, controllerModelKeyState, replay_result);
@@ -2059,8 +2065,10 @@ void OpenXrReplayConsumer::Process_xrEnumerateViveTrackerPathsHTCX(
     uint32_t* out_pathCountOutput = pathCountOutput->IsNull() ? nullptr : pathCountOutput->AllocateOutputData(1, static_cast<uint32_t>(0));
     XrViveTrackerPathsHTCX* out_paths = paths->IsNull() ? nullptr : paths->AllocateOutputData(pathCapacityInput, XrViveTrackerPathsHTCX{ XR_TYPE_VIVE_TRACKER_PATHS_HTCX, nullptr });
 
+    PushRecaptureStructArrayHandleIds(paths->GetMetaStructPointer(), paths->GetLength(), this);
     XrResult replay_result = GetInstanceTable(in_instance)->EnumerateViveTrackerPathsHTCX(in_instance, pathCapacityInput, out_pathCountOutput, out_paths);
     CheckResult("xrEnumerateViveTrackerPathsHTCX", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     AddStructArrayHandles<Decoded_XrViveTrackerPathsHTCX>(instance, paths->GetMetaStructPointer(), paths->GetLength(), out_paths, pathCapacityInput, &GetObjectInfoTable());
     CustomProcess<format::ApiCallId::ApiCall_xrEnumerateViveTrackerPathsHTCX>::UpdateState(this, call_info, returnValue, instance, pathCapacityInput, pathCountOutput, paths, replay_result);
@@ -2564,8 +2572,10 @@ void OpenXrReplayConsumer::Process_xrEnumerateRenderModelPathsFB(
     uint32_t* out_pathCountOutput = pathCountOutput->IsNull() ? nullptr : pathCountOutput->AllocateOutputData(1, static_cast<uint32_t>(0));
     XrRenderModelPathInfoFB* out_paths = paths->IsNull() ? nullptr : paths->AllocateOutputData(pathCapacityInput, XrRenderModelPathInfoFB{ XR_TYPE_RENDER_MODEL_PATH_INFO_FB, nullptr });
 
+    PushRecaptureStructArrayHandleIds(paths->GetMetaStructPointer(), paths->GetLength(), this);
     XrResult replay_result = GetInstanceTable(in_session)->EnumerateRenderModelPathsFB(in_session, pathCapacityInput, out_pathCountOutput, out_paths);
     CheckResult("xrEnumerateRenderModelPathsFB", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     AddStructArrayHandles<Decoded_XrRenderModelPathInfoFB>(session, paths->GetMetaStructPointer(), paths->GetLength(), out_paths, pathCapacityInput, &GetObjectInfoTable());
     CustomProcess<format::ApiCallId::ApiCall_xrEnumerateRenderModelPathsFB>::UpdateState(this, call_info, returnValue, session, pathCapacityInput, pathCountOutput, paths, replay_result);
@@ -2583,8 +2593,10 @@ void OpenXrReplayConsumer::Process_xrGetRenderModelPropertiesFB(
     XrRenderModelPropertiesFB* out_properties = properties->IsNull() ? nullptr : properties->AllocateOutputData(1, { XR_TYPE_RENDER_MODEL_PROPERTIES_FB, nullptr });
     InitializeOutputStructNext(properties);
 
+    PushRecaptureStructHandleIds(properties->GetMetaStructPointer(), this);
     XrResult replay_result = GetInstanceTable(in_session)->GetRenderModelPropertiesFB(in_session, in_path, out_properties);
     CheckResult("xrGetRenderModelPropertiesFB", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     AddStructHandles(session, properties->GetMetaStructPointer(), out_properties, &GetObjectInfoTable());
     CustomProcess<format::ApiCallId::ApiCall_xrGetRenderModelPropertiesFB>::UpdateState(this, call_info, returnValue, session, path, properties, replay_result);
@@ -3218,8 +3230,10 @@ void OpenXrReplayConsumer::Process_xrRetrieveSpaceQueryResultsFB(
     XrSpaceQueryResultsFB* out_results = results->IsNull() ? nullptr : results->AllocateOutputData(1, { XR_TYPE_SPACE_QUERY_RESULTS_FB, nullptr });
     InitializeOutputStructNext(results);
 
+    PushRecaptureStructHandleIds(results->GetMetaStructPointer(), this);
     XrResult replay_result = GetInstanceTable(in_session)->RetrieveSpaceQueryResultsFB(in_session, in_requestId, out_results);
     CheckResult("xrRetrieveSpaceQueryResultsFB", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     AddStructHandles(session, results->GetMetaStructPointer(), out_results, &GetObjectInfoTable());
     CustomProcess<format::ApiCallId::ApiCall_xrRetrieveSpaceQueryResultsFB>::UpdateState(this, call_info, returnValue, session, requestId, results, replay_result);

--- a/framework/generated/generated_openxr_struct_handle_mappers.cpp
+++ b/framework/generated/generated_openxr_struct_handle_mappers.cpp
@@ -1492,6 +1492,79 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_XrSpaceQueryResu
     }
 }
 
+void PushRecaptureStructHandleIds(const Decoded_XrSystemProperties* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleId(&id_wrapper->systemId);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_XrInteractionProfileState* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleId(&id_wrapper->interactionProfile);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_XrControllerModelKeyStateMSFT* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleId(&id_wrapper->modelKey);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_XrViveTrackerPathsHTCX* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleId(&id_wrapper->persistentPath);
+        consumer->PushRecaptureHandleId(&id_wrapper->rolePath);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_XrRenderModelPathInfoFB* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleId(&id_wrapper->path);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_XrRenderModelPropertiesFB* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleId(&id_wrapper->modelKey);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_XrSpaceQueryResultsFB* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        PushRecaptureStructArrayHandleIds<Decoded_XrSpaceQueryResultFB>(id_wrapper->results->GetMetaStructPointer(), id_wrapper->results->GetLength(), consumer);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_XrSpaceQueryResultFB* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleId(&id_wrapper->space);
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/generated/generated_openxr_struct_handle_mappers.h
+++ b/framework/generated/generated_openxr_struct_handle_mappers.h
@@ -29,6 +29,7 @@
 
 #if ENABLE_OPENXR_SUPPORT
 
+#include "decode/common_consumer_base.h"
 #include "decode/common_object_info_table.h"
 #include "decode/openxr_next_node.h"
 #include "format/platform_types.h"
@@ -280,6 +281,22 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_XrRenderModelPro
 void AddStructHandles(format::HandleId parent_id, const Decoded_XrSpaceQueryResultsFB* id_wrapper, const XrSpaceQueryResultsFB* handle_struct, CommonObjectInfoTable* object_info_table);
 
 void AddStructHandles(format::HandleId parent_id, const Decoded_XrSpaceQueryResultFB* id_wrapper, const XrSpaceQueryResultFB* handle_struct, CommonObjectInfoTable* object_info_table);
+
+void PushRecaptureStructHandleIds(const Decoded_XrSystemProperties* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_XrInteractionProfileState* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_XrControllerModelKeyStateMSFT* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_XrViveTrackerPathsHTCX* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_XrRenderModelPathInfoFB* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_XrRenderModelPropertiesFB* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_XrSpaceQueryResultsFB* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_XrSpaceQueryResultFB* id_wrapper, CommonConsumerBase* consumer);
 
 #include "decode/common_struct_handle_mappers.h"
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -2419,8 +2419,10 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     SetStructArrayHandleLengths<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength());
     if (!pPhysicalDeviceGroupProperties->IsNull()) { pPhysicalDeviceGroupProperties->AllocateOutputData(*pPhysicalDeviceGroupCount->GetOutputPointer(), VkPhysicalDeviceGroupProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, nullptr }); }
 
+    PushRecaptureStructArrayHandleIds(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), this);
     VkResult replay_result = OverrideEnumeratePhysicalDeviceGroups(GetInstanceTable(in_instance->handle)->EnumeratePhysicalDeviceGroups, returnValue, in_instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
     CheckResult("vkEnumeratePhysicalDeviceGroups", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<VulkanInstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroups, *pPhysicalDeviceGroupCount->GetOutputPointer(), &CommonObjectInfoTable::GetVkInstanceInfo); }
     AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(instance, pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), pPhysicalDeviceGroupProperties->GetOutputPointer(), *pPhysicalDeviceGroupCount->GetOutputPointer(), &GetObjectInfoTable());
@@ -4144,8 +4146,10 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkDisplayPropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
+    PushRecaptureStructArrayHandleIds(pProperties->GetMetaStructPointer(), pProperties->GetLength(), this);
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -4162,8 +4166,10 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkDisplayPlanePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
+    PushRecaptureStructArrayHandleIds(pProperties->GetMetaStructPointer(), pProperties->GetLength(), this);
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlanePropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPlanePropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -4204,8 +4210,10 @@ void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
     uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDisplayKHRInfo>("vkGetDisplayModePropertiesKHR", returnValue, display, kDisplayKHRArrayGetDisplayModePropertiesKHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkDisplayKHRInfo));
     VkDisplayModePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
+    PushRecaptureStructArrayHandleIds(pProperties->GetMetaStructPointer(), pProperties->GetLength(), this);
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModePropertiesKHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetDisplayModePropertiesKHR", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     if (pProperties->IsNull()) { SetOutputArrayCount<VulkanDisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModePropertiesKHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkDisplayKHRInfo); }
     AddStructArrayHandles<Decoded_VkDisplayModePropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -4879,8 +4887,10 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     SetStructArrayHandleLengths<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength());
     if (!pPhysicalDeviceGroupProperties->IsNull()) { pPhysicalDeviceGroupProperties->AllocateOutputData(*pPhysicalDeviceGroupCount->GetOutputPointer(), VkPhysicalDeviceGroupProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, nullptr }); }
 
+    PushRecaptureStructArrayHandleIds(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), this);
     VkResult replay_result = OverrideEnumeratePhysicalDeviceGroups(GetInstanceTable(in_instance->handle)->EnumeratePhysicalDeviceGroupsKHR, returnValue, in_instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
     CheckResult("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<VulkanInstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, *pPhysicalDeviceGroupCount->GetOutputPointer(), &CommonObjectInfoTable::GetVkInstanceInfo); }
     AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(instance, pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), pPhysicalDeviceGroupProperties->GetOutputPointer(), *pPhysicalDeviceGroupCount->GetOutputPointer(), &GetObjectInfoTable());
@@ -5388,8 +5398,10 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkDisplayProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR, nullptr });
 
+    PushRecaptureStructArrayHandleIds(pProperties->GetMetaStructPointer(), pProperties->GetLength(), this);
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -5406,8 +5418,10 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR
     uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanPhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo));
     VkDisplayPlaneProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayPlaneProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR, nullptr });
 
+    PushRecaptureStructArrayHandleIds(pProperties->GetMetaStructPointer(), pProperties->GetLength(), this);
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlaneProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     if (pProperties->IsNull()) { SetOutputArrayCount<VulkanPhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPlaneProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -5426,8 +5440,10 @@ void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
     uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, VulkanDisplayKHRInfo>("vkGetDisplayModeProperties2KHR", returnValue, display, kDisplayKHRArrayGetDisplayModeProperties2KHR, pPropertyCount, pProperties, &CommonObjectInfoTable::GetVkDisplayKHRInfo));
     VkDisplayModeProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayModeProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR, nullptr });
 
+    PushRecaptureStructArrayHandleIds(pProperties->GetMetaStructPointer(), pProperties->GetLength(), this);
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModeProperties2KHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetDisplayModeProperties2KHR", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     if (pProperties->IsNull()) { SetOutputArrayCount<VulkanDisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModeProperties2KHR, *out_pPropertyCount, &CommonObjectInfoTable::GetVkDisplayKHRInfo); }
     AddStructArrayHandles<Decoded_VkDisplayModeProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -6384,8 +6400,10 @@ void VulkanReplayConsumer::Process_vkCreatePipelineBinariesKHR(
     VkPipelineBinaryHandlesInfoKHR* out_pBinaries = pBinaries->IsNull() ? nullptr : pBinaries->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PIPELINE_BINARY_HANDLES_INFO_KHR, nullptr });
     InitializeOutputStructPNext(pBinaries);
 
+    PushRecaptureStructHandleIds(pBinaries->GetMetaStructPointer(), this);
     VkResult replay_result = GetDeviceTable(in_device)->CreatePipelineBinariesKHR(in_device, in_pCreateInfo, in_pAllocator, out_pBinaries);
     CheckResult("vkCreatePipelineBinariesKHR", returnValue, replay_result, call_info);
+    ClearRecaptureHandleIds();
 
     AddStructHandles(device, pBinaries->GetMetaStructPointer(), out_pBinaries, &GetObjectInfoTable());
 }

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -2314,6 +2314,78 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkPipelineBinary
     }
 }
 
+void PushRecaptureStructHandleIds(const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleIds(id_wrapper->physicalDevices.GetPointer(), id_wrapper->physicalDevices.GetLength());
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayPropertiesKHR* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleId(&id_wrapper->display);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleId(&id_wrapper->currentDisplay);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayModePropertiesKHR* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleId(&id_wrapper->displayMode);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayProperties2KHR* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        PushRecaptureStructHandleIds(id_wrapper->displayProperties, consumer);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        PushRecaptureStructHandleIds(id_wrapper->displayPlaneProperties, consumer);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayModeProperties2KHR* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        PushRecaptureStructHandleIds(id_wrapper->displayModeProperties, consumer);
+    }
+}
+
+void PushRecaptureStructHandleIds(const Decoded_VkPipelineBinaryHandlesInfoKHR* id_wrapper, CommonConsumerBase* consumer)
+{
+    GFXRECON_ASSERT(consumer != nullptr);
+    if (consumer->IsRecapture() && id_wrapper != nullptr)
+    {
+        consumer->PushRecaptureHandleIds(id_wrapper->pPipelineBinaries.GetPointer(), id_wrapper->pPipelineBinaries.GetLength());
+    }
+}
+
 void SetStructHandleLengths(Decoded_VkPhysicalDeviceGroupProperties* wrapper)
 {
     if (wrapper != nullptr)

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -30,6 +30,7 @@
 #ifndef  GFXRECON_GENERATED_VULKAN_STRUCT_HANDLE_MAPPERS_H
 #define  GFXRECON_GENERATED_VULKAN_STRUCT_HANDLE_MAPPERS_H
 
+#include "decode/common_consumer_base.h"
 #include "decode/common_object_info_table.h"
 #include "decode/vulkan_pnext_node.h"
 #include "format/platform_types.h"
@@ -438,6 +439,22 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlanePr
 void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, CommonObjectInfoTable* object_info_table);
 
 void AddStructHandles(format::HandleId parent_id, const Decoded_VkPipelineBinaryHandlesInfoKHR* id_wrapper, const VkPipelineBinaryHandlesInfoKHR* handle_struct, CommonObjectInfoTable* object_info_table);
+
+void PushRecaptureStructHandleIds(const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayPropertiesKHR* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayModePropertiesKHR* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayProperties2KHR* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_VkDisplayModeProperties2KHR* id_wrapper, CommonConsumerBase* consumer);
+
+void PushRecaptureStructHandleIds(const Decoded_VkPipelineBinaryHandlesInfoKHR* id_wrapper, CommonConsumerBase* consumer);
 
 void SetStructHandleLengths(Decoded_VkPhysicalDeviceGroupProperties* wrapper);
 

--- a/framework/generated/khronos_generators/khronos_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_replay_consumer_body_generator.py
@@ -818,6 +818,8 @@ class KhronosReplayConsumerBodyGenerator():
                                 )
                                 # If this is a struct with handles, we need to add replay mappings for the embedded handles.
                                 if value.base_type in self.structs_with_handles:
+                                    push_handleid_expr[0] = "    PushRecaptureStructArrayHandleIds({paramname}->GetMetaStructPointer(), {paramname}->GetLength(), this);\n".format(paramname=value.name)
+                                    push_handleid_expr[1] = "    ClearRecaptureHandleIds();\n"
                                     if value.base_type in self.structs_with_handle_ptrs:
                                         preexpr.append(
                                             'SetStructArrayHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'
@@ -842,6 +844,8 @@ class KhronosReplayConsumerBodyGenerator():
                                 )
                                 # If this is a struct with handles, we need to add replay mappings for the embedded handles.
                                 if value.base_type in self.structs_with_handles:
+                                    push_handleid_expr[0] = "    PushRecaptureStructArrayHandleIds({paramname}->GetMetaStructPointer(), {paramname}->GetLength(), this);\n".format(paramname=value.name)
+                                    push_handleid_expr[1] = "    ClearRecaptureHandleIds();\n"
                                     if value.base_type in self.structs_with_handle_ptrs:
                                         preexpr.append(
                                             'SetStructArrayHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'
@@ -995,6 +999,8 @@ class KhronosReplayConsumerBodyGenerator():
 
                                 # If this is a struct with handles, we need to add replay mappings for the embedded handles.
                                 if value.base_type in self.structs_with_handles:
+                                    push_handleid_expr[0] = "    PushRecaptureStructHandleIds({}->GetMetaStructPointer(), this);\n".format(value.name)
+                                    push_handleid_expr[1] = "    ClearRecaptureHandleIds();\n"
                                     if need_temp_value:
                                         if value.base_type in self.structs_with_handle_ptrs:
                                             preexpr.append(

--- a/framework/generated/khronos_generators/khronos_struct_handle_mappers_header_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_handle_mappers_header_generator.py
@@ -95,6 +95,14 @@ class KhronosStructHandleMappersHeaderGenerator():
             self.newline()
 
         for struct in self.output_structs:
+            write(
+                'void PushRecaptureStructHandleIds(const Decoded_{type}* id_wrapper, CommonConsumerBase* consumer);'
+                .format(type=struct),
+                file=self.outFile
+            )
+            self.newline()
+
+        for struct in self.output_structs:
             if struct in self.structs_with_handle_ptrs:
                 write(
                     'void SetStructHandleLengths(Decoded_{type}* wrapper);'.

--- a/framework/generated/khronos_generators/openxr_generators/openxr_struct_handle_mappers_header_generator.py
+++ b/framework/generated/khronos_generators/openxr_generators/openxr_struct_handle_mappers_header_generator.py
@@ -53,6 +53,7 @@ class OpenXrStructHandleMappersHeaderGeneratorOptions(OpenXrBaseGeneratorOptions
         )
 
         self.begin_end_file_data.specific_headers.extend((
+            'decode/common_consumer_base.h',
             'decode/common_object_info_table.h',
             'decode/openxr_next_node.h',
             'format/platform_types.h',

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
@@ -53,6 +53,7 @@ class VulkanStructHandleMappersHeaderGeneratorOptions(VulkanBaseGeneratorOptions
         )
 
         self.begin_end_file_data.specific_headers.extend((
+            'decode/common_consumer_base.h',
             'decode/common_object_info_table.h',
             'decode/vulkan_pnext_node.h',
             'format/platform_types.h',


### PR DESCRIPTION
Recapture should now preserve the Handle IDs of objects that are created and returned via output structs.