### PR TITLE
ci: fetch git PR data

### DIFF
--- a/ci/runJob.bat
+++ b/ci/runJob.bat
@@ -23,6 +23,8 @@ waitfor forever /t 60 2>nul
 goto :clone_suites
 :clone_suites_done
 cd ci-gfxr-suites
+git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
+git fetch origin
 git checkout %TEST_SUITE_BRANCH% || exit /b
 git submodule update --init --recursive
 git describe --tags --always
@@ -50,6 +52,8 @@ waitfor forever /t 60 2>nul
 goto :clone_tests
 :clone_tests_done
 cd VulkanTests
+git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
+git fetch origin
 git checkout %TEST_COMMIT% || exit /b
 git submodule update --init --recursive
 git describe --tags --always

--- a/ci/runJob.sh
+++ b/ci/runJob.sh
@@ -12,6 +12,8 @@ fi
 
 git clone --verbose $TEST_SUITE_REPO ci-gfxr-suites
 cd ci-gfxr-suites
+git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
+git fetch origin
 git checkout $TEST_SUITE_BRANCH
 git submodule update --init --recursive
 git describe --tags --always
@@ -28,6 +30,8 @@ fi
 
 git clone --verbose $TEST_REPO VulkanTests
 cd VulkanTests
+git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
+git fetch origin
 git checkout $TEST_COMMIT
 git submodule update --init --recursive
 git describe --tags --always

--- a/ci/runJobAndroid.sh
+++ b/ci/runJobAndroid.sh
@@ -12,6 +12,8 @@ fi
 
 git clone --verbose $TEST_SUITE_REPO ci-gfxr-suites
 cd ci-gfxr-suites
+git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
+git fetch origin
 git checkout $TEST_SUITE_BRANCH
 git submodule update --init --recursive
 git describe --tags --always
@@ -28,6 +30,8 @@ fi
 
 git clone --verbose $TEST_REPO VulkanTests
 cd VulkanTests
+git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
+git fetch origin
 git checkout $TEST_COMMIT
 git submodule update --init --recursive
 git describe --tags --always


### PR DESCRIPTION
This change allows testing commits that are currently PRs in
ci-gfxr-suite or the VulkanTests repo. Cloning a repo doesn't pull in
PR related information, so without this change, testing a PR commit for
test_suite.ref (ci-gfxr-suite) or test.ref (VulkanTests) isn't possible.

ci/runJob.sh
ci/runJob.bat
ci/runJobAndroid.sh
- Do a git fetch after configuring to pull PR data