### PR TITLE
replay: Add --idle-before-submit option

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -794,6 +794,7 @@ usage: gfxrecon.py replay [-h] [-p LOCAL_FILE] [--version] [--log-level LEVEL]
                           [--quit-after-frame FRAME]
                           [--screenshot-ignore-FrameBoundaryANDROID]
                           [--wait-before-first-submit MILLISECONDS]
+                          [--idle-before-submit]
                           [file]
 
 Launch the replay tool.
@@ -1005,6 +1006,8 @@ options:
   --wait-before-first-submit MILLISECONDS
                         Wait for the specified amount of milliseconds before
                         processing the first submit. (forwarded to replay tool)
+  --idle-before-submit  Wait for the GPU to become idle before each submit.
+                        (forwarded to replay tool)
 ```
 
 The command will force-stop an active replay process before starting the replay

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -635,6 +635,7 @@ gfxrecon-replay         [-h | --help] [--version] [--cpu-mask <binary-mask>] [--
                         [--pipeline-creation-jobs | --pcj <num_jobs>]
                         [--deduplicate-device]
                         [--wait-before-first-submit MILLISECONDS]
+                        [--idle-before-submit]
 
 
 Required arguments:
@@ -873,6 +874,8 @@ Optional arguments:
               If set, at most one VkDevice will be created for each VkPhysicalDevice for RenderDoc and DXVK case.
   --wait-before-first-submit <milliseconds>
               Wait for the specified amount of milliseconds before processing the first submit.
+  --idle-before-submit
+              Wait for the GPU to become idle before each submit.
 ```
 
 ### Key Controls

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -143,6 +143,7 @@ def CreateReplayParser():
     parser.add_argument('--quit-after-frame', metavar='FRAME', help='Specify a frame after which replay will terminate.')
     parser.add_argument('--screenshot-ignore-FrameBoundaryANDROID', action='store_true', default=False, help='If set, frames switced with vkFrameBoundANDROID will be ignored from the screenshot handler.')
     parser.add_argument('--wait-before-first-submit', metavar='MILLISECONDS', help='Wait for the specified amount of milliseconds before processing the first submit. (forwarded to replay tool)')
+    parser.add_argument('--idle-before-submit', action='store_true', default=False, help='Wait for the GPU to become idle before each submit. (forwarded to replay tool)')
 
     return parser
 
@@ -325,6 +326,9 @@ def MakeExtrasString(args):
     if args.wait_before_first_submit:
         arg_list.append('--wait-before-first-submit')
         arg_list.append('{}'.format(args.wait_before_first_submit))
+
+    if args.idle_before_submit:
+        arg_list.append('--idle-before-submit')
 
     if args.file:
         arg_list.append(args.file)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4174,6 +4174,11 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
     GFXRECON_ASSERT(allocator != nullptr);
     allocator->ClearStagingResources();
 
+    if (options_.idle_before_submit)
+    {
+        GetDeviceTable(device_info->handle)->DeviceWaitIdle(device_info->handle);
+    }
+
     VulkanSubmitJobPlan     plan;
     VulkanSubmitJobExecutor executor;
 
@@ -4389,6 +4394,11 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
     auto allocator = device_info->allocator.get();
     GFXRECON_ASSERT(allocator != nullptr);
     allocator->ClearStagingResources();
+
+    if (options_.idle_before_submit)
+    {
+        GetDeviceTable(device_info->handle)->DeviceWaitIdle(device_info->handle);
+    }
 
     VulkanSubmitJobPlan     plan;
     VulkanSubmitJobExecutor executor;

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -171,6 +171,9 @@ struct VulkanReplayOptions : public ReplayOptions
     // Milliseconds to wait before first queue submit.
     uint32_t wait_before_first_submit{ 0 };
 
+    /// Wait for the GPU to become idle before each submit.
+    bool idle_before_submit{ false };
+
     void MaybeWaitBeforeFirstSubmit() const;
 };
 

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -42,7 +42,7 @@ const char kArguments[] =
     "force-windowed,--fwo|--force-windowed-origin,--batching-memory-usage,--measurement-file,--swapchain,--sgfs|--skip-"
     "get-fence-status,--sgfr|--skip-get-fence-ranges,--dump-resources,--dump-resources-dir,--dump-resources-image-"
     "format,pbis,--pcj|--pipeline-creation-jobs,--save-pipeline-cache,--load-pipeline-cache,--quit-after-frame,--"
-    "present-mode,--wait-before-first-submit";
+    "present-mode,--wait-before-first-submit,--idle-before-submit";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -81,7 +81,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--fw <width,height> | --force-windowed <width,height>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sgfs <status> | --skip-get-fence-status <status>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sgfr <frame-ranges> | --skip-get-fence-ranges <frame-ranges>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--pbi-all] [--pbis <index1,index2>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--idle-before-submit] [--pbi-all] [--pbis <index1,index2>]");
 #if !defined(WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources <filename>.json]");
 #endif
@@ -356,6 +356,8 @@ static void PrintUsage(const char* exe_name)
                            "RenderDoc and DXVK case.");
     GFXRECON_WRITE_CONSOLE("  --wait-before-first-submit <milliseconds>");
     GFXRECON_WRITE_CONSOLE("          \t\tWait specified milliseconds before submitting the first command buffer.");
+    GFXRECON_WRITE_CONSOLE("  --idle-before-submit");
+    GFXRECON_WRITE_CONSOLE("          \t\tWait for the GPU to become idle before each submit.");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("D3D12 only:")

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -148,6 +148,7 @@ const char kLoadPipelineCacheArgument[]           = "--load-pipeline-cache";
 const char kCreateNewPipelineCacheOption[]        = "--add-new-pipeline-caches";
 const char kDeduplicateDevice[]                   = "--deduplicate-device";
 const char kWaitBeforeFirstSubmit[]               = "--wait-before-first-submit";
+const char kIdleBeforeSubmit[]                    = "--idle-before-submit";
 
 const char kScreenshotIgnoreFrameBoundaryArgument[] = "--screenshot-ignore-FrameBoundaryANDROID";
 
@@ -1241,6 +1242,7 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     replay_options.do_device_deduplication      = arg_parser.IsOptionSet(kDeduplicateDevice);
 
     GetWaitBeforeFirstSubmit(arg_parser, replay_options.wait_before_first_submit);
+    replay_options.idle_before_submit = arg_parser.IsOptionSet(kIdleBeforeSubmit);
 
     return replay_options;
 }


### PR DESCRIPTION
Add a replay option to wait for the GPU to become idle before submitting each command buffer to a queue.