### PR TITLE
Wait before frame

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -796,6 +796,7 @@ usage: gfxrecon.py replay [-h] [-p LOCAL_FILE] [--version] [--log-level LEVEL]
                           [--wait-before-first-submit MILLISECONDS]
                           [--idle-before-submit]
                           [--serialize-render-passes]
+                          [--wait-before-frame MILLISECONDS]
                           [file]
 
 Launch the replay tool.
@@ -1022,6 +1023,10 @@ options:
                         (forwarded to replay tool)
   --serialize-render-passes
                         Serialize render passes by injecting execution barriers before render pass begin during replay. (forwarded to replay tool)
+  --wait-before-frame MILLISECONDS
+                        Wait for the specified amount of milliseconds before starting
+                        to replay each frame. Default is 0 (no wait). (forwarded to
+                        replay tool)
 ```
 
 The command will force-stop an active replay process before starting the replay

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -636,6 +636,7 @@ gfxrecon-replay         [-h | --help] [--version] [--cpu-mask <binary-mask>] [--
                         [--deduplicate-device]
                         [--wait-before-first-submit MILLISECONDS]
                         [--idle-before-submit] [--serialize-render-passes]
+                        [--wait-before-frame MILLISECONDS]
 
 
 Required arguments:
@@ -887,6 +888,8 @@ Optional arguments:
   --frame-warm-up-load <load>
               Specify workload scale factor for a compute dispatch warm-up pass
               run before each frame replay. Default is 0 (disabled).
+  --wait-before-frame <milliseconds>
+              Specify a wait time in milliseconds before starting replay of each frame. Default is 0 (disabled).
 ```
 
 ### Frame Warm-Up

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -147,6 +147,7 @@ def CreateReplayParser():
     parser.add_argument('--serialize-render-passes', action='store_true', default=False, help='Serialize render passes by injecting execution barriers before render pass begin during replay. (forwarded to replay tool)')
     parser.add_argument('--frame-warm-up-spirv', metavar='DEVICE_FILE', help='Specify a user-provided SPIR-V compute shader for the warm-up pass. The shader must use entry point main and set 0, binding 0 as a storage buffer. Warm-up runs before the first submit of each replayed frame only when this option and a non-zero --frame-warm-up-load are both provided. (forwarded to replay tool)')
     parser.add_argument('--frame-warm-up-load', metavar='LOAD', default=0, help='Specify workload scale factor for a compute dispatch warm-up pass run before each frame replay. Default is 0 (disabled). (forwarded to replay tool)')
+    parser.add_argument('--wait-before-frame', metavar='MILLISECONDS', default=0, help='Wait for the specified amount of milliseconds before starting to replay each frame. Default is 0 (no wait). (forwarded to replay tool)')
 
     return parser
 
@@ -343,6 +344,10 @@ def MakeExtrasString(args):
     if args.frame_warm_up_load:
         arg_list.append('--frame-warm-up-load')
         arg_list.append('{}'.format(args.frame_warm_up_load))
+
+    if args.wait_before_frame:
+        arg_list.append('--wait-before-frame')
+        arg_list.append('{}'.format(args.wait_before_frame))
 
     if args.file:
         arg_list.append(args.file)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4182,6 +4182,10 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
                                                        const VulkanFenceInfo*                      fence_info)
 {
     options_.MaybeWaitBeforeFirstSubmit();
+    if (!fps_info_->IsFirstSubmitDone())
+    {
+        options_.MaybeWaitBeforeFrame();
+    }
 
     assert((queue_info != nullptr) && (pSubmits != nullptr));
 
@@ -4413,6 +4417,10 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
                                                         const VulkanFenceInfo*                       fence_info)
 {
     options_.MaybeWaitBeforeFirstSubmit();
+    if (!fps_info_->IsFirstSubmitDone())
+    {
+        options_.MaybeWaitBeforeFrame();
+    }
 
     GFXRECON_ASSERT((queue_info != nullptr) && (pSubmits != nullptr));
 

--- a/framework/decode/vulkan_replay_options.cpp
+++ b/framework/decode/vulkan_replay_options.cpp
@@ -46,5 +46,14 @@ void VulkanReplayOptions::MaybeWaitBeforeFirstSubmit() const
     });
 }
 
+void VulkanReplayOptions::MaybeWaitBeforeFrame() const
+{
+    if (wait_before_frame > 0)
+    {
+        GFXRECON_LOG_INFO("Waiting %u ms before starting to replay the frame.", wait_before_frame);
+        std::this_thread::sleep_for(std::chrono::milliseconds(wait_before_frame));
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -189,7 +189,11 @@ struct VulkanReplayOptions : public ReplayOptions
     // A bigger `frame_warm_up_load` means more synthetic GPU work to ramp/stabilize GPU clocks before replay.
     uint32_t frame_warm_up_load{ 0 };
 
+    /// Milliseconds to wait before starting to replay each frame.
+    uint32_t wait_before_frame{ 0 };
+
     void MaybeWaitBeforeFirstSubmit() const;
+    void MaybeWaitBeforeFrame() const;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -43,7 +43,7 @@ const char kArguments[] =
     "get-fence-status,--sgfr|--skip-get-fence-ranges,--dump-resources,--dump-resources-dir,--dump-resources-image-"
     "format,pbis,--pcj|--pipeline-creation-jobs,--save-pipeline-cache,--load-pipeline-cache,--quit-after-frame,--"
     "present-mode,--wait-before-first-submit,--idle-before-submit,--present-override,--serialize-render-passes,--frame-"
-    "warm-up-spirv,--frame-warm-up-load";
+    "warm-up-spirv,--frame-warm-up-load,--wait-before-frame";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -85,7 +85,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--wait-before-first-submit <milliseconds>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--frame-warm-up-spirv <spirv-file>] [--frame-warm-up-load <load>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--idle-before-submit] [--pbi-all] [--pbis <index1,index2>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--serialize-render-passes]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--serialize-render-passes] [--wait-before-frame <milliseconds>]");
 #if !defined(WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources <filename>.json]");
 #endif
@@ -380,6 +380,9 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --frame-warm-up-load <load>");
     GFXRECON_WRITE_CONSOLE("          \t\tSpecify workload scale factor for a compute dispatch warm-up pass");
     GFXRECON_WRITE_CONSOLE("          \t\trun before each frame replay. Default is 0 (disabled).");
+    GFXRECON_WRITE_CONSOLE("  --wait-before-frame <milliseconds>");
+    GFXRECON_WRITE_CONSOLE("          \t\tWait for the specified amount of milliseconds before starting to replay");
+    GFXRECON_WRITE_CONSOLE("          \t\teach frame. Default is 0 (no wait).");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("D3D12 only:")

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -151,6 +151,7 @@ const char kDeduplicateDevice[]                   = "--deduplicate-device";
 const char kWaitBeforeFirstSubmit[]               = "--wait-before-first-submit";
 const char kIdleBeforeSubmit[]                    = "--idle-before-submit";
 const char kSerializeRenderPasses[]               = "--serialize-render-passes";
+const char kWaitBeforeFrame[]                     = "--wait-before-frame";
 
 const char kScreenshotIgnoreFrameBoundaryArgument[] = "--screenshot-ignore-FrameBoundaryANDROID";
 
@@ -950,6 +951,25 @@ static void GetFrameWarmUpOptions(const gfxrecon::util::ArgumentParser& arg_pars
     }
 }
 
+static void GetWaitBeforeFrame(const gfxrecon::util::ArgumentParser& arg_parser, uint32_t& wait_before_frame)
+{
+    const auto& value = arg_parser.GetArgumentValue(kWaitBeforeFrame);
+
+    if (!value.empty())
+    {
+        try
+        {
+            wait_before_frame = std::stoul(value);
+        }
+        catch (std::exception&)
+        {
+            GFXRECON_LOG_WARNING(
+                "Ignoring invalid wait before frame option: \"%s\". Expected format is unsigned integer",
+                value.c_str());
+        }
+    }
+}
+
 static void GetReplayOptions(gfxrecon::decode::ReplayOptions&      options,
                              const gfxrecon::util::ArgumentParser& arg_parser,
                              const std::string&                    filename)
@@ -1308,6 +1328,7 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     replay_options.serialize_render_passes = arg_parser.IsOptionSet(kSerializeRenderPasses);
 
     GetFrameWarmUpOptions(arg_parser, replay_options.frame_warm_up_spirv_path, replay_options.frame_warm_up_load);
+    GetWaitBeforeFrame(arg_parser, replay_options.wait_before_frame);
 
     return replay_options;
 }


### PR DESCRIPTION
Add a replay option to sleep for a configurable number of milliseconds before the first queue submit of each frame.