### PR TITLE
Move block parsing to preload for optimized --preload-measurement-range performance

### DIFF
--- a/framework/decode/block_parser.h
+++ b/framework/decode/block_parser.h
@@ -75,7 +75,7 @@ class BlockParser
     // Always: non-preloaded replay
     // Never:  file transforming tools that pass through most blocks without decoding
     // Queue Optimized: pre-loaded replay of ParsedBlocks
-    enum DecompressionPolicy
+    enum class DecompressionPolicy
     {
         kAlways = 0,     // Always decompress parameter data when parsing blocks
         kNever,          // Never decompress parameter data when parsing blocks

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -32,8 +32,6 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-const uint32_t kFirstFrame = 0;
-
 FileProcessor::FileProcessor() :
     current_frame_number_(kFirstFrame), error_state_(kErrorInvalidFileDescriptor), bytes_read_(0),
     annotation_handler_(nullptr), compressor_(nullptr), block_index_(0), block_limit_(0),
@@ -83,57 +81,40 @@ bool FileProcessor::Initialize(const std::string& filename)
             HandleBlockReadError(err, message);
         } };
         block_parser_ = std::make_unique<BlockParser>(err_handler, pool_, compressor_.get());
-        success       = block_parser_.get() != nullptr;
-        if (!success)
+        if (block_parser_.get() != nullptr)
+        {
+            // For immediate dispatching (the default mode of operation) no need to defer decompression
+            block_parser_->SetDecompressionPolicy(BlockParser::DecompressionPolicy::kAlways);
+        }
+        else
         {
             error_state_ = kErrorOpeningFile;
+            success      = false;
         }
     }
 
     return success;
 }
 
-std::string FileProcessor::ApplyAbsolutePath(const std::string& file)
-{
-    if (absolute_path_.empty())
-    {
-        return file;
-    }
-
-    return absolute_path_ + file;
-}
-
 bool FileProcessor::ProcessNextFrame()
 {
-    auto block_processor = [this]() { return this->ProcessBlocksOneFrame(); };
-    return DoProcessNextFrame(block_processor);
-}
-
-bool FileProcessor::ProcessBlocksOneFrame()
-{
-    for (ApiDecoder* decoder : decoders_)
-    {
-        decoder->SetCurrentFrameNumber(current_frame_number_);
-    }
-    block_parser_->SetDecompressionPolicy(BlockParser::DecompressionPolicy::kAlways);
-    return ProcessBlocks();
-}
-
-bool FileProcessor::DoProcessNextFrame(const std::function<bool()>& block_processor)
-{
-    bool success = IsFileValid();
-
-    if (success)
-    {
-
-        success = block_processor();
-    }
-    else
+    if (!IsFileValid())
     {
         error_state_ = CheckFileStatus();
+        return false;
     }
 
-    return success;
+    DispatchVisitor  dispatch_visitor(decoders_, annotation_handler_);
+    DispatchFunction dispatch = [this, &dispatch_visitor](uint64_t block_index, ParsedBlock& block) {
+        dispatch_visitor.SetBlockIndex(block_index);
+        std::visit(dispatch_visitor, block.GetArgs());
+        return ProcessBlockState::kRunning;
+    };
+
+    SetDecoderFrameNumber(current_frame_number_);
+    ProcessBlockState process_result = ProcessBlocks(dispatch, true /* check decoder completion */);
+
+    return ContinueProcessing(process_result);
 }
 
 bool FileProcessor::ProcessAllFrames()
@@ -153,25 +134,25 @@ bool FileProcessor::ProcessAllFrames()
     return (error_state_ == kErrorNone);
 }
 
-bool FileProcessor::ContinueDecoding()
+bool FileProcessor::ContinueDecoding(uint64_t block_index, bool check_decoders)
 {
     bool early_exit = false;
     // If a block limit was specified, obey it.
     // If not (block_limit_ = 0),  then the consumer may determine early exit
     if (block_limit_ > 0)
     {
-        if (block_index_ > block_limit_)
+        if (block_index > block_limit_)
         {
             early_exit = true;
         }
     }
-    else
+    else if (check_decoders)
     {
         int completed_decoders = 0;
 
         for (auto& decoder : decoders_)
         {
-            if (decoder->IsComplete(block_index_) == true)
+            if (decoder->IsComplete(block_index) == true)
             {
                 completed_decoders++;
             }
@@ -272,31 +253,21 @@ void FileProcessor::DecrementRemainingCommands()
     }
 }
 
-bool FileProcessor::ProcessBlocks()
+FileProcessor::ProcessBlockState FileProcessor::ProcessBlocks(DispatchFunction& dispatch, bool check_decoder_completion)
 {
-    BlockBuffer block_buffer;
-    bool        success = true;
+    BlockBuffer       block_buffer;
+    ProcessBlockState process_state = ProcessBlockState::kRunning;
+    BlockParser&      block_parser  = *block_parser_.get();
+    ProcessVisitor    process_visitor(*this);
 
-    BlockParser& block_parser = GetBlockParser();
-    // NOTE: To test deferred decompression operation uncomment next line
-    // block_parser.SetDecompressionPolicy(BlockParser::DecompressionPolicy::kQueueOptimized);
-
-    ProcessVisitor  process_visitor(*this);
-    DispatchVisitor dispatch_visitor(decoders_, annotation_handler_);
-
-    while (success)
+    while (process_state == ProcessBlockState::kRunning)
     {
         PrintBlockInfo();
-        success = ContinueDecoding();
+        bool success = ContinueDecoding(block_index_, check_decoder_completion);
 
         if (success)
         {
-            success = GetBlockBuffer(block_parser, block_buffer);
-
-            for (auto decoder : decoders_)
-            {
-                decoder->SetCurrentBlockIndex(block_index_);
-            }
+            success = ReadBlockBuffer(block_parser, block_buffer);
 
             if (success)
             {
@@ -324,33 +295,61 @@ bool FileProcessor::ProcessBlocks()
                             success = process_visitor.IsSuccess();
                             if (success)
                             {
-                                std::visit(dispatch_visitor, parsed_block.GetArgs());
+                                process_state = dispatch(block_index_, parsed_block);
+                                if ((ProcessBlockState::kRunning == process_state) &&
+                                    process_visitor.IsFrameDelimiter())
+                                {
+                                    process_state = ProcessBlockState::kFrameBoundary;
+                                }
+                            }
+                            else
+                            {
+                                process_state = ProcessBlockState::kError;
                             }
                         }
+                        else
+                        {
+                            // Decompression failed. Decompress logs error.
+                            process_state = ProcessBlockState::kError;
+                        }
                     }
-
-                    // NOTE: Warnings for unknown/invalid blocks are handled in the BlockParser
-
-                    if (process_visitor.IsFrameDelimiter())
+                    else if (parsed_block.IsUnknown())
                     {
-                        // The ProcessVisitor (pre-dispatch) is not the right place to update the frame state, so do it
-                        // here
-                        UpdateEndFrameState();
-                        break;
+                        // Unrecognized block type.
+                        GFXRECON_LOG_WARNING("Skipping unrecognized file block with type %u (frame %u block %" PRIu64
+                                             ")",
+                                             block_buffer.Header().type,
+                                             current_frame_number_,
+                                             block_index_);
+                        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, block_buffer.Header().size);
+                    }
+                    else if (!parsed_block.IsValid())
+                    {
+                        // Invalid block. Error already logged in ParseBlock.
+                        process_state = ProcessBlockState::kError;
                     }
                 }
+                ++block_index_;
+                DecrementRemainingCommands();
             }
-            else
+            else // ReadBlockBuffer failed
             {
-                success = HandleBlockEof("read", true);
+                process_state = HandleBlockEof("read", true);
             }
         }
-        ++block_index_;
-        DecrementRemainingCommands();
+        else // ContinueDecoding returned false
+        {
+            process_state = ProcessBlockState::kEndProcessing;
+        }
     }
 
-    DecrementRemainingCommands();
-    return success;
+    // Update the frame number etc.
+    if (process_state == ProcessBlockState::kFrameBoundary)
+    {
+        UpdateEndFrameState();
+    }
+
+    return process_state;
 }
 
 // While ReadBlockBuffer both reads the block header and the block body, checks for
@@ -373,12 +372,6 @@ bool FileProcessor::ReadBlockBuffer(BlockParser& parser, BlockBuffer& block_buff
         success = false;
     }
     return success;
-}
-
-// Preloading overloads this to get preloaded blocks
-bool FileProcessor::GetBlockBuffer(BlockParser& parser, BlockBuffer& block_buffer)
-{
-    return ReadBlockBuffer(parser, block_buffer);
 }
 
 bool FileProcessor::ReadBytes(void* buffer, size_t buffer_size)
@@ -411,6 +404,18 @@ util::DataSpan FileProcessor::ReadSpan(size_t bytes)
         bytes_read_ += bytes;
     }
     return read_span;
+}
+
+bool FileProcessor::IsFileValid() const
+{
+    if (!file_stack_.empty())
+    {
+        return file_stack_.back().active_file->IsReady();
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool FileProcessor::SeekActiveFile(const FileInputStreamPtr&      active_file,
@@ -525,7 +530,6 @@ void FileProcessor::UpdateEndFrameState()
 
     // Make sure to increment the frame number on the way out.
     ++current_frame_number_;
-    ++block_index_;
 }
 
 bool FileProcessor::ProcessFrameDelimiter(gfxrecon::format::ApiCallId call_id)
@@ -635,10 +639,10 @@ void FileProcessor::PrintBlockInfo() const
     }
 }
 
-bool FileProcessor::HandleBlockEof(const char* operation, bool report_frame_and_block)
+FileProcessor::ProcessBlockState FileProcessor::HandleBlockEof(const char* operation, bool report_frame_and_block)
 {
 
-    bool success = false;
+    ProcessBlockState state = ProcessBlockState::kEndProcessing;
     if (!AtEof())
     {
         // No data has been read for the current block, so we don't use 'HandleBlockReadError' here, as it
@@ -659,6 +663,7 @@ bool FileProcessor::HandleBlockEof(const char* operation, bool report_frame_and_
         }
 
         error_state_ = kErrorReadingBlockHeader;
+        state        = ProcessBlockState::kError;
     }
     else
     {
@@ -668,10 +673,21 @@ bool FileProcessor::HandleBlockEof(const char* operation, bool report_frame_and_
         if (current_file.execute_till_eof)
         {
             file_stack_.pop_back();
-            success = !file_stack_.empty();
+            if (!file_stack_.empty())
+            {
+                state = ProcessBlockState::kRunning;
+            }
         }
     }
-    return success;
+    return state;
+}
+
+void FileProcessor::SetDecoderFrameNumber(uint64_t frame_number)
+{
+    for (auto* decoder : decoders_)
+    {
+        decoder->SetCurrentFrameNumber(frame_number);
+    }
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_transformer.cpp
+++ b/framework/decode/file_transformer.cpp
@@ -87,7 +87,7 @@ bool FileTransformer::Initialize(const std::string& input_filename,
         success = block_parser_ != nullptr;
         if (success)
         {
-            block_parser_->SetDecompressionPolicy(BlockParser::kNever);
+            block_parser_->SetDecompressionPolicy(BlockParser::DecompressionPolicy::kNever);
         }
         else
         {

--- a/framework/decode/preload_file_processor.cpp
+++ b/framework/decode/preload_file_processor.cpp
@@ -24,6 +24,8 @@
 #include "decode/preload_file_processor.h"
 #include "util/logging.h"
 
+#include <memory>
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
@@ -31,90 +33,182 @@ PreloadFileProcessor::PreloadFileProcessor() {}
 
 void PreloadFileProcessor::PreloadNextFrames(size_t count)
 {
-    while (--count != 0U)
+    if (!IsFileValid())
     {
-        DoProcessNextFrame([this]() { return this->PreloadBlocksOneFrame(); });
+        error_state_ = CheckFileStatus();
+        return;
     }
-    preload_block_data_ = std::move(pending_block_data_);
-}
 
-bool PreloadFileProcessor::PreloadBlocksOneFrame()
-{
-    BlockBuffer block_buffer;
-    bool        success = true;
+    // Block processing will update current_frame_number_, so save and restore it,
+    // as callers rely on it remaining unchanged by preload.
+    const uint64_t save_current_frame = current_frame_number_;
 
-    BlockParser block_parser([this](BlockIOError err, const char* message) { HandleBlockReadError(err, message); },
-                             pool_,
-                             compressor_.get());
-
-    while (success)
+    // Escalate block reference policy to owned to retain backing store for preloaded blocks
+    auto save_reference_policy = block_parser_->GetBlockReferencePolicy();
+    if (save_reference_policy == ParsedBlock::BlockReferencePolicy::kNonOwnedReference)
     {
-        PrintBlockInfo();
-        success = ContinueDecoding();
+        // Only need to change if was non-owned
+        block_parser_->SetBlockReferencePolicy(ParsedBlock::BlockReferencePolicy::kOwnedReferenceAsNeeded);
+    }
 
-        if (success)
+    // Use queue-optimized to set early decompression for "small" parsed blocks
+    auto save_decompression_policy = block_parser_->GetDecompressionPolicy();
+    block_parser_->SetDecompressionPolicy(BlockParser::DecompressionPolicy::kQueueOptimized);
+
+    preloaded_frames_.clear();
+    preloaded_frames_.reserve(count);
+
+    ProcessBlockState preload_result = ProcessBlockState::kFrameBoundary;
+    while ((count != 0U) && (preload_result == ProcessBlockState::kFrameBoundary))
+    {
+        uint64_t         current_preload_frame = current_frame_number_;
+        ParsedBlockQueue frame_blocks;
+        preload_result = PreloadBlocksOneFrame(frame_blocks);
+
+        if (preload_result != ProcessBlockState::kError)
         {
-            success = ReadBlockBuffer(block_parser, block_buffer);
-            if (success)
-            {
-                // Valid checks for the presence and size of the data span matching the header
-                success = block_buffer.IsValid();
+            // This is for the corner case where we are seeing an explicit frame boundary, for a file
+            // that assumes implicit frame boundaries on specific function call blocks.
+            // A WARNING is logged during block processing when this occurs.
 
-                if (success)
+            // We have two strategies to deal with this case:
+            const bool frame_stutter = (preload_result == ProcessBlockState::kFrameBoundary) &&
+                                       (current_frame_number_ == current_preload_frame);
+            if (frame_stutter)
+            {
+                // Deal with the frame marker after implied frame kFunctionCallBlock frame boundary case
+                GFXRECON_ASSERT(current_frame_number_ == (kFirstFrame + 1));
+                if (preloaded_frames_.empty())
                 {
-                    // Note: in order to support kExecuteBlocksFromFile in preload, we need to add special case logic
-                    //       to look for the meta data block here, and allow it to push itself on the stack, and then
-                    //       add command counting here as well.
-                    const bool end_of_frame = block_buffer.IsFrameDelimiter(*this);
-                    // Record the block data for replay, Moves DataSpan out of BlockBuffer, so don't use after this.
-                    // NOTE: It is intentional to only store only the data span to make preload lightweight a possible
-                    pending_block_data_.emplace_back(std::move(block_buffer.ReleaseData()));
-                    if (end_of_frame)
-                    {
-                        // GFXRECON_LOG_INFO("Frame delimiter encountered during preload, ending frame preload.");
-                        break;
-                    }
+                    // This is really part of the non-preloaded previous (first) frame,
+                    // so immediately replay it to complete that frame
+                    PreloadedFrame temp_frame(kFirstFrame);
+                    temp_frame.AppendMovedBlocks(frame_blocks);
+                    ProcessBlockState replay_result = ReplayOneFrame(temp_frame);
+                    GFXRECON_ASSERT(replay_result == ProcessBlockState::kFrameBoundary);
                 }
                 else
                 {
-                    std::string msg = "Failed to preload block data of size " +
-                                      std::to_string(block_buffer.Header().size) + " for block type " +
-                                      format::ToString(block_buffer.Header().type);
-                    HandleBlockReadError(kErrorReadingBlockData, msg.c_str());
+                    // Append the blocks leading up to the frame marker to the previous frame
+                    // completing that frame with the stuttered frame marker
+                    GFXRECON_ASSERT(!frame_blocks.empty());
+                    preloaded_frames_.back()->AppendMovedBlocks(frame_blocks);
                 }
             }
             else
             {
-                // We can succeed at EOF, if there are more files on the stack.
-                success = HandleBlockEof("preload", false /* no frame or block info */);
+                // Normal case, just add the preloaded frame
+                preloaded_frames_.emplace_back(std::make_unique<PreloadedFrame>(current_preload_frame));
+                preloaded_frames_.back()->AppendMovedBlocks(frame_blocks);
+                count--;
             }
         }
     }
 
-    return success;
-}
+    // Need to remember how preloading ended to know what to do after replay completes
+    final_process_state_ = preload_result;
 
-// Grab the block data off the front of the
-bool PreloadFileProcessor::GetBlockBuffer(BlockParser& block_parser, BlockBuffer& block_buffer)
-{
-    // Quick escape
-    if (preload_block_data_.empty())
+    if (count)
     {
-        return Base::GetBlockBuffer(block_parser, block_buffer);
+        const uint64_t found = preloaded_frames_.size();
+        const uint64_t total = count + found;
+        GFXRECON_LOG_INFO("Preload did not load all measurement frames. %" PRIu64 " frames found, %" PRIu64 " expected",
+                          found,
+                          total);
     }
 
-    block_buffer = BlockBuffer(std::move(preload_block_data_.front()));
-    preload_block_data_.pop_front();
+    current_preloaded_frame_ = preloaded_frames_.begin();
 
-    // Caller expects read position just past header
-    // Again the pattern is to validate the header presense, not span consistency
-    bool success = block_buffer.SeekTo(sizeof(format::BlockHeader));
+    // Restore the original parser policies
+    block_parser_->SetBlockReferencePolicy(save_reference_policy);
+    block_parser_->SetDecompressionPolicy(save_decompression_policy);
 
-    // However, preload should never add data the doesn't result in a valid block_buffer.
-    // Should have failed in preload.
-    GFXRECON_ASSERT(block_buffer.IsValid());
+    // Restore saved frame number callers expect it to be unchanged by preload
+    current_frame_number_ = save_current_frame;
+}
 
-    return success;
+FileProcessor::ProcessBlockState PreloadFileProcessor::PreloadBlocksOneFrame(ParsedBlockQueue& frame_queue)
+{
+    DispatchFunction dispatch = [&frame_queue](uint64_t block_index, ParsedBlock& block) {
+        frame_queue.emplace_back(std::move(block));
+        return ProcessBlockState::kRunning;
+    };
+
+    return ProcessBlocks(dispatch, false /* check decoder completion */);
+}
+
+bool PreloadFileProcessor::ProcessNextFrame()
+{
+    // Clean up preloaded frames if we're at the end of the preloaded frames.  It's done here
+    // so that the clean up time is not measured in the measurement-frame-range timing.
+    if (!preloaded_frames_.empty() && current_preloaded_frame_ == preloaded_frames_.end())
+    {
+        preloaded_frames_.clear();
+        current_preloaded_frame_ = preloaded_frames_.end();
+    }
+
+    // Passthrough if no preloaded frames.
+    if (preloaded_frames_.empty())
+    {
+        return FileProcessor::ProcessNextFrame();
+    }
+
+    PreloadedFrame&   frame          = *(current_preloaded_frame_->get());
+    ProcessBlockState process_result = ReplayOneFrame(frame);
+    ++current_preloaded_frame_;
+
+    const bool at_end = (current_preloaded_frame_ == preloaded_frames_.end());
+    if (at_end)
+    {
+        if (IsFrameBoundary(process_result) && IsFrameBoundary(final_process_state_))
+        {
+            // If we reached the end of preloaded frames on a frame boundary, increment the frame number
+            current_frame_number_++;
+        }
+        // Return true only if both the replay and preload are in a continue state
+        return ContinueProcessing(process_result) && ContinueProcessing(final_process_state_);
+    }
+
+    if (IsFrameBoundary(process_result))
+    {
+        current_frame_number_++;
+    }
+    return ContinueProcessing(process_result);
+}
+
+FileProcessor::ProcessBlockState PreloadFileProcessor::ReplayOneFrame(PreloadedFrame& frame)
+{
+    BlockParser&    block_parser = GetBlockParser();
+    DispatchVisitor dispatch_visitor(decoders_, annotation_handler_);
+    SetDecoderFrameNumber(frame.frame_number);
+
+    ProcessBlockState process_state = ProcessBlockState::kFrameBoundary;
+    for (auto& queued_block : frame.blocks)
+    {
+        uint64_t block_index = queued_block.GetBlockIndex();
+        if (!ContinueDecoding(block_index, true /* check decoder completion */))
+        {
+            process_state = ProcessBlockState::kEndProcessing;
+            break;
+        }
+
+        // We assume that only known, vistable blocks were preloaded
+        GFXRECON_ASSERT(queued_block.IsVisitable());
+
+        if (queued_block.NeedsDecompression())
+        {
+            if (!queued_block.Decompress(block_parser))
+            {
+                process_state = ProcessBlockState::kError;
+                break;
+            }
+        }
+
+        dispatch_visitor.SetBlockIndex(block_index);
+        std::visit(dispatch_visitor, queued_block.GetArgs());
+    }
+
+    return process_state;
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -80,7 +80,7 @@ bool FpsInfo::ShouldWaitIdleBeforeFrame(uint64_t frame)
 
 bool FpsInfo::ShouldQuit(uint64_t frame)
 {
-    return (quit_after_range_ && (frame > measurement_end_frame_)) || (quit_after_frame_ && frame > quit_frame_);
+    return (quit_after_range_ && (frame >= measurement_end_frame_)) || (quit_after_frame_ && frame > quit_frame_);
 }
 
 void FpsInfo::BeginFrame(uint64_t frame)

--- a/tools/compress/compression_converter.cpp
+++ b/tools/compress/compression_converter.cpp
@@ -105,7 +105,7 @@ bool CompressionConverter::ProcessMetaData(decode::ParsedBlock& parsed_block)
     // We can infer format::IsBlockCompressed from NeedsDecompression as long
     // as the DecompressionPolicy is "never".
     auto& block_parser = GetBlockParser();
-    GFXRECON_ASSERT(block_parser.GetDecompressionPolicy() == decode::BlockParser::kNever);
+    GFXRECON_ASSERT(block_parser.GetDecompressionPolicy() == decode::BlockParser::DecompressionPolicy::kNever);
     const bool compressed_block = parsed_block.NeedsDecompression();
 
     // Unconditional decompress the metadata block wastes no time as all compressible meta_data_id have non-trivial


### PR DESCRIPTION
Preload storage is vector of PreloadFrames containing vectors of ParsedBlocks moved from a deque of parsed blocks created during pre-loading.  Data construction and teardown are outside the measurement window.

Also fixes corner cases in 1st, 2nd, and stutter frames (when ProcessBlocks returns the same frame number twice), and removes extra frame when --quit-after-measurment-range is set.
