### PR TITLE
replay: Serialize Vulkan rendering scopes

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -795,6 +795,7 @@ usage: gfxrecon.py replay [-h] [-p LOCAL_FILE] [--version] [--log-level LEVEL]
                           [--screenshot-ignore-FrameBoundaryANDROID]
                           [--wait-before-first-submit MILLISECONDS]
                           [--idle-before-submit]
+                          [--serialize-render-passes]
                           [file]
 
 Launch the replay tool.
@@ -1008,6 +1009,8 @@ options:
                         processing the first submit. (forwarded to replay tool)
   --idle-before-submit  Wait for the GPU to become idle before each submit.
                         (forwarded to replay tool)
+  --serialize-render-passes
+                        Serialize render passes by injecting execution barriers before render pass begin during replay. (forwarded to replay tool)
 ```
 
 The command will force-stop an active replay process before starting the replay

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -635,7 +635,7 @@ gfxrecon-replay         [-h | --help] [--version] [--cpu-mask <binary-mask>] [--
                         [--pipeline-creation-jobs | --pcj <num_jobs>]
                         [--deduplicate-device]
                         [--wait-before-first-submit MILLISECONDS]
-                        [--idle-before-submit]
+                        [--idle-before-submit] [--serialize-render-passes]
 
 
 Required arguments:
@@ -876,6 +876,8 @@ Optional arguments:
               Wait for the specified amount of milliseconds before processing the first submit.
   --idle-before-submit
               Wait for the GPU to become idle before each submit.
+  --serialize-render-passes
+              Serialize render passes by injecting execution barriers before render pass begin during replay
 ```
 
 ### Key Controls

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -144,6 +144,7 @@ def CreateReplayParser():
     parser.add_argument('--screenshot-ignore-FrameBoundaryANDROID', action='store_true', default=False, help='If set, frames switced with vkFrameBoundANDROID will be ignored from the screenshot handler.')
     parser.add_argument('--wait-before-first-submit', metavar='MILLISECONDS', help='Wait for the specified amount of milliseconds before processing the first submit. (forwarded to replay tool)')
     parser.add_argument('--idle-before-submit', action='store_true', default=False, help='Wait for the GPU to become idle before each submit. (forwarded to replay tool)')
+    parser.add_argument('--serialize-render-passes', action='store_true', default=False, help='Serialize render passes by injecting execution barriers before render pass begin during replay. (forwarded to replay tool)')
 
     return parser
 
@@ -329,6 +330,9 @@ def MakeExtrasString(args):
 
     if args.idle_before_submit:
         arg_list.append('--idle-before-submit')
+
+    if args.serialize_render_passes:
+        arg_list.append('--serialize-render-passes')
 
     if args.file:
         arg_list.append(args.file)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10166,12 +10166,43 @@ void VulkanReplayConsumerBase::OverrideCmdPushConstants2(
     func(command_buffer, push_constants_info);
 }
 
+void VulkanReplayConsumerBase::MaybeInjectExecutionBarrier(const VulkanCommandBufferInfo* command_buffer_info) const
+{
+    if (!options_.serialize_render_passes)
+    {
+        return;
+    }
+
+    util::BeginInjectedCommands();
+
+    const VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
+    GFXRECON_ASSERT(device_info != nullptr);
+    const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device_info->handle);
+    GFXRECON_ASSERT(device_table != nullptr);
+
+    // Make sure graphics work before this barrier is completed before doing other graphics work.
+    device_table->CmdPipelineBarrier(command_buffer_info->handle,
+                                     VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                                     VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                                     0,
+                                     0,
+                                     nullptr,
+                                     0,
+                                     nullptr,
+                                     0,
+                                     nullptr);
+
+    util::EndInjectedCommands();
+}
+
 void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
     PFN_vkCmdBeginRenderPass                             func,
     VulkanCommandBufferInfo*                             command_buffer_info,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
     VkSubpassContents                                    contents)
 {
+    MaybeInjectExecutionBarrier(command_buffer_info);
+
     const auto render_pass_info_meta = render_pass_begin_info_decoder->GetMetaStructPointer();
     auto       framebuffer_id        = render_pass_info_meta->framebuffer;
     auto       render_pass_id        = render_pass_info_meta->renderPass;
@@ -10228,6 +10259,8 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>*    subpass_begin_info_decode)
 {
+    MaybeInjectExecutionBarrier(command_buffer_info);
+
     const auto render_pass_info_meta = render_pass_begin_info_decoder->GetMetaStructPointer();
     auto       framebuffer_id        = render_pass_info_meta->framebuffer;
     auto       render_pass_id        = render_pass_info_meta->renderPass;
@@ -10259,6 +10292,16 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
     VkCommandBuffer command_buffer = command_buffer_info->handle;
 
     func(command_buffer, render_pass_begin_info_decoder->GetPointer(), subpass_begin_info_decode->GetPointer());
+}
+
+void VulkanReplayConsumerBase::OverrideCmdBeginRendering(
+    PFN_vkCmdBeginRendering                        func,
+    VulkanCommandBufferInfo*                       command_buffer_info,
+    StructPointerDecoder<Decoded_VkRenderingInfo>* rendering_info_decoder)
+{
+    MaybeInjectExecutionBarrier(command_buffer_info);
+
+    func(command_buffer_info->handle, rendering_info_decoder->GetPointer());
 }
 
 void VulkanReplayConsumerBase::OverrideCmdTraceRaysKHR(

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1390,6 +1390,10 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
                                     VkSubpassContents                                    contents);
 
+    void OverrideCmdBeginRendering(PFN_vkCmdBeginRendering                        func,
+                                   VulkanCommandBufferInfo*                       command_buffer_info,
+                                   StructPointerDecoder<Decoded_VkRenderingInfo>* rendering_info_decoder);
+
     void
     OverrideCmdTraceRaysKHR(PFN_vkCmdTraceRaysKHR                                          func,
                             VulkanCommandBufferInfo*                                       command_buffer_info,
@@ -1852,6 +1856,12 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult SetDuplicateDeviceInfo(VkDevice*         replay_device,
                                     VulkanDeviceInfo* device_info,
                                     VulkanDeviceInfo* extant_device_info);
+
+    /**
+     * @brief If the option to serialize render passes is enabled, inject an execution barrier before each
+     * render pass begin to ensure render passes execute in the same order as they were captured.
+     */
+    void MaybeInjectExecutionBarrier(const VulkanCommandBufferInfo* command_buffer_info) const;
 
   private:
     struct HardwareBufferInfo

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -178,6 +178,9 @@ struct VulkanReplayOptions : public ReplayOptions
     /// Wait for the GPU to become idle before each submit.
     bool idle_before_submit{ false };
 
+    /// Serialize render passes by injecting an execution barrier before each render pass begin.
+    bool serialize_render_passes{ false };
+
     void MaybeWaitBeforeFirstSubmit() const;
 };
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -3398,15 +3398,15 @@ void VulkanReplayConsumer::Process_vkCmdBeginRendering(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
-    const VkRenderingInfo* in_pRenderingInfo = pRenderingInfo->GetPointer();
+    auto in_commandBuffer = GetObjectInfoTable().GetVkCommandBufferInfo(commandBuffer);
+
     MapStructHandles(pRenderingInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
-    GetDeviceTable(in_commandBuffer)->CmdBeginRendering(in_commandBuffer, in_pRenderingInfo);
+    OverrideCmdBeginRendering(GetDeviceTable(in_commandBuffer->handle)->CmdBeginRendering, in_commandBuffer, pRenderingInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper_->Process_vkCmdBeginRendering(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginRendering, in_commandBuffer, pRenderingInfo);
+        resource_dumper_->Process_vkCmdBeginRendering(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRendering, in_commandBuffer->handle, pRenderingInfo);
     }
 }
 
@@ -4799,15 +4799,15 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderingKHR(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<VulkanCommandBufferInfo>(commandBuffer, &CommonObjectInfoTable::GetVkCommandBufferInfo);
-    const VkRenderingInfo* in_pRenderingInfo = pRenderingInfo->GetPointer();
+    auto in_commandBuffer = GetObjectInfoTable().GetVkCommandBufferInfo(commandBuffer);
+
     MapStructHandles(pRenderingInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
-    GetDeviceTable(in_commandBuffer)->CmdBeginRenderingKHR(in_commandBuffer, in_pRenderingInfo);
+    OverrideCmdBeginRendering(GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderingKHR, in_commandBuffer, pRenderingInfo);
 
     if (options_.dumping_resources)
     {
-        resource_dumper_->Process_vkCmdBeginRenderingKHR(call_info, GetDeviceTable(in_commandBuffer)->CmdBeginRenderingKHR, in_commandBuffer, pRenderingInfo);
+        resource_dumper_->Process_vkCmdBeginRenderingKHR(call_info, GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderingKHR, in_commandBuffer->handle, pRenderingInfo);
     }
 }
 

--- a/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
@@ -173,6 +173,8 @@
     "vkGetDescriptorEXT": "OverrideGetDescriptorEXT",
     "vkCmdBindDescriptorBuffersEXT": "OverrideCmdBindDescriptorBuffersEXT",
     "vkCreateSampler": "OverrideCreateSampler",
-    "vkCreatePipelineBinariesKHR": "OverrideCreatePipelineBinariesKHR"
+    "vkCreatePipelineBinariesKHR": "OverrideCreatePipelineBinariesKHR",
+    "vkCmdBeginRendering": "OverrideCmdBeginRendering",
+    "vkCmdBeginRenderingKHR": "OverrideCmdBeginRendering"
   }
 }

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -42,7 +42,7 @@ const char kArguments[] =
     "force-windowed,--fwo|--force-windowed-origin,--batching-memory-usage,--measurement-file,--swapchain,--sgfs|--skip-"
     "get-fence-status,--sgfr|--skip-get-fence-ranges,--dump-resources,--dump-resources-dir,--dump-resources-image-"
     "format,pbis,--pcj|--pipeline-creation-jobs,--save-pipeline-cache,--load-pipeline-cache,--quit-after-frame,--"
-    "present-mode,--wait-before-first-submit,--idle-before-submit,--present-override";
+    "present-mode,--wait-before-first-submit,--idle-before-submit,--present-override,--serialize-render-passes";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -82,6 +82,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sgfs <status> | --skip-get-fence-status <status>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sgfr <frame-ranges> | --skip-get-fence-ranges <frame-ranges>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--idle-before-submit] [--pbi-all] [--pbis <index1,index2>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--serialize-render-passes]");
 #if !defined(WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources <filename>.json]");
 #endif
@@ -364,6 +365,9 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tWait specified milliseconds before submitting the first command buffer.");
     GFXRECON_WRITE_CONSOLE("  --idle-before-submit");
     GFXRECON_WRITE_CONSOLE("          \t\tWait for the GPU to become idle before each submit.");
+    GFXRECON_WRITE_CONSOLE("  --serialize-render-passes");
+    GFXRECON_WRITE_CONSOLE("          \t\tSerialize render passes by injecting execution barriers before render pass");
+    GFXRECON_WRITE_CONSOLE("          \t\tbegin during replay.");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("D3D12 only:")

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -150,6 +150,7 @@ const char kCreateNewPipelineCacheOption[]        = "--add-new-pipeline-caches";
 const char kDeduplicateDevice[]                   = "--deduplicate-device";
 const char kWaitBeforeFirstSubmit[]               = "--wait-before-first-submit";
 const char kIdleBeforeSubmit[]                    = "--idle-before-submit";
+const char kSerializeRenderPasses[]               = "--serialize-render-passes";
 
 const char kScreenshotIgnoreFrameBoundaryArgument[] = "--screenshot-ignore-FrameBoundaryANDROID";
 
@@ -1261,6 +1262,7 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
 
     GetWaitBeforeFirstSubmit(arg_parser, replay_options.wait_before_first_submit);
     replay_options.idle_before_submit = arg_parser.IsOptionSet(kIdleBeforeSubmit);
+    replay_options.serialize_render_passes = arg_parser.IsOptionSet(kSerializeRenderPasses);
 
     return replay_options;
 }


### PR DESCRIPTION
Add a replay option that injects execution barriers before render pass and dynamic rendering begins.