### PR TITLE
Remove format header

### DIFF
--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -64,7 +64,6 @@
 #include <cassert>
 #include <cstdarg>
 #include <cstdlib>
-#include <format>
 #include <limits>
 #include <set>
 #include <string>


### PR DESCRIPTION
14e2e48 removed usage of std::format but didn't remove the header