### PR TITLE
capture: unleash the chaos (aka 0-based frame numbering)

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -51,8 +51,7 @@ extern char** environ;
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-// One based frame count.
-const uint32_t kFirstFrame           = 1;
+const uint32_t kFirstFrame           = 0;
 const size_t   kFileStreamBufferSize = 256 * 1024;
 
 CommonCaptureManager*                          CommonCaptureManager::singleton_;


### PR DESCRIPTION
Heads up, this is the tiny-looking change with giant consequences. We are intentionally touching the capture output path, which means:
- golden files will drift,
- baselines will scream,
- every bot will wake up at once,
- and the CI lights are about to turn a festive shade of red.

This is not a bug, it’s a feature of progress.
Please forgive the noise while the new reality settles in.

Refs: #1195, #2483