### PR TITLE
VDR: Fix for secondaries

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -318,7 +318,7 @@ VulkanReplayDumpResourcesBase::FindDrawCallCommandBufferContext(VkCommandBuffer 
 
     for (auto it = draw_call_contexts_.begin(); it != draw_call_contexts_.end(); ++it)
     {
-        if (it->first.second == qs_index)
+        if (it->first.first == bcb_index && it->first.second == qs_index)
         {
             return &it->second;
         }
@@ -448,7 +448,7 @@ VulkanReplayDumpResourcesBase::FindDispatchRaysCommandBufferContext(VkCommandBuf
 
     for (auto it = dispatch_ray_contexts_.begin(); it != dispatch_ray_contexts_.end(); ++it)
     {
-        if (it->first.second == qs_index)
+        if (it->first.first == bcb_index && it->first.second == qs_index)
         {
             return &it->second;
         }


### PR DESCRIPTION
Logical error in search functions that are used to look up dumping contexts was causing them to return wrong contexts which led to crashes. This commit should address this