### PR TITLE
logging: Fix missing capture log file

### DIFF
--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -615,6 +615,10 @@ void CaptureSettings::ProcessLogOptions(OptionsMap* options, CaptureSettings* se
     settings->log_settings_.output_detailed_log_info =
         ParseBoolString(FindOption(options, kOptionKeyLogDetailed), settings->log_settings_.output_detailed_log_info);
     settings->log_settings_.file_name = FindOption(options, kOptionKeyLogFile, settings->log_settings_.file_name);
+    if (settings->log_settings_.file_name.size() > 0)
+    {
+        settings->log_settings_.write_to_file = true;
+    }
     settings->log_settings_.create_new =
         ParseBoolString(FindOption(options, kOptionKeyLogFileCreateNew), settings->log_settings_.create_new);
     settings->log_settings_.flush_after_write = ParseBoolString(FindOption(options, kOptionKeyLogFileFlushAfterWrite),


### PR DESCRIPTION
This fixes the issue where the defined log file wasn't created during capture if defined.