### PR TITLE
android: Replay app has code

### DIFF
--- a/android/tools/replay/src/main/AndroidManifest.xml
+++ b/android/tools/replay/src/main/AndroidManifest.xml
@@ -5,15 +5,13 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
 
-    <!-- This .apk has no Java code itself, so set hasCode to false. -->
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme"
-        android:supportsRtl="true"
-        android:hasCode="false">
+        android:supportsRtl="true">
         <activity android:name="android.app.NativeActivity"
                   android:exported="true"
                   android:configChanges="orientation|screenSize|keyboard|keyboardHidden|screenLayout"


### PR DESCRIPTION
The replay apk uses AndroidX libraries that contribute Java/Kotlin bytecode.

Fixes a bug introduced by https://github.com/LunarG/gfxreconstruct/pull/2738 that triggers an exception when starting the replay app (multi-win-replay is not affected):
```java
E AndroidRuntime: FATAL EXCEPTION: main
E AndroidRuntime: Process: com.lunarg.gfxreconstruct.replay, PID: 16123
E AndroidRuntime: java.lang.RuntimeException: Unable to get provider androidx.startup.InitializationProvider
E AndroidRuntime:        at android.app.ActivityThread.installProvider(ActivityThread.java:8734)
E AndroidRuntime:        at android.app.ActivityThread.installContentProviders(ActivityThread.java:8224)
E AndroidRuntime:        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7885)
E AndroidRuntime:        at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0)
E AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2559)
E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:110)
E AndroidRuntime:        at android.os.Looper.dispatchMessage(Looper.java:315)
E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:251)
E AndroidRuntime:        at android.os.Looper.loop(Looper.java:349)
E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:9041)
E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
E AndroidRuntime: Caused by: java.lang.ClassNotFoundException: Didn't find class "androidx.startup.InitializationProvider" on path: DexPathList[[],nativeLibraryDirectories=[/data/app/~~LkvHIrJfiLtMjkrgQxIxGA==/com.lunarg.gfxreconstruct.replay-P_wV1wO17c2QZv2PvmBCig==/lib/arm64, /data/app/~~LkvHIrJfiLtMjkrgQxIxGA==/com.lunarg.gfxreconstruct.replay-P_wV1wO17c2QZv2PvmBCig==/base.apk!/lib/arm64-v8a, /system/lib64, /system_ext/lib64]]
E AndroidRuntime:        at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:259)
E AndroidRuntime:        at java.lang.ClassLoader.loadClass(ClassLoader.java:642)
E AndroidRuntime:        at java.lang.ClassLoader.loadClass(ClassLoader.java:578)
E AndroidRuntime:        at android.app.AppComponentFactory.instantiateProvider(AppComponentFactory.java:147)
E AndroidRuntime:        at android.app.ActivityThread.installProvider(ActivityThread.java:8720)
E AndroidRuntime:        ... 12 more
```