### PR TITLE
Prevent false error detection on EOF during PeekBytes

### DIFF
--- a/framework/decode/block_parser.cpp
+++ b/framework/decode/block_parser.cpp
@@ -46,7 +46,10 @@ BlockIOError BlockParser::ReadBlockBuffer(FileInputStreamPtr& input_stream, Bloc
     }
     else if (peeked_bytes < sizeof(block_size))
     {
-        // The file ended, but doesn't contain even a full header's information
+        // The file ended, but doesn't contain even a full block_size field
+        // Clear the peek buffer, to make sure the input_stream reports EOF
+        // We don't need the result, just the side_effect
+        input_stream->ReadBytes(&block_size, peeked_bytes);
         status = kErrorReadingBlockHeader;
     }
 


### PR DESCRIPTION
The Peek failed with bytes still in the read_ahead_buffer (it asked for 8 but there were only 7 remaining in the file).  PeekBytes doesn't *consume* the accessed bytes so the input_stream though it wasn't EOF (you could still read from it), and since it wasn't EOF FileProcessor assumed that the PeekBytes failure must have been an Error.