### PR TITLE
info: Fix case when ApplicationInfo is nullptr

### DIFF
--- a/framework/decode/vulkan_stats_consumer.h
+++ b/framework/decode/vulkan_stats_consumer.h
@@ -192,16 +192,13 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         GFXRECON_UNREFERENCED_PARAMETER(allocCb);
         if ((pCreateInfo != nullptr) && (returnValue >= 0) && !pCreateInfo->IsNull())
         {
-            auto create_info = pCreateInfo->GetPointer();
-            auto app_info    = create_info->pApplicationInfo;
-            if (app_info != nullptr)
-            {
-                const VkInstance      inst = reinterpret_cast<const VkInstance>(*pInstance->GetPointer());
-                VulkanInstanceTracker instance_tracker(
-                    app_info, create_info->enabledExtensionCount, create_info->ppEnabledExtensionNames, inst);
-                instance_info_[inst]   = std::move(instance_tracker);
-                last_created_instance_ = inst;
-            }
+            auto                  create_info = pCreateInfo->GetPointer();
+            auto                  app_info    = create_info->pApplicationInfo;
+            const VkInstance      inst        = reinterpret_cast<const VkInstance>(*pInstance->GetPointer());
+            VulkanInstanceTracker instance_tracker(
+                app_info, create_info->enabledExtensionCount, create_info->ppEnabledExtensionNames, inst);
+            instance_info_[inst]   = std::move(instance_tracker);
+            last_created_instance_ = inst;
         }
     }
 


### PR DESCRIPTION
Small fix with issue discovered when trying to use Info on an application that set `VkInstanceCreateInfo`'s `pApplicationInfo` to `nullptr`.