### PR TITLE
Fix deadlock in GFXRECON_FORCE_COMMAND_SERIALIZATION with nested wrapped functions

### DIFF
--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -176,6 +176,7 @@ class ApiCaptureManager
     }
 
     bool GetIUnknownWrappingSetting() const { return common_manager_->GetIUnknownWrappingSetting(); }
+    int64_t& AvoidApiCallLock() { return common_manager_->AvoidApiCallLock(); }
     auto GetForceCommandSerialization() const { return common_manager_->GetForceCommandSerialization(); }
     auto GetQueueZeroOnly() const { return common_manager_->GetQueueZeroOnly(); }
     auto GetAllowPipelineCompileRequired() const { return common_manager_->GetAllowPipelineCompileRequired(); }

--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -175,12 +175,12 @@ class ApiCaptureManager
         common_manager_->WriteAnnotation(type, label, data);
     }
 
-    bool GetIUnknownWrappingSetting() const { return common_manager_->GetIUnknownWrappingSetting(); }
+    bool     GetIUnknownWrappingSetting() const { return common_manager_->GetIUnknownWrappingSetting(); }
     int64_t& AvoidApiCallLock() { return common_manager_->AvoidApiCallLock(); }
-    auto GetForceCommandSerialization() const { return common_manager_->GetForceCommandSerialization(); }
-    auto GetQueueZeroOnly() const { return common_manager_->GetQueueZeroOnly(); }
-    auto GetAllowPipelineCompileRequired() const { return common_manager_->GetAllowPipelineCompileRequired(); }
-    auto GetSkipThreadsWithInvalidData() const { return common_manager_->GetSkipThreadsWithInvalidData(); }
+    auto     GetForceCommandSerialization() const { return common_manager_->GetForceCommandSerialization(); }
+    auto     GetQueueZeroOnly() const { return common_manager_->GetQueueZeroOnly(); }
+    auto     GetAllowPipelineCompileRequired() const { return common_manager_->GetAllowPipelineCompileRequired(); }
+    auto     GetSkipThreadsWithInvalidData() const { return common_manager_->GetSkipThreadsWithInvalidData(); }
 
     bool     IsAnnotated() const { return common_manager_->IsAnnotated(); }
     uint16_t GetGPUVAMask() const { return common_manager_->GetGPUVAMask(); }

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -65,6 +65,7 @@ std::atomic<format::HandleId>              CommonCaptureManager::default_unique_
 uint64_t                                   CommonCaptureManager::default_unique_id_offset_ = 0;
 thread_local bool                          CommonCaptureManager::force_default_unique_id_  = false;
 thread_local std::vector<format::HandleId> CommonCaptureManager::unique_id_stack_;
+int64_t                                        CommonCaptureManager::avoid_api_call_lock_ = 0;
 
 static std::mutex external_trim_trigger_mutex_g;
 static bool       externally_set_trimming_state_g          = false;
@@ -689,7 +690,11 @@ ParameterEncoder* CommonCaptureManager::InitMethodCallCapture(format::ApiCallId 
 
 CommonCaptureManager::ApiCallLock CommonCaptureManager::AcquireCallLock() const
 {
-    if (force_command_serialization_)
+    if (avoid_api_call_lock_)
+    {
+        return ApiCallLock(ApiCallLock::Type::kNone, api_call_mutex_);
+    }
+    else if (force_command_serialization_)
     {
         return ApiCallLock(ApiCallLock::Type::kExclusive, api_call_mutex_);
     }
@@ -1368,7 +1373,7 @@ void CommonCaptureManager::ActivateTrimming(std::shared_lock<ApiCallMutexT>& cur
 
     {
         auto exclusive_api_call_lock = std::unique_lock<CommonCaptureManager::ApiCallMutexT>{};
-        if (!GetForceCommandSerialization())
+        if (!avoid_api_call_lock_ && !GetForceCommandSerialization())
         {
             // If command serialization is active, the caller already holds the exclusive lock.
             exclusive_api_call_lock = AcquireExclusiveApiCallLock();
@@ -1413,7 +1418,7 @@ void CommonCaptureManager::DeactivateTrimming(std::shared_lock<ApiCallMutexT>& c
 
     {
         auto exclusive_api_call_lock = std::unique_lock<CommonCaptureManager::ApiCallMutexT>{};
-        if (!GetForceCommandSerialization())
+        if (!avoid_api_call_lock_ && !GetForceCommandSerialization())
         {
             // If command serialization is active, the caller already holds the exclusive lock.
             exclusive_api_call_lock = AcquireExclusiveApiCallLock();
@@ -1854,13 +1859,16 @@ bool CaptureFileOutputStream::Write(const void* data, size_t len)
 
 CommonCaptureManager::ApiCallLock::ApiCallLock(Type type, ApiCallMutexT& mutex)
 {
-    if (type == Type::kExclusive)
+    switch (type)
     {
-        exclusive.emplace(mutex);
-    }
-    else
-    {
-        shared.emplace(mutex);
+        case Type::kExclusive:
+            exclusive.emplace(mutex);
+            break;
+        case Type::kShared:
+            shared.emplace(mutex);
+            break;
+        default:
+            break;
     }
 }
 

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -65,7 +65,7 @@ std::atomic<format::HandleId>              CommonCaptureManager::default_unique_
 uint64_t                                   CommonCaptureManager::default_unique_id_offset_ = 0;
 thread_local bool                          CommonCaptureManager::force_default_unique_id_  = false;
 thread_local std::vector<format::HandleId> CommonCaptureManager::unique_id_stack_;
-int64_t                                        CommonCaptureManager::avoid_api_call_lock_ = 0;
+int64_t                                    CommonCaptureManager::avoid_api_call_lock_ = 0;
 
 static std::mutex external_trim_trigger_mutex_g;
 static bool       externally_set_trimming_state_g          = false;

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -65,7 +65,7 @@ std::atomic<format::HandleId>              CommonCaptureManager::default_unique_
 uint64_t                                   CommonCaptureManager::default_unique_id_offset_ = 0;
 thread_local bool                          CommonCaptureManager::force_default_unique_id_  = false;
 thread_local std::vector<format::HandleId> CommonCaptureManager::unique_id_stack_;
-int64_t                                    CommonCaptureManager::avoid_api_call_lock_ = 0;
+int64_t                                        CommonCaptureManager::avoid_api_call_lock_ = 0;
 
 static std::mutex external_trim_trigger_mutex_g;
 static bool       externally_set_trimming_state_g          = false;

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -61,6 +61,19 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
+class ScopedCounter
+{
+  public:
+    ScopedCounter(int64_t& counter) : counter_(counter) { ++counter_; }
+    ~ScopedCounter() { --counter_; }
+
+    ScopedCounter(const ScopedCounter&)            = delete;
+    ScopedCounter& operator=(const ScopedCounter&) = delete;
+
+  private:
+    int64_t& counter_;
+};
+
 class ApiCaptureManager;
 
 // The CommonCaptureManager provides common functionality referenced API specific capture managers
@@ -88,15 +101,30 @@ class CommonCaptureManager
 
     using ApiSharedLockT    = std::shared_lock<ApiCallMutexT>;
     using ApiExclusiveLockT = std::unique_lock<ApiCallMutexT>;
-    static auto AcquireSharedApiCallLock() { return std::move(ApiSharedLockT(api_call_mutex_)); }
-    static auto AcquireExclusiveApiCallLock() { return std::move(ApiExclusiveLockT(api_call_mutex_)); }
+    static auto AcquireSharedApiCallLock()
+    {
+        if (avoid_api_call_lock_ != 0)
+        {
+            return std::move(ApiSharedLockT());
+        }
+        return std::move(ApiSharedLockT(api_call_mutex_));
+    }
+    static auto AcquireExclusiveApiCallLock()
+    {
+        if (avoid_api_call_lock_ != 0)
+        {
+            return std::move(ApiExclusiveLockT());
+        }
+        return std::move(ApiExclusiveLockT(api_call_mutex_));
+    }
     class ApiCallLock
     {
       public:
         enum class Type
         {
             kExclusive,
-            kShared
+            kShared,
+            kNone
         };
 
         ApiCallLock(Type type, ApiCallMutexT& mutex);
@@ -262,6 +290,10 @@ class CommonCaptureManager
     bool GetIUnknownWrappingSetting() const
     {
         return iunknown_wrapping_;
+    }
+    int64_t& AvoidApiCallLock()
+    {
+        return avoid_api_call_lock_;
     }
     auto GetForceCommandSerialization() const
     {
@@ -614,6 +646,9 @@ class CommonCaptureManager
     bool                                    write_state_files_;
     bool                                    ignore_frame_boundary_android_;
     bool                                    skip_threads_with_invalid_data_;
+    static int64_t avoid_api_call_lock_; // A original function could call sub wrapped functions. If the
+                                         // force_command_serialization is enabled, the sub wrapped functions could
+                                         // cause deadlock. The sub wrapped functions shouldn't be locked.
 
     struct
     {

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -3325,6 +3325,7 @@ void D3D12CaptureManager::TrimDrawCalls_ID3D12GraphicsCommandList_Reset(HRESULT 
                                                                         ID3D12CommandAllocator*            pAllocator,
                                                                         ID3D12PipelineState* pInitialState)
 {
+    ScopedCounter scoped(AvoidApiCallLock());
     DecrementCallScope();
 
     auto trim_draw_calls_command_sets =
@@ -3349,6 +3350,7 @@ void D3D12CaptureManager::TrimDrawCalls_ID3D12GraphicsCommandList_Reset(HRESULT 
 void D3D12CaptureManager::TrimDrawCalls_ID3D12GraphicsCommandList_ExecuteBundle(
     ID3D12GraphicsCommandList_Wrapper* wrapper, ID3D12GraphicsCommandList* pCommandList)
 {
+    ScopedCounter scoped(AvoidApiCallLock());
     DecrementCallScope();
 
     auto trim_draw_calls_command_sets =
@@ -3397,6 +3399,7 @@ void D3D12CaptureManager::TrimDrawCalls_ID3D12GraphicsCommandList4_BeginRenderPa
     const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC* pDepthStencil,
     D3D12_RENDER_PASS_FLAGS                     Flags)
 {
+    ScopedCounter scoped(AvoidApiCallLock());
     DecrementCallScope();
 
     auto trim_draw_calls_command_sets =
@@ -3589,6 +3592,7 @@ bool D3D12CaptureManager::TrimDrawCalls_ID3D12CommandQueue_ExecuteCommandLists(
         cmdlists.emplace_back(before_draw_call_cmd);
 
         // Here has to use the wrapped queue since this ExecuteCommandLists needs to be tracked.
+        ScopedCounter scoped(AvoidApiCallLock());
         DecrementCallScope();
         wrapper->ExecuteCommandLists(cmdlists.size(), cmdlists.data());
         IncrementCallScope();

--- a/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
@@ -808,6 +808,7 @@ class Dx12WrapperBodyGenerator(Dx12BaseGenerator):
                 expr += '\n'
                 expr += indent + 'if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)\n'
                 expr += indent + '{\n'
+                expr += indent1 + 'ScopedCounter scoped(manager->AvoidApiCallLock());\n'
                 expr += indent1 + 'manager->DecrementCallScope();\n'
                 expr += indent1 + 'auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_{}_{});\n'.format(class_name, method_name)
                 expr += indent1 + 'for(auto& command_set : trim_draw_calls_command_sets)\n'

--- a/framework/generated/generated_dx12_wrappers.cpp
+++ b/framework/generated/generated_dx12_wrappers.cpp
@@ -2598,6 +2598,7 @@ HRESULT STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::Close()
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_Close);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -2722,6 +2723,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ClearState(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_ClearState);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -2790,6 +2792,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::DrawInstanced(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_DrawInstanced);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -2873,6 +2876,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::DrawIndexedInstanced(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_DrawIndexedInstanced);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -2954,6 +2958,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::Dispatch(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_Dispatch);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3033,6 +3038,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::CopyBufferRegion(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_CopyBufferRegion);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3125,6 +3131,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::CopyTextureRegion(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_CopyTextureRegion);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3207,6 +3214,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::CopyResource(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_CopyResource);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3285,6 +3293,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::CopyTiles(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_CopyTiles);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3376,6 +3385,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ResolveSubresource(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_ResolveSubresource);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3451,6 +3461,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::IASetPrimitiveTopology
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_IASetPrimitiveTopology);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3513,6 +3524,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::RSSetViewports(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_RSSetViewports);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3579,6 +3591,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::RSSetScissorRects(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_RSSetScissorRects);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3642,6 +3655,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::OMSetBlendFactor(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_OMSetBlendFactor);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3701,6 +3715,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::OMSetStencilRef(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_OMSetStencilRef);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3760,6 +3775,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetPipelineState(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetPipelineState);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3824,6 +3840,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ResourceBarrier(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_ResourceBarrier);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -3939,6 +3956,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetDescriptorHeaps(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetDescriptorHeaps);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4002,6 +4020,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRootSignatur
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetComputeRootSignature);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4061,6 +4080,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRootSignatu
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootSignature);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4125,6 +4145,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRootDescript
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetComputeRootDescriptorTable);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4193,6 +4214,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRootDescrip
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4262,6 +4284,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRoot32BitCon
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetComputeRoot32BitConstant);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4335,6 +4358,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRoot32BitCo
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstant);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4411,6 +4435,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRoot32BitCon
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetComputeRoot32BitConstants);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4491,6 +4516,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRoot32BitCo
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstants);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4567,6 +4593,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRootConstant
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetComputeRootConstantBufferView);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4635,6 +4662,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRootConstan
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootConstantBufferView);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4703,6 +4731,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRootShaderRe
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetComputeRootShaderResourceView);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4771,6 +4800,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRootShaderR
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootShaderResourceView);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4839,6 +4869,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRootUnordere
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetComputeRootUnorderedAccessView);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4907,6 +4938,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRootUnorder
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootUnorderedAccessView);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -4977,6 +5009,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::IASetIndexBuffer(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_IASetIndexBuffer);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5049,6 +5082,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::IASetVertexBuffers(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_IASetVertexBuffers);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5129,6 +5163,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SOSetTargets(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SOSetTargets);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5207,6 +5242,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::OMSetRenderTargets(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_OMSetRenderTargets);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5295,6 +5331,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ClearDepthStencilView(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_ClearDepthStencilView);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5385,6 +5422,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ClearRenderTargetView(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_ClearRenderTargetView);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5475,6 +5513,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ClearUnorderedAccessVi
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_ClearUnorderedAccessViewUint);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5573,6 +5612,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ClearUnorderedAccessVi
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_ClearUnorderedAccessViewFloat);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5655,6 +5695,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::DiscardResource(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_DiscardResource);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5724,6 +5765,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::BeginQuery(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_BeginQuery);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5797,6 +5839,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::EndQuery(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_EndQuery);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5879,6 +5922,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ResolveQueryData(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_ResolveQueryData);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -5964,6 +6008,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetPredication(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetPredication);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6037,6 +6082,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetMarker(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_SetMarker);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6110,6 +6156,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::BeginEvent(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_BeginEvent);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6174,6 +6221,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::EndEvent()
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_EndEvent);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6244,6 +6292,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ExecuteIndirect(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList_ExecuteIndirect);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6347,6 +6396,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::AtomicCopyBufferUINT(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6452,6 +6502,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::AtomicCopyBufferUINT6
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT64);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6540,6 +6591,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::OMSetDepthBounds(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList1_OMSetDepthBounds);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6611,6 +6663,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::SetSamplePositions(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList1_SetSamplePositions);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6704,6 +6757,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::ResolveSubresourceReg
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList1_ResolveSubresourceRegion);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6797,6 +6851,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::SetViewInstanceMask(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList1_SetViewInstanceMask);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -6875,6 +6930,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList2_Wrapper::WriteBufferImmediate(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList2_WriteBufferImmediate);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -15553,6 +15609,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList3_Wrapper::SetProtectedResourceS
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList3_SetProtectedResourceSession);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -15760,6 +15817,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::EndRenderPass()
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList4_EndRenderPass);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -15823,6 +15881,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::InitializeMetaCommand
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList4_InitializeMetaCommand);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -15898,6 +15957,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::ExecuteMetaCommand(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList4_ExecuteMetaCommand);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -15988,6 +16048,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::BuildRaytracingAccele
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList4_BuildRaytracingAccelerationStructure);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -16077,6 +16138,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::EmitRaytracingAcceler
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -16156,6 +16218,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::CopyRaytracingAcceler
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList4_CopyRaytracingAccelerationStructure);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -16225,6 +16288,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::SetPipelineState1(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList4_SetPipelineState1);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -16293,6 +16357,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::DispatchRays(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList4_DispatchRays);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -19672,6 +19737,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList5_Wrapper::RSSetShadingRate(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList5_RSSetShadingRate);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -19737,6 +19803,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList5_Wrapper::RSSetShadingRateImage
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList5_RSSetShadingRateImage);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -19808,6 +19875,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList6_Wrapper::DispatchMesh(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList6_DispatchMesh);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -19886,6 +19954,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList7_Wrapper::Barrier(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList7_Barrier);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -19958,6 +20027,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList8_Wrapper::OMSetFrontAndBackSten
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList8_OMSetFrontAndBackStencilRef);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -20033,6 +20103,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList9_Wrapper::RSSetDepthBias(
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList9_RSSetDepthBias);
             for(auto& command_set : trim_draw_calls_command_sets)
@@ -20102,6 +20173,7 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList9_Wrapper::IASetIndexBufferStrip
 
         if(manager->GetTrimBoundary() == CaptureSettings::TrimBoundary::kDrawCalls)
         {
+            ScopedCounter scoped(manager->AvoidApiCallLock());
             manager->DecrementCallScope();
             auto trim_draw_calls_command_sets = manager->GetCommandListsForTrimDrawCalls(this, format::ApiCall_ID3D12GraphicsCommandList9_IASetIndexBufferStripCutValue);
             for(auto& command_set : trim_draw_calls_command_sets)


### PR DESCRIPTION
closed: https://github.com/LunarG/Projects/issues/1129

When `GFXRECON_FORCE_COMMAND_SERIALIZATION` is enabled, and the original function calls sub wrapped functions, the sub wrapped functions would cause deadlock, if `DecrementCallScope` is called before the sub wrapped functions, like capture draw calls. `AvoidApiCallLock` has to be called to avoid api call lock.