### PR TITLE
Deduplicate Unknown block warnings

### DIFF
--- a/framework/decode/block_parser.h
+++ b/framework/decode/block_parser.h
@@ -112,6 +112,8 @@ class BlockParser
     ParsedBlock ParseAnnotation(BlockBuffer& block_buffer);
 
     void HandleBlockReadError(BlockIOError error_code, const char* error_message);
+    void
+    WarnUnknownBlock(const BlockBuffer& block_buffer, const char* sub_type_label = nullptr, uint32_t sub_type = 0U);
 
     struct DecompressionResult
     {

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -318,18 +318,8 @@ bool FileProcessor::ProcessBlocks()
                             }
                         }
                     }
-                    else if (parsed_block.IsUnknown())
-                    {
-                        // Unrecognized block type.
-                        GFXRECON_LOG_WARNING("Skipping unrecognized file block with type %u (frame %u block %" PRIu64
-                                             ")",
-                                             block_buffer.Header().type,
-                                             current_frame_number_,
-                                             block_index_);
-                        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, block_buffer.Header().size);
-                        // Replacing the result of SkipBytes. The BlockBuffer read succeeded, so skip would.
-                        success = true;
-                    }
+
+                    // NOTE: Warnings for unknown/invalid blocks are handled in the BlockParser
 
                     if (process_visitor.IsFrameDelimiter())
                     {


### PR DESCRIPTION
All unknown block warnings are now localized to the BlockParser, such that policy choices like "warn once" can be done were the condition is identified and best known.

Fixes #2545 