### PR TITLE
Pass original pipelines to CreateRayTracingPipelines during capture.

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1604,7 +1604,6 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
             deferred_operation_wrapper->p_allocator = nullptr;
         }
         deferred_operation_wrapper->create_infos.resize(createInfoCount);
-        deferred_operation_wrapper->pipelines.resize(createInfoCount);
         deferred_operation_wrapper->pPipelines    = pPipelines;
         deferred_operation_wrapper->pipelineCache = pipelineCache;
     }
@@ -1636,28 +1635,8 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                                                                 createInfoCount,
                                                                 deferred_operation_wrapper->create_infos.data(),
                                                                 deferred_operation_wrapper->p_allocator,
-                                                                deferred_operation_wrapper->pipelines.data());
-
-            if ((result == VK_OPERATION_NOT_DEFERRED_KHR) || (result == VK_SUCCESS))
-            {
-                // VK_OPERATION_NOT_DEFERRED_KHR means the operation successfully completed immediately, so here we copy
-                // the created pipelines to original array which is used to store them by target application.
-                //
-                // Note:
-                //       VK_OPERATION_DEFERRED_KHR means the operation is successfully deferred, but the pipeline
-                //       creation might not be finished. We must therefore lean on
-                //       vkDeferredOperationJoinKHR/vkGetDeferredOperationResultKHR to get the final result. If the
-                //       result indicated the operation has finished, then the created pipelines are ready for use.
-                //
-                //       By Vulkan doc of VK_KHR_deferred_host_operations, if deferred operation object was
-                //       provided and the operation successfully completed immediately without deferring, the
-                //       command return VK_OPERATION_NOT_DEFERRED_KHR. Some hardware/driver may return VK_SUCCESS on
-                //       such case, so same handling is proceeded with VK_SUCCESS.
-                //
-                std::memcpy(
-                    pPipelines, deferred_operation_wrapper->pipelines.data(), sizeof(VkPipeline) * createInfoCount);
-            }
-            else if (result == VK_OPERATION_DEFERRED_KHR)
+                                                                pPipelines);
+            if (result == VK_OPERATION_DEFERRED_KHR)
             {
                 const std::lock_guard<std::mutex> lock(deferred_operation_mutex);
                 deferred_operation_wrapper->pending_state = true;
@@ -1688,15 +1667,8 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                                                                 createInfoCount,
                                                                 deferred_operation_wrapper->create_infos.data(),
                                                                 deferred_operation_wrapper->p_allocator,
-                                                                deferred_operation_wrapper->pipelines.data());
-            if ((result == VK_OPERATION_NOT_DEFERRED_KHR) || (result == VK_SUCCESS))
-            {
-                // If the driver doesn't defer the command, and instead completed the operation immediately, we copy the
-                // created pipelines to original array which is used to store them by target application.
-                std::memcpy(
-                    pPipelines, deferred_operation_wrapper->pipelines.data(), sizeof(VkPipeline) * createInfoCount);
-            }
-            else if (result == VK_OPERATION_DEFERRED_KHR)
+                                                                pPipelines);
+            if (result == VK_OPERATION_DEFERRED_KHR)
             {
                 const std::lock_guard<std::mutex> lock(deferred_operation_mutex);
                 deferred_operation_wrapper->pending_state = true;
@@ -1782,9 +1754,6 @@ void VulkanCaptureManager::DeferredOperationPostProcess(VkDevice               d
     {
         deferred_operation_wrapper->pending_state = false;
         uint32_t create_info_count                = deferred_operation_wrapper->create_infos.size();
-        std::memcpy(deferred_operation_wrapper->pPipelines,
-                    deferred_operation_wrapper->pipelines.data(),
-                    sizeof(VkPipeline) * deferred_operation_wrapper->create_infos.size());
 
         vulkan_wrappers::CreateWrappedHandles<vulkan_wrappers::DeviceWrapper,
                                               vulkan_wrappers::DeferredOperationKHRWrapper,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -510,8 +510,7 @@ struct DeferredOperationKHRWrapper : public HandleWrapper<VkDeferredOperationKHR
     std::vector<VkRayTracingPipelineCreateInfoKHR> create_infos;
     VkAllocationCallbacks                          allocator{};
     VkAllocationCallbacks*                         p_allocator{ nullptr };
-    std::vector<VkPipeline>                        pipelines;
-    VkPipeline*                                    pPipelines;
+    VkPipeline*                                    pPipelines; // count is the same as create_infos.size().
     VkPipelineCache                                pipelineCache;
     bool                                           pending_state = false;
 };


### PR DESCRIPTION
Not to allocate a new pipeline and pass the new pipelines, instead of passing the original pipelines