### PR TITLE
Add capture in replay option to copy source data

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -772,7 +772,7 @@ usage: gfxrecon.py replay [-h] [-p LOCAL_FILE] [--version] [--log-level LEVEL]
                           [--screenshot-prefix PREFIX]
                           [--screenshot-interval INTERVAL]
                           [--screenshot-size SIZE] [--screenshot-scale SCALE]
-                          [--capture]
+                          [--capture][--capture-copy-data]
                           [--sfa] [--opcd] [--surface-index N] [--sync]
                           [--remove-unsupported] [--validate] [--onhb]
                           [--use-colorspace-fallback]
@@ -872,6 +872,18 @@ options:
                         capture functionality is included in the `gfxrecon-replay`
                         executable--no GFXR capture layer is added to the Vulkan layer
                         chain.
+  --capture-copy-data
+                        An extended version of `--capture` that can be used with
+                        trimming. The capture data within the trim range is
+                        copied directly from the source capture file into the
+                        new trimmed file. Note that replay must still run in
+                        order to generate the trim state block. Portable replay
+                        features are not supported. For example, replay
+                        should be done on the same device as capture, memory
+                        translation options are not supported, and if ray
+                        tracing is used, the device must support Vulkan's opaque
+                        capture and replay features. This option also forces on
+                        the option `swapchain --captured`.
   --sfa, --skip-failed-allocations
                         Skip vkAllocateMemory, vkAllocateCommandBuffers, and
                         vkAllocateDescriptorSets calls that failed during

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -614,7 +614,7 @@ gfxrecon-replay         [-h | --help] [--version] [--cpu-mask <binary-mask>] [--
                         [--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]
                         [--screenshot-scale SCALE] [--screenshot-size WIDTHxHEIGHT]
                         [--screenshot-interval <N>]
-                        [--capture]
+                        [--capture][--capture-copy-data]
                         [--sfa | --skip-failed-allocations] [--replace-shaders <dir>]
                         [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
                         [--surface-index <N>] [--remove-unsupported] [--validate]
@@ -720,6 +720,18 @@ Optional arguments:
                         capture functionality is included in the `gfxrecon-replay`
                         executable--no GFXR capture layer is added to the Vulkan layer
                         chain.
+  --capture-copy-data
+                        An extended version of `--capture` that can be used with
+                        trimming. The capture data within the trim range is
+                        copied directly from the source capture file into the
+                        new trimmed file. Note that replay must still run in
+                        order to generate the trim state block. Portable replay
+                        features are not supported. For example, replay
+                        should be done on the same device as capture, memory
+                        translation options are not supported, and if ray
+                        tracing is used, the device must support Vulkan's opaque
+                        capture and replay features. This option also forces on
+                        the option `swapchain --captured`.
   --sfa                 Skip vkAllocateMemory, vkAllocateCommandBuffers, and
                         vkAllocateDescriptorSets calls that failed during
                         capture (same as --skip-failed-allocations).

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -36,14 +36,16 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+class ParsedBlock;
+
 struct ApiCallInfo
 {
     /// The block index of a function call. Stream processors like FileProcessor
     /// must set this before dispatching function calls to decoders.
     /// @note This is lightly used: only for a log output in replay and for JSON
     /// Convert.
-    /// @see ApiDecoder::SetCurrentBlockIndex() which can pass the block index
-    /// to decoders so it is available for any block type, not just API calls.
+    /// @see ApiDecoder::BeginDispatchBlock() which can pass the parsed block to
+    /// decoders so it is available for any block type, not just API calls.
     uint64_t index{ 0 };
 
     /// Thread id of captured function call.
@@ -203,7 +205,8 @@ class ApiDecoder
                                                int64_t            offset,
                                                const std::string& filename){};
 
-    virtual void SetCurrentBlockIndex(uint64_t block_index){};
+    virtual void BeginDispatchBlock(const ParsedBlock* parsed_block){};
+    virtual void EndDispatchBlock(){};
 
     // Expects zero-based frame_number to match the way FileProcessor::current_frame_number_ works
     virtual void SetCurrentFrameNumber(uint64_t frame_number){};

--- a/framework/decode/block_buffer.h
+++ b/framework/decode/block_buffer.h
@@ -113,7 +113,6 @@ class BlockBuffer
 
   private:
     size_t              read_pos_{ 0 };
-    uint64_t            block_index_{ 0U };
     util::DataSpan      block_span_;
     format::BlockHeader header_;
 };

--- a/framework/decode/block_parser.h
+++ b/framework/decode/block_parser.h
@@ -94,16 +94,14 @@ class BlockParser
     using UncompressedStore = ParsedBlock::UncompressedStore;
 
     void SetFrameNumber(uint64_t frame_number) noexcept { frame_number_ = frame_number; }
-    void SetBlockIndex(uint64_t block_index) noexcept { block_index_ = block_index; }
 
     [[nodiscard]] uint64_t GetFrameNumber() const noexcept { return frame_number_; }
-    [[nodiscard]] uint64_t GetBlockIndex() const noexcept { return block_index_; }
 
     // Parse the block header and load a block buffer
     BlockIOError ReadBlockBuffer(FileInputStreamPtr& input_stream, BlockBuffer& block_buffer);
 
     // Define parsers for every block and sub-block type
-    ParsedBlock ParseBlock(BlockBuffer& block_buffer);
+    ParsedBlock ParseBlock(BlockBuffer& block_buffer, uint64_t block_index);
     ParsedBlock ParseFunctionCall(BlockBuffer& block_buffer);
     ParsedBlock ParseMethodCall(BlockBuffer& block_buffer);
     ParsedBlock ParseMetaData(BlockBuffer& block_buffer);
@@ -170,10 +168,12 @@ class BlockParser
     DecompressionPolicy               decompression_policy_   = DecompressionPolicy::kAlways;
     ParsedBlock::BlockReferencePolicy block_reference_policy_ = ParsedBlock::BlockReferencePolicy::kNonOwnedReference;
 
-    uint64_t frame_number_ = 0;
-    uint64_t block_index_  = 0;
+    uint64_t frame_number_        = 0;
+    uint64_t current_block_index_ = 0;
 
     ParsedBlock::UncompressedStore uncompressed_working_buffer_;
+
+    [[nodiscard]] uint64_t GetBlockIndex() const noexcept { return current_block_index_; }
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/custom_ags_decoder.h
+++ b/framework/decode/custom_ags_decoder.h
@@ -167,8 +167,6 @@ class AgsDecoder : public ApiDecoder
                                                 const uint8_t*                              data) override
     {}
 
-    virtual void SetCurrentBlockIndex(uint64_t block_index) override {}
-
     virtual void DecodeFunctionCall(format::ApiCallId  call_id,
                                     const ApiCallInfo& call_options,
                                     const uint8_t*     parameter_buffer,

--- a/framework/decode/dx12_decoder_base.cpp
+++ b/framework/decode/dx12_decoder_base.cpp
@@ -340,11 +340,19 @@ void Dx12DecoderBase::DispatchSetEnvironmentVariablesCommand(const format::SetEn
     }
 }
 
-void Dx12DecoderBase::SetCurrentBlockIndex(uint64_t block_index)
+void Dx12DecoderBase::BeginDispatchBlock(const ParsedBlock* parsed_block)
 {
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index);
+        consumer->BeginProcessBlock(parsed_block);
+    }
+}
+
+void Dx12DecoderBase::EndDispatchBlock()
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->EndProcessBlock();
     }
 }
 

--- a/framework/decode/dx12_decoder_base.h
+++ b/framework/decode/dx12_decoder_base.h
@@ -215,7 +215,8 @@ class Dx12DecoderBase : public ApiDecoder
     virtual void DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
                                                         const char* env_string) override;
 
-    virtual void SetCurrentBlockIndex(uint64_t block_index) override;
+    virtual void BeginDispatchBlock(const ParsedBlock* parsed_block) override;
+    virtual void EndDispatchBlock() override;
 
     virtual void SetCurrentApiCallId(format::ApiCallId api_call_id) override;
 

--- a/framework/decode/dx12_json_consumer_base.cpp
+++ b/framework/decode/dx12_json_consumer_base.cpp
@@ -58,7 +58,7 @@ bool Dx12JsonConsumerBase::IsValid() const
 
 void Dx12JsonConsumerBase::ProcessCreateHeapAllocationCommand(uint64_t allocation_id, uint64_t allocation_size)
 {
-    writer_->SetCurrentBlockIndex(block_index_);
+    writer_->SetCurrentMetaCommandBlockIndex(GetCurrentBlockIndex());
     const util::JsonOptions& json_options = writer_->GetOptions();
     auto&                    jdata        = writer_->WriteMetaCommandStart("CreateHeapAllocationCommand");
     FieldToJson(jdata["allocation_id"], allocation_id, json_options);
@@ -69,7 +69,7 @@ void Dx12JsonConsumerBase::ProcessCreateHeapAllocationCommand(uint64_t allocatio
 void Dx12JsonConsumerBase::ProcessInitSubresourceCommand(const format::InitSubresourceCommandHeader& command_header,
                                                          const uint8_t*                              data)
 {
-    writer_->SetCurrentBlockIndex(block_index_);
+    writer_->SetCurrentMetaCommandBlockIndex(GetCurrentBlockIndex());
     const util::JsonOptions& json_options = writer_->GetOptions();
     auto&                    jdata        = writer_->WriteMetaCommandStart("InitSubresourceCommand");
 
@@ -95,7 +95,7 @@ void Dx12JsonConsumerBase::ProcessInitDx12AccelerationStructureCommand(
     const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
     const uint8_t*                                                        build_inputs_data)
 {
-    writer_->SetCurrentBlockIndex(block_index_);
+    writer_->SetCurrentMetaCommandBlockIndex(GetCurrentBlockIndex());
     const util::JsonOptions& json_options = writer_->GetOptions();
     auto&                    jdata        = writer_->WriteMetaCommandStart("InitDx12AccelerationStructureCommand");
     FieldToJson(jdata["thread_id"], command_header.thread_id, json_options);
@@ -131,7 +131,7 @@ void Dx12JsonConsumerBase::ProcessInitDx12AccelerationStructureCommand(
 void Dx12JsonConsumerBase::ProcessFillMemoryResourceValueCommand(
     const format::FillMemoryResourceValueCommandHeader& command_header, const uint8_t* data)
 {
-    writer_->SetCurrentBlockIndex(block_index_);
+    writer_->SetCurrentMetaCommandBlockIndex(GetCurrentBlockIndex());
     const util::JsonOptions& json_options = writer_->GetOptions();
     auto&                    jdata        = writer_->WriteMetaCommandStart("FillMemoryResourceValueCommand");
     FieldToJson(jdata["thread_id"], command_header.thread_id, json_options);
@@ -151,7 +151,7 @@ void Dx12JsonConsumerBase::ProcessFillMemoryResourceValueCommand(
 
 void Dx12JsonConsumerBase::ProcessDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header)
 {
-    writer_->SetCurrentBlockIndex(block_index_);
+    writer_->SetCurrentMetaCommandBlockIndex(GetCurrentBlockIndex());
     const util::JsonOptions& json_options = writer_->GetOptions();
     auto&                    jdata        = writer_->WriteMetaCommandStart("DxgiAdapterInfo");
     FieldToJson(jdata["thread_id"], adapter_info_header.thread_id, json_options);
@@ -162,7 +162,7 @@ void Dx12JsonConsumerBase::ProcessDxgiAdapterInfo(const format::DxgiAdapterInfoC
 /// @see DriverInfoBlock in format.h
 void Dx12JsonConsumerBase::Process_DriverInfo(const char* info_record)
 {
-    writer_->SetCurrentBlockIndex(block_index_);
+    writer_->SetCurrentMetaCommandBlockIndex(GetCurrentBlockIndex());
     const util::JsonOptions& json_options = writer_->GetOptions();
     auto&                    jdata        = writer_->WriteMetaCommandStart("DriverInfo");
     char                     driver_record[gfxrecon::util::filepath::kMaxDriverInfoSize + 1];
@@ -176,7 +176,7 @@ void Dx12JsonConsumerBase::Process_DriverInfo(const char* info_record)
 
 void Dx12JsonConsumerBase::ProcessDx12RuntimeInfo(const format::Dx12RuntimeInfoCommandHeader& runtime_info_header)
 {
-    writer_->SetCurrentBlockIndex(block_index_);
+    writer_->SetCurrentMetaCommandBlockIndex(GetCurrentBlockIndex());
     const util::JsonOptions& json_options = writer_->GetOptions();
     auto&                    jdata        = writer_->WriteMetaCommandStart("Dx12RuntimeInfoCommandHeader");
 

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -34,9 +34,9 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 FileProcessor::FileProcessor() :
     current_frame_number_(kFirstFrame), error_state_(kErrorInvalidFileDescriptor), bytes_read_(0),
-    annotation_handler_(nullptr), compressor_(nullptr), block_handler_callback_(nullptr), block_index_(0),
-    block_limit_(0), pending_capture_uses_frame_markers_(false), capture_uses_frame_markers_(false),
-    first_frame_(kFirstFrame + 1), loading_trimmed_capture_state_(false), pool_(util::HeapBufferPool::Create())
+    annotation_handler_(nullptr), compressor_(nullptr), block_index_(0), block_limit_(0),
+    pending_capture_uses_frame_markers_(false), capture_uses_frame_markers_(false), first_frame_(kFirstFrame + 1),
+    loading_trimmed_capture_state_(false), pool_(util::HeapBufferPool::Create())
 {}
 
 FileProcessor::FileProcessor(uint64_t block_limit) : FileProcessor()

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -34,9 +34,9 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 FileProcessor::FileProcessor() :
     current_frame_number_(kFirstFrame), error_state_(kErrorInvalidFileDescriptor), bytes_read_(0),
-    annotation_handler_(nullptr), compressor_(nullptr), block_index_(0), block_limit_(0),
-    pending_capture_uses_frame_markers_(false), capture_uses_frame_markers_(false), first_frame_(kFirstFrame + 1),
-    loading_trimmed_capture_state_(false), pool_(util::HeapBufferPool::Create())
+    annotation_handler_(nullptr), compressor_(nullptr), block_handler_callback_(nullptr), block_index_(0),
+    block_limit_(0), pending_capture_uses_frame_markers_(false), capture_uses_frame_markers_(false),
+    first_frame_(kFirstFrame + 1), loading_trimmed_capture_state_(false), pool_(util::HeapBufferPool::Create())
 {}
 
 FileProcessor::FileProcessor(uint64_t block_limit) : FileProcessor()

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -214,6 +214,8 @@ class FileProcessor
     BlockIOError             error_state_;
     uint64_t                 bytes_read_;
 
+    std::function<void(const ParsedBlock& parsed_block)> block_handler_callback_;
+
     /// @brief Incremented at the end of every block successfully processed.
     uint64_t block_index_;
 

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -214,8 +214,6 @@ class FileProcessor
     BlockIOError             error_state_;
     uint64_t                 bytes_read_;
 
-    std::function<void(const ParsedBlock& parsed_block)> block_handler_callback_;
-
     /// @brief Incremented at the end of every block successfully processed.
     uint64_t block_index_;
 

--- a/framework/decode/file_transformer.cpp
+++ b/framework/decode/file_transformer.cpp
@@ -162,8 +162,7 @@ bool FileTransformer::Process()
         {
             // Track bytes read by the parser, since we aren't using ReadBytes here
             bytes_read_ += block_buffer.Size();
-            block_parser_->SetBlockIndex(block_index_);
-            ParsedBlock parsed_block = block_parser_->ParseBlock(block_buffer);
+            ParsedBlock parsed_block = block_parser_->ParseBlock(block_buffer, block_index_);
 
             // There are four states for a parsed block
             //    kReady and kDeferredDecompress are "Visitable"

--- a/framework/decode/file_transformer.h
+++ b/framework/decode/file_transformer.h
@@ -102,7 +102,7 @@ class FileTransformer
     virtual bool ProcessStateBeginMarker(ParsedBlock& parsed_block);
     virtual bool ProcessStateEndMarker(ParsedBlock& parsed_block);
 
-    uint64_t GetCurrentBlockIndex() { return block_index_; }
+    uint64_t GetCurrentBlockIndex() const { return block_index_; }
 
     BlockParser& GetBlockParser() { return *block_parser_; }
 

--- a/framework/decode/json_writer.cpp
+++ b/framework/decode/json_writer.cpp
@@ -178,9 +178,9 @@ nlohmann::ordered_json& JsonWriter::WriteMetaCommandStart(const std::string_view
 {
     auto& json_data = WriteBlockStart();
 
-    json_data[format::kNameIndex] = block_index_;
-    nlohmann::ordered_json& meta = json_data[format::kNameMeta];
-    meta[format::kNameName]      = command_name;
+    json_data[format::kNameIndex] = meta_command_block_index_;
+    nlohmann::ordered_json& meta  = json_data[format::kNameMeta];
+    meta[format::kNameName]       = command_name;
     return meta[format::kNameArgs];
 }
 

--- a/framework/decode/json_writer.h
+++ b/framework/decode/json_writer.h
@@ -108,14 +108,14 @@ class JsonWriter : public AnnotationHandler
     std::string GenerateFilename(const std::string_view filename);
     bool        WriteBinaryFile(const std::string& filename, uint64_t data_size, const uint8_t* data);
 
-    inline void SetCurrentBlockIndex(uint64_t block_index) { block_index_ = block_index; }
+    inline void SetCurrentMetaCommandBlockIndex(uint64_t block_index) { meta_command_block_index_ = block_index; }
 
   private:
     util::OutputStream*    os_;
     nlohmann::ordered_json header_;
     util::JsonOptions      json_options_;
     nlohmann::ordered_json json_data_;
-    uint64_t               block_index_;
+    uint64_t               meta_command_block_index_{ 0 };
     uint32_t               num_streams_{ 0 };
     /// Number of side-files generated for dumping binary blobs etc.
     uint32_t num_files_{ 0 };

--- a/framework/decode/metadata_json_consumer.h
+++ b/framework/decode/metadata_json_consumer.h
@@ -54,7 +54,7 @@ class MetadataJsonConsumer : public Base
     inline const util::JsonOptions& GetJsonOptions() const { return this->writer_->GetOptions(); } // temp
     inline nlohmann::ordered_json&  WriteMetaCommandStart(const std::string& command_name) const
     {
-        this->writer_->SetCurrentBlockIndex(this->block_index_);
+        this->writer_->SetCurrentMetaCommandBlockIndex(this->GetCurrentBlockIndex());
         return this->writer_->WriteMetaCommandStart(command_name);
     }
     inline void WriteBlockEnd() { this->writer_->WriteBlockEnd(); }

--- a/framework/decode/openxr_decoder_base.cpp
+++ b/framework/decode/openxr_decoder_base.cpp
@@ -74,11 +74,19 @@ void OpenXrDecoderBase::DispatchDisplayMessageCommand(format::ThreadId thread_id
     }
 }
 
-void OpenXrDecoderBase::SetCurrentBlockIndex(uint64_t block_index)
+void OpenXrDecoderBase::BeginDispatchBlock(const ParsedBlock* parsed_block)
 {
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index);
+        consumer->BeginProcessBlock(parsed_block);
+    }
+}
+
+void OpenXrDecoderBase::EndDispatchBlock()
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->EndProcessBlock();
     }
 }
 

--- a/framework/decode/openxr_decoder_base.h
+++ b/framework/decode/openxr_decoder_base.h
@@ -84,7 +84,8 @@ class OpenXrDecoderBase : public ApiDecoder
 
     virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) override;
 
-    virtual void SetCurrentBlockIndex(uint64_t block_index) override;
+    virtual void BeginDispatchBlock(const ParsedBlock* parsed_block) override;
+    virtual void EndDispatchBlock() override;
 
     virtual void DispatchViewRelativeLocation(format::ThreadId                    thread_id,
                                               const format::ViewRelativeLocation& location) override;

--- a/framework/decode/openxr_json_consumer_base.cpp
+++ b/framework/decode/openxr_json_consumer_base.cpp
@@ -330,7 +330,7 @@ void OpenXrExportJsonConsumerBase::ProcessViewRelativeLocation(format::ThreadId 
 {
     const util::JsonOptions& json_options = writer_->GetOptions();
     // TODO: Fold this into a override for WriteMetaCommandStart if we add many more meta data blocks
-    writer_->SetCurrentBlockIndex(this->block_index_);
+    writer_->SetCurrentMetaCommandBlockIndex(this->GetCurrentBlockIndex());
     auto& jdata = writer_->WriteMetaCommandStart("ViewRelativeLocation");
 
     FieldToJson(jdata["session"], location.session_id, json_options);

--- a/framework/decode/preload_file_processor.cpp
+++ b/framework/decode/preload_file_processor.cpp
@@ -129,7 +129,7 @@ void PreloadFileProcessor::PreloadNextFrames(size_t count)
 
 FileProcessor::ProcessBlockState PreloadFileProcessor::PreloadBlocksOneFrame(ParsedBlockQueue& frame_queue)
 {
-    DispatchFunction dispatch = [&frame_queue](uint64_t block_index, ParsedBlock& block) {
+    DispatchFunction dispatch = [&frame_queue](ParsedBlock& block) {
         frame_queue.emplace_back(std::move(block));
         return ProcessBlockState::kRunning;
     };
@@ -204,8 +204,9 @@ FileProcessor::ProcessBlockState PreloadFileProcessor::ReplayOneFrame(PreloadedF
             }
         }
 
-        dispatch_visitor.SetBlockIndex(block_index);
+        dispatch_visitor.SetCurrentBlock(&queued_block);
         std::visit(dispatch_visitor, queued_block.GetArgs());
+        dispatch_visitor.SetCurrentBlock(nullptr);
     }
 
     return process_state;

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -575,11 +575,19 @@ void VulkanDecoderBase::DispatchSetEnvironmentVariablesCommand(const format::Set
     }
 }
 
-void VulkanDecoderBase::SetCurrentBlockIndex(uint64_t block_index)
+void VulkanDecoderBase::BeginDispatchBlock(const ParsedBlock* parsed_block)
 {
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index);
+        consumer->BeginProcessBlock(parsed_block);
+    }
+}
+
+void VulkanDecoderBase::EndDispatchBlock()
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->EndProcessBlock();
     }
 }
 

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -205,7 +205,8 @@ class VulkanDecoderBase : public ApiDecoder
     virtual void DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
                                                         const char* env_string) override;
 
-    virtual void SetCurrentBlockIndex(uint64_t block_index) override;
+    virtual void BeginDispatchBlock(const ParsedBlock* parsed_block) override;
+    virtual void EndDispatchBlock() override;
 
     virtual void SetCurrentFrameNumber(uint64_t frame_number) override;
 

--- a/framework/decode/vulkan_json_consumer_base.cpp
+++ b/framework/decode/vulkan_json_consumer_base.cpp
@@ -77,7 +77,7 @@ void VulkanExportJsonConsumerBase::ProcessSetDeviceMemoryPropertiesCommand(
 {
     const JsonOptions& json_options = GetJsonOptions();
 
-    writer_->SetCurrentBlockIndex(block_index_);
+    writer_->SetCurrentMetaCommandBlockIndex(GetCurrentBlockIndex());
     auto& jdata = writer_->WriteMetaCommandStart("SetDeviceMemoryPropertiesCommand");
 
     HandleToJson(jdata["physical_device_id"], physical_device_id, json_options);

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -12438,9 +12438,9 @@ void VulkanReplayConsumerBase::DestroyAsyncHandle(format::HandleId handle, std::
     }
 }
 
-void VulkanReplayConsumerBase::SetCurrentBlockIndex(uint64_t block_index)
+void VulkanReplayConsumerBase::BeginProcessBlock(const ParsedBlock* parsed_block)
 {
-    VulkanConsumer::SetCurrentBlockIndex(block_index);
+    VulkanConsumer::BeginProcessBlock(parsed_block);
 
     // poll main-dispatch-queue at beginning of new blocks
     main_thread_queue_.poll();

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -380,6 +380,13 @@ void VulkanReplayConsumerBase::ProcessStateEndMarker(uint64_t frame_number)
     {
         resource_dumper_->ProcessStateEndMarker();
     }
+
+    if (options_.capture_copy_data)
+    {
+        auto vulkan_capture_manager = encode::VulkanCaptureManager::Get();
+        GFXRECON_ASSERT(vulkan_capture_manager != nullptr);
+        vulkan_capture_manager->SetRecaptureTrimStartFrame(frame_number);
+    }
 }
 
 void VulkanReplayConsumerBase::ProcessDisplayMessageCommand(const std::string& message)
@@ -12514,6 +12521,13 @@ void VulkanReplayConsumerBase::EndProcessBlock()
 void VulkanReplayConsumerBase::SetCurrentFrameNumber(uint64_t frame_number)
 {
     VulkanConsumer::SetCurrentFrameNumber(frame_number);
+
+    if (options_.capture_copy_data && frame_number > 0)
+    {
+        auto vulkan_capture_manager = encode::VulkanCaptureManager::Get();
+        GFXRECON_ASSERT(vulkan_capture_manager != nullptr);
+        vulkan_capture_manager->EndFrameForRecapture();
+    }
 }
 
 bool VulkanReplayConsumerBase::CheckPipelineCacheUUID(const VulkanDeviceInfo*          device_info,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -79,7 +79,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     ~VulkanReplayConsumerBase() override;
 
-    void SetCurrentBlockIndex(uint64_t block_index) override;
+    void BeginProcessBlock(const ParsedBlock* parsed_block) override;
 
     void SetCurrentFrameNumber(uint64_t frame_number) override;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -80,6 +80,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     ~VulkanReplayConsumerBase() override;
 
     void BeginProcessBlock(const ParsedBlock* parsed_block) override;
+    void EndProcessBlock() override;
 
     void SetCurrentFrameNumber(uint64_t frame_number) override;
 
@@ -1643,22 +1644,24 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unique_ptr<VulkanReplayDumpResources> resource_dumper_;
 
     //// Begin recapture members
-  private:
-    // UINT64_MAX =                                      18446744073709551615ULL
-    static constexpr uint64_t kRecaptureHandleIdOffset = 10000000000000000000ULL;
-
   public:
     // Provide a custom implementation of vkGetInstanceProcAddr for the replay consumer to use to find Vulkan functions.
     // For example, this is used during recapture to return the capture layer's Vulkan functions.
-    void SetupForRecapture(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
-                           PFN_vkCreateInstance      create_instance,
-                           PFN_vkCreateDevice        create_device);
+    void SetupForRecaptureInReplay(PFN_vkGetInstanceProcAddr get_instance_proc_addr,
+                                   PFN_vkCreateInstance      create_instance,
+                                   PFN_vkCreateDevice        create_device,
+                                   FileProcessor*            file_processor);
 
     virtual void PushRecaptureHandleId(const format::HandleId* id) override;
     virtual void PushRecaptureHandleIds(const format::HandleId* id_array, uint64_t id_count) override;
     virtual void ClearRecaptureHandleIds() override;
     virtual bool IsRecapture() override { return options_.capture; }
 
+  private:
+    // UINT64_MAX =                                      18446744073709551615ULL
+    static constexpr uint64_t kRecaptureHandleIdOffset = 10000000000000000000ULL;
+
+    void WriteTrimBlockForRecapture(const ParsedBlock* parsed_block);
     //// End recapture members
 
   private:

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -802,14 +802,14 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                     HandlePointerDecoder<VkDeviceMemory>*                      pMemory);
 
-    VkResult OverrideMapMemory(PFN_vkMapMemory         func,
-                               VkResult                original_result,
-                               const VulkanDeviceInfo* device_info,
-                               VulkanDeviceMemoryInfo* memory_info,
-                               VkDeviceSize            offset,
-                               VkDeviceSize            size,
-                               VkMemoryMapFlags        flags,
-                               void**                  ppData);
+    VkResult OverrideMapMemory(PFN_vkMapMemory                  func,
+                               VkResult                         original_result,
+                               const VulkanDeviceInfo*          device_info,
+                               VulkanDeviceMemoryInfo*          memory_info,
+                               VkDeviceSize                     offset,
+                               VkDeviceSize                     size,
+                               VkMemoryMapFlags                 flags,
+                               PointerDecoder<uint64_t, void*>* ppData);
 
     void OverrideUnmapMemory(PFN_vkUnmapMemory       func,
                              const VulkanDeviceInfo* device_info,
@@ -1524,7 +1524,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                 VkResult                                       original_result,
                                 const VulkanDeviceInfo*                        device_info,
                                 StructPointerDecoder<Decoded_VkMemoryMapInfo>* pMemoryMapInfo,
-                                void**                                         ppData);
+                                PointerDecoder<uint64_t, void*>*               ppData);
 
     VkResult OverrideUnmapMemory2(PFN_vkUnmapMemory2                               func,
                                   VkResult                                         original_result,
@@ -1662,6 +1662,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     static constexpr uint64_t kRecaptureHandleIdOffset = 10000000000000000000ULL;
 
     void WriteTrimBlockForRecapture(const ParsedBlock* parsed_block);
+
+    void SetOriginalMappedMemoryPointer(VkResult                         replay_result,
+                                        VkDeviceMemory                   handle,
+                                        PointerDecoder<uint64_t, void*>* data_ptr_decoder);
+
     //// End recapture members
 
   private:

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -103,6 +103,7 @@ struct VulkanReplayOptions : public ReplayOptions
 {
     bool                         enable_vulkan{ true };
     bool                         capture{ false };
+    bool                         capture_copy_data{ false };
     bool                         omit_pipeline_cache_data{ false };
     bool                         use_colorspace_fallback{ false };
     bool                         offscreen_swapchain_frame_boundary{ false };

--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -109,7 +109,11 @@ class ApiCaptureManager
 
     void EndFrame(CommonCaptureManager::ApiSharedLockT& current_lock)
     {
-        common_manager_->EndFrame(api_family_, current_lock);
+        // When doing recapture in replay with copy data, replay is responsible for calling EndFrameForRecapture.
+        if (!CommonCaptureManager::IsRecaptureCopyData())
+        {
+            common_manager_->EndFrame(api_family_, current_lock);
+        }
     }
     void EndFrame(CommonCaptureManager::ApiCallLock& current_lock)
     {
@@ -122,6 +126,14 @@ class ApiCaptureManager
             CommonCaptureManager::ApiSharedLockT empty_lock;
             EndFrame(empty_lock);
         }
+    }
+
+    // Called by the replay consumer when processing a frame end marker.
+    void EndFrameForRecapture()
+    {
+        GFXRECON_ASSERT(CommonCaptureManager::IsRecaptureCopyData());
+        CommonCaptureManager::ApiSharedLockT empty_lock;
+        common_manager_->EndFrame(api_family_, empty_lock);
     }
 
     // Pre/PostQueueSubmit to be called immediately before and after work is submitted to the GPU by vkQueueSubmit for
@@ -194,6 +206,13 @@ class ApiCaptureManager
     {
         return common_manager_->GetPageGuardMemoryMode();
     }
+
+    uint32_t GetRecaptureTrimStartFrame() const { return common_manager_->GetRecaptureTrimStartFrame(); }
+    void     SetRecaptureTrimStartFrame(uint32_t frame_number) const
+    {
+        common_manager_->SetRecaptureTrimStartFrame(frame_number);
+    }
+
     const std::string&                GetTrimKey() const { return common_manager_->GetTrimKey(); }
     bool                              IsTrimEnabled() const { return common_manager_->IsTrimEnabled(); }
     uint32_t                          GetCurrentFrame() const { return common_manager_->GetCurrentFrame(); }

--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -59,6 +59,7 @@ class ApiCaptureManager
     format::ApiFamilyId GetApiFamily() const { return api_family_; }
     bool                IsCaptureModeTrack() const { return common_manager_->IsCaptureModeTrack(); }
     bool                IsCaptureModeWrite() const { return common_manager_->IsCaptureModeWrite(); }
+    bool                IsCaptureModeTrim() const { return common_manager_->IsCaptureModeTrim(); }
     bool                IsCaptureModeDisabled() const { return common_manager_->IsCaptureModeDisabled(); }
     bool IsCaptureSkippingCurrentThread() const { return common_manager_->IsCaptureSkippingCurrentThread(); }
 
@@ -135,12 +136,6 @@ class ApiCaptureManager
     }
 
     bool ShouldTriggerScreenshot() { return common_manager_->ShouldTriggerScreenshot(); }
-
-    void CheckContinueCaptureForWriteMode(uint32_t                                               current_boundary_count,
-                                          std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock)
-    {
-        common_manager_->CheckContinueCaptureForWriteMode(api_family_, current_boundary_count, current_lock);
-    }
 
     void CheckStartCaptureForTrackMode(uint32_t                                               current_boundary_count,
                                        std::shared_lock<CommonCaptureManager::ApiCallMutexT>& current_lock)

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -133,12 +133,13 @@ CommonCaptureManager::CommonCaptureManager() :
     page_guard_track_ahb_memory_(false), page_guard_unblock_sigsegv_(false), page_guard_signal_handler_watcher_(false),
     page_guard_memory_mode_(kMemoryModeShadowInternal), page_guard_external_memory_(false), trim_enabled_(false),
     trim_boundary_(CaptureSettings::TrimBoundary::kUnknown), trim_current_range_(0), current_frame_(kFirstFrame),
-    queue_submit_count_(0), capture_mode_(kModeWrite), previous_hotkey_state_(false),
-    previous_runtime_trigger_state_(CaptureSettings::RuntimeTriggerState::kNotUsed), debug_layer_(false),
-    debug_device_lost_(false), screenshot_prefix_(""), screenshots_enabled_(false), disable_dxr_(false),
-    accel_struct_padding_(0), iunknown_wrapping_(false), force_command_serialization_(false), queue_zero_only_(false),
-    allow_pipeline_compile_required_(false), quit_after_frame_ranges_(false), use_asset_file_(false), block_index_(0),
-    write_assets_(false), previous_write_assets_(false), skip_threads_with_invalid_data_(false)
+    recapture_trim_start_frame_(kFirstFrame), queue_submit_count_(0), capture_mode_(kModeWrite),
+    previous_hotkey_state_(false), previous_runtime_trigger_state_(CaptureSettings::RuntimeTriggerState::kNotUsed),
+    debug_layer_(false), debug_device_lost_(false), screenshot_prefix_(""), screenshots_enabled_(false),
+    disable_dxr_(false), accel_struct_padding_(0), iunknown_wrapping_(false), force_command_serialization_(false),
+    queue_zero_only_(false), allow_pipeline_compile_required_(false), quit_after_frame_ranges_(false),
+    use_asset_file_(false), block_index_(0), write_assets_(false), previous_write_assets_(false),
+    skip_threads_with_invalid_data_(false)
 {}
 
 CommonCaptureManager::~CommonCaptureManager()

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -73,18 +73,18 @@ class CommonCaptureManager
     static format::HandleId GetDefaultUniqueId() { return ++default_unique_id_counter_ + default_unique_id_offset_; }
 
   public:
-    static void SetDefaultUniqueIdOffset(format::HandleId offset) { default_unique_id_offset_ = offset; }
-
-    static format::HandleId GetUniqueId();
-    static void             PushUniqueId(const format::HandleId id);
-    static void             ClearUniqueIds();
+    static void SetupForRecaptureInReplay(format::HandleId offset, bool copy_data);
+    static bool IsRecaptureInReplay() { return recapture_in_replay_; }
+    static bool IsRecaptureCopyData() { return recapture_copy_data_; }
 
     static CommonCaptureManager* Get() { return singleton_; }
 
     // Set to true to force capture manager to generate new, default IDs instead of using the unique ID stack.
     static void SetForceDefaultUniqueId(bool force) { force_default_unique_id_ = force; }
 
-    static void SetInitializeLog(bool initialize_log) { initialize_log_ = initialize_log; }
+    static format::HandleId GetUniqueId();
+    static void             PushUniqueId(const format::HandleId id);
+    static void             ClearUniqueIds();
 
     using ApiSharedLockT    = std::shared_lock<ApiCallMutexT>;
     using ApiExclusiveLockT = std::unique_lock<ApiCallMutexT>;
@@ -223,9 +223,9 @@ class CommonCaptureManager
         return screenshot_format_;
     }
 
-    void CheckContinueCaptureForWriteMode(format::ApiFamilyId              api_family,
-                                          uint32_t                         current_boundary_count,
-                                          std::shared_lock<ApiCallMutexT>& current_lock);
+    void CheckContinueCaptureForTrimMode(format::ApiFamilyId              api_family,
+                                         uint32_t                         current_boundary_count,
+                                         std::shared_lock<ApiCallMutexT>& current_lock);
 
     void CheckStartCaptureForTrackMode(format::ApiFamilyId              api_family,
                                        uint32_t                         current_boundary_count,
@@ -314,10 +314,10 @@ class CommonCaptureManager
 
     enum CaptureModeFlags : uint32_t
     {
-        kModeDisabled      = 0x0,
-        kModeWrite         = 0x01,
-        kModeTrack         = 0x02,
-        kModeWriteAndTrack = (kModeWrite | kModeTrack)
+        kModeDisabled = 0x0,
+        kModeWrite    = 0x01,
+        kModeTrack    = 0x02,
+        kModeTrim     = 0x04, // Set when trimming is active.
     };
 
     enum PageGuardMemoryMode : uint32_t
@@ -333,6 +333,7 @@ class CommonCaptureManager
     util::ThreadData* GetThreadData();
     bool              IsCaptureModeTrack() const;
     bool              IsCaptureModeWrite() const;
+    bool              IsCaptureModeTrim() const;
     bool              IsCaptureModeDisabled() const;
     bool              IsCaptureSkippingCurrentThread() const;
 
@@ -546,7 +547,8 @@ class CommonCaptureManager
     static CommonCaptureManager*                          singleton_;
     static thread_local std::unique_ptr<util::ThreadData> thread_data_;
     static ApiCallMutexT                                  api_call_mutex_;
-    static bool                                           initialize_log_;
+    static bool                                           recapture_in_replay_;
+    static bool                                           recapture_copy_data_;
     static std::atomic<format::HandleId>                  default_unique_id_counter_;
     static uint64_t                                       default_unique_id_offset_;
     static thread_local bool                              force_default_unique_id_;

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -381,6 +381,16 @@ class CommonCaptureManager
     {
         return current_frame_;
     }
+    uint32_t GetRecaptureTrimStartFrame() const
+    {
+        GFXRECON_ASSERT(recapture_trim_start_frame_ > 0);
+        return recapture_trim_start_frame_;
+    }
+    void SetRecaptureTrimStartFrame(uint32_t frame_number)
+    {
+        GFXRECON_ASSERT(frame_number > 0);
+        recapture_trim_start_frame_ = frame_number;
+    }
     CaptureMode GetCaptureMode() const
     {
         return capture_mode_;
@@ -593,6 +603,7 @@ class CommonCaptureManager
     uint32_t                                trim_key_first_frame_;
     size_t                                  trim_current_range_;
     uint32_t                                current_frame_;
+    uint32_t                                recapture_trim_start_frame_;
     uint32_t                                queue_submit_count_;
     CaptureMode                             capture_mode_;
     bool                                    previous_hotkey_state_;

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2917,6 +2917,16 @@ void VulkanCaptureManager::PreProcess_vkFlushMappedMemoryRanges(VkDevice        
     }
 }
 
+void VulkanCaptureManager::SetOriginalMappedMemoryPointer(VkDeviceMemory memory, const void* original_ptr)
+{
+    auto wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceMemoryWrapper>(memory);
+    assert(wrapper != nullptr);
+    if (wrapper->mapped_data != nullptr)
+    {
+        wrapper->original_mapped_data = original_ptr;
+    }
+}
+
 void VulkanCaptureManager::PreProcess_vkUnmapMemory(VkDevice device, VkDeviceMemory memory)
 {
     auto wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceMemoryWrapper>(memory);
@@ -2931,6 +2941,7 @@ void VulkanCaptureManager::PreProcess_vkUnmapMemory(VkDevice device, VkDeviceMem
             GFXRECON_ASSERT(state_tracker_ != nullptr);
             state_tracker_->TrackAssetsInMemory(wrapper->handle_id);
         }
+        wrapper->original_mapped_data = nullptr;
 
         if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kPageGuard ||
             GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUserfaultfd)

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -108,8 +108,13 @@ void VulkanCaptureManager::DestroyInstance()
 
 void VulkanCaptureManager::WriteTrackedState(util::FileOutputStream* file_stream, util::ThreadData* thread_data)
 {
+    uint32_t trim_frame = GetCurrentFrame();
+    if (CommonCaptureManager::IsRecaptureCopyData())
+    {
+        trim_frame += (GetRecaptureTrimStartFrame() - 1);
+    }
     uint64_t n_blocks = state_tracker_->WriteState(
-        file_stream, thread_data, [] { return GetUniqueId(); }, GetCompressor(), GetCurrentFrame(), nullptr, nullptr);
+        file_stream, thread_data, [] { return GetUniqueId(); }, GetCompressor(), trim_frame, nullptr, nullptr);
 
     common_manager_->IncrementBlockIndex(n_blocks);
 }
@@ -119,12 +124,17 @@ void VulkanCaptureManager::WriteTrackedStateWithAssetFile(util::FileOutputStream
                                                           util::FileOutputStream* asset_file_stream,
                                                           const std::string*      asset_file_name)
 {
+    uint32_t trim_frame = GetCurrentFrame();
+    if (CommonCaptureManager::IsRecaptureCopyData())
+    {
+        trim_frame += (GetRecaptureTrimStartFrame() - 1);
+    }
     uint64_t n_blocks = state_tracker_->WriteState(
         file_stream,
         thread_data,
         [] { return GetUniqueId(); },
         GetCompressor(),
-        GetCurrentFrame(),
+        trim_frame,
         asset_file_stream,
         asset_file_name);
 

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1356,6 +1356,8 @@ class VulkanCaptureManager : public ApiCaptureManager
                                               uint32_t                   memoryRangeCount,
                                               const VkMappedMemoryRange* pMemoryRanges);
 
+    void SetOriginalMappedMemoryPointer(VkDeviceMemory memory, const void* original_ptr);
+
     void PreProcess_vkUnmapMemory(VkDevice device, VkDeviceMemory memory);
 
     void PreProcess_vkFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -281,6 +281,7 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
     // the memory.
     DeviceWrapper*   parent_device{ nullptr };
     const void*      mapped_data{ nullptr };
+    const void*      original_mapped_data{ nullptr };
     VkDeviceSize     mapped_offset{ 0 };
     VkDeviceSize     mapped_size{ 0 };
     VkMemoryMapFlags mapped_flags{ 0 };

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -3430,7 +3430,13 @@ void VulkanStateWriter::WriteMappedMemoryState(const VulkanStateTable& state_tab
             encoder_.EncodeUInt64Value(wrapper->mapped_offset);
             encoder_.EncodeUInt64Value(wrapper->mapped_size);
             encoder_.EncodeFlagsValue(wrapper->mapped_flags);
-            encoder_.EncodeVoidPtrPtr(&wrapper->mapped_data);
+
+            const void* mapped_data = wrapper->mapped_data;
+            if (wrapper->original_mapped_data != nullptr)
+            {
+                mapped_data = wrapper->original_mapped_data;
+            }
+            encoder_.EncodeVoidPtrPtr(&mapped_data);
             encoder_.EncodeEnumValue(result);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkMapMemory, &parameter_stream_);

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -311,9 +311,9 @@ void VulkanReplayConsumer::Process_vkMapMemory(
 {
     auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
     auto in_memory = GetObjectInfoTable().GetVkDeviceMemoryInfo(memory);
-    void** out_ppData = ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
+    ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
 
-    VkResult replay_result = OverrideMapMemory(GetDeviceTable(in_device->handle)->MapMemory, returnValue, in_device, in_memory, offset, size, flags, out_ppData);
+    VkResult replay_result = OverrideMapMemory(GetDeviceTable(in_device->handle)->MapMemory, returnValue, in_device, in_memory, offset, size, flags, ppData);
     CheckResult("vkMapMemory", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*ppData->GetPointer()), *ppData->GetOutputPointer(), format::ApiCallId::ApiCall_vkMapMemory, "vkMapMemory");
@@ -3640,9 +3640,9 @@ void VulkanReplayConsumer::Process_vkMapMemory2(
     auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
 
     MapStructHandles(pMemoryMapInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    void** out_ppData = ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
+    ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
 
-    VkResult replay_result = OverrideMapMemory2(GetDeviceTable(in_device->handle)->MapMemory2, returnValue, in_device, pMemoryMapInfo, out_ppData);
+    VkResult replay_result = OverrideMapMemory2(GetDeviceTable(in_device->handle)->MapMemory2, returnValue, in_device, pMemoryMapInfo, ppData);
     CheckResult("vkMapMemory2", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*ppData->GetPointer()), *ppData->GetOutputPointer(), format::ApiCallId::ApiCall_vkMapMemory2, "vkMapMemory2");
@@ -6000,9 +6000,9 @@ void VulkanReplayConsumer::Process_vkMapMemory2KHR(
     auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
 
     MapStructHandles(pMemoryMapInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    void** out_ppData = ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
+    ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
 
-    VkResult replay_result = OverrideMapMemory2(GetDeviceTable(in_device->handle)->MapMemory2KHR, returnValue, in_device, pMemoryMapInfo, out_ppData);
+    VkResult replay_result = OverrideMapMemory2(GetDeviceTable(in_device->handle)->MapMemory2KHR, returnValue, in_device, pMemoryMapInfo, ppData);
     CheckResult("vkMapMemory2KHR", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*ppData->GetPointer()), *ppData->GetOutputPointer(), format::ApiCallId::ApiCall_vkMapMemory2KHR, "vkMapMemory2KHR");

--- a/framework/generated/khronos_generators/khronos_base_generator.py
+++ b/framework/generated/khronos_generators/khronos_base_generator.py
@@ -468,6 +468,8 @@ class KhronosBaseGenerator(OutputGenerator):
         # These types represent pointers to non-Khronos objects that were written as 64-bit address IDs.
         self.EXTERNAL_OBJECT_TYPES = ['void', 'Void']
 
+        self.NEED_TEMP_VALUE_OVERRIDES = {}
+
         # Commands for which no code generation should be done
         self.MANUALLY_GENERATED_COMMANDS = set()
 

--- a/framework/generated/khronos_generators/khronos_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_replay_consumer_body_generator.py
@@ -623,6 +623,9 @@ class KhronosReplayConsumerBodyGenerator():
                     # instead of the PointerDecoder object.
                     need_temp_value = False
 
+                if name in self.NEED_TEMP_VALUE_OVERRIDES:
+                    need_temp_value = self.NEED_TEMP_VALUE_OVERRIDES[name]
+
                 # Determine name of variable specifying the length of an array.  An override may be required to
                 # replace the original length value with a temporary pointer variable.
                 length_name = value.array_length

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_base_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_base_generator.py
@@ -294,6 +294,12 @@ class VulkanBaseGenerator(KhronosBaseGenerator):
             "VkSurfaceCapabilities2KHR",
         ]
 
+        self.NEED_TEMP_VALUE_OVERRIDES = {
+            "vkMapMemory": False,
+            "vkMapMemory2": False,
+            "vkMapMemory2KHR": False,
+        }
+
         self.VIDEO_TREE = None
 
         self.generate_video = False

--- a/tools/optimize/dx12_resource_value_tracking_consumer.cpp
+++ b/tools/optimize/dx12_resource_value_tracking_consumer.cpp
@@ -30,7 +30,7 @@ Dx12ResourceValueTrackingConsumer::Dx12ResourceValueTrackingConsumer(
     Dx12ReplayConsumer(application, options),
     replay_resource_value_calls_(true)
 {
-    auto get_current_block_index_func = std::bind(static_cast<uint64_t (Dx12ReplayConsumerBase::*)(void)>(
+    auto get_current_block_index_func = std::bind(static_cast<uint64_t (Dx12ReplayConsumerBase::*)(void) const>(
                                                       &Dx12ResourceValueTrackingConsumer::GetCurrentBlockIndex),
                                                   this);
     GetResourceValueMapper()->EnableResourceValueTracker(get_current_block_index_func, experimental_tracker);

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -170,9 +170,11 @@ void android_main(struct android_app* app)
                     // Set replay to use the GetInstanceProcAddr function from RecaptureVulkanEntry so that replay first
                     // calls into the capture layer instead of directly into the loader and Vulkan runtime.
                     // Also sets the capture manager's instance and device creation callbacks.
-                    vulkan_replay_consumer.SetupForRecapture(gfxrecon::vulkan_recapture::GetInstanceProcAddr,
-                                                             gfxrecon::vulkan_recapture::dispatch_CreateInstance,
-                                                             gfxrecon::vulkan_recapture::dispatch_CreateDevice);
+                    vulkan_replay_consumer.SetupForRecaptureInReplay(
+                        gfxrecon::vulkan_recapture::GetInstanceProcAddr,
+                        gfxrecon::vulkan_recapture::dispatch_CreateInstance,
+                        gfxrecon::vulkan_recapture::dispatch_CreateDevice,
+                        file_processor.get());
                 }
 
                 ApiReplayOptions  api_replay_options;

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -212,9 +212,10 @@ int main(int argc, const char** argv)
                 // Set replay to use the GetInstanceProcAddr function from RecaptureVulkanEntry so that replay first
                 // calls into the capture layer instead of directly into the loader and Vulkan runtime.
                 // Set the capture manager's instance and device creation callbacks.
-                vulkan_replay_consumer.SetupForRecapture(gfxrecon::vulkan_recapture::GetInstanceProcAddr,
-                                                         gfxrecon::vulkan_recapture::dispatch_CreateInstance,
-                                                         gfxrecon::vulkan_recapture::dispatch_CreateDevice);
+                vulkan_replay_consumer.SetupForRecaptureInReplay(gfxrecon::vulkan_recapture::GetInstanceProcAddr,
+                                                                 gfxrecon::vulkan_recapture::dispatch_CreateInstance,
+                                                                 gfxrecon::vulkan_recapture::dispatch_CreateDevice,
+                                                                 file_processor.get());
             }
 
             ApiReplayOptions  api_replay_options;

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -34,7 +34,7 @@ const char kOptions[] =
     "indices,--dcp,--discard-cached-psos,--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names,--"
     "dx12-ags-inject-markers,--offscreen-swapchain-frame-boundary,--wait-before-present,--dump-resources-before-draw,"
     "--dump-resources-modifiable-state-only,--pbi-all,--preload-measurement-range,--add-new-pipeline-caches,--"
-    "screenshot-ignore-FrameBoundaryANDROID,--deduplicate-device,--log-timestamps,--capture";
+    "screenshot-ignore-FrameBoundaryANDROID,--deduplicate-device,--log-timestamps,--capture,--capture-copy-data";
 const char kArguments[] =
     "--log-level,--log-file,--cpu-mask,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--screenshot-interval,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -63,7 +63,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-size <width>x<height>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-scale <scale>] [--screenshot-interval <N>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--capture]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--capture][--capture-copy-data]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sfa | --skip-failed-allocations] [--replace-shaders <dir>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data] [--wsi <platform>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-cached-psos] [--surface-index <N>]");
@@ -205,6 +205,18 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("       \t\t\tcapture functionality is included in the `gfxrecon-replay`");
     GFXRECON_WRITE_CONSOLE("       \t\t\texecutable--no GFXR capture layer is added to the Vulkan layer");
     GFXRECON_WRITE_CONSOLE("       \t\t\tchain.");
+    GFXRECON_WRITE_CONSOLE("  --capture-copy-data");
+    GFXRECON_WRITE_CONSOLE("       \t\t\tAn extended version of `--capture` that can be used with");
+    GFXRECON_WRITE_CONSOLE("       \t\t\ttrimming. The capture data within the trim range is");
+    GFXRECON_WRITE_CONSOLE("       \t\t\tcopied directly from the source capture file into the");
+    GFXRECON_WRITE_CONSOLE("       \t\t\tnew trimmed file. Note that replay must still run in");
+    GFXRECON_WRITE_CONSOLE("       \t\t\torder to generate the trim state block. Portable replay");
+    GFXRECON_WRITE_CONSOLE("       \t\t\tfeatures are not supported. For example, replay");
+    GFXRECON_WRITE_CONSOLE("       \t\t\tshould be done on the same device as capture, memory");
+    GFXRECON_WRITE_CONSOLE("       \t\t\ttranslation options are not supported, and if ray");
+    GFXRECON_WRITE_CONSOLE("       \t\t\ttracing is used, the device must support Vulkan's opaque");
+    GFXRECON_WRITE_CONSOLE("       \t\t\tcapture and replay features. This option also forces on");
+    GFXRECON_WRITE_CONSOLE("       \t\t\tthe option `swapchain --captured`.");
     GFXRECON_WRITE_CONSOLE("  --sfa\t\t\tSkip vkAllocateMemory, vkAllocateCommandBuffers, and");
     GFXRECON_WRITE_CONSOLE("       \t\t\tvkAllocateDescriptorSets calls that failed during");
     GFXRECON_WRITE_CONSOLE("       \t\t\tcapture (same as --skip-failed-allocations).");


### PR DESCRIPTION
Adds replay option `--capture-copy-data`. This option is An extended version of `--capture` that can be used with trimming. The capture data within the trim range is copied directly from the source capture file into the new trimmed file. Note that replay must still run in order to generate the trim state block. Portable replay features are not supported. For example, replay should be done on the same device as capture, memory translation options are not supported, and if ray tracing is used, the device must support Vulkan's opaque capture and replay features.

This option currently forces on the option `swapchain --captured`, but this requirement is planned to be removed in future work.

Dependent on PR #2567