### PR TITLE
Use a global map to track Shader ID to LRS associations

### DIFF
--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -153,16 +153,14 @@ struct ResourceValueInfo
     uint64_t                offset{ 0 };
     ResourceValueType       type{ ResourceValueType::kUnknown };
     uint64_t                size{ 0 };
-    D3D12StateObjectInfo*   state_object{
-        nullptr
-    }; ///< State object bound for the command associated with this RV.
+    DxObjectInfo*           state_object{ nullptr }; ///< State object bound for the command associated with this RV.
     ArgumentBufferExtraInfo arg_buffer_extra_info;
     uint32_t                max_command_count{ 0 };
 
     ResourceValueInfo(uint64_t                in_offset,
                       ResourceValueType       in_type,
                       uint64_t                in_size,
-                      D3D12StateObjectInfo*   in_state_object,
+                      DxObjectInfo*           in_state_object,
                       ArgumentBufferExtraInfo in_arg_buffer_extra_info,
                       uint32_t                in_max_command_count)
     {
@@ -241,7 +239,7 @@ struct DxgiSwapchainInfo : DxObjectExtraInfo
 
     graphics::dx12::ID3D12CommandQueueComPtr command_queue{
         nullptr
-    }; ///< The command queue that was used to create the swapchain.
+    };                           ///< The command queue that was used to create the swapchain.
     bool is_fullscreen{ false }; ///< Swapchain full screen flag.
 };
 

--- a/framework/decode/dx12_resource_value_mapper.h
+++ b/framework/decode/dx12_resource_value_mapper.h
@@ -168,6 +168,13 @@ class Dx12ResourceValueMapper
         std::map<uint64_t, graphics::Dx12ShaderIdentifier> mapped_shader_ids;
     };
 
+    struct ShaderIdAssociationInfo
+    {
+        std::set<format::HandleId>  state_object_ids;
+        format::HandleId            lrs_id;
+        std::set<ResourceValueInfo> resource_values;
+    };
+
     static void CopyResourceValues(const ResourceCopyInfo& copy_info, ResourceValueInfoMap& resource_value_info_map);
 
     static void CopyMappedResourceValues(const ResourceCopyInfo& copy_info);
@@ -192,13 +199,13 @@ class Dx12ResourceValueMapper
     void InitializeRequiredObjects(ID3D12CommandQueue* command_queue, D3D12CommandQueueInfo* command_queue_extra_info);
 
     void GetShaderTableResourceValues(ResourceValueInfoMap&     resource_value_info_map,
-                                      D3D12StateObjectInfo*     state_object_extra_info,
+                                      DxObjectInfo*             state_object,
                                       D3D12_GPU_VIRTUAL_ADDRESS start_address,
                                       UINT64                    size,
                                       UINT64                    stride);
 
     void GetDispatchRaysResourceValues(ResourceValueInfoMap&           resource_value_info_map,
-                                       D3D12StateObjectInfo*           state_object_extra_info,
+                                       DxObjectInfo*                   state_object,
                                        const D3D12_DISPATCH_RAYS_DESC& desc);
 
     void GetExecuteIndirectResourceValues(std::set<ResourceValueInfo>& dst_resource_value_info_map,
@@ -206,7 +213,7 @@ class Dx12ResourceValueMapper
                                           uint32_t                     command_count,
                                           uint64_t                     command_offset,
                                           uint8_t                      stride,
-                                          D3D12StateObjectInfo*        state_object);
+                                          DxObjectInfo*                state_object);
 
     // Parse the D3D12_STATE_OBJECT_DESC for LRS association information.
     void GetStateObjectLrsAssociationInfo(
@@ -231,9 +238,9 @@ class Dx12ResourceValueMapper
     std::unique_ptr<Dx12ResourceValueTracker>       resource_value_tracker_;
     bool                                            performed_rv_mapping_{ false };
 
-    const graphics::Dx12GpuVaMap&                                         gpu_va_map_;
-    const decode::Dx12DescriptorMap&                                      descriptor_map_;
-    std::map<graphics::Dx12ShaderIdentifier, std::set<ResourceValueInfo>> shader_id_lrs_map_;
+    const graphics::Dx12GpuVaMap&                                     gpu_va_map_;
+    const decode::Dx12DescriptorMap&                                  descriptor_map_;
+    std::map<graphics::Dx12ShaderIdentifier, ShaderIdAssociationInfo> shader_id_associations_;
 
     bool do_value_mapping_;
 


### PR DESCRIPTION
Each shader identifier should be globally unique so it isn't necessary to track shader IDs per state object.

Below are supporting statements from the [DXR spec](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html):

**[Shader identifier](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#shader-identifier)**
"A shader identifier is an opaque data blob of 32 bytes that uniquely identifies (within the current device / process) one of the raytracing shaders"

"An application might create the same shader multiple times. This could be the same code but with same or different export names, potentially across separate raytracing pipelines or collections of code ([described later](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#state-object-types)). In this case the seemingly identical shaders may or may not return the same identifier depending on the implementation. Regardless, execution behavior will be consistent with the specified shader code."

**Regarding differing shader IDs on duplicate shaders:**

Update v1.24 05/30/2024 - "In GetShaderIdentifier removed the sentence: "The data itself globally identifies the shader, so even if the shader appears in a different state object (with same associations like any root signatures) it will have the same identifier.". This contradicted the text in Shader identifier that allows for duplicate shaders to have the same or different identifier depending on implementation."
