### PR TITLE
Disable `offscreen_swapchain_frame_boundary` swapchain option when `VK_EXT_frame_boundary` is not supported

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3277,6 +3277,9 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
         // Fake VK_EXT_frame_boundary if requested, but not supported
         if (sanitize_faked_extension(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
         {
+            VulkanSwapchainOptions modified_options = swapchain_->GetOptions();
+            modified_options.offscreen_swapchain_frame_boundary = false;
+            swapchain_->SetOptions(modified_options);
             // also remove related feature-struct from pnext-chain
             if (graphics::vulkan_struct_remove_pnext<VkPhysicalDeviceFrameBoundaryFeaturesEXT>(&modified_create_info))
             {

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3277,9 +3277,17 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
         // Fake VK_EXT_frame_boundary if requested, but not supported
         if (sanitize_faked_extension(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
         {
-            VulkanSwapchainOptions modified_options             = swapchain_->GetOptions();
-            modified_options.offscreen_swapchain_frame_boundary = false;
-            swapchain_->SetOptions(modified_options);
+            VulkanSwapchainOptions options             = swapchain_->GetOptions();
+            if (options.offscreen_swapchain_frame_boundary)
+            {
+                GFXRECON_LOG_ERROR(
+                    "--offscreen-swapchain-frame-boundary was enabled but %s "
+                    "is not available on the replay device. Quitting replay.",
+                    VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME
+                );
+                std::abort();
+            }
+
             // also remove related feature-struct from pnext-chain
             if (graphics::vulkan_struct_remove_pnext<VkPhysicalDeviceFrameBoundaryFeaturesEXT>(&modified_create_info))
             {

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3277,14 +3277,12 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
         // Fake VK_EXT_frame_boundary if requested, but not supported
         if (sanitize_faked_extension(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
         {
-            VulkanSwapchainOptions options             = swapchain_->GetOptions();
+            VulkanSwapchainOptions options = swapchain_->GetOptions();
             if (options.offscreen_swapchain_frame_boundary)
             {
-                GFXRECON_LOG_ERROR(
-                    "--offscreen-swapchain-frame-boundary was enabled but %s "
-                    "is not available on the replay device. Quitting replay.",
-                    VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME
-                );
+                GFXRECON_LOG_ERROR("--offscreen-swapchain-frame-boundary was enabled but %s "
+                                   "is not available on the replay device. Quitting replay.",
+                                   VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME);
                 std::abort();
             }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3277,7 +3277,7 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
         // Fake VK_EXT_frame_boundary if requested, but not supported
         if (sanitize_faked_extension(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
         {
-            VulkanSwapchainOptions modified_options = swapchain_->GetOptions();
+            VulkanSwapchainOptions modified_options             = swapchain_->GetOptions();
             modified_options.offscreen_swapchain_frame_boundary = false;
             swapchain_->SetOptions(modified_options);
             // also remove related feature-struct from pnext-chain

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -62,6 +62,7 @@ class VulkanSwapchain
 
     virtual void CleanDeviceResources(VkDevice, const graphics::VulkanDeviceTable*) {}
 
+    VulkanSwapchainOptions GetOptions() { return swapchain_options_; }
     void SetOptions(const VulkanSwapchainOptions& options) { swapchain_options_ = options; }
 
     virtual VkResult CreateSurface(VkResult                             original_result,


### PR DESCRIPTION
Resolves #1467 

This PR adds logic to disable the `offscreen_swapchain_frame_boundary` swapchain option if `VK_EXT_frame_boundary` is unsupported by the replay device.

A method is added to allow retrieving a copy of the swapchain options in order to facilitate modifying the existing option set.