### PR TITLE
Remove std::format

### DIFF
--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -202,10 +202,9 @@ void FilterUnreferencedResources(const std::string&                             
             exit(-1);
         }
 
-        GFXRECON_WRITE_CONSOLE(std::format("Resource filtering complete - Removed {} / {} blocks",
-                                           result.unreferenced_blocks.size(),
-                                           result.num_blocks)
-                                   .c_str());
+        GFXRECON_WRITE_CONSOLE("Resource filtering complete - Removed %zu / %" PRIu64 " blocks",
+                               result.unreferenced_blocks.size(),
+                               result.num_blocks);
         GFXRECON_WRITE_CONSOLE("\tOriginal file size: %" PRIu64 " bytes", file_optimizer.GetNumBytesRead());
         GFXRECON_WRITE_CONSOLE("\tOptimized file size: %" PRIu64 " bytes", file_optimizer.GetNumBytesWritten());
     }


### PR DESCRIPTION
Removing std::format for the same reasons as PRs 2728, 2718 and, 2647