### PR TITLE
Fix physical device discovery at replay time

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3766,6 +3766,10 @@ VulkanReplayConsumerBase::OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysic
 
                 if (old_physical_device_info->handle == new_physical_device_info->handle)
                 {
+                    GFXRECON_LOG_DEBUG("VulkanPhysicalDeviceInfo (%p) will be replaced with (%p) because of multiple "
+                                       "calls to vkEnumeratePhysicalDevices in the capture file.",
+                                       old_physical_device_info,
+                                       new_physical_device_info);
                     *new_physical_device_info = *old_physical_device_info;
                 }
             }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3756,6 +3756,21 @@ VulkanReplayConsumerBase::OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysic
         SetInstancePhysicalDeviceEntries(
             instance_info, capture_device_count, capture_devices, replay_device_count, replay_devices);
 
+        // If it's not the first time we enumerate physical devices, they may already exist in the object info table.
+        // If they do, we want to copy them because otherwise they will be overwritten and capture data will be lost.
+        GetObjectInfoTable().VisitVkPhysicalDeviceInfo([&](const VulkanPhysicalDeviceInfo* old_physical_device_info) {
+            for (uint32_t i = 0; i < replay_device_count; ++i)
+            {
+                VulkanPhysicalDeviceInfo* new_physical_device_info =
+                    reinterpret_cast<VulkanPhysicalDeviceInfo*>(pPhysicalDevices->GetConsumerData(i));
+
+                if (old_physical_device_info->handle == new_physical_device_info->handle)
+                {
+                    *new_physical_device_info = *old_physical_device_info;
+                }
+            }
+        });
+
         for (uint32_t i = 0; i < replay_device_count; ++i)
         {
             auto physical_device_info =


### PR DESCRIPTION
When the captured application enumerates physical devices multiple times, the `VulkanPhysicalDeviceInfo` instances get overwritten as many times in the table.
This leads to data acquired after the enumeration to be lost because the `VulkanPhysicalDeviceInfo` instances are not copied before being overwritten.

This is what this commit attempts to fix.