### PR TITLE
Correctly split the StateMaker handling visitors

### DIFF
--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -107,7 +107,7 @@ bool FileProcessor::ProcessNextFrame()
     GFXRECON_ASSERT(block_parser_->GetOperationMode() == BlockParser::OperationMode::kImmediate);
     GFXRECON_ASSERT(block_parser_->GetDecompressionPolicy() == BlockParser::DecompressionPolicy::kAlways);
 
-    DispatchVisitor  dispatch_visitor(decoders_, annotation_handler_);
+    DispatchVisitor  dispatch_visitor(*this, decoders_, annotation_handler_);
     DispatchFunction dispatch = [this, &dispatch_visitor](uint64_t block_index, ParsedBlock& block) {
         dispatch_visitor.SetBlockIndex(block_index);
         std::visit(dispatch_visitor, block.GetArgs());
@@ -557,10 +557,14 @@ void FileProcessor::ProcessStateBeginMarker(const StateBeginMarkerArgs& state_be
     loading_trimmed_capture_state_ = true;
 }
 
+void FileProcessor::ProcessStateEndMarkerFrameState(const StateEndMarkerArgs& state_end)
+{
+    first_frame_ = state_end.frame_number;
+}
+
 void FileProcessor::ProcessStateEndMarker(const StateEndMarkerArgs& state_end)
 {
     GFXRECON_LOG_INFO("Finished loading state for captured frame %" PRId64, state_end.frame_number);
-    first_frame_                   = state_end.frame_number;
     loading_trimmed_capture_state_ = false;
 }
 

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -171,6 +171,7 @@ class FileProcessor
     bool ProcessExecuteBlocksFromFile(const ExecuteBlocksFromFileArgs& execute_blocks_info);
     void ProcessStateBeginMarker(const StateBeginMarkerArgs& state_begin);
     void ProcessStateEndMarker(const StateEndMarkerArgs& state_end);
+    void ProcessStateEndMarkerFrameState(const StateEndMarkerArgs& state_end);
     void ProcessAnnotation(const AnnotationArgs& annotation);
 
   protected:
@@ -271,6 +272,48 @@ class FileProcessor
         template <typename Args>
         void operator()(const Args* args)
         {
+            DispatchArgs(args);
+        }
+
+        // State Marker control
+        void operator()(const StateBeginMarkerArgs* state_begin)
+        {
+            // The block and marker type are implied by the Args type
+            file_processor_.ProcessStateBeginMarker(*state_begin);
+            DispatchArgs(state_begin);
+        }
+
+        void operator()(const StateEndMarkerArgs* state_end)
+        {
+            // The block and marker type are implied by the Args type
+            file_processor_.ProcessStateEndMarker(*state_end);
+            DispatchArgs(state_end);
+        }
+
+        void operator()(const AnnotationArgs* annotation)
+        {
+            if (annotation_handler_)
+            {
+                auto annotation_call = [this](auto&&... expanded_args) {
+                    annotation_handler_->ProcessAnnotation(std::forward<decltype(expanded_args)>(expanded_args)...);
+                };
+                std::apply(annotation_call, annotation->GetTuple());
+            }
+        }
+
+        DispatchVisitor(FileProcessor&                  file_processor,
+                        const std::vector<ApiDecoder*>& decoders,
+                        AnnotationHandler*              annotation_handler) :
+            file_processor_(file_processor),
+            decoders_(decoders), annotation_handler_(annotation_handler)
+        {}
+
+        void SetBlockIndex(uint64_t block_index) { block_index_ = block_index; }
+
+      private:
+        template <typename Args>
+        void DispatchArgs(const Args* args)
+        {
             constexpr auto decode_method = DispatchTraits<Args>::kDecoderMethod;
             for (auto decoder : decoders_)
             {
@@ -286,24 +329,8 @@ class FileProcessor
                 }
             }
         }
-        void operator()(const AnnotationArgs* annotation)
-        {
-            if (annotation_handler_)
-            {
-                auto annotation_call = [this](auto&&... expanded_args) {
-                    annotation_handler_->ProcessAnnotation(std::forward<decltype(expanded_args)>(expanded_args)...);
-                };
-                std::apply(annotation_call, annotation->GetTuple());
-            }
-        }
 
-        DispatchVisitor(const std::vector<ApiDecoder*>& decoders, AnnotationHandler* annotation_handler) :
-            decoders_(decoders), annotation_handler_(annotation_handler)
-        {}
-
-        void SetBlockIndex(uint64_t block_index) { block_index_ = block_index; }
-
-      private:
+        FileProcessor&                  file_processor_;
         const std::vector<ApiDecoder*>& decoders_;
         AnnotationHandler*              annotation_handler_;
         uint64_t                        block_index_;
@@ -344,21 +371,12 @@ class FileProcessor
             success            = file_processor_.ProcessExecuteBlocksFromFile(*execute_blocks);
         }
 
-        // State Marker control
-        void operator()(const StateBeginMarkerArgs* state_begin)
-        {
-            // The block and marker type are implied by the Args type
-            is_frame_delimiter = false;
-            success            = true;
-            file_processor_.ProcessStateBeginMarker(*state_begin);
-        }
-
         void operator()(const StateEndMarkerArgs* state_end)
         {
             // The block and marker type are implied by the Args type
             is_frame_delimiter = false;
             success            = true;
-            file_processor_.ProcessStateEndMarker(*state_end);
+            file_processor_.ProcessStateEndMarkerFrameState(*state_end);
         }
 
         void operator()(const AnnotationArgs* annotation)

--- a/framework/decode/preload_file_processor.cpp
+++ b/framework/decode/preload_file_processor.cpp
@@ -250,7 +250,7 @@ PreloadFileProcessor::ReplayFrameResult PreloadFileProcessor::ReplayOneFrame()
     auto current_cursor = replay_cursor_;
 
     BlockParser&    block_parser = GetBlockParser();
-    DispatchVisitor dispatch_visitor(decoders_, annotation_handler_);
+    DispatchVisitor dispatch_visitor(*this, decoders_, annotation_handler_);
     SetDecoderFrameNumber(current_frame_number_);
 
     ProcessBlockState process_state = ProcessBlockState::kRunning;


### PR DESCRIPTION
Ensure that preload time and replay time state updates match the logical state of the system.  Fixes a small issue with update timing of `loading_trimmed_capture_state_` .

NOTE: This state does not appear to be used, however an accessor is exported in

`android_main.cpp: bool MainGetLoadingTrimmedState()`

Not clear if there is application usage or if `loading_trimmed_capture_state_`  is actually vestigial.