### PR TITLE
Turn a problematic asserting into a warning, continue loop-iteration

### DIFF
--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2553,7 +2553,11 @@ void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper*
             (((image_wrapper->is_swapchain_image || image_wrapper->is_sparse_image) && memory_wrapper == nullptr) ||
              ((!image_wrapper->is_swapchain_image && !image_wrapper->is_sparse_image) && memory_wrapper != nullptr)));
 
-        GFXRECON_ASSERT(snapshot_entry.resource_size > 0);
+        if (snapshot_entry.resource_size == 0)
+        {
+            GFXRECON_LOG_WARNING("%s: expected snapshot_entry.resource_size > 0 - skipping", __func__);
+            continue;
+        }
 
         ImageResource image_resource        = {};
         image_resource.handle_id            = image_wrapper->handle_id;


### PR DESCRIPTION
the motivation for this PR is a case where I'm able to replay a capture using:
`gfxrecon-replay -m rebind --remove-unsupported`

trying to trim this capture, using the same command for replay,  crashed somewhere deep into the capture.
debug-builds were hitting the mentioned assert.
before that, I was seeing the following logs:
`[gfxrecon] ERROR - Format VK_FORMAT_D24_UNORM_S8_UINT is not supported by the implementation`

the suggested change simply skips over the assertion, logs a warning and continues processing other loop-items.
this fixes trimming on different device for me. 
otherwise I would depend on trimming on the same device (which I don't have here)