### PR TITLE
Address novel errors found in -G Xcode builds

### DIFF
--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -89,7 +89,7 @@ class Application final
 
     uint32_t GetCurrentFrameNumber() const
     {
-        return file_processor_->GetCurrentFrameNumber();
+        return GFXRECON_NARROWING_CAST(uint32_t, file_processor_->GetCurrentFrameNumber());
     }
 
   private:

--- a/framework/decode/common_handle_mapping_util.h
+++ b/framework/decode/common_handle_mapping_util.h
@@ -207,7 +207,9 @@ static void AddHandleArrayAsync(format::HandleId        parent_id,
     {
         assert(ids_len <= initial_infos.size());
 
-        for (size_t i = 0; i < ids_len; ++i)
+        // future_handle_index below is uint32_t, so the length must be bounded
+        const auto ids_len_32 = GFXRECON_NARROWING_CAST(uint32_t, ids_len);
+        for (uint32_t i = 0; i < ids_len_32; ++i)
         {
             auto& initial_info               = initial_infos[i];
             initial_info.handle              = VK_NULL_HANDLE; // handle does not yet exist

--- a/framework/decode/descriptor_update_template_decoder.cpp
+++ b/framework/decode/descriptor_update_template_decoder.cpp
@@ -133,8 +133,8 @@ size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buf
                         break;
                     case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
                     {
-                        cur_type.offset    = total_size;
-                        uint32_t num_bytes = cur_type.count;
+                        cur_type.offset        = total_size;
+                        const size_t num_bytes = cur_type.count;
 
                         // We will read/write raw bytes in the allocated memory block, they should be the same
                         required_read_memory_size  = num_bytes;

--- a/framework/decode/file_transformer.cpp
+++ b/framework/decode/file_transformer.cpp
@@ -141,7 +141,7 @@ bool FileTransformer::Process()
         annotation.block_header.size = format::GetAnnotationBlockBaseSize() + label_length + data_length;
         annotation.block_header.type = format::BlockType::kAnnotation;
         annotation.annotation_type   = format::kJson;
-        annotation.label_length      = label_length;
+        GFXRECON_NARROWING_ASSIGN(annotation.label_length, label_length);
         annotation.data_length       = data_length;
         if (!WriteBytes(&annotation, sizeof(annotation)) || !WriteBytes(label, label_length) ||
             !WriteBytes(data.c_str(), data_length))

--- a/framework/decode/openxr_replay_consumer_base.cpp
+++ b/framework/decode/openxr_replay_consumer_base.cpp
@@ -1045,10 +1045,11 @@ void OpenXrReplayConsumerBase::Process_xrEnumerateDisplayRefreshRatesFB(
 
             // Allocate the blend mode array and get all the values
             std::vector<float> display_refresh_rates(replay_count);
-            replay_result = pfn_enum_dis_refresh_rates_fb(in_session,
-                                                          display_refresh_rates.size(),
-                                                          out_displayRefreshRateCountOutput,
-                                                          display_refresh_rates.data());
+            replay_result =
+                pfn_enum_dis_refresh_rates_fb(in_session,
+                                              GFXRECON_NARROWING_CAST(uint32_t, display_refresh_rates.size()),
+                                              out_displayRefreshRateCountOutput,
+                                              display_refresh_rates.data());
 
             // We are comparing against success, but the original replay may have had an incomplete
             CheckResult("xrEnumerateEnvironmentBlendModes", XR_SUCCESS, replay_result, call_info);

--- a/framework/decode/openxr_stats_consumer.h
+++ b/framework/decode/openxr_stats_consumer.h
@@ -55,7 +55,7 @@ struct OpenXrInstanceTracker
     uint32_t                 app_version{ 0 };
     std::string              engine_name;
     uint32_t                 engine_version{ 0 };
-    uint32_t                 api_version{ 0 };
+    XrVersion                api_version{ 0 };
     std::vector<std::string> enabled_extensions;
 };
 

--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -697,7 +697,9 @@ void VulkanCppConsumerBase::Generate_vkGetSwapchainImagesKHR(VkResult           
         AddKnownVariables("VkImage*", swapchain_images_var_name);
         if (returnValue == VK_SUCCESS)
         {
-            AddHandles(swapchain_images_var_name, pSwapchainImages->GetPointer(), pSwapchainImages->GetLength());
+            AddHandles(swapchain_images_var_name,
+                       pSwapchainImages->GetPointer(),
+                       GFXRECON_NARROWING_CAST(uint32_t, pSwapchainImages->GetLength()));
         }
     }
 
@@ -2388,8 +2390,8 @@ void VulkanCppConsumerBase::GenerateDescriptorUpdateTemplateData(DescriptorUpdat
     }
 
     // Check if the number of descriptors in pData equal the number of descriptors in the template
-    uint32_t expected_data_count = decoder->GetImageInfoCount() + decoder->GetBufferInfoCount() +
-                                   decoder->GetTexelBufferViewCount() + decoder->GetAccelerationStructureKHRCount();
+    const auto expected_data_count = decoder->GetImageInfoCount() + decoder->GetBufferInfoCount() +
+                                     decoder->GetTexelBufferViewCount() + decoder->GetAccelerationStructureKHRCount();
     assert(template_descriptor_count == expected_data_count);
 
     // Sort the variables based on the offset

--- a/framework/decode/vulkan_cpp_consumer_base.h
+++ b/framework/decode/vulkan_cpp_consumer_base.h
@@ -611,11 +611,11 @@ class VulkanCppConsumerBase : public VulkanConsumer
     static std::string BuildValue(const StdVideoAV1FrameRestorationType* values, uint32_t count);
 
     template <typename T, class = typename std::enable_if<std::is_arithmetic<T>::value>::type>
-    static std::string BuildValue(const T* values, uint32_t count)
+    static std::string BuildValue(const T* values, size_t count)
     {
         std::stringstream output;
         output << "{";
-        for (uint32_t idx = 0; idx < count; idx++)
+        for (size_t idx = 0; idx < count; idx++)
         {
             output << std::to_string(values[idx]) << ", ";
         }

--- a/framework/decode/vulkan_cpp_structs.cpp
+++ b/framework/decode/vulkan_cpp_structs.cpp
@@ -1374,7 +1374,7 @@ std::string GenerateStruct_VkMemoryToImageCopy(std::ostream&                out,
         out << "\t\t"
             << "const uint8_t " << phost_pointer_array << "[] = "
             << VulkanCppConsumerBase::BuildValue(reinterpret_cast<const uint8_t*>(structInfo->pHostPointer),
-                                                 metaInfo->pHostPointer.GetLength())
+                                                 GFXRECON_NARROWING_CAST(uint32_t, metaInfo->pHostPointer.GetLength()))
             << ";" << std::endl;
     }
 
@@ -1465,7 +1465,7 @@ std::string GenerateStruct_VkImageToMemoryCopy(std::ostream&                out,
         out << "\t\t"
             << "uint8_t " << phost_pointer_array << "[] = "
             << VulkanCppConsumerBase::BuildValue(reinterpret_cast<const uint8_t*>(structInfo->pHostPointer),
-                                                 metaInfo->pHostPointer.GetLength())
+                                                 GFXRECON_NARROWING_CAST(uint32_t, metaInfo->pHostPointer.GetLength()))
             << ";" << std::endl;
     }
 

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -606,7 +606,7 @@ void VulkanDecoderBase::DispatchVulkanAccelerationStructuresBuildMetaCommand(con
     for (auto consumer : consumers_)
     {
         consumer->ProcessVulkanBuildAccelerationStructuresCommand(
-            device_id, pInfos.GetLength(), &pInfos, &ppRangeInfos);
+            device_id, GFXRECON_NARROWING_CAST(uint32_t, pInfos.GetLength()), &pInfos, &ppRangeInfos);
     }
 }
 

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -249,7 +249,7 @@ VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                     
                             ->virtual_swapchain_images[present_info->pImageIndices[i]]
                             .image;
         }
-        frame_boundary_.imageCount = images.size();
+        GFXRECON_NARROWING_ASSIGN(frame_boundary_.imageCount, images.size());
         frame_boundary_.pImages    = images.data();
         ++frame_boundary_.frameID;
 

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -1856,7 +1856,7 @@ void VulkanRebindAllocator::WriteBoundResourceStaging(ResourceAllocInfo* resourc
         compute_submit_info.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
         compute_submit_info.commandBufferCount   = 1;
         compute_submit_info.pCommandBuffers      = &staging_resources.cmd_buffer;
-        compute_submit_info.waitSemaphoreCount   = waiting_semaphores.size();
+        GFXRECON_NARROWING_ASSIGN(compute_submit_info.waitSemaphoreCount, waiting_semaphores.size());
         compute_submit_info.pWaitSemaphores      = waiting_semaphores.data();
         compute_submit_info.pWaitDstStageMask    = waiting_semaphores_dst_stage_mask.data();
         compute_submit_info.signalSemaphoreCount = 1;
@@ -3037,11 +3037,11 @@ VkResult VulkanRebindAllocator::QueueBindSparse(VkQueue                 queue,
             ++alc_img_i;
         }
 
-        modified_bind_info.bufferBindCount      = modified_buffer_bind_infos[i].size();
+        GFXRECON_NARROWING_ASSIGN(modified_bind_info.bufferBindCount, modified_buffer_bind_infos[i].size());
         modified_bind_info.pBufferBinds         = modified_buffer_bind_infos[i].data();
-        modified_bind_info.imageOpaqueBindCount = modified_image_opaque_bind_infos[i].size();
+        GFXRECON_NARROWING_ASSIGN(modified_bind_info.imageOpaqueBindCount, modified_image_opaque_bind_infos[i].size());
         modified_bind_info.pImageOpaqueBinds    = modified_image_opaque_bind_infos[i].data();
-        modified_bind_info.imageBindCount       = modified_image_bind_infos[i].size();
+        GFXRECON_NARROWING_ASSIGN(modified_bind_info.imageBindCount, modified_image_bind_infos[i].size());
         modified_bind_info.pImageBinds          = modified_image_bind_infos[i].data();
     }
 
@@ -3050,7 +3050,8 @@ VkResult VulkanRebindAllocator::QueueBindSparse(VkQueue                 queue,
         block->m_MapAndBindMutex.Lock();
     }
 
-    result = functions_.queue_bind_sparse(queue, modified_bind_infos.size(), modified_bind_infos.data(), fence);
+    result = functions_.queue_bind_sparse(
+        queue, GFXRECON_NARROWING_CAST(uint32_t, modified_bind_infos.size()), modified_bind_infos.data(), fence);
 
     for (VmaDeviceMemoryBlock* block : vma_mem_blocks)
     {
@@ -3202,9 +3203,9 @@ void VulkanRebindAllocator::ClearStagingResources()
     {
         return;
     }
-    const uint64_t       num_fences = staging_resources_.size();
+    const auto           num_fences = GFXRECON_NARROWING_CAST(uint32_t, staging_resources_.size());
     std::vector<VkFence> fences(num_fences);
-    for (uint64_t i = 0; i < num_fences; i++)
+    for (uint32_t i = 0; i < num_fences; i++)
     {
         fences[i] = staging_resources_[i].staging_fence;
     }
@@ -3218,7 +3219,10 @@ void VulkanRebindAllocator::ClearStagingResources()
         functions_.destroy_semaphore(device_, staging_resource.staging_semaphore, nullptr);
         vmaDestroyBuffer(allocator_, staging_resource.staging_buf, staging_resource.staging_alloc);
     }
-    functions_.free_command_buffers(device_, cmd_pool_, cmd_buffers_to_delete.size(), cmd_buffers_to_delete.data());
+    functions_.free_command_buffers(device_,
+                                    cmd_pool_,
+                                    GFXRECON_NARROWING_CAST(uint32_t, cmd_buffers_to_delete.size()),
+                                    cmd_buffers_to_delete.data());
     staging_resources_.clear();
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3102,7 +3102,7 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
                                                          ext, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
                                                  }),
                                   modified_extensions.end());
-        create_state.modified_create_info.enabledExtensionCount = modified_extensions.size();
+        GFXRECON_NARROWING_ASSIGN(create_state.modified_create_info.enabledExtensionCount, modified_extensions.size());
 
         // Try to create instance again
         result = create_instance_proc_(
@@ -6643,7 +6643,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass(
     if (original_result == VK_SUCCESS && options_.dumping_resources)
     {
         const VkRenderPassCreateInfo* create_info = pCreateInfo->GetPointer();
-        uint32_t                      num_bytes   = graphics::vulkan_struct_deep_copy(create_info, 1, nullptr);
+        size_t                        num_bytes   = graphics::vulkan_struct_deep_copy(create_info, 1, nullptr);
 
         render_pass_info->func_version = VulkanRenderPassInfo::kCreateRenderPass;
         render_pass_info->create_info.resize(num_bytes);
@@ -6696,7 +6696,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRenderPass2(
     if (original_result == VK_SUCCESS && options_.dumping_resources)
     {
         const VkRenderPassCreateInfo2* create_info = pCreateInfo->GetPointer();
-        uint32_t                       num_bytes   = graphics::vulkan_struct_deep_copy(create_info, 1, nullptr);
+        const size_t                   num_bytes   = graphics::vulkan_struct_deep_copy(create_info, 1, nullptr);
 
         render_pass_info->func_version = (func == GetDeviceTable(device_info->handle)->CreateRenderPass2)
                                              ? VulkanRenderPassInfo::kCreateRenderPass2
@@ -7158,7 +7158,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
         // following process, we'll try to find corresponding replay time pipeline cache data.
         auto capture_pipeline_cache_data_hash = gfxrecon::util::hash::GenerateCheckSum<uint32_t>(
             reinterpret_cast<const uint8_t*>(override_create_info.pInitialData), override_create_info.initialDataSize);
-        uint32_t capture_pipeline_cache_data_size = override_create_info.initialDataSize;
+        size_t capture_pipeline_cache_data_size = override_create_info.initialDataSize;
 
         object_info_table_->VisitVkPipelineCacheInfo([&](const VulkanPipelineCacheInfo* pipeline_cache_info) {
             GFXRECON_ASSERT(pipeline_cache_info != nullptr);
@@ -11348,7 +11348,7 @@ void VulkanReplayConsumerBase::ProcessVulkanCopyAccelerationStructuresCommand(
             const auto& address_tracker  = GetDeviceAddressTracker(device_info);
             auto&       address_replacer = GetDeviceAddressReplacer(device_info);
             address_replacer.ProcessCopyVulkanAccelerationStructuresMetaCommand(
-                copy_infos->GetLength(), copy_infos->GetPointer(), address_tracker);
+                GFXRECON_NARROWING_CAST(uint32_t, copy_infos->GetLength()), copy_infos->GetPointer(), address_tracker);
         }
     }
 }
@@ -11709,7 +11709,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateGraphicsPipelines(
 
     if (original_result >= 0 && !options_.replace_shader_dir.empty())
     {
-        uint32_t num_bytes = graphics::vulkan_struct_deep_copy(in_p_create_infos, create_info_count, nullptr);
+        const size_t num_bytes = graphics::vulkan_struct_deep_copy(in_p_create_infos, create_info_count, nullptr);
         create_info_data.resize(num_bytes);
         graphics::vulkan_struct_deep_copy(in_p_create_infos, create_info_count, create_info_data.data());
         auto* replaced_create_infos = reinterpret_cast<VkGraphicsPipelineCreateInfo*>(create_info_data.data());
@@ -11864,7 +11864,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShadersEXT(
 
     if (original_result >= 0 && !options_.replace_shader_dir.empty())
     {
-        uint32_t num_bytes = graphics::vulkan_struct_deep_copy(in_p_create_infos, create_info_count, nullptr);
+        const size_t num_bytes = graphics::vulkan_struct_deep_copy(in_p_create_infos, create_info_count, nullptr);
         create_info_data.resize(num_bytes);
         graphics::vulkan_struct_deep_copy(in_p_create_infos, create_info_count, create_info_data.data());
         auto* replaced_create_infos = reinterpret_cast<VkShaderCreateInfoEXT*>(create_info_data.data());
@@ -12145,7 +12145,7 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
     }
 
     // replace with deep-copy of create-info array
-    uint32_t             num_bytes = graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, nullptr);
+    const size_t         num_bytes = graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, nullptr);
     std::vector<uint8_t> create_info_data(num_bytes);
     graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, create_info_data.data());
     std::vector<format::HandleId> pipeline_ids(createInfoCount);
@@ -12265,7 +12265,7 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
     graphics::populate_shader_stages(pCreateInfos, pPipelines, GetObjectInfoTable());
 
     // replace with deep-copy of create-info array
-    uint32_t             num_bytes = graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, nullptr);
+    const size_t         num_bytes = graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, nullptr);
     std::vector<uint8_t> create_info_data(num_bytes);
     graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, create_info_data.data());
     std::vector<format::HandleId> pipeline_ids(createInfoCount);
@@ -12345,7 +12345,7 @@ VulkanReplayConsumerBase::AsyncCreateShadersEXT(PFN_vkCreateShadersEXT          
     VkDevice                     device_handle   = device_info->handle;
 
     // replace with deep-copy of create-info array
-    uint32_t             num_bytes = graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, nullptr);
+    const size_t         num_bytes = graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, nullptr);
     std::vector<uint8_t> create_info_data(num_bytes);
     graphics::vulkan_struct_deep_copy(in_pCreateInfos, createInfoCount, create_info_data.data());
     std::vector<format::HandleId> shaders(createInfoCount);
@@ -12654,10 +12654,10 @@ void VulkanReplayConsumerBase::TrackNewPipelineCache(const VulkanDeviceInfo* dev
                                                      format::HandleId        id,
                                                      VkPipelineCache         pipelineCache,
                                                      VkPipeline*             pipelines,
-                                                     uint32_t                pipelineCount)
+                                                     size_t                  pipelineCount)
 {
     tracked_pipeline_caches_.emplace(id, std::make_pair(device_info, pipelineCache));
-    for (uint32_t i = 0; i < pipelineCount; ++i)
+    for (size_t i = 0; i < pipelineCount; ++i)
     {
         pipeline_cache_correspondances_.emplace(pipelines[i], id);
     }
@@ -13018,7 +13018,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineBinariesKHR(
     VkPipelineBinaryHandlesInfoKHR* out_pBinaries = pBinaries->GetOutputPointer();
     if (out_pBinaries != nullptr && pBinaries->GetLength() > 0)
     {
-        out_pBinaries->pipelineBinaryCount = pBinaries->GetLength();
+        GFXRECON_NARROWING_ASSIGN(out_pBinaries->pipelineBinaryCount, pBinaries->GetLength());
         out_pBinaries->pPipelineBinaries =
             DecodeAllocator::Allocate<VkPipelineBinaryKHR>(out_pBinaries->pipelineBinaryCount);
     }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1846,7 +1846,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                           format::HandleId        id,
                                           VkPipelineCache         pipelineCache,
                                           VkPipeline*             pipelines,
-                                          uint32_t                pipelineCount);
+                                          size_t                  pipelineCount);
 
     bool IsExtensionBeingFaked(const char* extension);
 

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -814,7 +814,8 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRenderPass(
                     pRenderPassBegin->GetMetaStructPointer()->pNext);
                 GFXRECON_ASSERT(attachment_begin_info);
 
-                uint32_t                num_attachments = attachment_begin_info->pAttachments.GetLength();
+                const auto num_attachments =
+                    GFXRECON_NARROWING_CAST(uint32_t, attachment_begin_info->pAttachments.GetLength());
                 const format::HandleId* handle_ids      = attachment_begin_info->pAttachments.GetPointer();
 
                 GFXRECON_ASSERT(num_attachments == render_pass_info->attachment_description_final_layouts.size());
@@ -885,7 +886,8 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRenderPass2(
                     pRenderPassBegin->GetMetaStructPointer()->pNext);
                 GFXRECON_ASSERT(attachment_begin_info);
 
-                uint32_t                num_attachments = attachment_begin_info->pAttachments.GetLength();
+                const auto num_attachments =
+                    GFXRECON_NARROWING_CAST(uint32_t, attachment_begin_info->pAttachments.GetLength());
                 const format::HandleId* handle_ids      = attachment_begin_info->pAttachments.GetPointer();
 
                 GFXRECON_ASSERT(num_attachments == render_pass_info->attachment_description_final_layouts.size());
@@ -1861,7 +1863,8 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(const std::vector<VkSubmitIn
 
         if (modified_command_buffer_handles[s].size())
         {
-            modified_submit_infos[s].commandBufferCount = modified_command_buffer_handles[s].size();
+            GFXRECON_NARROWING_ASSIGN(modified_submit_infos[s].commandBufferCount,
+                                      modified_command_buffer_handles[s].size());
             modified_submit_infos[s].pCommandBuffers    = modified_command_buffer_handles[s].data();
         }
         else
@@ -1878,8 +1881,10 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(const std::vector<VkSubmitIn
 
     if (pre_submit)
     {
-        VkResult res = device_table.QueueSubmit(
-            queue_info->handle, modified_submit_infos.size(), modified_submit_infos.data(), fence);
+        VkResult res = device_table.QueueSubmit(queue_info->handle,
+                                                GFXRECON_NARROWING_CAST(uint32_t, modified_submit_infos.size()),
+                                                modified_submit_infos.data(),
+                                                fence);
         if (res != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR(
@@ -1990,7 +1995,8 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(const std::vector<VkSubmitIn
     // without further modifications
     if (!submitted)
     {
-        VkResult res = device_table.QueueSubmit(queue_info->handle, submit_infos.size(), submit_infos.data(), fence);
+        VkResult res = device_table.QueueSubmit(
+            queue_info->handle, GFXRECON_NARROWING_CAST(uint32_t, submit_infos.size()), submit_infos.data(), fence);
         if (res != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR(
@@ -2119,7 +2125,7 @@ void VulkanReplayDumpResourcesBase::DumpGraphicsPipelineInfos(
             GetPNextMetaStruct<Decoded_VkPipelineLibraryCreateInfoKHR>(create_info_meta->pNext);
         if (pipeline_library_info != nullptr)
         {
-            const uint32_t          library_count = pipeline_library_info->pLibraries.GetLength();
+            const auto library_count = GFXRECON_NARROWING_CAST(uint32_t, pipeline_library_info->pLibraries.GetLength());
             const format::HandleId* ppl_ids       = pipeline_library_info->pLibraries.GetPointer();
 
             for (uint32_t lib_idx = 0; lib_idx < library_count; ++lib_idx)
@@ -2208,7 +2214,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdExecuteCommands(const ApiCallInfo
                             // Each primary should execute the command buffer from the previous
                             // secondary contexts as well
                             func(*(primary_first + finalized_primaries),
-                                 accumulated_secondaries_command_buffers.size(),
+                                 GFXRECON_NARROWING_CAST(uint32_t, accumulated_secondaries_command_buffers.size()),
                                  accumulated_secondaries_command_buffers.data());
 
                             func(*(primary_first + finalized_primaries), 1, &secondaries_command_buffers[scb]);

--- a/framework/decode/vulkan_replay_dump_resources.h
+++ b/framework/decode/vulkan_replay_dump_resources.h
@@ -463,7 +463,8 @@ class VulkanReplayDumpResourcesBase
                     GetPNextMetaStruct<Decoded_VkPipelineLibraryCreateInfoKHR>(create_info_meta->pNext);
                 if (pipeline_library_info != nullptr)
                 {
-                    const uint32_t          library_count = pipeline_library_info->pLibraries.GetLength();
+                    const auto library_count =
+                        GFXRECON_NARROWING_CAST(uint32_t, pipeline_library_info->pLibraries.GetLength());
                     const format::HandleId* ppl_ids       = pipeline_library_info->pLibraries.GetPointer();
 
                     for (uint32_t lib_idx = 0; lib_idx < library_count; ++lib_idx)

--- a/framework/decode/vulkan_replay_dump_resources_as.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_as.cpp
@@ -415,7 +415,7 @@ VkResult AccelerationStructureDumpResourcesContext::CloneBuildAccelerationStruct
                 const size_t instance_buffer_stride = sizeof(VkAccelerationStructureInstanceKHR);
                 const size_t instance_buffer_size   = range.primitiveCount * instance_buffer_stride;
                 new_instances.instance_count        = range.primitiveCount;
-                new_instances.instance_buffer_size  = instance_buffer_size;
+                GFXRECON_NARROWING_ASSIGN(new_instances.instance_buffer_size, instance_buffer_size);
 
                 size_t                  buffer_device_address_offset;
                 const VulkanBufferInfo* instances_buffer_info =

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -389,8 +389,8 @@ VkResult DumpImage(DumpedImage&                         dumped_image,
     std::vector<VkImageAspectFlagBits> aspects;
     graphics::AspectFlagsToFlagBits(modified_subresource_range.aspectMask, aspects);
 
-    const uint32_t total_subresources =
-        aspects.size() * (modified_subresource_range.layerCount * modified_subresource_range.levelCount);
+    const uint32_t total_subresources = GFXRECON_NARROWING_CAST(
+        uint32_t, (aspects.size() * (modified_subresource_range.layerCount * modified_subresource_range.levelCount)));
 
     data.resize(total_subresources);
 
@@ -1758,7 +1758,8 @@ void CopyBufferAndBarrier(VkCommandBuffer                    command_buffer,
                           VkPipelineStageFlags               src_stage_mask,
                           VkPipelineStageFlags               dst_stage_mask)
 {
-    device_table.CmdCopyBuffer(command_buffer, src, dst, regions.size(), regions.data());
+    device_table.CmdCopyBuffer(
+        command_buffer, src, dst, GFXRECON_NARROWING_CAST(uint32_t, regions.size()), regions.data());
 
     const VkBufferMemoryBarrier buffer_barrier = { VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
                                                    nullptr,

--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -409,7 +409,7 @@ void DispatchTraceRaysDumpingContext::BindDescriptorSets(
     uint32_t dynamic_offset_index = 0;
     for (size_t i = 0; i < descriptor_sets_infos.size(); ++i)
     {
-        uint32_t set_index = first_set + i;
+        const auto set_index = GFXRECON_NARROWING_CAST(uint32_t, (first_set + i));
 
         VulkanDescriptorSetInfo::VulkanDescriptorBindingsInfo& bound_descriptor_sets =
             pipeline_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE ? bound_descriptor_sets_compute_[set_index]
@@ -638,7 +638,7 @@ void DispatchTraceRaysDumpingContext::CopyImageResource(const VulkanImageInfo* s
                                 VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                 dst_image,
                                 VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                copies.size(),
+                                GFXRECON_NARROWING_CAST(uint32_t, copies.size()),
                                 copies.data());
 
     // Wait for transfer and transition source image back to previous layout

--- a/framework/decode/vulkan_replay_dump_resources_delegate.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_delegate.cpp
@@ -2044,7 +2044,8 @@ bool DefaultVulkanDumpResourcesDelegate::DumpTransferCommandToFile(
             GFXRECON_ASSERT(dumped_copy_buffer != nullptr);
 
             GFXRECON_ASSERT(buffer_copy_host_data->regions_data.size() == dumped_copy_buffer->regions.size());
-            for (size_t i = 0; i < buffer_copy_host_data->regions_data.size(); ++i)
+            const auto region_count = GFXRECON_NARROWING_CAST(uint32_t, buffer_copy_host_data->regions_data.size());
+            for (uint32_t i = 0; i < region_count; ++i)
             {
                 const auto&       region_host_data = buffer_copy_host_data->regions_data[i];
                 const std::string filename         = GenerateTransferToBufferRegionFilename(
@@ -2065,7 +2066,8 @@ bool DefaultVulkanDumpResourcesDelegate::DumpTransferCommandToFile(
             GFXRECON_ASSERT(dumped_copy_image_to_buffer != nullptr);
 
             GFXRECON_ASSERT(buffer_copy_host_data->regions_data.size() == dumped_copy_image_to_buffer->regions.size());
-            for (size_t i = 0; i < buffer_copy_host_data->regions_data.size(); ++i)
+            const auto region_count = GFXRECON_NARROWING_CAST(uint32_t, buffer_copy_host_data->regions_data.size());
+            for (uint32_t i = 0; i < region_count; ++i)
             {
                 const auto&       region_host_data = buffer_copy_host_data->regions_data[i];
                 const std::string filename         = GenerateTransferToBufferRegionFilename(

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -1377,7 +1377,7 @@ void VulkanVirtualSwapchain::FrameBoundaryANDROID(PFN_vkFrameBoundaryANDROID    
         VkSubmitInfo submit_info;
         submit_info.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
         submit_info.pNext                = nullptr;
-        submit_info.waitSemaphoreCount   = submit_wait_semaphores.size();
+        GFXRECON_NARROWING_ASSIGN(submit_info.waitSemaphoreCount, submit_wait_semaphores.size());
         submit_info.pWaitSemaphores      = submit_wait_semaphores.data();
         submit_info.pWaitDstStageMask    = submit_wait_stages.data();
         submit_info.commandBufferCount   = 1;
@@ -1401,7 +1401,7 @@ void VulkanVirtualSwapchain::FrameBoundaryANDROID(PFN_vkFrameBoundaryANDROID    
 
     if (swapchain_options_.virtual_swapchain_skip_blit)
     {
-        present_info.waitSemaphoreCount = submit_wait_semaphores.size();
+        GFXRECON_NARROWING_ASSIGN(present_info.waitSemaphoreCount, submit_wait_semaphores.size());
         present_info.pWaitSemaphores    = submit_wait_semaphores.data();
     }
     else

--- a/framework/graphics/vulkan_check_buffer_references.cpp
+++ b/framework/graphics/vulkan_check_buffer_references.cpp
@@ -34,9 +34,9 @@ void populate_shader_stages(const decode::StructPointerDecoder<T>*    pCreateInf
                             decode::HandlePointerDecoder<VkPipeline>* pPipelines,
                             const decode::CommonObjectInfoTable&      object_info_table)
 {
-    uint32_t pipeline_count = pPipelines->GetLength();
+    size_t pipeline_count = pPipelines->GetLength();
 
-    for (uint32_t i = 0; i < pipeline_count; ++i)
+    for (size_t i = 0; i < pipeline_count; ++i)
     {
         auto* pipeline_info = reinterpret_cast<decode::VulkanPipelineInfo*>(pPipelines->GetConsumerData(i));
         GFXRECON_ASSERT(pipeline_info);
@@ -92,9 +92,9 @@ void populate_shader_stages(
     decode::HandlePointerDecoder<VkPipeline>*                                        pPipelines,
     const decode::CommonObjectInfoTable&                                             object_info_table)
 {
-    uint32_t pipeline_count = pPipelines->GetLength();
+    size_t pipeline_count = pPipelines->GetLength();
 
-    for (uint32_t i = 0; i < pipeline_count; ++i)
+    for (size_t i = 0; i < pipeline_count; ++i)
     {
         auto* pipeline_info = reinterpret_cast<decode::VulkanPipelineInfo*>(pPipelines->GetConsumerData(i));
 

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -1336,7 +1336,7 @@ void VulkanResourcesUtil::TransitionImageFromTransferOptimal(VkCommandBuffer    
 void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_buffer,
                                           VkImage                      image,
                                           VkBuffer                     buffer,
-                                          uint32_t                     buffer_offset,
+                                          VkDeviceSize                 buffer_offset,
                                           const VkExtent3D&            extent,
                                           uint32_t                     mip_levels,
                                           uint32_t                     array_layers,
@@ -2263,21 +2263,21 @@ void VulkanResourcesUtil::ReadBufferResources(const std::vector<BufferResource>&
     }
 }
 
-bool GetIntersectForSparseMemoryBind(uint32_t               new_bind_resource_offset,
-                                     uint32_t               new_bind_resource_size,
-                                     uint32_t               existing_bind_resource_offset,
-                                     uint32_t               existing_bind_resource_size,
-                                     uint32_t&              intersection_resource_offset,
-                                     uint32_t&              intersection_resource_size,
-                                     std::vector<uint32_t>& remaining_resource_offsets,
-                                     std::vector<uint32_t>& remaining_resource_sizes,
-                                     bool&                  new_bind_range_include_existing_bind_tange,
-                                     bool&                  existing_bind_range_include_new_bind_tange)
+bool GetIntersectForSparseMemoryBind(VkDeviceSize               new_bind_resource_offset,
+                                     VkDeviceSize               new_bind_resource_size,
+                                     VkDeviceSize               existing_bind_resource_offset,
+                                     VkDeviceSize               existing_bind_resource_size,
+                                     VkDeviceSize&              intersection_resource_offset,
+                                     VkDeviceSize&              intersection_resource_size,
+                                     std::vector<VkDeviceSize>& remaining_resource_offsets,
+                                     std::vector<VkDeviceSize>& remaining_resource_sizes,
+                                     bool&                      new_bind_range_include_existing_bind_tange,
+                                     bool&                      existing_bind_range_include_new_bind_tange)
 {
     bool     intersection_exist = false;
-    uint32_t intersection_start = std::max(new_bind_resource_offset, existing_bind_resource_offset);
-    uint32_t intersection_end   = std::min(new_bind_resource_offset + new_bind_resource_size,
-                                         existing_bind_resource_offset + existing_bind_resource_size);
+    VkDeviceSize intersection_start = std::max(new_bind_resource_offset, existing_bind_resource_offset);
+    VkDeviceSize intersection_end   = std::min(new_bind_resource_offset + new_bind_resource_size,
+                                             existing_bind_resource_offset + existing_bind_resource_size);
 
     existing_bind_range_include_new_bind_tange = false;
     new_bind_range_include_existing_bind_tange = false;
@@ -2334,8 +2334,8 @@ void UpdateSparseMemoryBindMap(std::map<VkDeviceSize, VkSparseMemoryBind>& spars
     {
         for (auto item = sparse_memory_bind_map.begin(); item != iterator; item++)
         {
-            uint32_t              intersection_resource_offset, intersection_resource_size;
-            std::vector<uint32_t> remaining_resource_offsets, remaining_resource_sizes;
+            VkDeviceSize              intersection_resource_offset, intersection_resource_size;
+            std::vector<VkDeviceSize> remaining_resource_offsets, remaining_resource_sizes;
             bool new_bind_range_include_existing_bind_tange, existing_bind_range_include_new_bind_tange;
 
             bool is_intersected = GetIntersectForSparseMemoryBind(new_sparse_memory_bind.resourceOffset,

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -209,7 +209,7 @@ class VulkanResourcesUtil
     void CopyImageBuffer(VkCommandBuffer              command_buffer,
                          VkImage                      image,
                          VkBuffer                     buffer,
-                         uint32_t                     buffer_offset,
+                         VkDeviceSize                 buffer_offset,
                          const VkExtent3D&            extent,
                          uint32_t                     mip_levels,
                          uint32_t                     array_layers,

--- a/framework/util/spirv_parsing_util.cpp
+++ b/framework/util/spirv_parsing_util.cpp
@@ -81,12 +81,12 @@ LayoutInfo compute_type_layout(const SpvReflectTypeDescription* type_description
             for (uint32_t i = 0; i < type_description->member_count; ++i)
             {
                 LayoutInfo layout_info = compute_type_layout(&type_description->members[i]);
-                offset                 = util::aligned_value(offset, layout_info.alignment);
+                GFXRECON_NARROWING_ASSIGN(offset, util::aligned_value(offset, layout_info.alignment));
                 offset += layout_info.size;
                 max_align = std::max(max_align, layout_info.alignment);
             }
 
-            num_bytes = util::aligned_value(offset, max_align);
+            GFXRECON_NARROWING_ASSIGN(num_bytes, util::aligned_value(offset, max_align));
         }
         break;
 
@@ -367,7 +367,7 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
 
                         // align offset, add size
                         auto layout_info = compute_type_layout(member);
-                        offset           = util::aligned_value(offset, layout_info.alignment);
+                        GFXRECON_NARROWING_ASSIGN(offset, util::aligned_value(offset, layout_info.alignment));
                         offset += layout_info.size;
                     }
                 }
@@ -521,8 +521,10 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
                                         auto layout_info = compute_type_layout(&td->members[m]);
 
                                         // align offset, add size
-                                        buffer_reference_info.buffer_offset = util::aligned_value(
-                                            buffer_reference_info.buffer_offset, layout_info.alignment);
+                                        GFXRECON_NARROWING_ASSIGN(
+                                            buffer_reference_info.buffer_offset,
+                                            util::aligned_value(buffer_reference_info.buffer_offset,
+                                                                layout_info.alignment));
                                         buffer_reference_info.buffer_offset += layout_info.size;
                                     }
 

--- a/framework/util/strings.cpp
+++ b/framework/util/strings.cpp
@@ -116,7 +116,7 @@ bool StringToU32(const std::string& value_string, uint32_t& value)
     bool success = true;
     try
     {
-        value = std::stoul(value_string);
+        GFXRECON_NARROWING_ASSIGN(value, std::stoul(value_string));
     }
     catch (std::exception&)
     {

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -291,7 +291,7 @@ static std::string GetVkVersionString(uint32_t api_version)
 }
 
 #if ENABLE_OPENXR_SUPPORT
-static std::string GetXrVersionString(uint32_t api_version)
+static std::string GetXrVersionString(XrVersion api_version)
 {
     uint32_t major = XR_VERSION_MAJOR(api_version);
     uint32_t minor = XR_VERSION_MINOR(api_version);
@@ -321,7 +321,7 @@ void GatherApiAgnosticStats(ApiAgnosticStats&                api_agnostic_stats,
     }
     api_agnostic_stats.compression_type   = compression_type;
     api_agnostic_stats.trim_start_frame   = stat_consumer.GetTrimmedStartFrame();
-    api_agnostic_stats.frame_count        = file_processor.GetCurrentFrameNumber();
+    GFXRECON_NARROWING_ASSIGN(api_agnostic_stats.frame_count, file_processor.GetCurrentFrameNumber());
     api_agnostic_stats.uses_frame_markers = file_processor.UsesFrameMarkers();
     api_agnostic_stats.blank_frame_count  = blank_frame_count;
 }
@@ -642,9 +642,9 @@ nlohmann::json GetVulkanDeviceMemoryStatsJson(uint64_t alloc_count,
 void PrintVulkanDeviceMemoryStatsText(uint64_t alloc_count,
                                       uint64_t min_alloc,
                                       uint64_t max_alloc,
-                                      uint32_t gfx_pipelines,
-                                      uint32_t comp_pipelines,
-                                      uint32_t rt_pipelines)
+                                      uint64_t gfx_pipelines,
+                                      uint64_t comp_pipelines,
+                                      uint64_t rt_pipelines)
 {
     WriteOutput("\nVulkan device memory allocation info:");
     WriteOutput("\tTotal allocations:   %" PRIu64, alloc_count);
@@ -748,12 +748,13 @@ nlohmann::json GetVulkanStatsJson(const gfxrecon::decode::FileProcessor&       f
                     dev_json["extensions"] = dev_info[dev].enabled_extensions;
 
                     // For Verbose, we write out each devices alloc info.
-                    dev_json["memory"] = GetVulkanDeviceMemoryStatsJson(dev_info[dev].allocation_count,
-                                                                        dev_info[dev].min_allocation_size,
-                                                                        dev_info[dev].max_allocation_size,
-                                                                        dev_info[dev].graphics_pipelines,
-                                                                        dev_info[dev].compute_pipelines,
-                                                                        dev_info[dev].raytracing_pipelines);
+                    dev_json["memory"] = GetVulkanDeviceMemoryStatsJson(
+                        dev_info[dev].allocation_count,
+                        dev_info[dev].min_allocation_size,
+                        dev_info[dev].max_allocation_size,
+                        GFXRECON_NARROWING_CAST(uint32_t, dev_info[dev].graphics_pipelines),
+                        GFXRECON_NARROWING_CAST(uint32_t, dev_info[dev].compute_pipelines),
+                        GFXRECON_NARROWING_CAST(uint32_t, dev_info[dev].raytracing_pipelines));
 
                     vulkan_devices.push_back(dev_json);
                 }


### PR DESCRIPTION
Was experimenting with the XCode generator to build graphics reconstruct, encountered a set of narrowing related "warnings as errors".  Updated the CONVERSION_DATA_LOSS to support to easily address and patched the issues, streamlined to cast only operations for release builds.  Additionally, some errors involved VkDeviceSize information narrowing through 32bit paths back to VkDeviceSize.  Addressed the narrow impacts on hash seeding.  