### PR TITLE
Build and ship x86_64 ABI for Android

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -190,9 +190,9 @@ jobs:
         if [ "${{ matrix.config.type }}" == "release" ]
         then
           sh gradlew assembleRelease -Parm64-v8a
-          sh gradlew assembleRelease -Parmeabi-v7a
+          sh gradlew assembleRelease -Px86_64
         else
-          sh gradlew assembleDebug -Parm64-v8a
+          sh gradlew assembleDebug
         fi
     - name: Prepare artifacts
       run: |
@@ -206,7 +206,7 @@ jobs:
         if [ "${{ matrix.config.type }}" == "release" ]
         then
             cp -r android/layer/build/intermediates/cxx/RelWithDebInfo/*/obj/arm64-v8a gfxreconstruct-dev/layer/
-            cp -r android/layer/build/intermediates/cxx/RelWithDebInfo/*/obj/armeabi-v7a gfxreconstruct-dev/layer/
+            cp -r android/layer/build/intermediates/cxx/RelWithDebInfo/*/obj/x86_64 gfxreconstruct-dev/layer/
         else
             cp android/tools/replay/build/outputs/apk/debug/replay-debug.apk gfxreconstruct-dev/tools/
         fi

--- a/.github/workflows/sdk_android_build.yml
+++ b/.github/workflows/sdk_android_build.yml
@@ -57,7 +57,7 @@ jobs:
         cp USAGE_android.md gfxreconstruct-dev/
         cp layer/vk_layer_settings.txt gfxreconstruct-dev/
         cp -r android/layer/build/intermediates/cxx/RelWithDebInfo/*/obj/arm64-v8a gfxreconstruct-dev/layer/
-        cp -r android/layer/build/intermediates/cxx/RelWithDebInfo/*/obj/armeabi-v7a gfxreconstruct-dev/layer/
+        cp -r android/layer/build/intermediates/cxx/RelWithDebInfo/*/obj/x86_64 gfxreconstruct-dev/layer/
         cp android/tools/replay/build/outputs/apk/debug/replay-debug.apk gfxreconstruct-dev/tools/
         cp android/scripts/gfxrecon.py gfxreconstruct-dev/tools/
     - name: Upload artifacts


### PR DESCRIPTION
1. In release builds: Build and ship Android x86_64 ABI instead of the Android armeabi-v7a ABI. This should have no impact on the CI execution time.

2. In debug builds: Build the default set of ABIs, which is {arm64, x86_64} in build.gradle. This will build a second ABI, which will double the CI execution time of the AndroidDebug workflow (but it should take same time as the AndroidRelease workflow).