### PR TITLE
fix some cmake warnings

### DIFF
--- a/layer/ags_capture/CMakeLists.txt
+++ b/layer/ags_capture/CMakeLists.txt
@@ -37,9 +37,7 @@ target_include_directories(ags_capture PUBLIC
                            ${PROJECT_SOURCE_DIR})
 target_link_libraries(ags_capture gfxrecon_util ${LINK_AGS_OUTPUT})
 add_custom_command(TARGET ags_capture PRE_BUILD
-                    COMMAND lib /def:${CMAKE_CURRENT_LIST_DIR}/amd_ags_x64_orig.def /out:${LINK_AGS_OUTPUT} /machine:${LINK_ARCH}
-                    DEPENDS ${CMAKE_CURRENT_LIST_DIR}/amd_ags_x64_orig.def)
-
+                    COMMAND lib /def:${CMAKE_CURRENT_LIST_DIR}/amd_ags_x64_orig.def /out:${LINK_AGS_OUTPUT} /machine:${LINK_ARCH})
 
 install(FILES $<TARGET_FILE_DIR:ags_capture>/amd_ags_x64_capture.dll DESTINATION ${CMAKE_INSTALL_BINDIR}/d3d12_capture)
 

--- a/layer/d3d12/CMakeLists.txt
+++ b/layer/d3d12/CMakeLists.txt
@@ -44,8 +44,7 @@ target_include_directories(d3d12
 target_link_libraries(d3d12 gfxrecon_encode gfxrecon_util ${LINK_D3D12_OUTPUT})
 common_build_directives(d3d12)
 add_custom_command(TARGET d3d12 PRE_BUILD
-                    COMMAND lib /def:${CMAKE_CURRENT_LIST_DIR}/d3d12_ms.def /out:${LINK_D3D12_OUTPUT} /machine:${LINK_ARCH}
-                    DEPENDS ${CMAKE_CURRENT_LIST_DIR}/d3d12_ms.def)
+                    COMMAND lib /def:${CMAKE_CURRENT_LIST_DIR}/d3d12_ms.def /out:${LINK_D3D12_OUTPUT} /machine:${LINK_ARCH})
 
 install(FILES $<TARGET_FILE_DIR:d3d12>/d3d12.dll DESTINATION ${CMAKE_INSTALL_BINDIR}/d3d12_capture)
 

--- a/layer/dxgi/CMakeLists.txt
+++ b/layer/dxgi/CMakeLists.txt
@@ -38,7 +38,6 @@ target_include_directories(dxgi PUBLIC ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}
 target_link_libraries(dxgi gfxrecon_encode gfxrecon_util ${LINK_DXGI_OUTPUT})
 common_build_directives(dxgi)
 add_custom_command(TARGET dxgi PRE_BUILD
-                    COMMAND lib /def:${CMAKE_CURRENT_LIST_DIR}/dxgi_ms.def /out:${LINK_DXGI_OUTPUT} /machine:${LINK_ARCH}
-                    DEPENDS ${CMAKE_CURRENT_LIST_DIR}/dxgi_ms.def)
+                    COMMAND lib /def:${CMAKE_CURRENT_LIST_DIR}/dxgi_ms.def /out:${LINK_DXGI_OUTPUT} /machine:${LINK_ARCH})
 
 install(FILES $<TARGET_FILE_DIR:dxgi>/dxgi.dll DESTINATION ${CMAKE_INSTALL_BINDIR}/d3d12_capture)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -28,8 +28,7 @@ if (D3D12_SUPPORT)
 
     add_custom_target(gfxrecon-optimize-renamed.py ALL)
 
-    add_custom_command(TARGET gfxrecon-optimize-renamed.py
-                       DEPENDS ${CMAKE_SOURCE_SOURCE_DIR}/gfxrecon-optimize-renamed.py
+    add_custom_command(TARGET gfxrecon-optimize-renamed.py POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon-optimize-renamed.py ${CMAKE_CURRENT_BINARY_DIR}/gfxrecon-optimize-renamed.py)
 
     install(FILES gfxrecon-optimize-renamed.py DESTINATION ${CMAKE_INSTALL_BINDIR} PERMISSIONS
@@ -37,8 +36,7 @@ if (D3D12_SUPPORT)
 
     add_custom_target(gfxrecon-replay-renamed.py ALL)
 
-    add_custom_command(TARGET gfxrecon-replay-renamed.py
-                       DEPENDS ${CMAKE_SOURCE_SOURCE_DIR}/gfxrecon-replay-renamed.py
+    add_custom_command(TARGET gfxrecon-replay-renamed.py POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gfxrecon-replay-renamed.py ${CMAKE_CURRENT_BINARY_DIR}/gfxrecon-replay-renamed.py)
 
     install(FILES gfxrecon-replay-renamed.py DESTINATION ${CMAKE_INSTALL_BINDIR} PERMISSIONS


### PR DESCRIPTION
* delete illegal "DEPENDS" keyword from add_custom_command
* add POST_BUILD to some add_custom_command

Should quiet some of the warnings printed by CMake 3.31 and later.