### PR TITLE
Fix duplicate 'OutputDir' in DumpResourcesOptions

### DIFF
--- a/vulkan_dump_resources.md
+++ b/vulkan_dump_resources.md
@@ -437,7 +437,6 @@ A json example specifying the above options:
 {
   "DumpResourcesOptions": {
       "Scale": 0.2,
-      "OutputDir": "",
       "ColorAttachmentIndex": -1,
       "OutputDir": "",
       "ImageFormat": "png",


### PR DESCRIPTION
Removed duplicate 'OutputDir' entry in example dump resources config.