### PR TITLE
Use a global map to track Shader ID to LRS associations

### DIFF
--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -460,8 +460,7 @@ struct D3D12StateObjectInfo : DxObjectExtraInfo
     static constexpr char             kObjectType[] = "ID3D12StateObjectInfo";
     D3D12StateObjectInfo() : DxObjectExtraInfo(kType) {}
 
-    std::map<std::wstring, format::HandleId>                              export_name_lrs_map;
-    std::map<graphics::Dx12ShaderIdentifier, std::set<ResourceValueInfo>> shader_id_lrs_map;
+    std::map<std::wstring, format::HandleId> export_name_lrs_map;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/dx12_resource_value_mapper.cpp
+++ b/framework/decode/dx12_resource_value_mapper.cpp
@@ -767,8 +767,7 @@ void Dx12ResourceValueMapper::PostProcessCreateStateObject(
                     auto local_root_sig_extra_info = GetExtraInfo<D3D12RootSignatureInfo>(local_root_sig_object_info);
                     GFXRECON_ASSERT(local_root_sig_extra_info != nullptr);
 
-                    state_object_extra_info->shader_id_lrs_map[replay_shader_id] =
-                        local_root_sig_extra_info->resource_value_infos;
+                    shader_id_lrs_map_[replay_shader_id] = local_root_sig_extra_info->resource_value_infos;
                 }
             }
         }
@@ -1259,8 +1258,8 @@ bool Dx12ResourceValueMapper::MapValue(const ResourceValueInfo& value_info,
         resource_info->mapped_shader_ids[final_offset] = replay_shader_id;
 
         // Map values in the shader record's local root signature.
-        auto shader_id_lrs_iter = value_info.state_object->shader_id_lrs_map.find(replay_shader_id);
-        if (shader_id_lrs_iter != value_info.state_object->shader_id_lrs_map.end())
+        auto shader_id_lrs_iter = shader_id_lrs_map_.find(replay_shader_id);
+        if (shader_id_lrs_iter != shader_id_lrs_map_.end())
         {
             for (const auto& shader_record_value_info : shader_id_lrs_iter->second)
             {

--- a/framework/decode/dx12_resource_value_mapper.h
+++ b/framework/decode/dx12_resource_value_mapper.h
@@ -231,8 +231,9 @@ class Dx12ResourceValueMapper
     std::unique_ptr<Dx12ResourceValueTracker>       resource_value_tracker_;
     bool                                            performed_rv_mapping_{ false };
 
-    const graphics::Dx12GpuVaMap&    gpu_va_map_;
-    const decode::Dx12DescriptorMap& descriptor_map_;
+    const graphics::Dx12GpuVaMap&                                         gpu_va_map_;
+    const decode::Dx12DescriptorMap&                                      descriptor_map_;
+    std::map<graphics::Dx12ShaderIdentifier, std::set<ResourceValueInfo>> shader_id_lrs_map_;
 
     bool do_value_mapping_;
 


### PR DESCRIPTION
Each shader identifier should be globally unique so it isn't necessary to track shader IDs per state object.

Below are supporting statements from the [DXR spec](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html):

**[Shader identifier](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#shader-identifier)**
"A shader identifier is an opaque data blob of 32 bytes that uniquely identifies (within the current device / process) one of the raytracing shaders"

"An application might create the same shader multiple times. This could be the same code but with same or different export names, potentially across separate raytracing pipelines or collections of code ([described later](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#state-object-types)). In this case the seemingly identical shaders may or may not return the same identifier depending on the implementation. Regardless, execution behavior will be consistent with the specified shader code."

**Regarding differing shader IDs on duplicate shaders:**

Update v1.24 05/30/2024 - "In GetShaderIdentifier removed the sentence: "The data itself globally identifies the shader, so even if the shader appears in a different state object (with same associations like any root signatures) it will have the same identifier.". This contradicted the text in Shader identifier that allows for duplicate shaders to have the same or different identifier depending on implementation."
