### PR TITLE
Fix screenshots from `VkFrameBoundaryEXT`

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2780,8 +2780,13 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDevic
     {
         for (uint32_t i = 0; i < frame_boundary->pImages.GetLength(); ++i)
         {
-            const std::string filename_prefix =
+            std::string filename_prefix =
                 screenshot_file_prefix_ + "_frame_" + std::to_string(screenshot_handler_->GetCurrentFrame());
+
+            if (frame_boundary->pImages.GetLength() > 1)
+            {
+                filename_prefix += "_image_" + std::to_string(i);
+            }
 
             const format::HandleId handleId   = frame_boundary->pImages.GetPointer()[i];
             const VulkanImageInfo* image_info = GetObjectInfoTable().GetVkImageInfo(handleId);


### PR DESCRIPTION
`VkFrameBoundaryEXT` can specify multiple images as being part of the same frame. Currently, when taking screenshots, GFXReconstruct will override the image instead of adding multiple images for the same frame.

This commit fixes this by adding `_image_{n}` to the name of the screenshot file if multiple images are present in the frame boundary.
