### PR TITLE
Remove unnecessary payload `data_size` duplication

### DIFF
--- a/framework/decode/api_payload.h
+++ b/framework/decode/api_payload.h
@@ -429,8 +429,6 @@ struct InitSubresourceArgs
 struct InitDx12AccelerationStructureArgs
 {
     format::MetaDataId meta_data_id; // Needed by DispatchVisitor, but not ApiDecoder
-    // Note: the command header has uniquely named size field... so duplicate this info for visitor use
-    size_t data_size; // Needed for deferred decompression, but not ApiDecoder
 
     format::InitDx12AccelerationStructureCommandHeader             command_header;
     std::vector<format::InitDx12AccelerationStructureGeometryDesc> geometry_descs;
@@ -548,7 +546,7 @@ struct AnnotationArgs
 
     // NOTE: The string name is intentionally *not* data to differ from the "data" fields that are uint8_t *
     // parameter data for the next level Decode operations, simplifying DispatchHasData logic
-    std::string            annotation_data;
+    std::string annotation_data;
 
     auto GetTuple() const { return std::tie(block_index, type, label, annotation_data); }
 };

--- a/framework/decode/block_parser.cpp
+++ b/framework/decode/block_parser.cpp
@@ -1223,7 +1223,7 @@ ParsedBlock BlockParser::ParseMetaData(BlockBuffer& block_buffer)
         success = success && block_buffer.Read(header.inputs_flags);
         success = success && block_buffer.Read(header.inputs_num_instance_descs);
         success = success && block_buffer.Read(header.inputs_num_geometry_descs);
-        success = success && block_buffer.Read(header.inputs_data_size);
+        success = success && block_buffer.Read(header.data_size);
 
         // Parse geometry descs.
         std::vector<format::InitDx12AccelerationStructureGeometryDesc> geom_descs;
@@ -1250,15 +1250,12 @@ ParsedBlock BlockParser::ParseMetaData(BlockBuffer& block_buffer)
         if (success)
         {
             const char*         label       = "init DX12 acceleration structure meta-data block";
-            ParameterReadResult read_result = ReadParameterBuffer(label, block_buffer, header.inputs_data_size);
+            ParameterReadResult read_result = ReadParameterBuffer(label, block_buffer, header.data_size);
             if (read_result.success)
             {
                 return ParsedBlock(block_buffer.ReleaseData(),
-                                   InitDx12AccelerationStructureArgs{ meta_data_id,
-                                                                      read_result.uncompressed_size,
-                                                                      header,
-                                                                      geom_descs,
-                                                                      read_result.buffer.GetDataAs<uint8_t>() },
+                                   InitDx12AccelerationStructureArgs{
+                                       meta_data_id, header, geom_descs, read_result.buffer.GetDataAs<uint8_t>() },
                                    read_result.is_compressed);
             }
         }

--- a/framework/decode/dx12_acceleration_structure_builder.cpp
+++ b/framework/decode/dx12_acceleration_structure_builder.cpp
@@ -236,9 +236,8 @@ void Dx12AccelerationStructureBuilder::SetupBuild(
 
         // Map GPU VAs in instance desc input data.
         temp_instance_desc_input_data_.clear();
-        temp_instance_desc_input_data_.insert(temp_instance_desc_input_data_.end(),
-                                              build_inputs_data,
-                                              build_inputs_data + command_header.inputs_data_size);
+        temp_instance_desc_input_data_.insert(
+            temp_instance_desc_input_data_.end(), build_inputs_data, build_inputs_data + command_header.data_size);
         constexpr auto address_stride = sizeof(D3D12_RAYTRACING_INSTANCE_DESC);
         constexpr auto address_offset = offsetof(D3D12_RAYTRACING_INSTANCE_DESC, AccelerationStructure);
         for (UINT i = 0; i < inputs_desc.NumDescs; ++i)
@@ -260,7 +259,7 @@ void Dx12AccelerationStructureBuilder::SetupBuild(
     graphics::dx12::GetAccelerationStructureInputsBufferEntries(
         inputs_desc, temp_geometry_descs_.data(), inputs_buffer_size, inputs_buffer_entries);
 
-    GFXRECON_ASSERT(inputs_buffer_size == command_header.inputs_data_size);
+    GFXRECON_ASSERT(inputs_buffer_size == command_header.data_size);
 
     // Get required sizes and update buffers.
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuild_info;
@@ -275,7 +274,7 @@ void Dx12AccelerationStructureBuilder::SetupBuild(
     UpdateBufferSize(device5_,
                      inputs_buffer_,
                      inputs_buffer_size_,
-                     command_header.inputs_data_size,
+                     command_header.data_size,
                      D3D12_HEAP_TYPE_UPLOAD,
                      D3D12_RESOURCE_STATE_GENERIC_READ,
                      D3D12_RESOURCE_FLAG_NONE);
@@ -292,9 +291,9 @@ void Dx12AccelerationStructureBuilder::SetupBuild(
     }
 
     // Write inputs data to resources.
-    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, command_header.inputs_data_size);
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, command_header.data_size);
     HRESULT hr =
-        MapSubresourceAndWriteData(inputs_buffer_, 0, static_cast<size_t>(command_header.inputs_data_size), final_data);
+        MapSubresourceAndWriteData(inputs_buffer_, 0, static_cast<size_t>(command_header.data_size), final_data);
     GFXRECON_ASSERT(SUCCEEDED(hr));
 
     // Fix GPU VAs that point into buffers.

--- a/framework/decode/dx12_json_consumer_base.cpp
+++ b/framework/decode/dx12_json_consumer_base.cpp
@@ -115,11 +115,11 @@ void Dx12JsonConsumerBase::ProcessInitDx12AccelerationStructureCommand(
         json_options);
     FieldToJson(jdata["inputs_num_instance_descs"], command_header.inputs_num_instance_descs, json_options);
     FieldToJson(jdata["inputs_num_geometry_descs"], command_header.inputs_num_geometry_descs, json_options);
-    FieldToJson(jdata["inputs_data_size"], command_header.inputs_data_size, json_options);
+    FieldToJson(jdata["data_size"], command_header.data_size, json_options);
     RepresentBinaryFile(*(this->writer_),
                         jdata[format::kNameData],
                         "initdx12accelerationstructurecommand.bin",
-                        command_header.inputs_data_size,
+                        command_header.data_size,
                         build_inputs_data);
     FieldToJson(jdata["geometry_descs"], geometry_descs.data(), geometry_descs.size(), json_options);
     writer_->WriteBlockEnd();

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -38,7 +38,8 @@ Dx12StateWriter::Dx12StateWriter(util::FileOutputStream* output_stream,
                                  util::Compressor*       compressor,
                                  format::ThreadId        thread_id,
                                  util::FileOutputStream* asset_file_stream) :
-    output_stream_(output_stream), compressor_(compressor), thread_id_(thread_id), encoder_(&parameter_stream_)
+    output_stream_(output_stream),
+    compressor_(compressor), thread_id_(thread_id), encoder_(&parameter_stream_)
 {
     assert(output_stream != nullptr);
 }
@@ -790,7 +791,7 @@ void Dx12StateWriter::WriteMetaCommandCreationState(const Dx12StateTable& state_
         for (auto wrapper : metacommand_wrappers)
         {
             // Write the meta command init call.
-            auto                          wrapper_info = wrapper->GetObjectInfo();
+            auto wrapper_info = wrapper->GetObjectInfo();
             if (wrapper_info->was_initialized == true)
             {
                 format::InitializeMetaCommand init_meta_command;
@@ -846,13 +847,13 @@ void Dx12StateWriter::WriteResourceSnapshots(
             begin_cmd.meta_header.block_header.type = format::kMetaDataBlock;
             begin_cmd.meta_header.meta_data_id      = format::MakeMetaDataId(
                 format::ApiFamilyId::ApiFamily_D3D12, format::MetaDataType::kBeginResourceInitCommand);
-            begin_cmd.thread_id       = thread_id_;
-            begin_cmd.device_id       = device_id;
+            begin_cmd.thread_id = thread_id_;
+            begin_cmd.device_id = device_id;
 
             // TODO: adjust to hold sum of resource-sizes
             begin_cmd.total_copy_size = max_resource_size;
 
-            begin_cmd.max_copy_size   = max_resource_size;
+            begin_cmd.max_copy_size = max_resource_size;
 
             output_stream_->Write(&begin_cmd, sizeof(begin_cmd));
 
@@ -1748,12 +1749,12 @@ void Dx12StateWriter::WriteAccelerationStructuresState(
 
         // Get NumDescs and data sizes.
         size_t inputs_data_ptr_file_size = 0;
-        cmd.inputs_data_size             = 0;
+        cmd.data_size                    = 0;
         cmd.inputs_num_instance_descs    = 0;
         cmd.inputs_num_geometry_descs    = 0;
         if (write_build_data)
         {
-            cmd.inputs_data_size = as_build.input_data_size - as_build.input_data_header_size;
+            cmd.data_size = as_build.input_data_size - as_build.input_data_header_size;
             if (as_build.inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL)
             {
                 cmd.inputs_num_geometry_descs = as_build.inputs.NumDescs;
@@ -1767,15 +1768,15 @@ void Dx12StateWriter::WriteAccelerationStructuresState(
                 GFXRECON_ASSERT(false && "Invalid D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE.");
             }
 
-            GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, cmd.inputs_data_size);
-            inputs_data_ptr_file_size = static_cast<size_t>(cmd.inputs_data_size);
+            GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, cmd.data_size);
+            inputs_data_ptr_file_size = static_cast<size_t>(cmd.data_size);
             if (compressor_ != nullptr)
             {
                 // Compress block data.
                 size_t compressed_size =
                     compressor_->Compress(inputs_data_ptr_file_size, inputs_data_ptr, &compressed_parameter_buffer_, 0);
 
-                if ((compressed_size > 0) && (compressed_size < cmd.inputs_data_size))
+                if ((compressed_size > 0) && (compressed_size < cmd.data_size))
                 {
                     cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
 

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -616,7 +616,7 @@ struct InitDx12AccelerationStructureCommandHeader
     uint32_t       inputs_flags{ 0 };
     uint32_t       inputs_num_instance_descs{ 0 }; ///< NumDescs for TLAS
     uint32_t       inputs_num_geometry_descs{ 0 }; ///< NumDescs for BLAS
-    uint64_t       inputs_data_size{ 0 };
+    uint64_t       data_size{ 0 };
 
     // In the capture file, accel struct data is written in the following order:
     // InitDx12AccelerationStructureCommandHeader

--- a/tools/compress/compression_converter.cpp
+++ b/tools/compress/compression_converter.cpp
@@ -413,7 +413,7 @@ decode::FileTransformer::VisitResult CompressionConverter::WriteMetaData(const d
     if (init_cmd.data_size > 0)
     {
         GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.data_size);
-        size_t data_size = static_cast<size_t>(init_cmd.data_size);
+        size_t         data_size    = static_cast<size_t>(init_cmd.data_size);
         const uint8_t* data_address = args.data;
 
         PrepMetadataBlock(init_cmd.meta_header, args.meta_data_id, data_address, data_size);
@@ -501,8 +501,8 @@ CompressionConverter::WriteMetaData(const decode::InitDx12AccelerationStructureA
     const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geom_descs = args.geometry_descs;
     GFXRECON_ASSERT(args.geometry_descs.size() == init_cmd.inputs_num_geometry_descs);
 
-    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.inputs_data_size);
-    size_t         data_size    = static_cast<size_t>(init_cmd.inputs_data_size);
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.data_size);
+    size_t         data_size    = static_cast<size_t>(init_cmd.data_size);
     const uint8_t* data_address = args.data;
 
     PrepMetadataBlock(init_cmd.meta_header, args.meta_data_id, data_address, data_size);


### PR DESCRIPTION
The `InitDx12AccelerationStructureCommandHeader` meta command header already contains the "uncompressed data size" as a field, it is just named `inputs_data_size` instead of `data_size`.

Because of this, an additonal `data_size` field has been added to the associated API Payload structure instead of simply renaming the field.

I propose to remove this additional `data_size` field and rename `inputs_data_size` into `data_size` to be more coherent with the meta command dispatching framework.