### PR TITLE
macOS: Ignore some warnings

### DIFF
--- a/android/framework/util/CMakeLists.txt
+++ b/android/framework/util/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(gfxrecon_util
                    ${GFXRECON_SOURCE_DIR}/framework/util/callbacks.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/callbacks.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/clock_cache.h
+                   ${GFXRECON_SOURCE_DIR}/framework/util/compiler_diagnostics.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/compressor.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/date_time.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/date_time.cpp

--- a/framework/application/metal_context.mm
+++ b/framework/application/metal_context.mm
@@ -24,7 +24,6 @@
 #include "application/metal_context.h"
 #include "application/metal_window.h"
 #include "application/application.h"
-#include <AppKit/AppKit.h>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)

--- a/framework/application/metal_window.h
+++ b/framework/application/metal_window.h
@@ -25,8 +25,11 @@
 #define GFXRECON_APPLICATION_METAL_WINDOW_H
 
 #include "decode/window.h"
+#include "util/compiler_diagnostics.h"
 
+GFXRECON_BEGIN_SUPPRESS_APPLE_SDK_WARNINGS
 #include <AppKit/AppKit.h>
+GFXRECON_END_SUPPRESS_APPLE_SDK_WARNINGS
 
 @class GFXReconWindowDelegate;
 

--- a/framework/application/metal_window.mm
+++ b/framework/application/metal_window.mm
@@ -25,8 +25,10 @@
 #include "application/metal_context.h"
 #include "application/application.h"
 
+GFXRECON_BEGIN_SUPPRESS_APPLE_SDK_WARNINGS
 #include <Carbon/Carbon.h>
 #include <QuartzCore/QuartzCore.h>
+GFXRECON_END_SUPPRESS_APPLE_SDK_WARNINGS
 
 #if !__has_feature(objc_arc)
 #error "Compile this with -fobjc-arc"

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(gfxrecon_util
                     ${CMAKE_CURRENT_LIST_DIR}/callbacks.h
                     ${CMAKE_CURRENT_LIST_DIR}/callbacks.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/clock_cache.h
+                    ${CMAKE_CURRENT_LIST_DIR}/compiler_diagnostics.h
                     ${CMAKE_CURRENT_LIST_DIR}/compressor.h
                     ${CMAKE_CURRENT_LIST_DIR}/date_time.h
                     ${CMAKE_CURRENT_LIST_DIR}/date_time.cpp

--- a/framework/util/compiler_diagnostics.h
+++ b/framework/util/compiler_diagnostics.h
@@ -1,0 +1,43 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_URIL_COMPILER_DIAGNOSTICS_H
+#define GFXRECON_URIL_COMPILER_DIAGNOSTICS_H
+
+#if defined(__clang__)
+#define GFXRECON_BEGIN_SUPPRESS_APPLE_SDK_WARNINGS                                                     \
+    _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"") \
+        _Pragma("clang diagnostic ignored \"-Welaborated-enum-base\"")                                 \
+            _Pragma("clang diagnostic ignored \"-Wdeprecated-anon-enum-enum-conversion\"")             \
+                _Pragma("clang diagnostic ignored \"-Wdeprecated-enum-enum-conversion\"")              \
+                    _Pragma("clang diagnostic ignored \"-Wavailability\"")
+#else
+#define GFXRECON_BEGIN_SUPPRESS_APPLE_SDK_WARNINGS
+#endif
+
+#ifdef __clang__
+#define GFXRECON_END_SUPPRESS_APPLE_SDK_WARNINGS _Pragma("clang diagnostic pop")
+#else
+#define GFXRECON_END_SUPPRESS_APPLE_SDK_WARNINGS
+#endif
+
+#endif // GFXRECON_URIL_COMPILER_DIAGNOSTICS_H

--- a/framework/util/keyboard.cpp
+++ b/framework/util/keyboard.cpp
@@ -38,7 +38,9 @@
 #endif
 
 #if defined(VK_USE_PLATFORM_METAL_EXT)
+GFXRECON_BEGIN_SUPPRESS_APPLE_SDK_WARNINGS
 #include <Carbon/Carbon.h>
+GFXRECON_END_SUPPRESS_APPLE_SDK_WARNINGS
 #endif
 
 #include <unordered_map>

--- a/framework/util/strings.h
+++ b/framework/util/strings.h
@@ -27,9 +27,12 @@
 #define GFXRECON_UTIL_STRINGS_H
 
 #include "util/defines.h"
+#include "util/compiler_diagnostics.h"
 
 #include <string>
+GFXRECON_BEGIN_SUPPRESS_APPLE_SDK_WARNINGS
 #include <vector>
+GFXRECON_END_SUPPRESS_APPLE_SDK_WARNINGS
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)


### PR DESCRIPTION
Some macOS SDK headers may trigger several warnings treated as errors in our build. We can't do much other than ignoring them.