### PR TITLE
Fix for unassisted

### DIFF
--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -641,8 +641,7 @@ void VulkanStateTracker::TrackMappedMemory(VkDevice         device,
                                            void*            mapped_data,
                                            VkDeviceSize     mapped_offset,
                                            VkDeviceSize     mapped_size,
-                                           VkMemoryMapFlags mapped_flags,
-                                           bool             track_assets)
+                                           VkMemoryMapFlags mapped_flags)
 {
     assert((device != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
@@ -651,12 +650,6 @@ void VulkanStateTracker::TrackMappedMemory(VkDevice         device,
     wrapper->mapped_offset = mapped_offset;
     wrapper->mapped_size   = mapped_size;
     wrapper->mapped_flags  = mapped_flags;
-
-    // Scan assets on unmap
-    if (track_assets && mapped_data == nullptr)
-    {
-        TrackMappedAssetsWrites(wrapper->handle_id);
-    }
 }
 
 void VulkanStateTracker::TrackBeginRenderPass(VkCommandBuffer command_buffer, const VkRenderPassBeginInfo* begin_info)
@@ -3329,6 +3322,11 @@ void VulkanStateTracker::TrackAssetsInSubmission(uint32_t submitCount, const VkS
 
         TrackMappedAssetsWrites(format::kNullHandleId);
     }
+}
+
+void VulkanStateTracker::TrackAssetsInMemory(format::HandleId memory_id)
+{
+    TrackMappedAssetsWrites(memory_id);
 }
 
 void VulkanStateTracker::TrackBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo)

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -387,8 +387,7 @@ class VulkanStateTracker
                            void*            mapped_data,
                            VkDeviceSize     mapped_offset,
                            VkDeviceSize     mapped_size,
-                           VkMemoryMapFlags mapped_flags,
-                           bool             track_assets);
+                           VkMemoryMapFlags mapped_flags);
 
     void TrackBeginRenderPass(VkCommandBuffer command_buffer, const VkRenderPassBeginInfo* begin_info);
 
@@ -747,6 +746,8 @@ class VulkanStateTracker
     void TrackAssetsInSubmission(uint32_t submitCount, const VkSubmitInfo* pSubmits);
 
     void TrackAssetsInSubmission(uint32_t submitCount, const VkSubmitInfo2* pSubmits);
+
+    void TrackAssetsInMemory(format::HandleId memory_id);
 
     void TrackBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo);
 


### PR DESCRIPTION
On vkUnmapMemory memory wrapper's information was zeroed out before reaching the unassisted logic. This caused artifacts when replaying captures that were captured using the unassisted memory tracking method. This commit fixes the issue