### PR TITLE
Move "Entering android_main" message

### DIFF
--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -102,8 +102,8 @@ extern "C"
 
 void android_main(struct android_app* app)
 {
-    GFXRECON_WRITE_CONSOLE("====== Entering android_main");
     gfxrecon::util::Log::Init();
+    GFXRECON_WRITE_CONSOLE("====== Entering android_main");
 
     // Keep screen on while window is active.
     ANativeActivity_setWindowFlags(app->activity, AWINDOW_FLAG_KEEP_SCREEN_ON, 0);


### PR DESCRIPTION
The "Entering android_main" message was called before the logger was initialized. This worked because Log::Settings is set to valid defaults, allowing GFXRECON_WRITE_CONSOLE to pass through the function and trigger the Android log message.