### PR TITLE
Revert 2740

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -1537,14 +1537,16 @@ void Dx12ReplayConsumerBase::InitializeD3D12Device(HandlePointerDecoder<void*>* 
 
 void Dx12ReplayConsumerBase::DetectAdapters()
 {
-    graphics::dx12::IDXGIFactory1ComPtr factory1 = nullptr;
+    IDXGIFactory1* factory1 = nullptr;
 
-    HRESULT result = CreateDXGIFactory1(IID_PPV_ARGS(&factory1));
+    HRESULT result = CreateDXGIFactory1(IID_IDXGIFactory1, reinterpret_cast<void**>(&factory1));
 
     if (SUCCEEDED(result))
     {
-        graphics::dx12::TrackAdapters(result, reinterpret_cast<void**>(&factory1.GetInterfacePtr()), adapters_);
+        graphics::dx12::TrackAdapters(result, reinterpret_cast<void**>(&factory1), adapters_);
         render_adapter_ = graphics::dx12::GetAdapterbyIndex(adapters_, options_.override_gpu_index);
+
+        factory1->Release();
     }
 }
 
@@ -3784,7 +3786,7 @@ IDXGIAdapter* Dx12ReplayConsumerBase::GetAdapter()
     {
         for (const auto& adapter : adapters_)
         {
-            if (adapter.second.adapter.GetInterfacePtr() == adapter_found)
+            if (adapter.second.adapter == adapter_found)
             {
                 if (graphics::dx12::IsSoftwareAdapter(adapter.second.internal_desc) == true)
                 {
@@ -3801,7 +3803,7 @@ IDXGIAdapter* Dx12ReplayConsumerBase::GetAdapter()
         {
             if (graphics::dx12::IsSoftwareAdapter(adapter.second.internal_desc) == false)
             {
-                adapter_found = adapter.second.adapter.GetInterfacePtr();
+                adapter_found = adapter.second.adapter;
                 break;
             }
         }

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -384,14 +384,6 @@ struct ID3D12ProtectedResourceSessionInfo : public DxWrapperInfo
 
 struct ID3D12DeviceInfo : public DxWrapperInfo
 {
-    virtual ~ID3D12DeviceInfo()
-    {
-        if (adapter3 != nullptr)
-        {
-            adapter3->Release();
-        }
-    }
-
     // Track the device's parent adapter as IDXGIAdapter3
     // This enables checking GPU memory availability via QueryVideoMemoryInfo()
     IDXGIAdapter3* adapter3{ nullptr };

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -770,20 +770,18 @@ void TrackAdapters(HRESULT result, void** ppFactory, graphics::dx12::ActiveAdapt
     if (SUCCEEDED(result))
     {
         // First see if the created factory can be queried as a 1.1 factory
-        auto*               base_factory = reinterpret_cast<IUnknown*>(*ppFactory);
-        IDXGIFactory1ComPtr factory1     = nullptr;
+        IDXGIFactory1* factory1 = reinterpret_cast<IDXGIFactory1*>(*ppFactory);
 
         // DXGI 1.1 tracking (default)
-        if (SUCCEEDED(base_factory->QueryInterface(IID_PPV_ARGS(&factory1))))
+        if (SUCCEEDED(factory1->QueryInterface(__uuidof(IDXGIFactory1), reinterpret_cast<void**>(&factory1))))
         {
             // Get a fresh enumeration, in case it was previously filled by 1.0 tracking
             RemoveDeactivatedAdapters(adapters);
 
             // Enumerate 1.1 adapters and fetch data with GetDesc1()
-            IDXGIAdapter1ComPtr adapter1 = nullptr;
+            IDXGIAdapter1* adapter1 = nullptr;
 
-            for (UINT adapter_idx = 0; SUCCEEDED(factory1->EnumAdapters1(adapter_idx, &adapter1.GetInterfacePtr()));
-                 ++adapter_idx)
+            for (UINT adapter_idx = 0; SUCCEEDED(factory1->EnumAdapters1(adapter_idx, &adapter1)); ++adapter_idx)
             {
                 DXGI_ADAPTER_DESC1 dxgi_desc = {};
                 adapter1->GetDesc1(&dxgi_desc);
@@ -794,7 +792,7 @@ void TrackAdapters(HRESULT result, void** ppFactory, graphics::dx12::ActiveAdapt
                     adapter_type = format::AdapterType::kSoftwareAdapter;
                 }
 
-                TrackAdapterDesc(adapter1.GetInterfacePtr(), adapter_idx, dxgi_desc, adapters, adapter_type);
+                TrackAdapterDesc(adapter1, adapter_idx, dxgi_desc, adapters, adapter_type);
             }
         }
 
@@ -804,25 +802,20 @@ void TrackAdapters(HRESULT result, void** ppFactory, graphics::dx12::ActiveAdapt
             // Only enumerate 1.0 factory adapters if nothing has been seen yet
             if (adapters.empty())
             {
-                IDXGIFactoryComPtr factory = nullptr;
+                IDXGIFactory* factory = reinterpret_cast<IDXGIFactory*>(*ppFactory);
 
-                if (SUCCEEDED(base_factory->QueryInterface(IID_PPV_ARGS(&factory))))
+                if (SUCCEEDED(factory->QueryInterface(__uuidof(IDXGIFactory), reinterpret_cast<void**>(&factory))))
                 {
                     // Enumerate 1.0 adapters and fetch data with GetDesc()
-                    IDXGIAdapterComPtr adapter = nullptr;
+                    IDXGIAdapter* adapter = nullptr;
 
-                    for (UINT adapter_idx = 0;
-                         SUCCEEDED(factory->EnumAdapters(adapter_idx, &adapter.GetInterfacePtr()));
-                         ++adapter_idx)
+                    for (UINT adapter_idx = 0; SUCCEEDED(factory->EnumAdapters(adapter_idx, &adapter)); ++adapter_idx)
                     {
                         DXGI_ADAPTER_DESC dxgi_desc = {};
                         adapter->GetDesc(&dxgi_desc);
 
-                        TrackAdapterDesc(adapter.GetInterfacePtr(),
-                                         adapter_idx,
-                                         dxgi_desc,
-                                         adapters,
-                                         format::AdapterType::kUnknownAdapter);
+                        TrackAdapterDesc(
+                            adapter, adapter_idx, dxgi_desc, adapters, format::AdapterType::kUnknownAdapter);
                     }
                 }
                 else
@@ -949,7 +942,7 @@ bool GetAdapterAndIndexbyLUID(LUID                              luid,
     if (search != adapters.end())
     {
         index       = search->second.adapter_idx;
-        adapter_ptr = search->second.adapter.GetInterfacePtr();
+        adapter_ptr = search->second.adapter;
         success     = true;
     }
     return success;
@@ -979,7 +972,7 @@ IDXGIAdapter* GetAdapterbyIndex(graphics::dx12::ActiveAdapterMap& adapters, int3
     {
         if (static_cast<int32_t>(adapter.second.adapter_idx) == index)
         {
-            return adapter.second.adapter.GetInterfacePtr();
+            return adapter.second.adapter;
         }
     }
     return nullptr;

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -57,12 +57,6 @@ GFXRECON_BEGIN_NAMESPACE(dx12)
 
 #ifdef WIN32
 typedef _com_ptr_t<_com_IIID<IDXGISwapChain3, &__uuidof(IDXGISwapChain3)>> IDXGISwapChain3ComPtr;
-typedef _com_ptr_t<_com_IIID<IDXGIAdapter, &__uuidof(IDXGIAdapter)>>       IDXGIAdapterComPtr;
-typedef _com_ptr_t<_com_IIID<IDXGIAdapter1, &__uuidof(IDXGIAdapter1)>>     IDXGIAdapter1ComPtr;
-typedef _com_ptr_t<_com_IIID<IDXGIAdapter2, &__uuidof(IDXGIAdapter2)>>     IDXGIAdapter2ComPtr;
-typedef _com_ptr_t<_com_IIID<IDXGIAdapter3, &__uuidof(IDXGIAdapter3)>>     IDXGIAdapter3ComPtr;
-typedef _com_ptr_t<_com_IIID<IDXGIFactory, &__uuidof(IDXGIFactory)>>       IDXGIFactoryComPtr;
-typedef _com_ptr_t<_com_IIID<IDXGIFactory1, &__uuidof(IDXGIFactory1)>>     IDXGIFactory1ComPtr;
 
 typedef _com_ptr_t<_com_IIID<ID3D12DescriptorHeap, &__uuidof(ID3D12DescriptorHeap)>>     ID3D12DescriptorHeapComPtr;
 typedef _com_ptr_t<_com_IIID<ID3D12Device, &__uuidof(ID3D12Device)>>                     ID3D12DeviceComPtr;
@@ -141,7 +135,7 @@ uint32_t Dx12DumpResourcePosToArrayIndex(Dx12DumpResourcePos pos);
 struct ActiveAdapterInfo
 {
     format::DxgiAdapterDesc internal_desc;
-    IDXGIAdapterComPtr      adapter;
+    IDXGIAdapter*           adapter;
     UINT32                  adapter_idx;
     bool                    active;
 };

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -1102,15 +1102,14 @@ static bool CheckOptionEnumGpuIndices(const char* exe_name, const gfxrecon::util
 {
     if (arg_parser.IsOptionSet(kEnumGpuIndices))
     {
-        gfxrecon::graphics::dx12::IDXGIFactory1ComPtr factory1 = nullptr;
+        IDXGIFactory1* factory1 = nullptr;
 
-        HRESULT result = CreateDXGIFactory1(IID_PPV_ARGS(&factory1));
+        HRESULT result = CreateDXGIFactory1(IID_IDXGIFactory1, reinterpret_cast<void**>(&factory1));
 
         if (SUCCEEDED(result))
         {
             gfxrecon::graphics::dx12::ActiveAdapterMap adapters{};
-            gfxrecon::graphics::dx12::TrackAdapters(
-                result, reinterpret_cast<void**>(&factory1.GetInterfacePtr()), adapters);
+            gfxrecon::graphics::dx12::TrackAdapters(result, reinterpret_cast<void**>(&factory1), adapters);
 
             WriteOutput("GPU index\tGPU name\tSubSys ID");
             for (size_t index = 0; index < adapters.size(); ++index)
@@ -1126,10 +1125,12 @@ static bool CheckOptionEnumGpuIndices(const char* exe_name, const gfxrecon::util
                                     adapter.second.adapter_idx,
                                     replay_adapter_str.c_str(),
                                     adapter.second.internal_desc.SubSysId);
+                        adapter.second.adapter->Release();
                         break;
                     }
                 }
             }
+            factory1->Release();
         }
         else
         {


### PR DESCRIPTION
Probably #2740 is good, but it caused extended suite failures, so revert it and follow on with a version of 2740 with either a fix to the code or an updated capture-draw-calls reference.