### PR TITLE
Batch Build Raytracing Acceleration Structure

### DIFF
--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -215,6 +215,8 @@ Usage:
                         [--fwo <x,y> | --force-windowed-origin <x,y>]
                         [--log-level <level>] [--log-file <file>] [--log-debugview]
                         [--batching-memory-usage <pct>]
+                        [--dx12-batched-as-build-mode <mode>]
+                        [--dx12-batched-as-build-memory-usage <pct>]
                         [--dump-resources <submit-index,command-index,draw-call-index>]
                         [--dump-resources-before-draw]
                         [--dump-resources-dir <dir>]
@@ -321,6 +323,15 @@ Optional arguments:
                         only limits memory use for batching and does not guarantee overall max memory usage.
                         Acceptable values range from 0 to 100 (default: 80). 0 means no batching, 100 means
                         use all available system and GPU memory.
+  --dx12-batched-as-build-mode <mode>
+                        Enable batching of AS builds for trimmed capture files, and set operational mode
+                        0: No batching of AS builds
+                        1: Submit grouping happens incrementally as AS builds are encountered
+                        2: Submit grouping happens after all AS builds have been seen
+  --dx12-batched-as-build-memory-usage <pct>
+                        Max amount of memory consumption dedicated to AS building while loading a trimmed
+                        capture file. Acceptable values range from 0 to 100 (default: 80). 0 means no batching
+                        at all, 100 means use all available GPU memory.
   --dump-resources <submit-index,command-index,draw-call-index>
                         Output binary resources for a specific draw call.  The draw call is specified as a
                         submit index, command index, and draw call index triplet.  The output includes vertex,

--- a/framework/decode/dx12_acceleration_structure_builder.cpp
+++ b/framework/decode/dx12_acceleration_structure_builder.cpp
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -22,14 +23,19 @@
 
 #include "decode/dx12_acceleration_structure_builder.h"
 
+#include "decode/dx12_object_info.h"
 #include "graphics/dx12_gpu_va_map.h"
 #include "graphics/dx12_util.h"
 #include "util/logging.h"
 
+#include <functional>
 #include <inttypes.h>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
+
+// Maximum 1GB allowed for batched group allocations
+static const uint64_t kMaxStaticGpuBudget = 0x40000000;
 
 void UpdateBufferSize(ID3D12Device*                         device,
                       graphics::dx12::ID3D12ResourceComPtr& buffer,
@@ -69,9 +75,11 @@ HRESULT MapSubresourceAndWriteData(ID3D12Resource* resource, UINT subresource, s
     return result;
 }
 
-Dx12AccelerationStructureBuilder::Dx12AccelerationStructureBuilder(graphics::dx12::ID3D12Device5ComPtr device5) :
-    device5_(device5), inputs_buffer_(nullptr), inputs_buffer_size_(0), scratch_buffer_(nullptr),
-    scratch_buffer_size_(0), temp_dest_buffer_(nullptr), temp_dest_buffer_size_(0), fence_value_(0)
+Dx12AccelerationStructureBuilder::Dx12AccelerationStructureBuilder(graphics::dx12::ID3D12Device5ComPtr device5,
+                                                                   IDXGIAdapter3*                      adapter3,
+                                                                   const BatchedASBuildConfig&         config) :
+    device5_(device5),
+    adapter3_(adapter3), config_(config), fence_value_(0)
 {
     HRESULT result = E_FAIL;
 
@@ -109,98 +117,188 @@ Dx12AccelerationStructureBuilder::Dx12AccelerationStructureBuilder(graphics::dx1
         GFXRECON_LOG_ERROR(
             "Failed to initialize required DX12 objects for Dx12AccelerationStructureBuilder. (error = %lx)", result);
     }
+
+    max_batched_mem_usage_ = static_cast<double>(config_.memory_usage) / 100.0;
+
+    is_uma_ = graphics::dx12::IsUma(device5);
 }
 
-// TODO: Consider batching multiple accel struct builds where possible.
+void Dx12AccelerationStructureBuilder::AddNewInstance(
+    const format::InitDx12AccelerationStructureCommandHeader& command_header,
+    const uint8_t*                                            build_inputs_data,
+    const IDASCInstance&                                      new_instance)
+{
+    batched_instances_.push_back(new_instance);
+    IDASCInstance& batched_instance = batched_instances_.back();
+
+    batched_instance.build_inputs_data = new uint8_t[command_header.inputs_data_size]{};
+    memcpy(batched_instance.build_inputs_data, build_inputs_data, command_header.inputs_data_size);
+
+    batched_instance.cpu_build_inputs_data = batched_instance.build_inputs_data;
+}
+
 void Dx12AccelerationStructureBuilder::Build(
     const graphics::Dx12GpuVaMap&                                         gpu_va_map,
     const format::InitDx12AccelerationStructureCommandHeader&             command_header,
     const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& init_geometry_descs,
     const uint8_t*                                                        build_inputs_data)
 {
-    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC build_desc;
+    IDASCInstance new_instance;
+    new_instance.command_header      = command_header;
+    new_instance.init_geometry_descs = init_geometry_descs;
+    new_instance.build               = true;
+    new_instance.copy                = false;
 
-    bool build = true;
-    bool copy  = false;
     if (command_header.copy_source_gpu_va != 0)
     {
-        copy = true;
+        new_instance.copy = true;
 
-        // If the source GPU VA is not the same as the destination, then this is not an in-place build/copy. Skip the
-        // build and instead copy from the previously built acceleration structure.
+        // If the source GPU VA is not the same as the destination, then this is not an in-place build/copy. Skip
+        // the build and instead copy from the previously built acceleration structure.
         if (command_header.copy_source_gpu_va != command_header.dest_acceleration_structure_data)
         {
-            build = false;
+            new_instance.build = false;
         }
     }
-    bool use_temp_dest_buffer = build && copy;
 
-    if (build)
+    new_instance.use_temp_dest_buffer = new_instance.build && new_instance.copy;
+
+    // Batching disabled
+    if (config_.mode == BATCHED_AS_BUILD_MODE_DISABLED)
     {
-        SetupBuild(
-            gpu_va_map, command_header, init_geometry_descs, build_inputs_data, build_desc, use_temp_dest_buffer);
-        ExecuteBuild(gpu_va_map, build_desc);
+        unbatched_instance_.command_header       = new_instance.command_header;
+        unbatched_instance_.init_geometry_descs  = new_instance.init_geometry_descs;
+        unbatched_instance_.build                = new_instance.build;
+        unbatched_instance_.copy                 = new_instance.copy;
+        unbatched_instance_.use_temp_dest_buffer = new_instance.use_temp_dest_buffer;
+
+        unbatched_instance_.build_inputs_data = const_cast<uint8_t*>(build_inputs_data);
+
+        ExecuteNoBatch(gpu_va_map, unbatched_instance_);
     }
 
-    if (copy)
+    // Batch as blocks are seen
+    else if (config_.mode == BATCHED_AS_BUILD_MODE_INCREMENTAL_GROUPING)
     {
-        D3D12_GPU_VIRTUAL_ADDRESS dest = gpu_va_map.Map(command_header.dest_acceleration_structure_data);
-        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode =
-            static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE>(command_header.copy_mode);
+        AddNewInstance(command_header, build_inputs_data, new_instance);
 
-        D3D12_GPU_VIRTUAL_ADDRESS source = 0;
-        if (use_temp_dest_buffer)
+        IDASCInstance& batched_instance = batched_instances_.back();
+
+        SetupInstance(gpu_va_map, batched_instance);
+
+        const uint64_t total_requirement = batched_instance.buffer_sizes.total_size * graphics::dx12::kMemoryTolerance;
+
+        incremental_info_.running_requirement += total_requirement;
+
+        const uint64_t budget = GetMemoryBudget();
+
+        if (incremental_info_.running_requirement >= budget)
         {
-            source = temp_dest_buffer_->GetGPUVirtualAddress();
-        }
-        else
-        {
-            source = gpu_va_map.Map(command_header.copy_source_gpu_va);
+            ExecuteBatchIncrementalGrouping(gpu_va_map, incremental_info_.idasc_start);
+
+            incremental_info_.idasc_start         = incremental_info_.idasc_idx;
+            incremental_info_.running_requirement = total_requirement;
         }
 
-        ExecuteCopy(dest, source, mode);
+        incremental_info_.idasc_idx++;
+    }
+
+    // Batch once we find the final IDASC
+    else if (config_.mode == BATCHED_AS_BUILD_MODE_END_GROUPING)
+    {
+        AddNewInstance(command_header, build_inputs_data, new_instance);
     }
 }
 
-void Dx12AccelerationStructureBuilder::SetupBuild(
-    const graphics::Dx12GpuVaMap&                                         gpu_va_map,
-    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& init_geometry_descs,
-    const uint8_t*                                                        build_inputs_data,
-    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC&                   build_desc,
-    bool                                                                  use_temp_dest_buffer)
+void Dx12AccelerationStructureBuilder::End(const graphics::Dx12GpuVaMap& gpu_va_map)
+{
+    if (fence_ != nullptr)
+    {
+        if (config_.mode == BATCHED_AS_BUILD_MODE_INCREMENTAL_GROUPING)
+        {
+            ExecuteRemainingInstances(gpu_va_map);
+        }
+        else if (config_.mode == BATCHED_AS_BUILD_MODE_END_GROUPING)
+        {
+            ExecuteBatchEndGrouping(gpu_va_map);
+        }
+        fence_ = nullptr;
+    }
+}
+
+void Dx12AccelerationStructureBuilder::ExecuteBatchIncrementalGrouping(const graphics::Dx12GpuVaMap& gpu_va_map,
+                                                                       uint32_t                      start)
+{
+    IDASCGroup group;
+    if (batched_instances_.size() > 0)
+    {
+        for (UINT i = start; i < batched_instances_.size() - 1; i++)
+        {
+            IDASCInstance& instance = batched_instances_[i];
+
+            instance.build_info.inputs_buffer_entries.clear();
+            graphics::dx12::GetAccelerationStructureInputsBufferEntries(instance.build_info.build_desc.Inputs,
+                                                                        instance.build_info.temp_geometry_descs.data(),
+                                                                        instance.build_info.inputs_buffer_size,
+                                                                        instance.build_info.inputs_buffer_entries);
+
+            AddInstanceToGroup(group, instance);
+        }
+
+        ExecuteGroup(gpu_va_map, group);
+    }
+}
+
+void Dx12AccelerationStructureBuilder::ExecuteBatchEndGrouping(const graphics::Dx12GpuVaMap& gpu_va_map)
+{
+    for (auto& instance : batched_instances_)
+    {
+        SetupInstance(gpu_va_map, instance);
+    }
+
+    std::vector<IDASCGroup> groups;
+    GroupInstancesByMemoryBudget(groups);
+
+    for (auto& group : groups)
+    {
+        ExecuteGroup(gpu_va_map, group);
+    }
+}
+
+void Dx12AccelerationStructureBuilder::SetupBuild(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance)
 {
     // Build D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC from decoded data.
-    build_desc.DestAccelerationStructureData    = gpu_va_map.Map(command_header.dest_acceleration_structure_data);
-    auto& inputs_desc                           = build_desc.Inputs;
-    build_desc.SourceAccelerationStructureData  = 0;
-    build_desc.ScratchAccelerationStructureData = 0;
+    instance.build_info.build_desc.DestAccelerationStructureData =
+        gpu_va_map.Map(instance.command_header.dest_acceleration_structure_data);
+    auto& inputs_desc                                               = instance.build_info.build_desc.Inputs;
+    instance.build_info.build_desc.SourceAccelerationStructureData  = 0;
+    instance.build_info.build_desc.ScratchAccelerationStructureData = 0;
 
-    inputs_desc.Type  = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE>(command_header.inputs_type);
-    inputs_desc.Flags = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS>(command_header.inputs_flags);
+    inputs_desc.Type = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE>(instance.command_header.inputs_type);
+    inputs_desc.Flags =
+        static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS>(instance.command_header.inputs_flags);
+
     inputs_desc.DescsLayout     = D3D12_ELEMENTS_LAYOUT_ARRAY;
     inputs_desc.InstanceDescs   = 0;
     inputs_desc.pGeometryDescs  = nullptr;
     inputs_desc.ppGeometryDescs = nullptr;
-
-    const uint8_t* final_data = build_inputs_data;
 
     // In order for GetAccelerationStructureInputsBufferEntries to correctly process inputs buffer entries, a
     // non-zero GPU VA must be set for values that will be used.
     const D3D12_GPU_VIRTUAL_ADDRESS kDefaultGpuVa = 1;
 
     // Reconstruct acceleration structure build descs.
-    temp_geometry_descs_.clear();
     if (inputs_desc.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL)
     {
-        temp_geometry_descs_.resize(command_header.inputs_num_geometry_descs);
+        instance.build_info.temp_geometry_descs.resize(instance.command_header.inputs_num_geometry_descs);
 
-        inputs_desc.NumDescs = command_header.inputs_num_geometry_descs;
-        GFXRECON_ASSERT(command_header.inputs_num_geometry_descs == init_geometry_descs.size());
-        for (UINT i = 0; i < init_geometry_descs.size(); ++i)
+        inputs_desc.NumDescs = instance.command_header.inputs_num_geometry_descs;
+        GFXRECON_ASSERT(instance.command_header.inputs_num_geometry_descs == instance.init_geometry_descs.size());
+        for (UINT i = 0; i < instance.init_geometry_descs.size(); ++i)
+
         {
-            const auto&                     init_geom_desc = init_geometry_descs[i];
-            D3D12_RAYTRACING_GEOMETRY_DESC& geom_desc      = temp_geometry_descs_[i];
+            const auto&                     init_geom_desc = instance.init_geometry_descs[i];
+            D3D12_RAYTRACING_GEOMETRY_DESC& geom_desc      = instance.build_info.temp_geometry_descs[i];
 
             geom_desc.Type  = static_cast<D3D12_RAYTRACING_GEOMETRY_TYPE>(init_geom_desc.geometry_type);
             geom_desc.Flags = static_cast<D3D12_RAYTRACING_GEOMETRY_FLAGS>(init_geom_desc.geometry_flags);
@@ -227,27 +325,29 @@ void Dx12AccelerationStructureBuilder::SetupBuild(
                 GFXRECON_ASSERT(false && "Invalid D3D12_RAYTRACING_GEOMETRY_TYPE.");
             }
         }
-        inputs_desc.pGeometryDescs = temp_geometry_descs_.data();
+        inputs_desc.pGeometryDescs = instance.build_info.temp_geometry_descs.data();
     }
     else if (inputs_desc.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL)
     {
-        inputs_desc.NumDescs      = command_header.inputs_num_instance_descs;
+        inputs_desc.NumDescs      = instance.command_header.inputs_num_instance_descs;
         inputs_desc.InstanceDescs = (inputs_desc.NumDescs > 0) ? kDefaultGpuVa : 0;
 
         // Map GPU VAs in instance desc input data.
-        temp_instance_desc_input_data_.clear();
-        temp_instance_desc_input_data_.insert(temp_instance_desc_input_data_.end(),
-                                              build_inputs_data,
-                                              build_inputs_data + command_header.inputs_data_size);
+        instance.build_info.temp_instance_desc_input_data.clear();
+        instance.build_info.temp_instance_desc_input_data.insert(
+            instance.build_info.temp_instance_desc_input_data.end(),
+            instance.build_inputs_data,
+            instance.build_inputs_data + instance.command_header.inputs_data_size);
+
         constexpr auto address_stride = sizeof(D3D12_RAYTRACING_INSTANCE_DESC);
         constexpr auto address_offset = offsetof(D3D12_RAYTRACING_INSTANCE_DESC, AccelerationStructure);
         for (UINT i = 0; i < inputs_desc.NumDescs; ++i)
         {
             D3D12_GPU_VIRTUAL_ADDRESS* address = reinterpret_cast<D3D12_GPU_VIRTUAL_ADDRESS*>(
-                temp_instance_desc_input_data_.data() + i * address_stride + address_offset);
+                instance.build_info.temp_instance_desc_input_data.data() + i * address_stride + address_offset);
             *address = gpu_va_map.Map(*address);
         }
-        final_data = temp_instance_desc_input_data_.data();
+        instance.build_inputs_data = instance.build_info.temp_instance_desc_input_data.data();
     }
     else
     {
@@ -255,87 +355,449 @@ void Dx12AccelerationStructureBuilder::SetupBuild(
     }
 
     // Compute the required inputs buffer size and entry information.
-    uint64_t                                       inputs_buffer_size = 0;
-    std::vector<graphics::dx12::InputsBufferEntry> inputs_buffer_entries;
-    graphics::dx12::GetAccelerationStructureInputsBufferEntries(
-        inputs_desc, temp_geometry_descs_.data(), inputs_buffer_size, inputs_buffer_entries);
+    uint64_t inputs_buffer_size = 0;
+    graphics::dx12::GetAccelerationStructureInputsBufferEntries(inputs_desc,
+                                                                instance.build_info.temp_geometry_descs.data(),
+                                                                inputs_buffer_size,
+                                                                instance.build_info.inputs_buffer_entries);
 
-    GFXRECON_ASSERT(inputs_buffer_size == command_header.inputs_data_size);
+    GFXRECON_ASSERT(inputs_buffer_size == instance.command_header.inputs_data_size);
 
     // Get required sizes and update buffers.
-    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuild_info;
-    device5_->GetRaytracingAccelerationStructurePrebuildInfo(&inputs_desc, &prebuild_info);
+    device5_->GetRaytracingAccelerationStructurePrebuildInfo(&inputs_desc, &instance.build_info.prebuild_info);
+}
+
+void Dx12AccelerationStructureBuilder::UpdateGpuMemBuild(const graphics::Dx12GpuVaMap& gpu_va_map,
+                                                         IDASCInstance&                instance)
+{
+    if (instance.use_temp_dest_buffer)
+    {
+        UpdateBufferSize(device5_,
+                         instance.temp_dest_buffer,
+                         instance.buffer_sizes.temp_dest_buffer_size,
+                         instance.build_info.prebuild_info.ResultDataMaxSizeInBytes,
+                         D3D12_HEAP_TYPE_DEFAULT,
+                         D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
+                         D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+
+        // Fix GPU VAs that point into buffers.
+        instance.build_info.build_desc.DestAccelerationStructureData =
+            instance.temp_dest_buffer->GetGPUVirtualAddress();
+    }
+
     UpdateBufferSize(device5_,
-                     scratch_buffer_,
-                     scratch_buffer_size_,
-                     prebuild_info.ScratchDataSizeInBytes,
+                     instance.scratch_buffer,
+                     instance.build_info.scratch_buffer_size,
+                     instance.build_info.prebuild_info.ScratchDataSizeInBytes,
                      D3D12_HEAP_TYPE_DEFAULT,
                      D3D12_RESOURCE_STATE_COMMON,
                      D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+
     UpdateBufferSize(device5_,
-                     inputs_buffer_,
-                     inputs_buffer_size_,
-                     command_header.inputs_data_size,
+                     instance.inputs_buffer,
+                     instance.build_info.inputs_buffer_size,
+                     instance.command_header.inputs_data_size,
                      D3D12_HEAP_TYPE_UPLOAD,
                      D3D12_RESOURCE_STATE_GENERIC_READ,
                      D3D12_RESOURCE_FLAG_NONE);
 
-    if (use_temp_dest_buffer)
-    {
-        UpdateBufferSize(device5_,
-                         temp_dest_buffer_,
-                         temp_dest_buffer_size_,
-                         prebuild_info.ResultDataMaxSizeInBytes,
-                         D3D12_HEAP_TYPE_DEFAULT,
-                         D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
-                         D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-    }
-
     // Write inputs data to resources.
-    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, command_header.inputs_data_size);
-    HRESULT hr =
-        MapSubresourceAndWriteData(inputs_buffer_, 0, static_cast<size_t>(command_header.inputs_data_size), final_data);
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, instance.command_header.inputs_data_size);
+    HRESULT hr = MapSubresourceAndWriteData(instance.inputs_buffer,
+                                            0,
+                                            static_cast<size_t>(instance.command_header.inputs_data_size),
+                                            instance.build_inputs_data);
     GFXRECON_ASSERT(SUCCEEDED(hr));
 
-    // Fix GPU VAs that point into buffers.
-    if (use_temp_dest_buffer)
-    {
-        build_desc.DestAccelerationStructureData = temp_dest_buffer_->GetGPUVirtualAddress();
-    }
-    build_desc.ScratchAccelerationStructureData  = scratch_buffer_->GetGPUVirtualAddress();
-    D3D12_GPU_VIRTUAL_ADDRESS inputs_buffer_base = inputs_buffer_->GetGPUVirtualAddress();
-    for (auto& inputs_buffer_entry : inputs_buffer_entries)
+    instance.build_info.build_desc.ScratchAccelerationStructureData = instance.scratch_buffer->GetGPUVirtualAddress();
+
+    D3D12_GPU_VIRTUAL_ADDRESS inputs_buffer_base = instance.inputs_buffer->GetGPUVirtualAddress();
+    for (auto& inputs_buffer_entry : instance.build_info.inputs_buffer_entries)
     {
         *inputs_buffer_entry.desc_gpu_va = inputs_buffer_base + inputs_buffer_entry.offset;
     }
+
+    instance.build_info.inputs_buffer_entries.clear();
 }
 
-void Dx12AccelerationStructureBuilder::ExecuteBuild(const graphics::Dx12GpuVaMap&                       gpu_va_map,
-                                                    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC& build_desc)
+void Dx12AccelerationStructureBuilder::SetupCopy(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance)
 {
-    // Reset command allocator and command list.
-    HRESULT hr = command_allocator_->Reset();
-    GFXRECON_ASSERT(SUCCEEDED(hr));
-    hr = command_list4_->Reset(command_allocator_, nullptr);
-    GFXRECON_ASSERT(SUCCEEDED(hr));
+    instance.copy_info.dst = gpu_va_map.Map(instance.command_header.dest_acceleration_structure_data);
+    instance.copy_info.mode =
+        static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE>(instance.command_header.copy_mode);
+    instance.copy_info.src = gpu_va_map.Map(instance.command_header.copy_source_gpu_va);
+}
 
-    D3D12_RESOURCE_TRANSITION_BARRIER transition;
-    transition.pResource   = scratch_buffer_.GetInterfacePtr();
-    transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-    transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
-    transition.StateAfter  = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+void Dx12AccelerationStructureBuilder::UpdateGpuMemCopy(IDASCInstance& instance)
+{
+    if (instance.use_temp_dest_buffer)
+    {
+        UpdateBufferSize(device5_,
+                         instance.temp_dest_buffer,
+                         instance.buffer_sizes.temp_dest_buffer_size,
+                         instance.build_info.prebuild_info.ResultDataMaxSizeInBytes,
+                         D3D12_HEAP_TYPE_DEFAULT,
+                         D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
+                         D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
 
-    D3D12_RESOURCE_BARRIER barrier;
-    barrier.Type       = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-    barrier.Flags      = D3D12_RESOURCE_BARRIER_FLAG_NONE;
-    barrier.Transition = transition;
+        instance.copy_info.src = instance.temp_dest_buffer->GetGPUVirtualAddress();
+    }
+}
+
+void Dx12AccelerationStructureBuilder::ExecuteNoBatch(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance)
+{
+    if (instance.build)
+    {
+        SetupBuild(gpu_va_map, instance);
+        UpdateGpuMemBuild(gpu_va_map, instance);
+        ExecuteBuild(instance);
+    }
+
+    if (instance.copy)
+    {
+        SetupCopy(gpu_va_map, instance);
+        UpdateGpuMemCopy(instance);
+        ExecuteCopy(instance.copy_info);
+    }
+}
+
+void Dx12AccelerationStructureBuilder::ExecuteRemainingInstances(const graphics::Dx12GpuVaMap& gpu_va_map)
+{
+    IDASCGroup group;
+
+    for (auto& instance : batched_instances_)
+    {
+        if (instance.executed == false)
+        {
+            instance.build_info.inputs_buffer_entries.clear();
+            graphics::dx12::GetAccelerationStructureInputsBufferEntries(instance.build_info.build_desc.Inputs,
+                                                                        instance.build_info.temp_geometry_descs.data(),
+                                                                        instance.build_info.inputs_buffer_size,
+                                                                        instance.build_info.inputs_buffer_entries);
+
+            AddInstanceToGroup(group, instance);
+        }
+    }
+
+    ExecuteGroup(gpu_va_map, group);
+}
+
+uint64_t UpdateSizeAligned(uint64_t increment_size, uint64_t& out_size)
+{
+    D3D12_GPU_VIRTUAL_ADDRESS non_aligned_offset = out_size + increment_size;
+
+    D3D12_GPU_VIRTUAL_ADDRESS aligned_offset =
+        util::platform::AlignValue<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BYTE_ALIGNMENT>(non_aligned_offset);
+
+    uint64_t size_increase = increment_size + (aligned_offset - non_aligned_offset);
+
+    out_size += size_increase;
+
+    return size_increase;
+}
+
+uint64_t Dx12AccelerationStructureBuilder::GetMemoryBudget()
+{
+    uint64_t available_gpu_mem =
+        graphics::dx12::GetAvailableGpuAdapterMemory(adapter3_, max_batched_mem_usage_, is_uma_);
+    uint64_t available_cpu_mem = graphics::dx12::GetAvailableCpuMemory(max_batched_mem_usage_);
+
+    // 1 GB limit for each group
+    uint64_t dynamic_budget = std::min(available_gpu_mem, available_cpu_mem);
+
+    return std::min(kMaxStaticGpuBudget, dynamic_budget);
+}
+
+uint64_t Dx12AccelerationStructureBuilder::GetIDASCConsumption(const IDASCInstance& instance,
+                                                               uint64_t&            scratch_buffer_size,
+                                                               uint64_t&            inputs_buffer_size,
+                                                               uint64_t&            temp_dest_buffer_size)
+{
+    UpdateSizeAligned(instance.build_info.prebuild_info.ScratchDataSizeInBytes, scratch_buffer_size);
+    UpdateSizeAligned(instance.command_header.inputs_data_size, inputs_buffer_size);
+
+    if (instance.use_temp_dest_buffer)
+    {
+        UpdateSizeAligned(instance.build_info.prebuild_info.ResultDataMaxSizeInBytes, temp_dest_buffer_size);
+    }
+
+    return scratch_buffer_size + inputs_buffer_size + temp_dest_buffer_size;
+}
+
+void Dx12AccelerationStructureBuilder::ResetGroupSizes(IDASCGroup& group)
+{
+    group.buffer_sizes.scratch_buffer_size   = 0;
+    group.buffer_sizes.inputs_buffer_size    = 0;
+    group.buffer_sizes.temp_dest_buffer_size = 0;
+    group.buffer_sizes.total_size            = 0;
+}
+
+void Dx12AccelerationStructureBuilder::UpdateGroupSizes(IDASCGroup& group, const IDASCInstance& instance)
+{
+    group.buffer_sizes.scratch_buffer_size += instance.buffer_sizes.scratch_buffer_size;
+    group.buffer_sizes.inputs_buffer_size += instance.buffer_sizes.inputs_buffer_size;
+    group.buffer_sizes.temp_dest_buffer_size += instance.buffer_sizes.temp_dest_buffer_size;
+    group.buffer_sizes.total_size += instance.buffer_sizes.total_size;
+}
+
+void Dx12AccelerationStructureBuilder::AddInstanceToGroup(IDASCGroup& group, IDASCInstance& instance)
+{
+    group.instances.push_back(&instance);
+    UpdateGroupSizes(group, instance);
+}
+
+void Dx12AccelerationStructureBuilder::GroupInstancesByMemoryBudget(std::vector<IDASCGroup>& groups)
+{
+    const uint64_t budget = GetMemoryBudget();
+
+    IDASCGroup group;
+
+    uint64_t running_requirement = 0;
+    for (auto& instance : batched_instances_)
+    {
+        if (instance.build)
+        {
+            const uint64_t total_requirement = instance.buffer_sizes.total_size * graphics::dx12::kMemoryTolerance;
+
+            running_requirement += total_requirement;
+
+            if (running_requirement >= budget)
+            {
+                groups.push_back(group);
+                group.instances.clear();
+                ResetGroupSizes(group);
+                running_requirement = 0;
+            }
+        }
+
+        AddInstanceToGroup(group, instance);
+    }
+
+    if (group.instances.empty() == false)
+    {
+        groups.push_back(group);
+    }
+}
+
+void Dx12AccelerationStructureBuilder::ExecuteGroup(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCGroup& group)
+{
+    if (group.instances.empty() == false)
+    {
+        // Scratch
+        graphics::dx12::ID3D12ResourceComPtr big_scratch_buffer{ nullptr };
+        UpdateBufferSize(device5_,
+                         big_scratch_buffer,
+                         group.buffer_sizes.scratch_buffer_size,
+                         group.buffer_sizes.scratch_buffer_size,
+                         D3D12_HEAP_TYPE_DEFAULT,
+                         D3D12_RESOURCE_STATE_COMMON,
+                         D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+
+        D3D12_GPU_VIRTUAL_ADDRESS scratch_offset = big_scratch_buffer->GetGPUVirtualAddress();
+        for (auto instance : group.instances)
+        {
+            if (instance->build)
+            {
+                instance->build_info.build_desc.ScratchAccelerationStructureData = scratch_offset;
+
+                scratch_offset += instance->buffer_sizes.scratch_buffer_size;
+            }
+        }
+
+        // Inputs
+        graphics::dx12::ID3D12ResourceComPtr big_inputs_buffer{ nullptr };
+        UpdateBufferSize(device5_,
+                         big_inputs_buffer,
+                         group.buffer_sizes.inputs_buffer_size,
+                         group.buffer_sizes.inputs_buffer_size,
+                         D3D12_HEAP_TYPE_UPLOAD,
+                         D3D12_RESOURCE_STATE_GENERIC_READ,
+                         D3D12_RESOURCE_FLAG_NONE);
+
+        uint8_t* subresource_data = nullptr;
+        HRESULT  result =
+            graphics::dx12::MapSubresource(big_inputs_buffer, 0, &graphics::dx12::kZeroRange, subresource_data);
+
+        if (SUCCEEDED(result))
+        {
+            D3D12_GPU_VIRTUAL_ADDRESS inputs_offset = big_inputs_buffer->GetGPUVirtualAddress();
+
+            for (auto instance : group.instances)
+            {
+                if (instance->build)
+                {
+                    // Write inputs data to resources.
+                    util::platform::MemoryCopy(subresource_data,
+                                               instance->command_header.inputs_data_size,
+                                               instance->build_inputs_data,
+                                               instance->command_header.inputs_data_size);
+
+                    for (auto& inputs_buffer_entry : instance->build_info.inputs_buffer_entries)
+                    {
+                        *inputs_buffer_entry.desc_gpu_va = inputs_offset + inputs_buffer_entry.offset;
+                    }
+
+                    inputs_offset += instance->buffer_sizes.inputs_buffer_size;
+                    subresource_data += instance->buffer_sizes.inputs_buffer_size;
+                }
+            }
+
+            big_inputs_buffer->Unmap(0, nullptr);
+        }
+
+        // Temp desc buffer
+        graphics::dx12::ID3D12ResourceComPtr big_temp_desc_buffer{ nullptr };
+        if (group.buffer_sizes.temp_dest_buffer_size > 0)
+        {
+            UpdateBufferSize(device5_,
+                             big_temp_desc_buffer,
+                             group.buffer_sizes.temp_dest_buffer_size,
+                             group.buffer_sizes.temp_dest_buffer_size,
+                             D3D12_HEAP_TYPE_DEFAULT,
+                             D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
+                             D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+
+            D3D12_GPU_VIRTUAL_ADDRESS temp_desc_offset = big_temp_desc_buffer->GetGPUVirtualAddress();
+
+            for (auto instance : group.instances)
+            {
+                if (instance->use_temp_dest_buffer)
+                {
+                    // Fix GPU VAs that point into buffers.
+                    instance->build_info.build_desc.DestAccelerationStructureData = temp_desc_offset;
+
+                    instance->copy_info.src = temp_desc_offset;
+
+                    temp_desc_offset += instance->buffer_sizes.temp_dest_buffer_size;
+                }
+            }
+        }
+
+        // Execute
+        BeginCommandList();
+
+        InjectTransitionBarrierCmd(
+            big_scratch_buffer, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+        for (auto instance : group.instances)
+        {
+            InjectBlockCmd(gpu_va_map, *instance);
+        }
+
+        CloseAndExecute();
+
+        // Cleanup
+        for (uint32_t i = 0; i < group.instances.size(); i++)
+        {
+            IDASCInstance* instance = group.instances[i];
+
+            if (instance->cpu_build_inputs_data)
+            {
+                delete[] instance->cpu_build_inputs_data;
+                instance->cpu_build_inputs_data = nullptr;
+            }
+        }
+    }
+}
+
+void Dx12AccelerationStructureBuilder::InjectTransitionBarrierCmd(ID3D12Resource*       resource,
+                                                                  D3D12_RESOURCE_STATES state_before,
+                                                                  D3D12_RESOURCE_STATES state_after)
+{
+    if (resource != nullptr)
+    {
+        D3D12_RESOURCE_BARRIER barrier = {};
+        barrier.Type                   = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+        barrier.Transition.pResource   = resource;
+        barrier.Transition.StateBefore = state_before;
+        barrier.Transition.StateAfter  = state_after;
+
+        command_list4_->ResourceBarrier(1, &barrier);
+    }
+}
+
+void Dx12AccelerationStructureBuilder::SetupInstance(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance)
+{
+    if (instance.build)
+    {
+        SetupBuild(gpu_va_map, instance);
+    }
+
+    if (instance.copy)
+    {
+        SetupCopy(gpu_va_map, instance);
+    }
+
+    instance.buffer_sizes.total_size = GetIDASCConsumption(instance,
+                                                           instance.buffer_sizes.scratch_buffer_size,
+                                                           instance.buffer_sizes.inputs_buffer_size,
+                                                           instance.buffer_sizes.temp_dest_buffer_size);
+}
+
+void Dx12AccelerationStructureBuilder::InjectBlockCmd(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance)
+{
+    if (instance.build)
+    {
+        if (instance.build_info.build_desc.Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL)
+        {
+            InjectUavBarrierCmd();
+        }
+
+        command_list4_->BuildRaytracingAccelerationStructure(&instance.build_info.build_desc, 0, nullptr);
+    }
+
+    if (instance.copy)
+    {
+        InjectUavBarrierCmd();
+
+        command_list4_->CopyRaytracingAccelerationStructure(
+            instance.copy_info.dst, instance.copy_info.src, instance.copy_info.mode);
+    }
+
+    instance.executed = true;
+}
+
+void Dx12AccelerationStructureBuilder::InjectUavBarrierCmd()
+{
+    D3D12_RESOURCE_BARRIER barrier = {};
+    barrier.Type                   = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+    barrier.UAV.pResource          = nullptr;
 
     command_list4_->ResourceBarrier(1, &barrier);
+}
+
+void Dx12AccelerationStructureBuilder::ExecuteBuild(IDASCInstance& instance)
+{
+    BeginCommandList();
 
     // Add the build command.
-    command_list4_->BuildRaytracingAccelerationStructure(&build_desc, 0, nullptr);
+    command_list4_->BuildRaytracingAccelerationStructure(&instance.build_info.build_desc, 0, nullptr);
 
-    hr = command_list4_->Close();
+    CloseAndExecute();
+}
+
+void Dx12AccelerationStructureBuilder::ExecuteCopy(AsCopyInfo& copy_info)
+{
+    BeginCommandList();
+
+    // Add copy command
+    command_list4_->CopyRaytracingAccelerationStructure(copy_info.dst, copy_info.src, copy_info.mode);
+
+    CloseAndExecute();
+}
+
+void Dx12AccelerationStructureBuilder::BeginCommandList()
+{
+    // Reset command allocator and command list.
+    HRESULT hr = command_allocator_->Reset();
+    GFXRECON_ASSERT(SUCCEEDED(hr));
+    hr = command_list4_->Reset(command_allocator_, nullptr);
+    GFXRECON_ASSERT(SUCCEEDED(hr));
+}
+
+void Dx12AccelerationStructureBuilder::CloseAndExecute()
+{
+    HRESULT hr = command_list4_->Close();
 
     // Execute the command list and wait for completion.
     ID3D12CommandList* cmd_lists[] = { command_list4_ };
@@ -344,26 +806,29 @@ void Dx12AccelerationStructureBuilder::ExecuteBuild(const graphics::Dx12GpuVaMap
     GFXRECON_ASSERT(SUCCEEDED(hr));
 }
 
-void Dx12AccelerationStructureBuilder::ExecuteCopy(D3D12_GPU_VIRTUAL_ADDRESS                         dest_gpu_va,
-                                                   D3D12_GPU_VIRTUAL_ADDRESS                         source_gpu_va,
-                                                   D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode)
+void Dx12AccelerationStructureBuilder::BeginTimestamp()
 {
-    // Reset command allocator and command list.
-    HRESULT hr = command_allocator_->Reset();
-    GFXRECON_ASSERT(SUCCEEDED(hr));
-    hr = command_list4_->Reset(command_allocator_, nullptr);
-    GFXRECON_ASSERT(SUCCEEDED(hr));
+    static bool timestamped_start = false;
 
-    // Add copy commands.
-    command_list4_->CopyRaytracingAccelerationStructure(dest_gpu_va, source_gpu_va, mode);
+    if (timestamped_start == false)
+    {
+        QueryPerformanceFrequency(&frequency);
+        QueryPerformanceCounter(&begin_ts);
+        timestamped_start = true;
+    }
+}
 
-    hr = command_list4_->Close();
+void Dx12AccelerationStructureBuilder::EndTimestamp()
+{
+    static bool timestamped_end = false;
 
-    // Execute the command list and wait for completion.
-    ID3D12CommandList* cmd_lists[] = { command_list4_ };
-    command_queue_->ExecuteCommandLists(1, cmd_lists);
-    hr = graphics::dx12::WaitForQueue(command_queue_, fence_, ++fence_value_);
-    GFXRECON_ASSERT(SUCCEEDED(hr));
+    if (timestamped_end == false)
+    {
+        QueryPerformanceCounter(&end_ts);
+        double duration = ((end_ts.QuadPart - begin_ts.QuadPart) / (double)frequency.QuadPart);
+        GFXRECON_LOG_INFO("Duration of all InitDx12AccelerationStructureCommands: %.2f sec", duration);
+        timestamped_end = true;
+    }
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/dx12_acceleration_structure_builder.h
+++ b/framework/decode/dx12_acceleration_structure_builder.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2022 LunarG, Inc.
+** Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -23,6 +24,8 @@
 #ifndef GFXRECON_DECODE_DX12_ACCELERATION_STRUCTURE_BUILDER_H
 #define GFXRECON_DECODE_DX12_ACCELERATION_STRUCTURE_BUILDER_H
 
+#include "decode/dx_replay_options.h"
+#include "decode/dx12_object_info.h"
 #include "graphics/dx12_gpu_va_map.h"
 #include "graphics/dx12_util.h"
 #include "format/format.h"
@@ -30,14 +33,87 @@
 
 #include <d3d12.h>
 #include <vector>
+#include <functional>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+// Information specific to copies
+struct AsCopyInfo
+{
+    D3D12_GPU_VIRTUAL_ADDRESS                         dst;
+    D3D12_GPU_VIRTUAL_ADDRESS                         src;
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode;
+};
+
+// Information specific to builds
+struct AsBuildInfo
+{
+    uint64_t                                    inputs_buffer_size{ 0 };
+    uint64_t                                    scratch_buffer_size{ 0 };
+    std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> temp_geometry_descs;
+    std::vector<uint8_t>                        temp_instance_desc_input_data;
+
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuild_info{};
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC    build_desc{};
+
+    std::vector<graphics::dx12::InputsBufferEntry> inputs_buffer_entries;
+};
+
+// GPU buffer sizes
+struct AsBufferSizes
+{
+    uint64_t scratch_buffer_size{ 0 };
+    uint64_t inputs_buffer_size{ 0 };
+    uint64_t temp_dest_buffer_size{ 0 };
+    uint64_t total_size{ 0 };
+};
+
+// Contains everything needed to execute an IDASC block
+struct IDASCInstance
+{
+    format::InitDx12AccelerationStructureCommandHeader             command_header;
+    std::vector<format::InitDx12AccelerationStructureGeometryDesc> init_geometry_descs;
+    bool                                                           build{ false };
+    bool                                                           copy{ false };
+    bool                                                           use_temp_dest_buffer{ false };
+
+    AsBuildInfo build_info{};
+    AsCopyInfo  copy_info{};
+
+    AsBufferSizes buffer_sizes{};
+
+    graphics::dx12::ID3D12ResourceComPtr temp_dest_buffer{ nullptr };
+    graphics::dx12::ID3D12ResourceComPtr inputs_buffer{ nullptr };
+    graphics::dx12::ID3D12ResourceComPtr scratch_buffer{ nullptr };
+
+    uint8_t* build_inputs_data{ nullptr };
+    uint8_t* cpu_build_inputs_data{ nullptr };
+
+    bool executed{ false };
+};
+
+// For batching purposes, these groups contain lists of instances plus their total size
+struct IDASCGroup
+{
+    std::vector<IDASCInstance*> instances;
+    AsBufferSizes               buffer_sizes{};
+};
+
+// Information only relevant to BATCHED_AS_BUILD_MODE_INCREMENTAL_GROUPING
+struct IncrementalBatchingInfo
+{
+    uint64_t running_requirement{ 0 };
+    uint32_t idasc_start{ 0 };
+    uint32_t idasc_idx{ 0 };
+};
+
 class Dx12AccelerationStructureBuilder
 {
   public:
-    Dx12AccelerationStructureBuilder(graphics::dx12::ID3D12Device5ComPtr device5);
+    Dx12AccelerationStructureBuilder(graphics::dx12::ID3D12Device5ComPtr device5,
+                                     IDXGIAdapter3*                      adapter3,
+                                     const BatchedASBuildConfig&         config);
 
     virtual ~Dx12AccelerationStructureBuilder() {}
 
@@ -46,37 +122,91 @@ class Dx12AccelerationStructureBuilder
                const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& init_geometry_descs,
                const uint8_t*                                                        build_inputs_data);
 
+    void End(const graphics::Dx12GpuVaMap& gpu_va_map);
+
+    void BeginTimestamp();
+
+    void EndTimestamp();
+
   private:
-    void SetupBuild(const graphics::Dx12GpuVaMap&                                         gpu_va_map,
-                    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-                    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& init_geometry_descs,
-                    const uint8_t*                                                        build_inputs_data,
-                    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC&                   build_desc,
-                    bool                                                                  use_temp_dest_buffer);
+    void AddNewInstance(const format::InitDx12AccelerationStructureCommandHeader& command_header,
+                        const uint8_t*                                            build_inputs_data,
+                        const IDASCInstance&                                      new_instance);
 
-    void ExecuteBuild(const graphics::Dx12GpuVaMap&                       gpu_va_map,
-                      D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC& build_desc);
+    void InjectUavBarrierCmd();
 
-    void ExecuteCopy(D3D12_GPU_VIRTUAL_ADDRESS                         dest_gpu_va,
-                     D3D12_GPU_VIRTUAL_ADDRESS                         source_gpu_va,
-                     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode);
+    void ExecuteGroup(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCGroup& group);
+
+    void UpdateGpuMemCopy(IDASCInstance& instance);
+
+    void InjectBlockCmd(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance);
+
+    void BeginCommandList();
+
+    void CloseAndExecute();
+
+    void ExecuteBatchEndGrouping(const graphics::Dx12GpuVaMap& gpu_va_map);
+
+    void SetupInstance(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance);
+
+    void GroupInstancesByMemoryBudget(std::vector<IDASCGroup>& groups);
+
+    void UpdateGpuMemBuild(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance);
+
+    void ExecuteBuild(IDASCInstance& instance);
+
+    void SetupCopy(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance);
+
+    void SetupBuild(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance);
+
+    void ExecuteNoBatch(const graphics::Dx12GpuVaMap& gpu_va_map, IDASCInstance& instance);
+
+    void AddInstanceToGroup(IDASCGroup& group, IDASCInstance& instance);
+
+    void ResetGroupSizes(IDASCGroup& group);
+
+    void ExecuteRemainingInstances(const graphics::Dx12GpuVaMap& gpu_va_map);
+
+    void ExecuteBatchIncrementalGrouping(const graphics::Dx12GpuVaMap& gpu_va_map, uint32_t start);
+
+    void ExecuteCopy(AsCopyInfo& copy_info);
+
+    uint64_t GetMemoryBudget();
+
+    uint64_t GetIDASCConsumption(const IDASCInstance& instance,
+                                 uint64_t&            scratch_buffer_size,
+                                 uint64_t&            inputs_buffer_size,
+                                 uint64_t&            temp_dest_buffer_size);
+
+    void UpdateGroupSizes(IDASCGroup& group, const IDASCInstance& instance);
+
+    void InjectTransitionBarrierCmd(ID3D12Resource*       resource,
+                                    D3D12_RESOURCE_STATES state_before,
+                                    D3D12_RESOURCE_STATES state_after);
 
   private:
     graphics::dx12::ID3D12Device5ComPtr              device5_;
     graphics::dx12::ID3D12CommandQueueComPtr         command_queue_;
     graphics::dx12::ID3D12CommandAllocatorComPtr     command_allocator_;
     graphics::dx12::ID3D12GraphicsCommandList4ComPtr command_list4_;
-    graphics::dx12::ID3D12ResourceComPtr             inputs_buffer_;
     graphics::dx12::ID3D12FenceComPtr                fence_;
-    uint64_t                                         inputs_buffer_size_;
-    graphics::dx12::ID3D12ResourceComPtr             scratch_buffer_;
-    uint64_t                                         scratch_buffer_size_;
-    graphics::dx12::ID3D12ResourceComPtr             temp_dest_buffer_;
-    uint64_t                                         temp_dest_buffer_size_;
+    graphics::dx12::IDXGIAdapter3ComPtr              adapter3_{ nullptr };
+    bool                                             is_uma_{ false };
     uint64_t                                         fence_value_;
 
-    std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> temp_geometry_descs_;
-    std::vector<uint8_t>                        temp_instance_desc_input_data_;
+    // Unbatched data
+    IDASCInstance unbatched_instance_;
+
+    // Batched data
+    std::vector<IDASCInstance> batched_instances_;
+    IncrementalBatchingInfo    incremental_info_{};
+    BatchedASBuildConfig       config_;
+    double                     max_batched_mem_usage_{ 0 };
+
+    // Timestamping
+    LARGE_INTEGER begin_ts  = {};
+    LARGE_INTEGER end_ts    = {};
+    LARGE_INTEGER frequency = {};
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021-2023 LunarG, Inc.
-** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2023-2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -123,7 +123,7 @@ Dx12ReplayConsumerBase::Dx12ReplayConsumerBase(std::shared_ptr<application::Appl
     options_(options), current_message_length_(0), info_queue_(nullptr), resource_data_util_(nullptr),
     frame_buffer_renderer_(nullptr), debug_layer_enabled_(false), set_auto_breadcrumbs_enablement_(false),
     set_breadcrumb_context_enablement_(false), set_page_fault_enablement_(false), loading_trim_state_(false),
-    fps_info_(nullptr), unique_proxy_window_id_counter_(0), frame_end_marker_count_(0)
+    fps_info_(nullptr), unique_proxy_window_id_counter_(0), frame_end_marker_count_(0), accel_struct_builder_(nullptr)
 {
     if (options_.enable_validation_layer)
     {
@@ -746,10 +746,20 @@ void Dx12ReplayConsumerBase::ProcessInitDx12AccelerationStructureCommand(
         GFXRECON_ASSERT(dest_resource);
 
         auto device5          = graphics::dx12::GetDeviceComPtrFromChild<ID3D12Device5>(dest_resource);
-        accel_struct_builder_ = std::make_unique<Dx12AccelerationStructureBuilder>(device5);
+        
+        uint32_t       index       = 0;
+        IDXGIAdapter3* adapter3    = nullptr;
+        bool obtained_adapter_info = graphics::dx12::GetAdapterAndIndexbyDevice(device5, adapter3, index, adapters_);
+
+        accel_struct_builder_ =
+            std::make_unique<Dx12AccelerationStructureBuilder>(device5, adapter3, options_.batched_as_build_config);
+        GFXRECON_ASSERT(accel_struct_builder_ != nullptr);
     }
 
+    accel_struct_builder_->BeginTimestamp();
     accel_struct_builder_->Build(gpu_va_map_, command_header, geometry_descs, build_inputs_data);
+    
+    GFXRECON_LOG_DEBUG("InitDx12AccelerationStructureCommand BlockIndex = %u", GetCurrentBlockIndex());
 
     dxr_workload_ = true;
 }
@@ -4120,6 +4130,26 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateCommandList1(DxObjectInfo*        
         cmd_list_info->create_list_type = type;
         SetExtraInfo(command_list1_decoder, std::move(cmd_list_info));
     }
+    return replay_result;
+}
+
+HRESULT Dx12ReplayConsumerBase::OverrideCreateCommandAllocator(DxObjectInfo*                device_object_info,
+                                                               HRESULT                      original_result,
+                                                               D3D12_COMMAND_LIST_TYPE      type,
+                                                               Decoded_GUID                 riid,
+                                                               HandlePointerDecoder<void*>* command_allocator_decoder)
+{
+    auto device = static_cast<ID3D12Device*>(device_object_info->object);
+
+    if (accel_struct_builder_ != nullptr)
+    {
+        accel_struct_builder_->End(gpu_va_map_);
+        accel_struct_builder_->EndTimestamp();
+    }
+
+    auto replay_result =
+        device->CreateCommandAllocator(type, *riid.decoded_value, command_allocator_decoder->GetHandlePointer());
+
     return replay_result;
 }
 

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021-2022 LunarG, Inc.
-** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2023-2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -932,6 +932,12 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                        D3D12_COMMAND_LIST_FLAGS     flags,
                                        Decoded_GUID                 riid,
                                        HandlePointerDecoder<void*>* command_list1_decoder);
+
+    HRESULT OverrideCreateCommandAllocator(DxObjectInfo*                device_object_info,
+                                           HRESULT                      original_result,
+                                           D3D12_COMMAND_LIST_TYPE      type,
+                                           Decoded_GUID                 riid,
+                                           HandlePointerDecoder<void*>* command_allocator_decoder);
 
     HRESULT OverrideCommandListReset(DxObjectInfo* command_list_object_info,
                                      HRESULT       original_result,

--- a/framework/decode/dx_replay_options.h
+++ b/framework/decode/dx_replay_options.h
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2019-2020 Valve Corporation
 ** Copyright (c) 2019-2021 LunarG, Inc.
-** Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -39,6 +39,19 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 static constexpr uint32_t kDefaultBatchingMemoryUsage = 80;
 
+enum BatchedASBuildMode
+{
+    BATCHED_AS_BUILD_MODE_DISABLED,
+    BATCHED_AS_BUILD_MODE_INCREMENTAL_GROUPING,
+    BATCHED_AS_BUILD_MODE_END_GROUPING,
+};
+
+struct BatchedASBuildConfig
+{
+    BatchedASBuildMode mode{ BATCHED_AS_BUILD_MODE_DISABLED };
+    int32_t            memory_usage{ kDefaultBatchingMemoryUsage };
+};
+
 struct DxReplayOptions : public ReplayOptions
 {
     bool                 enable_d3d12{ true };
@@ -49,6 +62,8 @@ struct DxReplayOptions : public ReplayOptions
     bool                 override_object_names{ false };
     bool                 ags_inject_markers{ false };
     int32_t              memory_usage{ kDefaultBatchingMemoryUsage };
+
+    BatchedASBuildConfig batched_as_build_config{};
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/dx12_generators/replay_overrides.json
+++ b/framework/generated/dx12_generators/replay_overrides.json
@@ -36,7 +36,8 @@
       "CreateCommandSignature": "OverrideCreateCommandSignature",
       "CreateCommandList": "OverrideCreateCommandList",
       "CreateRootSignature": "OverrideCreateRootSignature",
-      "OpenSharedHandle": "OverrideOpenSharedHandle"
+      "OpenSharedHandle": "OverrideOpenSharedHandle",
+      "CreateCommandAllocator": "OverrideCreateCommandAllocator"
     },
     "ID3D12Device1": {
       "CreatePipelineLibrary": "OverrideCreatePipelineLibrary"

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -4465,15 +4465,20 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandAllocator(
             type,
             riid,
             ppCommandAllocator);
-        if(!ppCommandAllocator->IsNull()) ppCommandAllocator->SetHandleLength(1);
-        auto out_p_ppCommandAllocator    = ppCommandAllocator->GetPointer();
-        auto out_hp_ppCommandAllocator   = ppCommandAllocator->GetHandlePointer();
-        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->CreateCommandAllocator(type,
-                                                                                                            *riid.decoded_value,
-                                                                                                            out_hp_ppCommandAllocator);
+        DxObjectInfo object_info_ppCommandAllocator{};
+        if(!ppCommandAllocator->IsNull())
+        {
+            ppCommandAllocator->SetHandleLength(1);
+            ppCommandAllocator->SetConsumerData(0, &object_info_ppCommandAllocator);
+        }
+        auto replay_result = OverrideCreateCommandAllocator(replay_object,
+                                                            return_value,
+                                                            type,
+                                                            riid,
+                                                            ppCommandAllocator);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppCommandAllocator, out_hp_ppCommandAllocator, format::ApiCall_ID3D12Device_CreateCommandAllocator);
+            AddObject(ppCommandAllocator->GetPointer(), ppCommandAllocator->GetHandlePointer(), std::move(object_info_ppCommandAllocator), format::ApiCall_ID3D12Device_CreateCommandAllocator);
         }
         CheckReplayResult("ID3D12Device_CreateCommandAllocator", return_value, replay_result);
         CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommandAllocator>::Dispatch(

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -1060,7 +1060,7 @@ bool IsUma(ID3D12Device* device)
 
 uint64_t GetAvailableGpuAdapterMemory(IDXGIAdapter3* adapter, double memory_usage, const bool is_uma)
 {
-    GFXRECON_ASSERT(memory_usage > 0.0 && memory_usage <= 1.0);
+    GFXRECON_ASSERT(memory_usage >= 0.0 && memory_usage <= 1.0);
     uint64_t available_mem = 0;
     if (adapter != nullptr)
     {
@@ -1093,7 +1093,7 @@ uint64_t GetAvailableGpuAdapterMemory(IDXGIAdapter3* adapter, double memory_usag
 
 uint64_t GetAvailableCpuMemory(double max_usage)
 {
-    GFXRECON_ASSERT(max_usage > 0.0 && max_usage <= 1.0);
+    GFXRECON_ASSERT(max_usage >= 0.0 && max_usage <= 1.0);
     MEMORYSTATUSEX mem_info = {};
     mem_info.dwLength       = sizeof(MEMORYSTATUSEX);
     if (GlobalMemoryStatusEx(&mem_info) == FALSE)

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -106,6 +106,7 @@ typedef _com_ptr_t<
     _com_IIID<ID3D12VersionedRootSignatureDeserializer, &__uuidof(ID3D12VersionedRootSignatureDeserializer)>>
                                                                      ID3D12VersionedRootSignatureDeserializerComPtr;
 typedef _com_ptr_t<_com_IIID<ID3D12Object, &__uuidof(ID3D12Object)>> ID3D12ObjectComPtr;
+typedef _com_ptr_t<_com_IIID<IDXGIAdapter3, &__uuidof(IDXGIAdapter3)>> IDXGIAdapter3ComPtr;
 
 #if defined(GFXRECON_DXC_SUPPORT)
 typedef _com_ptr_t<_com_IIID<IDxcUtils, &__uuidof(IDxcUtils)>> IDxcUtilsComPtr;

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2019-2023 LunarG, Inc.
-** Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -42,7 +42,7 @@ const char kArguments[] =
     "force-windowed,--fwo|--force-windowed-origin,--batching-memory-usage,--measurement-file,--swapchain,--sgfs|--skip-"
     "get-fence-status,--sgfr|--skip-get-fence-ranges,--dump-resources,--dump-resources-dir,--dump-resources-image-"
     "format,pbis,--pcj|--pipeline-creation-jobs,--save-pipeline-cache,--load-pipeline-cache,--quit-after-frame,--"
-    "present-mode,--wait-before-first-submit";
+    "present-mode,--wait-before-first-submit,--dx12-batched-as-build-mode,--dx12-batched-as-build-memory-usage";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -94,6 +94,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--fwo <x,y> | --force-windowed-origin <x,y>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--log-level <level>] [--log-file <file>] [--log-debugview]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--batching-memory-usage <pct>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--dx12-batched-as-build-mode <mode>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--dx12-batched-as-build-memory-usage <pct>]");
 #if defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--no-debug-popup]");
 #endif
@@ -382,6 +384,19 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tAcceptable values range from 0 to 100 (default: 80)");
     GFXRECON_WRITE_CONSOLE("          \t\t0 means no batching at all");
     GFXRECON_WRITE_CONSOLE("          \t\t100 means use all available system and GPU memory");
+    GFXRECON_WRITE_CONSOLE("  --dx12-batched-as-build-mode <mode>");
+    GFXRECON_WRITE_CONSOLE(
+        "          \t\tEnable batching of AS builds for trimmed capture files, and set operational mode");
+    GFXRECON_WRITE_CONSOLE("          \t\t0: No batching of AS builds");
+    GFXRECON_WRITE_CONSOLE("          \t\t1: Submit grouping happens incrementally as AS builds are encountered");
+    GFXRECON_WRITE_CONSOLE("          \t\t2: Submit grouping happens after all AS builds have been seen");
+
+    GFXRECON_WRITE_CONSOLE("  --dx12-batched-as-build-memory-usage <pct>");
+    GFXRECON_WRITE_CONSOLE("          \t\tMax amount of memory consumption dedicated to AS building while loading a "
+                           "trimmed capture file.");
+    GFXRECON_WRITE_CONSOLE("          \t\tAcceptable values range from 0 to 100 (default: 80)");
+    GFXRECON_WRITE_CONSOLE("          \t\t0 means no batching at all");
+    GFXRECON_WRITE_CONSOLE("          \t\t100 means use all available GPU memory");
     GFXRECON_WRITE_CONSOLE("  --dump-resources-modifiable-state-only");
     GFXRECON_WRITE_CONSOLE(
         "          \t\tOnly dump resources that are in a modifiable state set by D3D12 ResourceBarrier")

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2019-2025 LunarG, Inc.
-** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -158,6 +158,8 @@ const char kDxAgsMarkRenderPasses[]            = "--dx12-ags-inject-markers";
 const char kBatchingMemoryUsageArgument[]      = "--batching-memory-usage";
 const char kDumpResourcesModifiableStateOnly[] = "--dump-resources-modifiable-state-only";
 const char kDumpResourcesBeforeDrawOption[]    = "--dump-resources-before-draw";
+const char kDxBatchedAsBuildModeArgument[]        = "--dx12-batched-as-build-mode";
+const char kDxBatchedAsBuildMemoryUsageArgument[] = "--dx12-batched-as-build-memory-usage";
 #endif
 
 const char kDumpResourcesArgument[]    = "--dump-resources";
@@ -1310,11 +1312,39 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
         if (memory_usage_int >= 0 && memory_usage_int <= 100)
         {
             replay_options.memory_usage = static_cast<uint32_t>(memory_usage_int);
+
+            // By default, batched AS builds' memory usage will inherit the value from --batching-memory-usage
+            // However, this can be overridden if explicitly setting --dx12-batched-as-build-memory-usage
+            replay_options.batched_as_build_config.memory_usage = static_cast<uint32_t>(memory_usage_int);
         }
         else
         {
             GFXRECON_LOG_WARNING(
                 "The parameter to --batching-memory-usage is out of range [0, 100], will use 80 as default value.");
+        }
+    }
+
+    const std::string& batched_as_build_mode = arg_parser.GetArgumentValue(kDxBatchedAsBuildModeArgument);
+    if (!batched_as_build_mode.empty())
+    {
+        replay_options.batched_as_build_config.mode =
+            static_cast<gfxrecon::decode::BatchedASBuildMode>(std::stoi(batched_as_build_mode));
+    }
+
+    const std::string& batched_as_build_mem_consumption =
+        arg_parser.GetArgumentValue(kDxBatchedAsBuildMemoryUsageArgument);
+    if (!batched_as_build_mem_consumption.empty())
+    {
+        int batched_as_build_mem_consumption_int = std::stoi(batched_as_build_mem_consumption);
+        if (batched_as_build_mem_consumption_int >= 0 && batched_as_build_mem_consumption_int <= 100)
+        {
+            replay_options.batched_as_build_config.memory_usage =
+                static_cast<uint32_t>(batched_as_build_mem_consumption_int);
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING("The parameter to --dx12-batched-as-build-memory-usage is out of range [0, 100], will "
+                                 "use 80 as default value.");
         }
     }
 


### PR DESCRIPTION
To replay trimmed trace, GFXR build an AS and submit it to GPU. To improve the performace, add a new replay options allow to batch build AS base on CPU&GPU memory usage.