### PR TITLE
Fix packed LUID conversions

### DIFF
--- a/framework/encode/parameter_encoder.h
+++ b/framework/encode/parameter_encoder.h
@@ -77,7 +77,7 @@ class ParameterEncoder
     void EncodeD3D_FEATURE_LEVELValue(D3D_FEATURE_LEVEL value) { EncodeValue(value); }
 #endif // ENABLE_OPENXR_SUPPORT
     void EncodeLARGE_INTEGERValue(LARGE_INTEGER& value) { EncodeValue(value.QuadPart); }
-    void EncodeLUIDValue(LUID value) { EncodeValue(*reinterpret_cast<int64_t*>(&value)); }
+    void EncodeLUIDValue(LUID value) { EncodeValue((static_cast<uint64_t>(value.HighPart) << 32) | value.LowPart); }
 
     // Encode the address values for pointers to non-Vulkan objects to be used as object IDs.
     void EncodeAddress(const void* value)                                                                             { EncodeValue(reinterpret_cast<format::AddressEncodeType>(value)); }


### PR DESCRIPTION
Two commits. I'm on Linux, so I'm unable to test the Windows-only changes. Hopefully CI will handle that.

---
Add and use packed_luid() function

Nearly all of the open-coded implementations were wrong in multiple ways:

- shifting by 31 instead of 32
- shifting a 32-bit value (the HighPart) without first casting to a 64-bit type
- shifting into the sign bit (undefined behavior)

---
Use packed_luid() to avoid aliasing violation

This solves the compile error when building with `-Werror=strict-aliasing`.

```
/home/mattst88/projects/gfxreconstruct/framework/encode/parameter_encoder.h: In member function ‘void gfxrecon::encode::ParameterEncoder::EncodeLUIDValue(LUID)’:
/home/mattst88/projects/gfxreconstruct/framework/encode/parameter_encoder.h:80:53: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
   80 |     void EncodeLUIDValue(LUID value) { EncodeValue(*reinterpret_cast<int64_t*>(&value)); }
      |                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Closes: https://github.com/LunarG/gfxreconstruct/issues/2358

---

cc: @igorbrsn, @JerryAMD, @rurra-amd because they all introduced instances of `<< 31`
cc: @jzulauf-lunarg because he introduced the aliasing violation and then dutifully ignored issue #2358