### PR TITLE
Skip call to vkAcquireNextImage2KHR if capture status wasn't VK_SUCCESS

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -8236,7 +8236,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
     // If image acquire failed at capture, there is nothing worth replaying as the fence and semaphore aren't processed
     // and a successful acquire on replay of an image that does not have a corresponding present to replay can lead to
     // OUT_OF_DATE errors.
-    if (original_result < 0)
+    if (original_result != VK_SUCCESS && original_result != VK_SUBOPTIMAL_KHR)
     {
         result = original_result;
     }


### PR DESCRIPTION
Same fix as in 94c7267deb2fbce10bf663c0dd407f7c345edae2 for vkAcquireNextImageKHR but this fix missed the vkAcquireNextImage2KHR extension variant. The below-zero comparison misses some key return values like VK_TIMEOUT that are positive.