### PR TITLE
Initial image info for incomplete

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -7988,7 +7988,10 @@ VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapch
         result = swapchain_->GetSwapchainImagesKHR(
             original_result, func, device_info, swapchain_info, capture_image_count, replay_image_count, replay_images);
 
-        if ((result == VK_SUCCESS) && (replay_images != nullptr) && (replay_image_count != nullptr))
+        // If replay_image_count isn't full image count, it will return VK_INCOMPLETE.
+        // Their image infos should also be initialized, even if it's VK_INCOMPLETE.
+        if ((result == VK_SUCCESS || result == VK_INCOMPLETE) && (replay_images != nullptr) &&
+            (replay_image_count != nullptr))
         {
             uint32_t count = (*replay_image_count);
 


### PR DESCRIPTION
If the swapchain count isn't full image count, `GetSwapchainImagesKHR` will return `VK_INCOMPLETE`. It should also initialize image infos.  If it doesn't initialize, it won't be able to know whether the image info is for swapchain or not. It might also have other issues caused by lack of initialization.