### PR TITLE
Fix anchor links in OpenXR and Vulkan usage documentation (#1939)

### DIFF
--- a/USAGE_desktop_OpenXR.md
+++ b/USAGE_desktop_OpenXR.md
@@ -34,7 +34,7 @@ If OpenXR support is desired, please pull the source down from the
 GitHub repo and build manually.
 
 Additionally, see the list of
-[Known Limitations](#openxr-capture-known-limitations] below.
+[Known Limitations](#openxr-capture-known-limitations) below.
 
 
 ## Index
@@ -56,7 +56,6 @@ Additionally, see the list of
     4. [Trimmed File Optimization](#trimmed-file-optimization)
     5. [JSON Lines Conversion](#json-lines-conversion)
     6. [Command Launcher](#command-launcher)
-    7. [Options Common To All Tools](#common-options)
 
 ## Capturing API calls
 

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -41,7 +41,7 @@ to one of these other documents:
     4. [Trimmed File Optimization](#trimmed-file-optimization)
     5. [JSON Lines Conversion](#json-lines-conversion)
     6. [Command Launcher](#command-launcher)
-    7. [Options Common To All Tools](#common-options)
+    7. [Options Common To All Tools](#options-common-to-all-tools)
 
 ## Capturing API calls
 


### PR DESCRIPTION
Hi there,
I’m happy to start contributing to this cool gfxreconstruct tool !

removed anchor link "Options Common To All Tools" in USAGE_desktop_OpenXR.md as there was no corresponding section.
Fixed the "Options Common To All Tools" anchor link in USAGE_desktop_Vulkan.md.
Documentation only change. Please let me know if anything needs adjustment.