### PR TITLE
Remove false assert for device queue create

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -817,9 +817,6 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
         for (uint32_t q = 0; q < pCreateInfo_unwrapped->queueCreateInfoCount; ++q)
         {
             const VkDeviceQueueCreateInfo* queue_create_info = &pCreateInfo_unwrapped->pQueueCreateInfos[q];
-            GFXRECON_ASSERT(wrapper->queue_family_creation_flags.find(queue_create_info->queueFamilyIndex) ==
-                            wrapper->queue_family_creation_flags.end());
-            wrapper->queue_family_creation_flags[queue_create_info->queueFamilyIndex] = queue_create_info->flags;
             wrapper->queue_family_indices[q] = pCreateInfo_unwrapped->pQueueCreateInfos[q].queueFamilyIndex;
         }
     }

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -174,7 +174,6 @@ struct DeviceWrapper : public HandleWrapper<VkDevice>
 
     // Physical device property & feature state at device creation
     graphics::VulkanDevicePropertyFeatureInfo              property_feature_info;
-    std::unordered_map<uint32_t, VkDeviceQueueCreateFlags> queue_family_creation_flags;
     std::vector<uint32_t>                                  queue_family_indices;
 };
 


### PR DESCRIPTION
Remove `queue_family_creation_flags`, because it was not used anywhere, other than a false assert.

The assert was checking that each queueFamilyIndex in VkDeviceQueueCreateInfo is unique, but this is not required, you can have two VkDeviceQueueCreateInfo with the same queueFamilyIndex, if they have different flags.