### PR TITLE
tools/convert: accept 0-based frame ranges

### DIFF
--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -32,7 +32,6 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-// TODO GH #1195: frame numbering should be 1-based.
 const uint32_t kFirstFrame = 0;
 
 FileProcessor::FileProcessor() :

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -171,7 +171,7 @@ static bool GetFrameIndices(const gfxrecon::util::ArgumentParser& arg_parser, st
     if (!input_ranges.empty())
     {
         std::vector<gfxrecon::util::UintRange> frame_ranges =
-            gfxrecon::util::GetUintRanges(input_ranges.c_str(), "frames to be converted", true);
+            gfxrecon::util::GetUintRanges(input_ranges.c_str(), "frames to be converted", true, true);
 
         for (uint32_t i = 0; i < frame_ranges.size(); ++i)
         {


### PR DESCRIPTION
Align convert --frame-range with 0-based frame numbering.

Refs: #1195, #2483