### PR TITLE
Add memory capturing for vkMapMemory2

### DIFF
--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -677,6 +677,26 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkMapMemory>
 };
 
 template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkMapMemory2>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkMapMemory2(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkMapMemory2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkMapMemory2(result, args...);
+    }
+};
+
+template <>
 struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkFlushMappedMemoryRanges>
 {
     template <typename... Args>
@@ -693,6 +713,26 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkUnmapMemory>
     static void Dispatch(VulkanCaptureManager* manager, Args... args)
     {
         manager->PreProcess_vkUnmapMemory(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkUnmapMemory2>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkUnmapMemory2(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkUnmapMemory2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkUnmapMemory2(args...);
     }
 };
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2844,6 +2844,23 @@ void VulkanCaptureManager::PostProcess_vkMapMemory(VkResult         result,
     }
 }
 
+void VulkanCaptureManager::PostProcess_vkMapMemory2(VkResult               result,
+                                                    VkDevice               device,
+                                                    const VkMemoryMapInfo* pMemoryMapInfo,
+                                                    void**                 ppData)
+{
+    if ((result == VK_SUCCESS) && (pMemoryMapInfo != nullptr))
+    {
+        PostProcess_vkMapMemory(result,
+                                device,
+                                pMemoryMapInfo->memory,
+                                pMemoryMapInfo->offset,
+                                pMemoryMapInfo->size,
+                                pMemoryMapInfo->flags,
+                                ppData);
+    }
+}
+
 void VulkanCaptureManager::PreProcess_vkFlushMappedMemoryRanges(VkDevice                   device,
                                                                 uint32_t                   memoryRangeCount,
                                                                 const VkMappedMemoryRange* pMemoryRanges)
@@ -2982,6 +2999,15 @@ void VulkanCaptureManager::PreProcess_vkUnmapMemory(VkDevice device, VkDeviceMem
     {
         GFXRECON_LOG_WARNING(
             "Attempting to unmap VkDeviceMemory object with handle = %" PRIx64 " that has not been mapped", memory);
+    }
+}
+
+void VulkanCaptureManager::PreProcess_vkUnmapMemory2(VkDevice device, const VkMemoryUnmapInfo* pMemoryUnmapInfo)
+{
+
+    if (pMemoryUnmapInfo != nullptr)
+    {
+        PreProcess_vkUnmapMemory(device, pMemoryUnmapInfo->memory);
     }
 }
 

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1332,6 +1332,9 @@ class VulkanCaptureManager : public ApiCaptureManager
                                  VkMemoryMapFlags flags,
                                  void**           ppData);
 
+    void
+    PostProcess_vkMapMemory2(VkResult result, VkDevice device, const VkMemoryMapInfo* pMemoryMapInfo, void** ppData);
+
     void PostProcess_vkAcquireFullScreenExclusiveModeEXT(VkResult result, VkDevice device, VkSwapchainKHR swapchain);
 
     void PostProcess_vkGetPhysicalDeviceSurfacePresentModes2EXT(VkResult                               result,
@@ -1357,6 +1360,8 @@ class VulkanCaptureManager : public ApiCaptureManager
                                               const VkMappedMemoryRange* pMemoryRanges);
 
     void PreProcess_vkUnmapMemory(VkDevice device, VkDeviceMemory memory);
+
+    void PreProcess_vkUnmapMemory2(VkDevice device, const VkMemoryUnmapInfo* pMemoryUnmapInfo);
 
     void PreProcess_vkFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator);
 


### PR DESCRIPTION
Support for VK_KHR_map_memory2 was missing. This forwards calls from new 2 functions to the old ones