### PR TITLE
Enable external Vulkan layers for Android replay

### DIFF
--- a/android/tools/multi-win-replay/AndroidManifest.xml
+++ b/android/tools/multi-win-replay/AndroidManifest.xml
@@ -21,6 +21,8 @@
                   android:screenOrientation="unspecified">
             <meta-data android:name="android.app.lib_name"
                        android:value="gfxrecon-replay" />
+            <meta-data android:name="com.android.graphics.injectLayers.enable"
+                       android:value="true"/>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/android/tools/replay/src/main/AndroidManifest.xml
+++ b/android/tools/replay/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
                   android:screenOrientation="unspecified">
             <meta-data android:name="android.app.lib_name"
                        android:value="gfxrecon-replay" />
+            <meta-data android:name="com.android.graphics.injectLayers.enable"
+                       android:value="true"/>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Usually only debug builds are allowed to load external Vulkan layers on Android, which can be useful for validation/re-capture/etc. This change should allow release builds to also load external Vulkan layers for cases where performance is more important.