### PR TITLE
Fix support for `VK_KHR_pipeline_binary`

### DIFF
--- a/framework/decode/custom_vulkan_struct_decoders.h
+++ b/framework/decode/custom_vulkan_struct_decoders.h
@@ -331,6 +331,15 @@ struct Decoded_VkDescriptorGetInfoEXT
     Decoded_VkDescriptorDataEXT* data{ nullptr };
 };
 
+struct Decoded_VkPipelineCreateInfoKHR
+{
+    using struct_type = VkPipelineCreateInfoKHR;
+
+    VkPipelineCreateInfoKHR* decoded_value{ nullptr };
+
+    PNextNode* pNext{ nullptr };
+};
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/decode/custom_vulkan_struct_decoders_forward.h
+++ b/framework/decode/custom_vulkan_struct_decoders_forward.h
@@ -67,6 +67,7 @@ struct Decoded_VkCopyImageToMemoryInfo;
 struct Decoded_VkImageToMemoryCopy;
 struct Decoded_VkLayerSettingEXT;
 struct Decoded_VkDescriptorGetInfoEXT;
+struct Decoded_VkPipelineCreateInfoKHR;
 
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorImageInfo* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWriteDescriptorSet* wrapper);
@@ -81,6 +82,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyIma
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageToMemoryCopy* wrapper);
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkLayerSettingEXT* wrapper);
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorGetInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineCreateInfoKHR* wrapper);
 
 // Decoded struct wrappers for SECURITY_ATTRIBUTES and related WIN32 structures.
 struct Decoded_ACL;

--- a/framework/decode/custom_vulkan_struct_handle_mappers.cpp
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.cpp
@@ -221,5 +221,35 @@ void MapStructHandles(Decoded_VkDescriptorGetInfoEXT* wrapper, const CommonObjec
     }
 }
 
+void MapStructHandles(Decoded_VkPipelineCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table)
+{
+    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
+    {
+        GFXRECON_ASSERT(wrapper->decoded_value->pNext != nullptr);
+        VkBaseOutStructure* pNext = reinterpret_cast<VkBaseOutStructure*>(wrapper->decoded_value->pNext);
+        switch (pNext->sType)
+        {
+            case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO:
+                MapStructHandles(
+                    reinterpret_cast<Decoded_VkGraphicsPipelineCreateInfo*>(wrapper->pNext->GetMetaStructPointer()),
+                    object_info_table);
+                break;
+            case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR:
+                MapStructHandles(reinterpret_cast<Decoded_VkRayTracingPipelineCreateInfoKHR*>(
+                                     wrapper->pNext->GetMetaStructPointer()),
+                                 object_info_table);
+                break;
+            case VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO:
+                MapStructHandles(
+                    reinterpret_cast<Decoded_VkComputePipelineCreateInfo*>(wrapper->pNext->GetMetaStructPointer()),
+                    object_info_table);
+                break;
+            default:
+                GFXRECON_LOG_ERROR("Unrecognized VkPipelineCreateInfoKHR::pNext structure type: %d", pNext->sType);
+                break;
+        }
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/custom_vulkan_struct_handle_mappers.h
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.h
@@ -47,6 +47,8 @@ void MapStructHandles(Decoded_VkCopyImageToMemoryInfo* wrapper, const CommonObje
 
 void MapStructHandles(Decoded_VkDescriptorGetInfoEXT* wrapper, const CommonObjectInfoTable& object_info_table);
 
+void MapStructHandles(Decoded_VkPipelineCreateInfoKHR* wrapper, const CommonObjectInfoTable& object_info_table);
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/decode/custom_vulkan_struct_to_json.cpp
+++ b/framework/decode/custom_vulkan_struct_to_json.cpp
@@ -692,5 +692,49 @@ void FieldToJson(nlohmann::ordered_json&               jdata,
     }
 }
 
+void FieldToJson(nlohmann::ordered_json&                jdata,
+                 const Decoded_VkPipelineCreateInfoKHR* data,
+                 const util::JsonOptions&               options)
+{
+    if (data && data->decoded_value)
+    {
+        const VkPipelineCreateInfoKHR&         decoded_value = *data->decoded_value;
+        const Decoded_VkPipelineCreateInfoKHR& meta_struct   = *data;
+
+        FieldToJson(jdata["sType"], decoded_value.sType, options);
+
+        const VkBaseInStructure* pNext = (const VkBaseInStructure*)decoded_value.pNext;
+        switch (pNext->sType)
+        {
+            case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO:
+            {
+                FieldToJson(jdata["pNext"],
+                            (const Decoded_VkGraphicsPipelineCreateInfo*)meta_struct.pNext->GetMetaStructPointer(),
+                            options);
+                break;
+            }
+            case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR:
+            {
+                FieldToJson(jdata["pNext"],
+                            (const Decoded_VkRayTracingPipelineCreateInfoKHR*)meta_struct.pNext->GetMetaStructPointer(),
+                            options);
+                break;
+            }
+            case VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO:
+            {
+                FieldToJson(jdata["pNext"],
+                            (const Decoded_VkComputePipelineCreateInfo*)meta_struct.pNext->GetMetaStructPointer(),
+                            options);
+                break;
+            }
+            default:
+            {
+                GFXRECON_LOG_ERROR("Unrecognized VkPipelineCreateInfoKHR::pNext structure type: %d", pNext->sType);
+                break;
+            }
+        }
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/custom_vulkan_struct_to_json.h
+++ b/framework/decode/custom_vulkan_struct_to_json.h
@@ -156,6 +156,10 @@ void FieldToJson(nlohmann::ordered_json&               jdata,
                  const Decoded_VkDescriptorGetInfoEXT* data,
                  const util::JsonOptions&              options = util::JsonOptions());
 
+void FieldToJson(nlohmann::ordered_json&                jdata,
+                 const Decoded_VkPipelineCreateInfoKHR* data,
+                 const util::JsonOptions&               options = util::JsonOptions());
+
 template <typename T>
 void FieldToJson(nlohmann::ordered_json&  jdata,
                  const std::vector<T>&    data,

--- a/framework/decode/vulkan_cpp_structs.cpp
+++ b/framework/decode/vulkan_cpp_structs.cpp
@@ -1605,5 +1605,70 @@ std::string GenerateStruct_VkDescriptorGetInfoEXT(std::ostream&                 
     return {};
 }
 
+std::string GenerateStruct_VkPipelineCreateInfoKHR(std::ostream&                    out,
+                                                   const VkPipelineCreateInfoKHR*   structInfo,
+                                                   Decoded_VkPipelineCreateInfoKHR* metaInfo,
+                                                   VulkanCppConsumerBase&           consumer)
+{
+    std::string pnext_name;
+
+    const VkBaseInStructure* pNext = reinterpret_cast<const VkBaseInStructure*>(structInfo->pNext);
+    GFXRECON_ASSERT(pNext != nullptr);
+
+    switch (pNext->sType)
+    {
+        case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO:
+        {
+            pnext_name =
+                "&" +
+                GenerateStruct_VkGraphicsPipelineCreateInfo(
+                    out,
+                    reinterpret_cast<const VkGraphicsPipelineCreateInfo*>(pNext),
+                    reinterpret_cast<Decoded_VkGraphicsPipelineCreateInfo*>(metaInfo->pNext->GetMetaStructPointer()),
+                    consumer);
+            break;
+        }
+        case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR:
+        {
+            pnext_name = "&" + GenerateStruct_VkRayTracingPipelineCreateInfoKHR(
+                                   out,
+                                   reinterpret_cast<const VkRayTracingPipelineCreateInfoKHR*>(pNext),
+                                   reinterpret_cast<Decoded_VkRayTracingPipelineCreateInfoKHR*>(
+                                       metaInfo->pNext->GetMetaStructPointer()),
+                                   consumer);
+            break;
+        }
+        case VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO:
+        {
+            pnext_name =
+                "&" +
+                GenerateStruct_VkComputePipelineCreateInfo(
+                    out,
+                    reinterpret_cast<const VkComputePipelineCreateInfo*>(pNext),
+                    reinterpret_cast<Decoded_VkComputePipelineCreateInfo*>(metaInfo->pNext->GetMetaStructPointer()),
+                    consumer);
+            break;
+        }
+        default:
+        {
+            GFXRECON_LOG_ERROR("Unrecognized VkPipelineCreateInfoKHR::pNext structure type: %d", pNext->sType);
+            break;
+        }
+    }
+
+    std::stringstream struct_body;
+    struct_body << "\t"
+                << "VkStructureType(" << structInfo->sType << ")"
+                << "," << std::endl;
+    struct_body << "\t\t\t" << pnext_name << "," << std::endl;
+    std::string variable_name = consumer.AddStruct(struct_body, "pipelineCreateInfoKHR");
+    out << "\t\t"
+        << "VkPipelineCreateInfoKHR " << variable_name << " {" << std::endl;
+    out << "\t\t" << struct_body.str() << std::endl;
+    out << "\t\t"
+        << "};" << std::endl;
+    return variable_name;
+}
+
 GFXRECON_END_NAMESPACE(gfxrecon)
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_cpp_structs.h
+++ b/framework/decode/vulkan_cpp_structs.h
@@ -165,6 +165,11 @@ std::string GenerateStruct_VkDescriptorGetInfoEXT(std::ostream&                 
                                                   Decoded_VkDescriptorGetInfoEXT* metaInfo,
                                                   VulkanCppConsumerBase&          consumer);
 
+std::string GenerateStruct_VkPipelineCreateInfoKHR(std::ostream&                    out,
+                                                   const VkPipelineCreateInfoKHR*   structInfo,
+                                                   Decoded_VkPipelineCreateInfoKHR* metaInfo,
+                                                   VulkanCppConsumerBase&           consumer);
+
 GFXRECON_END_NAMESPACE(gfxrecon)
 GFXRECON_END_NAMESPACE(decode)
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1606,6 +1606,19 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                         uint32_t                          bufferCount,
                                         StructPointerDecoder<Decoded_VkDescriptorBufferBindingInfoEXT>* pBindingInfos);
 
+    VkResult OverrideCreatePipelineBinariesKHR(PFN_vkCreatePipelineBinariesKHR func,
+                                               VkResult                        original_result,
+                                               const VulkanDeviceInfo*         device_info,
+                                               StructPointerDecoder<Decoded_VkPipelineBinaryCreateInfoKHR>* pCreateInfo,
+                                               StructPointerDecoder<Decoded_VkAllocationCallbacks>*         pAllocator,
+                                               StructPointerDecoder<Decoded_VkPipelineBinaryHandlesInfoKHR>* pBinaries);
+
+    VkResult OverrideGetPipelineKeyKHR(PFN_vkGetPipelineKeyKHR                                func,
+                                       VkResult                                               original_result,
+                                       const VulkanDeviceInfo*                                device_info,
+                                       StructPointerDecoder<Decoded_VkPipelineCreateInfoKHR>* pPipelineCreateInfo,
+                                       StructPointerDecoder<Decoded_VkPipelineBinaryKeyKHR>*  pPipelineKey);
+
     std::function<handle_create_result_t<VkPipeline>()>
     AsyncCreateGraphicsPipelines(PFN_vkCreateGraphicsPipelines                               func,
                                  VkResult                                                    returnValue,

--- a/framework/encode/custom_vulkan_struct_encoders.cpp
+++ b/framework/encode/custom_vulkan_struct_encoders.cpp
@@ -499,5 +499,27 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorGetInfoEXT& value
     }
 }
 
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCreateInfoKHR& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+
+    const VkBaseInStructure* pNextUntyped = (const VkBaseInStructure*)value.pNext;
+    switch (pNextUntyped->sType)
+    {
+        case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkGraphicsPipelineCreateInfo*>(value.pNext));
+            break;
+        case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkRayTracingPipelineCreateInfoKHR*>(value.pNext));
+            break;
+        case VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkComputePipelineCreateInfo*>(value.pNext));
+            break;
+        default:
+            GFXRECON_LOG_ERROR("Unrecognized VkPipelineCreateInfoKHR::pNext structure type: %d", pNextUntyped->sType);
+            break;
+    }
+}
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/custom_vulkan_struct_encoders.h
+++ b/framework/encode/custom_vulkan_struct_encoders.h
@@ -50,6 +50,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToImageInfo& valu
 void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageToMemoryInfo& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkLayerSettingEXT& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorGetInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCreateInfoKHR& value);
 
 // Platform defined structures that are external to Vulkan.
 void EncodeStruct(ParameterEncoder* encoder, const ACL& value);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -97,12 +97,6 @@ struct VideoSessionParametersKHRWrapper               : public HandleWrapper<VkV
 struct ShaderEXTWrapper                               : public HandleWrapper<VkShaderEXT> {};
 
 struct PipelineBinaryKHRWrapper                       : public HandleWrapper<VkPipelineBinaryKHR> {};
-struct PipelineBinaryCreateInfoKHRWrapper             : public HandleWrapper<VkPipelineBinaryCreateInfoKHR> {};
-struct PipelineBinaryDataInfoKHRWrapper               : public HandleWrapper<VkPipelineBinaryDataInfoKHR> {};
-struct PipelineBinaryDataKHRWrapper                   : public HandleWrapper<VkPipelineBinaryDataKHR> {};
-struct PipelineBinaryHandlesInfoKHRWrapper            : public HandleWrapper<VkPipelineBinaryHandlesInfoKHR> {};
-struct PipelineBinaryKeyKHRWrapper                    : public HandleWrapper<VkPipelineBinaryKeyKHR> {};
-struct PipelineBinaryKeysAndDataKHRWrapper            : public HandleWrapper<VkPipelineBinaryKeysAndDataKHR> {};
 struct ReleaseCapturedPipelineDataInfoKHRWrapper      : public HandleWrapper<VkReleaseCapturedPipelineDataInfoKHR> {};
 struct DevicePipelineBinaryInternalCacheControlKHRWrapper      : public HandleWrapper<VkDevicePipelineBinaryInternalCacheControlKHR> {};
 struct PipelineBinaryInfoKHRWrapper      : public HandleWrapper<VkPipelineBinaryInfoKHR> {};

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -194,6 +194,7 @@ uint64_t VulkanStateWriter::WriteState(const VulkanStateTable& state_table, uint
     WritePipelineLayoutState(state_table);
     WritePipelineCacheState(state_table);
     WritePipelineState(state_table);
+    StandardCreateWrite<vulkan_wrappers::PipelineBinaryKHRWrapper>(state_table);
     WriteAccelerationStructureKHRState(state_table);
     WriteTlasToBlasDependenciesMetadata(state_table);
     WriteAccelerationStructureStateMetaCommands(state_table);

--- a/framework/generated/generated_vulkan_cpp_structs.cpp
+++ b/framework/generated/generated_vulkan_cpp_structs.cpp
@@ -11743,19 +11743,6 @@ std::string GenerateStruct_VkPipelineBinaryKeysAndDataKHR(std::ostream &out, con
 }
 
 
-std::string GenerateStruct_VkPipelineCreateInfoKHR(std::ostream &out, const VkPipelineCreateInfoKHR* structInfo, Decoded_VkPipelineCreateInfoKHR* metaInfo, VulkanCppConsumerBase &consumer){
-    std::stringstream struct_body;
-    std::string pnext_name = GenerateExtension(out, structInfo->pNext, metaInfo->pNext, consumer);
-    struct_body << "\t" << "VkStructureType(" << structInfo->sType << ")" << "," << std::endl;
-    struct_body << "\t\t\t" << pnext_name << ",";
-    std::string variable_name = consumer.AddStruct(struct_body, "pipelineCreateInfoKHR");
-    out << "\t\t" << "VkPipelineCreateInfoKHR " << variable_name << " {" << std::endl;
-    out << "\t\t" << struct_body.str() << std::endl;
-    out << "\t\t" << "};" << std::endl;
-    return variable_name;
-}
-
-
 std::string GenerateStruct_VkReleaseCapturedPipelineDataInfoKHR(std::ostream &out, const VkReleaseCapturedPipelineDataInfoKHR* structInfo, Decoded_VkReleaseCapturedPipelineDataInfoKHR* metaInfo, VulkanCppConsumerBase &consumer){
     std::stringstream struct_body;
     std::string pnext_name = GenerateExtension(out, structInfo->pNext, metaInfo->pNext, consumer);

--- a/framework/generated/generated_vulkan_cpp_structs.h
+++ b/framework/generated/generated_vulkan_cpp_structs.h
@@ -1116,8 +1116,6 @@ std::string GenerateStruct_VkPipelineBinaryKeyKHR(std::ostream &out, const VkPip
 
 std::string GenerateStruct_VkPipelineBinaryKeysAndDataKHR(std::ostream &out, const VkPipelineBinaryKeysAndDataKHR* structInfo, Decoded_VkPipelineBinaryKeysAndDataKHR* metaInfo, VulkanCppConsumerBase &consumer);
 
-std::string GenerateStruct_VkPipelineCreateInfoKHR(std::ostream &out, const VkPipelineCreateInfoKHR* structInfo, Decoded_VkPipelineCreateInfoKHR* metaInfo, VulkanCppConsumerBase &consumer);
-
 std::string GenerateStruct_VkReleaseCapturedPipelineDataInfoKHR(std::ostream &out, const VkReleaseCapturedPipelineDataInfoKHR* structInfo, Decoded_VkReleaseCapturedPipelineDataInfoKHR* metaInfo, VulkanCppConsumerBase &consumer);
 
 std::string GenerateStruct_VkSurfacePresentModeCompatibilityKHR(std::ostream &out, const VkSurfacePresentModeCompatibilityKHR* structInfo, Decoded_VkSurfacePresentModeCompatibilityKHR* metaInfo, VulkanCppConsumerBase &consumer);

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -6467,20 +6467,19 @@ void VulkanReplayConsumer::Process_vkCreatePipelineBinariesKHR(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     StructPointerDecoder<Decoded_VkPipelineBinaryHandlesInfoKHR>* pBinaries)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
-    const VkPipelineBinaryCreateInfoKHR* in_pCreateInfo = pCreateInfo->GetPointer();
+    auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
+
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
-    SetStructArrayHandleLengths<Decoded_VkPipelineBinaryHandlesInfoKHR>(pBinaries->GetMetaStructPointer(), pBinaries->GetLength());
-    VkPipelineBinaryHandlesInfoKHR* out_pBinaries = pBinaries->IsNull() ? nullptr : pBinaries->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PIPELINE_BINARY_HANDLES_INFO_KHR, nullptr });
+    SetStructHandleLengths(pBinaries->GetMetaStructPointer());
+    pBinaries->IsNull() ? nullptr : pBinaries->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PIPELINE_BINARY_HANDLES_INFO_KHR, nullptr });
     InitializeOutputStructPNext(pBinaries);
 
     PushRecaptureStructHandleIds(pBinaries->GetMetaStructPointer(), this);
-    VkResult replay_result = GetDeviceTable(in_device)->CreatePipelineBinariesKHR(in_device, in_pCreateInfo, in_pAllocator, out_pBinaries);
+    VkResult replay_result = OverrideCreatePipelineBinariesKHR(GetDeviceTable(in_device->handle)->CreatePipelineBinariesKHR, returnValue, in_device, pCreateInfo, pAllocator, pBinaries);
     CheckResult("vkCreatePipelineBinariesKHR", returnValue, replay_result, call_info);
     ClearRecaptureHandleIds();
 
-    AddStructHandles(device, pBinaries->GetMetaStructPointer(), out_pBinaries, &GetObjectInfoTable());
+    AddStructHandles(device, pBinaries->GetMetaStructPointer(), pBinaries->GetOutputPointer(), &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPipelineBinaryKHR(
@@ -6504,12 +6503,11 @@ void VulkanReplayConsumer::Process_vkGetPipelineKeyKHR(
     StructPointerDecoder<Decoded_VkPipelineCreateInfoKHR>* pPipelineCreateInfo,
     StructPointerDecoder<Decoded_VkPipelineBinaryKeyKHR>* pPipelineKey)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
-    const VkPipelineCreateInfoKHR* in_pPipelineCreateInfo = pPipelineCreateInfo->GetPointer();
-    VkPipelineBinaryKeyKHR* out_pPipelineKey = pPipelineKey->IsNull() ? nullptr : pPipelineKey->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR, nullptr });
+    auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
+    pPipelineKey->IsNull() ? nullptr : pPipelineKey->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR, nullptr });
     InitializeOutputStructPNext(pPipelineKey);
 
-    VkResult replay_result = GetDeviceTable(in_device)->GetPipelineKeyKHR(in_device, in_pPipelineCreateInfo, out_pPipelineKey);
+    VkResult replay_result = OverrideGetPipelineKeyKHR(GetDeviceTable(in_device->handle)->GetPipelineKeyKHR, returnValue, in_device, pPipelineCreateInfo, pPipelineKey);
     CheckResult("vkGetPipelineKeyKHR", returnValue, replay_result, call_info);
 }
 

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -11031,20 +11031,6 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     return bytes_read;
 }
 
-size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineCreateInfoKHR* wrapper)
-{
-    assert((wrapper != nullptr) && (wrapper->decoded_value != nullptr));
-
-    size_t bytes_read = 0;
-    VkPipelineCreateInfoKHR* value = wrapper->decoded_value;
-
-    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
-    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-
-    return bytes_read;
-}
-
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineBinaryCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->decoded_value != nullptr));

--- a/framework/generated/generated_vulkan_struct_decoders.h
+++ b/framework/generated/generated_vulkan_struct_decoders.h
@@ -5324,15 +5324,6 @@ struct Decoded_VkPipelineBinaryKeysAndDataKHR
     StructPointerDecoder<Decoded_VkPipelineBinaryDataKHR>* pPipelineBinaryData{ nullptr };
 };
 
-struct Decoded_VkPipelineCreateInfoKHR
-{
-    using struct_type = VkPipelineCreateInfoKHR;
-
-    VkPipelineCreateInfoKHR* decoded_value{ nullptr };
-
-    PNextNode* pNext{ nullptr };
-};
-
 struct Decoded_VkPipelineBinaryCreateInfoKHR
 {
     using struct_type = VkPipelineBinaryCreateInfoKHR;

--- a/framework/generated/generated_vulkan_struct_decoders_forward.h
+++ b/framework/generated/generated_vulkan_struct_decoders_forward.h
@@ -586,7 +586,6 @@ struct Decoded_VkDevicePipelineBinaryInternalCacheControlKHR;
 struct Decoded_VkPipelineBinaryKeyKHR;
 struct Decoded_VkPipelineBinaryDataKHR;
 struct Decoded_VkPipelineBinaryKeysAndDataKHR;
-struct Decoded_VkPipelineCreateInfoKHR;
 struct Decoded_VkPipelineBinaryCreateInfoKHR;
 struct Decoded_VkPipelineBinaryInfoKHR;
 struct Decoded_VkReleaseCapturedPipelineDataInfoKHR;
@@ -1817,7 +1816,6 @@ size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineBinaryKeyKHR* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineBinaryDataKHR* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineBinaryKeysAndDataKHR* wrapper);
-size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineCreateInfoKHR* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineBinaryCreateInfoKHR* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineBinaryInfoKHR* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkReleaseCapturedPipelineDataInfoKHR* wrapper);

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -5570,12 +5570,6 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryKeysAndDataKH
     EncodeStructArray(encoder, value.pPipelineBinaryData, value.binaryCount);
 }
 
-void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCreateInfoKHR& value)
-{
-    encoder->EncodeEnumValue(value.sType);
-    EncodePNextStructIfValid(encoder, value.pNext);
-}
-
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);

--- a/framework/generated/generated_vulkan_struct_encoders.h
+++ b/framework/generated/generated_vulkan_struct_encoders.h
@@ -589,7 +589,6 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDevicePipelineBinaryInterna
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryKeyKHR& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryDataKHR& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryKeysAndDataKHR& value);
-void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCreateInfoKHR& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryCreateInfoKHR& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineBinaryInfoKHR& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkReleaseCapturedPipelineDataInfoKHR& value);

--- a/framework/generated/generated_vulkan_struct_to_json.cpp
+++ b/framework/generated/generated_vulkan_struct_to_json.cpp
@@ -8762,18 +8762,6 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineBinaryKe
     }
 }
 
-void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineCreateInfoKHR* data, const JsonOptions& options)
-{
-    if (data && data->decoded_value)
-    {
-        const VkPipelineCreateInfoKHR& decoded_value = *data->decoded_value;
-        const Decoded_VkPipelineCreateInfoKHR& meta_struct = *data;
-
-        FieldToJson(jdata["sType"], decoded_value.sType, options);
-        FieldToJson(jdata["pNext"], meta_struct.pNext, options);
-    }
-}
-
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineBinaryCreateInfoKHR* data, const JsonOptions& options)
 {
     if (data && data->decoded_value)

--- a/framework/generated/generated_vulkan_struct_to_json.h
+++ b/framework/generated/generated_vulkan_struct_to_json.h
@@ -572,7 +572,6 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDevicePipelineBi
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineBinaryKeyKHR* data, const util::JsonOptions& options = util::JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineBinaryDataKHR* data, const util::JsonOptions& options = util::JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineBinaryKeysAndDataKHR* data, const util::JsonOptions& options = util::JsonOptions());
-void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineCreateInfoKHR* data, const util::JsonOptions& options = util::JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineBinaryCreateInfoKHR* data, const util::JsonOptions& options = util::JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineBinaryInfoKHR* data, const util::JsonOptions& options = util::JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkReleaseCapturedPipelineDataInfoKHR* data, const util::JsonOptions& options = util::JsonOptions());

--- a/framework/generated/khronos_generators/khronos_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_replay_consumer_body_generator.py
@@ -1056,14 +1056,14 @@ class KhronosReplayConsumerBodyGenerator():
                                     else:
                                         if value.base_type in self.structs_with_handle_ptrs:
                                             preexpr.append(
-                                                'SetStructHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'
+                                                'SetStructHandleLengths({paramname}->GetMetaStructPointer());'
                                                 .format(
                                                     value.base_type,
                                                     paramname=value.name
                                                 )
                                             )
                                         postexpr.append(
-                                            'AddStructHandles<Decoded_{basetype}>({}, {name}->GetMetaStructPointer(), {name}->GetOutputPointer(), &GetObjectInfoTable());'
+                                            'AddStructHandles({}, {name}->GetMetaStructPointer(), {name}->GetOutputPointer(), &GetObjectInfoTable());'
                                             .format(
                                                 self.get_parent_id(
                                                     api_data, value, values

--- a/framework/generated/khronos_generators/vulkan_generators/blacklists.json
+++ b/framework/generated/khronos_generators/vulkan_generators/blacklists.json
@@ -53,6 +53,7 @@
     "VkCopyImageToMemoryInfo",
     "VkImageToMemoryCopy",
     "VkLayerSettingEXT",
-    "VkDescriptorGetInfoEXT"
+    "VkDescriptorGetInfoEXT",
+    "VkPipelineCreateInfoKHR"
   ]
 }

--- a/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
@@ -173,6 +173,8 @@
     "vkGetPhysicalDeviceSurfaceFormats2KHR" : "OverrideGetPhysicalDeviceSurfaceFormats2KHR",
     "vkGetDescriptorEXT": "OverrideGetDescriptorEXT",
     "vkCmdBindDescriptorBuffersEXT": "OverrideCmdBindDescriptorBuffersEXT",
-    "vkCreateSampler": "OverrideCreateSampler"
+    "vkCreateSampler": "OverrideCreateSampler",
+    "vkCreatePipelineBinariesKHR": "OverrideCreatePipelineBinariesKHR",
+    "vkGetPipelineKeyKHR": "OverrideGetPipelineKeyKHR"
   }
 }


### PR DESCRIPTION
`VkPipelineCreateInfoKHR` is a particular structure as it can take any kind of `PipelineCreateInfo` in its `pNext` chain, in addition to being required to have a non-null `pNext` member.

This was not correctly handled by the generated code because `Vk*PipelineCreateInfo` structures don't have the `structextends` flag set in the Vulkan registry. This commit aims at fixing that by blacklisting this structure and writing the encoder/decoders manually.

Ideally, this should be solved in the codegen by not considering only structs with the `structextends` flag as possible encounters in a `pNext` chain
