### PR TITLE
Track Backbuffer's RenderTarget

### DIFF
--- a/framework/encode/custom_dx12_wrapper_commands.h
+++ b/framework/encode/custom_dx12_wrapper_commands.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -91,6 +91,16 @@ struct CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_Present>
                          Args... args)
     {
         manager->PostProcess_IDXGISwapChain_Present(current_lock, args...);
+    }
+};
+
+template <>
+struct CustomWrapperPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetBuffer>
+{
+    template <typename... Args>
+    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_IDXGISwapChain_GetBuffer(args...);
     }
 };
 
@@ -469,6 +479,16 @@ struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandLis
     static void Dispatch(D3D12CaptureManager* manager, Args... args)
     {
         manager->PostProcess_ID3D12GraphicsCommandList_ResourceBarrier(args...);
+    }
+};
+
+template <>
+struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetRenderTargets>
+{
+    template <typename... Args>
+    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_ID3D12GraphicsCommandList_OMSetRenderTargets(args...);
     }
 };
 

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
-** Copyright (c) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -271,6 +271,9 @@ class D3D12CaptureManager : public ApiCaptureManager
                                                  DXGI_FORMAT             new_format,
                                                  UINT                    flags);
 
+    void PostProcess_IDXGISwapChain_GetBuffer(
+        IDXGISwapChain_Wrapper* wrapper, HRESULT result, UINT Buffer, REFIID riid, void** ppSurface);
+
     void PostProcess_IDXGISwapChain_ResizeBuffers(IDXGISwapChain_Wrapper* wrapper,
                                                   HRESULT                 result,
                                                   UINT                    buffer_count,
@@ -489,6 +492,13 @@ class D3D12CaptureManager : public ApiCaptureManager
     void PostProcess_ID3D12GraphicsCommandList_ResourceBarrier(ID3D12CommandList_Wrapper*    list_wrapper,
                                                                UINT                          num_barriers,
                                                                const D3D12_RESOURCE_BARRIER* barriers);
+
+    void PostProcess_ID3D12GraphicsCommandList_OMSetRenderTargets(
+        ID3D12CommandList_Wrapper*         list_wrapper,
+        UINT                               NumRenderTargetDescriptors,
+        const D3D12_CPU_DESCRIPTOR_HANDLE* pRenderTargetDescriptors,
+        BOOL                               RTsSingleHandleToDescriptorRange,
+        const D3D12_CPU_DESCRIPTOR_HANDLE* pDepthStencilDescriptor);
 
     void PostProcess_ID3D12GraphicsCommandList_Reset(ID3D12CommandList_Wrapper* list_wrapper,
                                                      HRESULT                    result,
@@ -955,6 +965,10 @@ class D3D12CaptureManager : public ApiCaptureManager
     graphics::dx12::ActiveAdapterMap adapters_;
 
     std::unique_ptr<Dx12ResourceValueAnnotator> resource_value_annotator_{ nullptr };
+
+    std::vector<IUnknown*> backbuffers_;
+
+    UINT RTV_increment_{ 0 };
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -130,6 +130,8 @@ struct DxDescriptorInfo
     // Descriptors can be created with up to 2 resource dependencies or a GPU VA.
     std::array<format::HandleId, 2> resource_ids{ format::kNullHandleId, format::kNullHandleId };
     D3D12_GPU_VIRTUAL_ADDRESS       resource_gpu_va{ 0 };
+
+    bool is_backbuffer_rendertargetview{ false };
 };
 
 struct DxTransitionBarrier
@@ -311,7 +313,8 @@ struct AccelerationStructureBuildTrackingObjects
         graphics::dx12::ID3D12ResourceComPtr             _resource,
         graphics::dx12::ID3D12CommandAllocatorComPtr     _post_build_copy_cmd_allocator,
         graphics::dx12::ID3D12GraphicsCommandList4ComPtr _post_build_copy_cmd_list) :
-        resource(_resource), post_build_copy_cmd_allocator(_post_build_copy_cmd_allocator),
+        resource(_resource),
+        post_build_copy_cmd_allocator(_post_build_copy_cmd_allocator),
         post_build_copy_cmd_list(_post_build_copy_cmd_list)
     {}
 
@@ -505,6 +508,7 @@ struct ID3D12CommandListInfo : public DxWrapperInfo
     uint32_t                                     find_target_draw_call_count{ 0 };
     std::shared_ptr<const ID3D12CommandListInfo> target_bundle_commandlist_info;
     bool                                         is_trim_target{ false };
+    bool                                         is_OMRenderTarget{ false };
 };
 
 struct ID3D10BlobInfo : public DxWrapperInfo

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -181,7 +181,8 @@ class Dx12StateTracker
 
     void TrackDescriptorResources(SIZE_T          descriptor_cpu_address,
                                   ID3D12Resource* resource1,
-                                  ID3D12Resource* resource2 = nullptr);
+                                  ID3D12Resource* resource2      = nullptr,
+                                  bool            backbufferview = false);
 
     void TrackDescriptorGpuVa(SIZE_T descriptor_cpu_address, D3D12_GPU_VIRTUAL_ADDRESS address);
 

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,8 @@ Dx12StateWriter::Dx12StateWriter(util::FileOutputStream* output_stream,
                                  util::Compressor*       compressor,
                                  format::ThreadId        thread_id,
                                  util::FileOutputStream* asset_file_stream) :
-    output_stream_(output_stream), compressor_(compressor), thread_id_(thread_id), encoder_(&parameter_stream_)
+    output_stream_(output_stream),
+    compressor_(compressor), thread_id_(thread_id), encoder_(&parameter_stream_)
 {
     assert(output_stream != nullptr);
 }
@@ -790,7 +791,7 @@ void Dx12StateWriter::WriteMetaCommandCreationState(const Dx12StateTable& state_
         for (auto wrapper : metacommand_wrappers)
         {
             // Write the meta command init call.
-            auto                          wrapper_info = wrapper->GetObjectInfo();
+            auto wrapper_info = wrapper->GetObjectInfo();
             if (wrapper_info->was_initialized == true)
             {
                 format::InitializeMetaCommand init_meta_command;
@@ -846,13 +847,13 @@ void Dx12StateWriter::WriteResourceSnapshots(
             begin_cmd.meta_header.block_header.type = format::kMetaDataBlock;
             begin_cmd.meta_header.meta_data_id      = format::MakeMetaDataId(
                 format::ApiFamilyId::ApiFamily_D3D12, format::MetaDataType::kBeginResourceInitCommand);
-            begin_cmd.thread_id       = thread_id_;
-            begin_cmd.device_id       = device_id;
+            begin_cmd.thread_id = thread_id_;
+            begin_cmd.device_id = device_id;
 
             // TODO: adjust to hold sum of resource-sizes
             begin_cmd.total_copy_size = max_resource_size;
 
-            begin_cmd.max_copy_size   = max_resource_size;
+            begin_cmd.max_copy_size = max_resource_size;
 
             output_stream_->Write(&begin_cmd, sizeof(begin_cmd));
 
@@ -1218,6 +1219,10 @@ void Dx12StateWriter::WriteCommandListCommands(const ID3D12CommandList_Wrapper* 
                                                const Dx12StateTable&            state_table)
 {
     auto list_info = list_wrapper->GetObjectInfo();
+    if (list_info->is_OMRenderTarget)
+    {
+        return;
+    }
 
     bool invalid_command_allocator =
         (list_info->reset_command_allocator_id != format::kNullHandleId) &&


### PR DESCRIPTION
When trim capture was activated, the commandlist might call OMSetRenderTarget() to design a backbuffer's rendertarget view.
GFXR should remove the left over commandlist, otherwise the rendertarget might not match the current backbuffer index.