### PR TITLE
Set Python to 3.10 to match CONTRIBUTING

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -34,6 +34,10 @@ jobs:
             cc: "gcc", cxx: "g++"
           }
     steps:
+    - name: Require Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
     - name: Clone repository
       uses: actions/checkout@v4
       with:

--- a/framework/generated/generate_vulkan.py
+++ b/framework/generated/generate_vulkan.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
                  os.path.abspath(args.headers_dir)]
             )
         gencode_args.append(target)
-        subprocess.call(
+        subprocess.check_call(
             gencode_args,
             shell=False,
             env=env,


### PR DESCRIPTION
Use Python 3.10 in Ubuntu Vulkan codegen verification to catch any post-3.10 constructs in use