### PR TITLE
Automatically rename player process name at runtime to captured application name

### DIFF
--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -465,9 +465,24 @@ Optional arguments:
 Note: running without optional arguments will instruct the optimizer to detect API and run all available optimizations.
 ```
 
-### Renaming Scripts
+### Renaming Player
 
-In order to obtain application-matching playback, it is sometimes necessary to rename `gfxrecon-replay.exe` to match the captured application's executable name. This is because driver behavior can sometimes change depending on the executable name of the running application. Renaming is not always required, but it is an added measure towards functional replay. The two following utility scripts are bundled, which extract the application name from the capture file and make the renaming task automatic. Renaming can also be done manually, since the application executable name can be extracted using the `gfxrecon-info` tool.
+In order to obtain application-matching playback, it is sometimes necessary for the replayer to report the captured application's executable name to the driver. This is because driver behavior can sometimes change depending on the executable name of the running application.
+
+#### Process Name Override (Default Behavior)
+
+`gfxrecon-replay.exe` and `gfxrecon-optimize.exe` automatically override the process name reported to the driver. They read the captured application's executable name from the capture file and hook `GetModuleFileNameA`/`GetModuleFileNameW` so that the process name is transparently reported as the original application's name — without requiring any physical renaming of the executable.
+
+This behavior is enabled by default. If it is not required, it can be disabled with the `--disable-process-name-override` flag:
+
+```bat
+gfxrecon-replay.exe --disable-process-name-override <file>
+gfxrecon-optimize.exe --disable-process-name-override <input-file> <output-file>
+```
+
+#### Manual Renaming Scripts (Alternative)
+
+As an alternative to the automatic process name override, the following utility scripts perform physical renaming of `gfxrecon-replay.exe` or `gfxrecon-optimize.exe` to match the captured application's name. They extract the application name from the capture file automatically. Manual renaming is also possible using the `gfxrecon-info` tool to retrieve the application executable name.
 
 #### gfxrecon-replay-renamed.py
 

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -41,7 +41,8 @@ to one of these other documents:
     4. [Trimmed File Optimization](#trimmed-file-optimization)
     5. [JSON Lines Conversion](#json-lines-conversion)
     6. [Command Launcher](#command-launcher)
-    7. [Options Common To All Tools](#options-common-to-all-tools)
+    7. [Renaming Player (Windows Only)](#renaming-player-windows-only)
+    8. [Options Common To All Tools](#options-common-to-all-tools)
 
 ## Capturing API calls
 
@@ -1184,6 +1185,41 @@ gfxrecon.py capture -o vkcube.gfxr vkcube
 
 On Windows, after installing Python3, be sure to associate the `.py` file extension with
 the Python3 interpreter before you run the script.
+
+### Renaming Player (Windows Only)
+
+In order to obtain application-matching playback on Windows, it is sometimes necessary for the replayer to report the captured application's executable name to the driver. This is because driver behavior can sometimes change depending on the executable name of the running application.
+
+#### Process Name Override (Default Behavior, Windows Only)
+
+`gfxrecon-replay.exe` automatically overrides the process name reported to the driver. It reads the captured application's executable name from the capture file and hooks `GetModuleFileNameA`/`GetModuleFileNameW` so that the process name is transparently reported as the original application's name — without requiring any physical renaming of the executable.
+
+This behavior is enabled by default on Windows. If it is not required, it can be disabled with the `--disable-process-name-override` flag:
+
+```bat
+gfxrecon-replay.exe --disable-process-name-override <file>
+```
+
+#### Manual Renaming Script (Alternative)
+
+As an alternative to the automatic process name override, the following utility script performs physical renaming of `gfxrecon-replay.exe` to match the captured application's name. It extracts the application name from the capture file automatically. Manual renaming is also possible using the `gfxrecon-info` tool to retrieve the application executable name.
+
+##### gfxrecon-replay-renamed.py
+
+This script can be used to replay capture files. It performs automatic renaming and execution of `gfxrecon-replay.exe`
+
+```text
+gfxrecon-replay-renamed.py - Helper script to perform automatic renaming of gfxrecon-replay.exe prior to playback.
+
+Usage:
+  gfxrecon-replay-renamed.py <file> [optional_replayer_args]
+
+Required arguments:
+  <file>                     Path to the capture file to replay.
+
+Optional arguments:
+  [optional_replayer_args]   All optional arguments exposed by gfxrecon-replay.exe
+```
 
 ### Options Common To all Tools
 

--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
 ** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -42,6 +43,8 @@
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
+
+using ProcessNameOverrideCallbackFunc = void (*)(char const* app_name, size_t app_name_size);
 
 class Application final
 {

--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -92,10 +92,7 @@ class Application final
     void InitializeDx12WsiContext();
 #endif
 
-    void StopRunning()
-    {
-        running_ = false;
-    }
+    void StopRunning() { running_ = false; }
 
     uint32_t GetCurrentFrameNumber() const
     {

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021-2022 LunarG, Inc.
-** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2023-2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -64,8 +64,20 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     virtual ~Dx12ReplayConsumerBase() override;
 
+    void SetProcessNameCallback(application::ProcessNameOverrideCallbackFunc callback)
+    { 
+        if (callback != nullptr)
+        {
+            process_name_callback_ = callback; 
+        }
+    }
+
     virtual void Process_ExeFileInfo(const util::filepath::FileInfo& info_record)
     {
+        if (process_name_callback_ != nullptr)
+        {
+            process_name_callback_(info_record.AppName, strnlen(info_record.AppName, sizeof(info_record.AppName)));
+        }
         gfxrecon::util::filepath::CheckReplayerName(info_record.AppName);
     }
 
@@ -1368,6 +1380,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 #ifdef GFXRECON_AGS_SUPPORT
     graphics::Dx12AgsMarkerInjector* ags_marker_injector_{ nullptr };
 #endif
+    application::ProcessNameOverrideCallbackFunc          process_name_callback_{ nullptr };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -65,10 +65,10 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     virtual ~Dx12ReplayConsumerBase() override;
 
     void SetProcessNameCallback(application::ProcessNameOverrideCallbackFunc callback)
-    { 
+    {
         if (callback != nullptr)
         {
-            process_name_callback_ = callback; 
+            process_name_callback_ = callback;
         }
     }
 
@@ -1248,10 +1248,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     void RaiseFatalError(const char* message) const;
 
-    uint64_t GetUniqueProxyWindowId()
-    {
-        return ++unique_proxy_window_id_counter_;
-    }
+    uint64_t GetUniqueProxyWindowId() { return ++unique_proxy_window_id_counter_; }
 
     HRESULT
     CreateSwapChainForHwnd(DxObjectInfo*                           replay_object_info,
@@ -1380,7 +1377,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 #ifdef GFXRECON_AGS_SUPPORT
     graphics::Dx12AgsMarkerInjector* ags_marker_injector_{ nullptr };
 #endif
-    application::ProcessNameOverrideCallbackFunc          process_name_callback_{ nullptr };
+    application::ProcessNameOverrideCallbackFunc process_name_callback_{ nullptr };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1970,7 +1970,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unique_ptr<VulkanSwapchain>                                         swapchain_;
     std::string                                                              screenshot_file_prefix_;
     graphics::FpsInfo*                                                       fps_info_;
-    application::ProcessNameOverrideCallbackFunc                             process_name_callback_{nullptr};
+    application::ProcessNameOverrideCallbackFunc                             process_name_callback_{ nullptr };
 
     VulkanPerDeviceAddressTrackers  _device_address_trackers;
     VulkanPerDeviceAddressReplacers _device_address_replacers;

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
 ** Copyright (c) 2018-2025 LunarG, Inc.
-** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -85,12 +85,24 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void Process_ExeFileInfo(const util::filepath::FileInfo& info_record) override
     {
+        if (process_name_callback_ != nullptr)
+        {
+            process_name_callback_(info_record.AppName, strnlen(info_record.AppName, sizeof(info_record.AppName)));
+        }
         gfxrecon::util::filepath::CheckReplayerName(info_record.AppName);
     }
 
     void SetFatalErrorHandler(std::function<void(const char*)> handler);
 
     void SetFpsInfo(graphics::FpsInfo* fps_info) { fps_info_ = fps_info; }
+
+    void SetProcessNameCallback(application::ProcessNameOverrideCallbackFunc callback)
+    {
+        if (callback != nullptr)
+        {
+            process_name_callback_ = callback;
+        }
+    }
 
     virtual void WaitDevicesIdle() override;
 
@@ -1958,6 +1970,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unique_ptr<VulkanSwapchain>                                         swapchain_;
     std::string                                                              screenshot_file_prefix_;
     graphics::FpsInfo*                                                       fps_info_;
+    application::ProcessNameOverrideCallbackFunc                             process_name_callback_{nullptr};
 
     VulkanPerDeviceAddressTrackers  _device_address_trackers;
     VulkanPerDeviceAddressReplacers _device_address_replacers;

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -135,6 +135,8 @@ target_sources(gfxrecon_util
                     $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_loader.h>
                     $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_loader.cpp>
                     $<$<BOOL:${WAYLAND_FOUND}>:${PROJECT_SOURCE_DIR}/framework/generated/generated_wayland_xdg_shell.h>
+                    $<$<BOOL:${WIN32}>:${CMAKE_CURRENT_LIST_DIR}/process_name_override.h>                  
+                    $<$<BOOL:${WIN32}>:${CMAKE_CURRENT_LIST_DIR}/process_name_override.cpp>
 )
 
 

--- a/framework/util/process_name_override.cpp
+++ b/framework/util/process_name_override.cpp
@@ -1,0 +1,144 @@
+/*
+** Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include <windows.h> 
+#include <string>
+#include <filesystem>
+#include "util/to_string.h"
+#include "util/logging.h"
+#include "util/interception/hooking_detours.h"
+#include "util/process_name_override.h"
+
+namespace 
+{
+// App Name set by callback from replay consumer
+std::string s_app_name{}; 
+
+// Helper function to construct the modified application path based on the original application path and the new application name.
+std::string GetModifiedApplicationPath(DWORD (*real_getmodule_filename_a)(HMODULE, LPSTR, DWORD), std::string app_name)
+{
+    if(app_name.empty() || real_getmodule_filename_a == nullptr)
+    {
+        return {};
+    }
+    std::string result{}; 
+    char application_name[MAX_PATH]{};
+    DWORD length = real_getmodule_filename_a(nullptr, application_name, sizeof(application_name));
+    if(length > 0 && length < MAX_PATH)
+    {
+        std::filesystem::path application_current_path(application_name);
+        application_current_path = application_current_path.parent_path();
+        application_current_path /= app_name;
+        result = application_current_path.string();
+    }
+    return result;
+}
+} // anonymous namespace
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+DWORD (*real_getmodule_filename_a)(HMODULE, LPSTR, DWORD) = GetModuleFileNameA;
+DWORD (*real_getmodule_filename_w)(HMODULE, LPWSTR, DWORD) = GetModuleFileNameW;
+
+
+// Based on MSDN documentation for GetModuleFileNameA/W, if hModule is null, the function returns the path of the executable of the current process. 
+// By hooking this function, we can override the process name that is reported to the driver. 
+// https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew
+DWORD HookGetModuleFilenameA(HMODULE hModule, LPSTR lpFilename, DWORD nSize)
+{
+    if (hModule == nullptr && !s_app_name.empty() && nSize > 0)
+    {
+        GFXRECON_LOG_INFO("Overriding process name to: %s", s_app_name.c_str());
+        std::string full_app_path = GetModifiedApplicationPath(real_getmodule_filename_a, s_app_name);
+
+        // If the provided buffer is too small, return the required size and set the last error to ERROR_INSUFFICIENT_BUFFER, as per the documentation for GetModuleFileNameA/W.
+        if (full_app_path.size() >= nSize) 
+        {
+            // ensure null termination. 
+            lpFilename[nSize - 1] = '\0';
+            // Copy as much of the app name as will fit in the buffer, leaving space for the null terminator.
+            memcpy_s(lpFilename, nSize - 2, full_app_path.c_str(), nSize - 1);
+            SetLastError(ERROR_INSUFFICIENT_BUFFER); 
+            return nSize;
+        }
+        else
+        {
+            snprintf(lpFilename, full_app_path.size() + 1, "%s", full_app_path.c_str());
+            return full_app_path.size(); 
+        }
+        
+    }
+    return real_getmodule_filename_a(hModule, lpFilename, nSize);
+}
+
+DWORD HookGetModuleFilenameW(HMODULE hModule, LPWSTR lpFilename, DWORD nSize) 
+{
+    if (hModule == nullptr && !s_app_name.empty() && nSize > 0)
+    {
+        GFXRECON_LOG_INFO("Overriding process name to: %s", s_app_name.c_str());
+        std::string  full_app_path = GetModifiedApplicationPath(real_getmodule_filename_a, s_app_name);
+        std::wstring w_full_app_path = gfxrecon::util::StringToWideString(full_app_path); 
+        if (w_full_app_path.size() >= nSize)
+        {
+            // ensure null termination. 
+            lpFilename[nSize - 1] = '\0';
+            // Copy as much of the app name as will fit in the buffer, leaving space for the null terminator.
+            memcpy_s(lpFilename, (nSize - 2) * sizeof(wchar_t), w_full_app_path.c_str(), (nSize - 1) * sizeof(wchar_t));
+            SetLastError(ERROR_INSUFFICIENT_BUFFER); 
+            return nSize;
+        }
+        else
+        {
+            swprintf(lpFilename, w_full_app_path.size() + 1, L"%s", w_full_app_path.c_str());
+            return w_full_app_path.size(); 
+        }
+    }
+    return real_getmodule_filename_w(hModule, lpFilename, nSize);
+}
+
+void ProcessNameOverrideCallback(char const* app_name, size_t app_name_size)
+{
+    if(app_name && app_name_size > 0)
+    {
+        s_app_name.resize(app_name_size); 
+        memcpy(&s_app_name[0], app_name, app_name_size);
+    }
+}
+
+void InitializeProcessNameOverride()
+{
+    bool success = false; 
+    success = gfxrecon::util::interception::HookAPICall(&(PVOID&)real_getmodule_filename_a, HookGetModuleFilenameA);
+    if (!success)
+    {
+        GFXRECON_LOG_WARNING("Failed to hook GetModuleFileNameA. Process name override will not work.");
+    }
+    success = gfxrecon::util::interception::HookAPICall(&(PVOID&)real_getmodule_filename_w, HookGetModuleFilenameW);
+    if (!success)
+    {
+        GFXRECON_LOG_WARNING("Failed to hook GetModuleFileNameW. Process name override will not work.");
+    }
+}
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/process_name_override.cpp
+++ b/framework/util/process_name_override.cpp
@@ -68,7 +68,7 @@ DWORD HookGetModuleFilenameA(HMODULE hModule, LPSTR lpFilename, DWORD nSize)
 {
     if (hModule == nullptr && !s_app_name.empty() && nSize > 0)
     {
-        GFXRECON_LOG_INFO("Overriding process name to: %s", s_app_name.c_str());
+        GFXRECON_LOG_INFO_ONCE("Overriding process name to: %s", s_app_name.c_str());
         std::string full_app_path = GetModifiedApplicationPath(real_getmodule_filename_a, s_app_name);
 
         // If the provided buffer is too small, return the required size and set the last error to ERROR_INSUFFICIENT_BUFFER, as per the documentation for GetModuleFileNameA/W.
@@ -95,7 +95,7 @@ DWORD HookGetModuleFilenameW(HMODULE hModule, LPWSTR lpFilename, DWORD nSize)
 {
     if (hModule == nullptr && !s_app_name.empty() && nSize > 0)
     {
-        GFXRECON_LOG_INFO("Overriding process name to: %s", s_app_name.c_str());
+        GFXRECON_LOG_INFO_ONCE("Overriding process name to: %s", s_app_name.c_str());
         std::string  full_app_path = GetModifiedApplicationPath(real_getmodule_filename_a, s_app_name);
         std::wstring w_full_app_path = gfxrecon::util::StringToWideString(full_app_path); 
         if (w_full_app_path.size() >= nSize)

--- a/framework/util/process_name_override.cpp
+++ b/framework/util/process_name_override.cpp
@@ -20,7 +20,7 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include <windows.h> 
+#include <windows.h>
 #include <string>
 #include <filesystem>
 #include "util/to_string.h"
@@ -28,22 +28,23 @@
 #include "util/interception/hooking_detours.h"
 #include "util/process_name_override.h"
 
-namespace 
+namespace
 {
 // App Name set by callback from replay consumer
-std::string s_app_name{}; 
+std::string s_app_name{};
 
-// Helper function to construct the modified application path based on the original application path and the new application name.
+// Helper function to construct the modified application path based on the original application path and the new
+// application name.
 std::string GetModifiedApplicationPath(DWORD (*real_getmodule_filename_a)(HMODULE, LPSTR, DWORD), std::string app_name)
 {
-    if(app_name.empty() || real_getmodule_filename_a == nullptr)
+    if (app_name.empty() || real_getmodule_filename_a == nullptr)
     {
         return {};
     }
-    std::string result{}; 
-    char application_name[MAX_PATH]{};
-    DWORD length = real_getmodule_filename_a(nullptr, application_name, sizeof(application_name));
-    if(length > 0 && length < MAX_PATH)
+    std::string result{};
+    char        application_name[MAX_PATH]{};
+    DWORD       length = real_getmodule_filename_a(nullptr, application_name, sizeof(application_name));
+    if (length > 0 && length < MAX_PATH)
     {
         std::filesystem::path application_current_path(application_name);
         application_current_path = application_current_path.parent_path();
@@ -57,13 +58,12 @@ std::string GetModifiedApplicationPath(DWORD (*real_getmodule_filename_a)(HMODUL
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
 
-DWORD (*real_getmodule_filename_a)(HMODULE, LPSTR, DWORD) = GetModuleFileNameA;
+DWORD (*real_getmodule_filename_a)(HMODULE, LPSTR, DWORD)  = GetModuleFileNameA;
 DWORD (*real_getmodule_filename_w)(HMODULE, LPWSTR, DWORD) = GetModuleFileNameW;
 
-
-// Based on MSDN documentation for GetModuleFileNameA/W, if hModule is null, the function returns the path of the executable of the current process. 
-// By hooking this function, we can override the process name that is reported to the driver. 
-// https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew
+// Based on MSDN documentation for GetModuleFileNameA/W, if hModule is null, the function returns the path of the
+// executable of the current process. By hooking this function, we can override the process name that is reported to the
+// driver. https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew
 DWORD HookGetModuleFilenameA(HMODULE hModule, LPSTR lpFilename, DWORD nSize)
 {
     if (hModule == nullptr && !s_app_name.empty() && nSize > 0)
@@ -71,46 +71,46 @@ DWORD HookGetModuleFilenameA(HMODULE hModule, LPSTR lpFilename, DWORD nSize)
         GFXRECON_LOG_INFO_ONCE("Overriding process name to: %s", s_app_name.c_str());
         std::string full_app_path = GetModifiedApplicationPath(real_getmodule_filename_a, s_app_name);
 
-        // If the provided buffer is too small, return the required size and set the last error to ERROR_INSUFFICIENT_BUFFER, as per the documentation for GetModuleFileNameA/W.
-        if (full_app_path.size() >= nSize) 
+        // If the provided buffer is too small, return the required size and set the last error to
+        // ERROR_INSUFFICIENT_BUFFER, as per the documentation for GetModuleFileNameA/W.
+        if (full_app_path.size() >= nSize)
         {
-            // ensure null termination. 
+            // ensure null termination.
             lpFilename[nSize - 1] = '\0';
             // Copy as much of the app name as will fit in the buffer, leaving space for the null terminator.
             memcpy_s(lpFilename, nSize - 2, full_app_path.c_str(), nSize - 1);
-            SetLastError(ERROR_INSUFFICIENT_BUFFER); 
+            SetLastError(ERROR_INSUFFICIENT_BUFFER);
             return nSize;
         }
         else
         {
             snprintf(lpFilename, full_app_path.size() + 1, "%s", full_app_path.c_str());
-            return full_app_path.size(); 
+            return full_app_path.size();
         }
-        
     }
     return real_getmodule_filename_a(hModule, lpFilename, nSize);
 }
 
-DWORD HookGetModuleFilenameW(HMODULE hModule, LPWSTR lpFilename, DWORD nSize) 
+DWORD HookGetModuleFilenameW(HMODULE hModule, LPWSTR lpFilename, DWORD nSize)
 {
     if (hModule == nullptr && !s_app_name.empty() && nSize > 0)
     {
         GFXRECON_LOG_INFO_ONCE("Overriding process name to: %s", s_app_name.c_str());
-        std::string  full_app_path = GetModifiedApplicationPath(real_getmodule_filename_a, s_app_name);
-        std::wstring w_full_app_path = gfxrecon::util::StringToWideString(full_app_path); 
+        std::string  full_app_path   = GetModifiedApplicationPath(real_getmodule_filename_a, s_app_name);
+        std::wstring w_full_app_path = gfxrecon::util::StringToWideString(full_app_path);
         if (w_full_app_path.size() >= nSize)
         {
-            // ensure null termination. 
+            // ensure null termination.
             lpFilename[nSize - 1] = '\0';
             // Copy as much of the app name as will fit in the buffer, leaving space for the null terminator.
             memcpy_s(lpFilename, (nSize - 2) * sizeof(wchar_t), w_full_app_path.c_str(), (nSize - 1) * sizeof(wchar_t));
-            SetLastError(ERROR_INSUFFICIENT_BUFFER); 
+            SetLastError(ERROR_INSUFFICIENT_BUFFER);
             return nSize;
         }
         else
         {
             swprintf(lpFilename, w_full_app_path.size() + 1, L"%s", w_full_app_path.c_str());
-            return w_full_app_path.size(); 
+            return w_full_app_path.size();
         }
     }
     return real_getmodule_filename_w(hModule, lpFilename, nSize);
@@ -118,16 +118,16 @@ DWORD HookGetModuleFilenameW(HMODULE hModule, LPWSTR lpFilename, DWORD nSize)
 
 void ProcessNameOverrideCallback(char const* app_name, size_t app_name_size)
 {
-    if(app_name && app_name_size > 0)
+    if (app_name && app_name_size > 0)
     {
-        s_app_name.resize(app_name_size); 
+        s_app_name.resize(app_name_size);
         memcpy(&s_app_name[0], app_name, app_name_size);
     }
 }
 
 void InitializeProcessNameOverride()
 {
-    bool success = false; 
+    bool success = false;
     success = gfxrecon::util::interception::HookAPICall(&(PVOID&)real_getmodule_filename_a, HookGetModuleFilenameA);
     if (!success)
     {

--- a/framework/util/process_name_override.h
+++ b/framework/util/process_name_override.h
@@ -22,7 +22,6 @@
 
 #include "util/defines.h"
 
-
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
 

--- a/framework/util/process_name_override.h
+++ b/framework/util/process_name_override.h
@@ -1,0 +1,36 @@
+/*
+** Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "util/defines.h"
+
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+// Callback function that will be called by the replay consumer to set the process name.
+void ProcessNameOverrideCallback(char const* app_name, size_t app_name_size);
+
+// Initialize the process name override by hooking GetModuleFileNameA and GetModuleFileNameW.
+void InitializeProcessNameOverride();
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/to_string.cpp
+++ b/framework/util/to_string.cpp
@@ -125,7 +125,7 @@ void FieldToString(std::ostringstream& strStrm,
 std::wstring StringToWideString(const std::string& str)
 {
     std::wstring wstr(str.size(), L'\0');
-    std::size_t converted = std::mbstowcs(&wstr[0], str.c_str(), str.size());
+    std::size_t  converted = std::mbstowcs(&wstr[0], str.c_str(), str.size());
     if (converted != static_cast<std::size_t>(-1))
     {
         wstr.resize(converted);

--- a/framework/util/to_string.cpp
+++ b/framework/util/to_string.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2023 LunarG, Inc.
 ** Copyright (c) 2023 Valve Corporation.
+** Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -23,6 +24,8 @@
 #include "util/to_string.h"
 #include "util/logging.h"
 #include "to_string.h"
+
+#include <cstdlib>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
@@ -117,6 +120,17 @@ void FieldToString(std::ostringstream& strStrm,
     strStrm << "\"" << fieldName << "\":";
     strStrm << GetWhitespaceString(toStringFlags);
     strStrm << fieldString;
+}
+
+std::wstring StringToWideString(const std::string& str)
+{
+    std::wstring wstr(str.size(), L'\0');
+    std::size_t converted = std::mbstowcs(&wstr[0], str.c_str(), str.size());
+    if (converted != static_cast<std::size_t>(-1))
+    {
+        wstr.resize(converted);
+    }
+    return wstr;
 }
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2021-2023 LunarG, Inc.
 ** Copyright (c) 2022-2023 Valve Corporation
+** Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -143,6 +144,8 @@ inline std::string HandleIdToString(format::HandleId handleId)
 {
     return std::to_string(handleId);
 }
+
+std::wstring StringToWideString(const std::string& str);
 
 #if defined(WIN32)
 inline std::string WCharArrayToString(const wchar_t* pStr)

--- a/tools/optimize/CMakeLists.txt
+++ b/tools/optimize/CMakeLists.txt
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2026 LunarG, Inc.
-# Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+# Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 # All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -65,6 +65,7 @@ target_link_libraries(gfxrecon-optimize
                           gfxrecon_format
                           platform_specific
                           project_version
+                          gfxrecon_util
                           $<$<BOOL:${D3D12_SUPPORT}>:d3d12.lib>
                           $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>
                           $<$<BOOL:${DXC_FOUND}>:${DXC_LIBRARY_PATH}>)

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2022 LunarG, Inc.
-** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -30,6 +30,11 @@
 #include "generated/generated_dx12_replay_consumer.h"
 #include "decode/dx12_resource_value_tracker.h"
 #include "decode/file_processor.h"
+
+// Process name override
+#if _WIN32
+#include "util/process_name_override.h"
+#endif
 
 #ifdef GFXRECON_AGS_SUPPORT
 #include "decode/custom_ags_consumer_base.h"
@@ -87,6 +92,10 @@ void CreateResourceValueTrackingConsumer(
     {
         dx12_replay_consumer->EnableReplayOfResourceValueCalls(false);
     }
+
+#if _WIN32
+    dx12_replay_consumer->SetProcessNameCallback(gfxrecon::util::ProcessNameOverrideCallback);
+#endif
 }
 
 bool FileProcessorSucceeded(const decode::FileProcessor& processor)

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -32,7 +32,7 @@
 #include "decode/file_processor.h"
 
 // Process name override
-#if _WIN32
+#if defined(WIN32)
 #include "util/process_name_override.h"
 #endif
 
@@ -93,7 +93,7 @@ void CreateResourceValueTrackingConsumer(
         dx12_replay_consumer->EnableReplayOfResourceValueCalls(false);
     }
 
-#if _WIN32
+#if defined(WIN32)
     dx12_replay_consumer->SetProcessNameCallback(gfxrecon::util::ProcessNameOverrideCallback);
 #endif
 }

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2020 LunarG, Inc.
-** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -28,6 +28,11 @@
 
 #if defined(D3D12_SUPPORT)
 #include "dx12_optimize_util.h"
+#endif
+
+// Process name override
+#if _WIN32
+#include "util/process_name_override.h"
 #endif
 
 #include "decode/decode_api_detection.h"
@@ -58,8 +63,8 @@ extern "C"
 }
 #endif
 
-constexpr char kOptions[] =
-    "-h|--help,--version,--no-debug-popup,--d3d12-pso-removal,--d3d12-resource-removal,--dxr,--dxr-experimental";
+constexpr char kOptions[] = 
+    "-h|--help,--version,--no-debug-popup,--d3d12-pso-removal,--d3d12-resource-removal,--dxr,--dxr-experimental,--disable-process-name-override";
 constexpr char kArguments[] = "--gpu";
 
 constexpr char kD3d12PsoRemoval[]             = "--d3d12-pso-removal";
@@ -84,7 +89,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("");
     GFXRECON_WRITE_CONSOLE("Usage:");
     GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] [--d3d12-pso-removal] [--d3d12-resource-removal] [--dxr] "
-                           "[--gpu <index>] <input-file> <output-file>",
+                           "[--gpu <index>] [--disable-process-name-override] <input-file> <output-file>",
                            app_name.c_str());
     GFXRECON_WRITE_CONSOLE("");
     GFXRECON_WRITE_CONSOLE("Required arguments:");
@@ -112,6 +117,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("");
     GFXRECON_WRITE_CONSOLE("Note: running without optional arguments will instruct the optimizer to detect API and run "
                            "all available optimizations.");
+    GFXRECON_WRITE_CONSOLE("  --disable-process-name-override\tDisable process name override (Windows only).");
 #endif
 }
 
@@ -279,6 +285,12 @@ int main(int argc, const char** argv)
 
     try
     {
+#if _WIN32
+        if(!arg_parser.IsOptionSet(kDisableProcessNameOverride))
+        {
+            gfxrecon::util::InitializeProcessNameOverride();
+        }
+#endif
         std::string                     input_filename;
         std::string                     output_filename;
         const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -63,8 +63,8 @@ extern "C"
 }
 #endif
 
-constexpr char kOptions[] = 
-    "-h|--help,--version,--no-debug-popup,--d3d12-pso-removal,--d3d12-resource-removal,--dxr,--dxr-experimental,--disable-process-name-override";
+constexpr char kOptions[] = "-h|--help,--version,--no-debug-popup,--d3d12-pso-removal,--d3d12-resource-removal,--dxr,--"
+                            "dxr-experimental,--disable-process-name-override";
 constexpr char kArguments[] = "--gpu";
 
 constexpr char kD3d12PsoRemoval[]             = "--d3d12-pso-removal";
@@ -286,7 +286,7 @@ int main(int argc, const char** argv)
     try
     {
 #if _WIN32
-        if(!arg_parser.IsOptionSet(kDisableProcessNameOverride))
+        if (!arg_parser.IsOptionSet(kDisableProcessNameOverride))
         {
             gfxrecon::util::InitializeProcessNameOverride();
         }

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2018-2026 LunarG, Inc.
-# Copyright (c) 2020-2022 Advanced Micro Devices, Inc.
+# Copyright (c) 2020-2026 Advanced Micro Devices, Inc.
 # All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -53,6 +53,7 @@ target_link_libraries(gfxrecon-replay
                           gfxrecon_format
                           platform_specific
                           project_version
+                          gfxrecon_util # required for process name override
                           $<$<BOOL:${D3D12_SUPPORT}>:d3d12.lib>
                           $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>
                           $<$<BOOL:${DXC_FOUND}>:${DXC_LIBRARY_PATH}>)

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
 ** Copyright (c) 2018-2025 LunarG, Inc.
-** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -59,6 +59,10 @@
 #endif
 #include "parse_dump_resources_cli.h"
 #include "replay_pre_processing.h"
+
+#if _WIN32
+#include "util/process_name_override.h"
+#endif
 
 // Includes for recapture
 #include "encode/vulkan_capture_manager.h"
@@ -127,6 +131,13 @@ int main(int argc, const char** argv)
     {
         ProcessDisableDebugPopup(arg_parser);
     }
+
+#if _WIN32
+    if(!arg_parser.IsOptionSet(kDisableProcessNameOverride))
+    {
+        gfxrecon::util::InitializeProcessNameOverride();
+    }
+#endif
 
     // Update logging with values retrieved from command line arguments
     gfxrecon::util::Log::Settings log_settings;
@@ -240,6 +251,10 @@ int main(int argc, const char** argv)
                                                           gfxrecon::vulkan_recapture::dispatch_CreateDevice);
             }
 
+#if _WIN32
+            vulkan_replay_consumer.SetProcessNameCallback(gfxrecon::util::ProcessNameOverrideCallback);
+#endif
+
             ApiReplayOptions  api_replay_options;
             ApiReplayConsumer api_replay_consumer;
             api_replay_options.vk_replay_options   = &vulkan_replay_options;
@@ -292,6 +307,10 @@ int main(int argc, const char** argv)
                 dx12_replay_consumer.SetFatalErrorHandler(
                     [](const char* message) { throw std::runtime_error(message); });
                 dx12_replay_consumer.SetFpsInfo(&fps_info);
+
+#if _WIN32       
+                dx12_replay_consumer.SetProcessNameCallback(gfxrecon::util::ProcessNameOverrideCallback);
+#endif
 
                 // check for user option if first pass tracking is enabled
                 if (dx_replay_options.enable_d3d12_two_pass_replay)

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -252,7 +252,7 @@ int main(int argc, const char** argv)
             }
 
 #if _WIN32
-            vulkan_replay_consumer.SetProcessNameCallback(gfxrecon::util::ProcessNameOverrideCallback);
+            vulkan_replay_consumer->SetProcessNameCallback(gfxrecon::util::ProcessNameOverrideCallback);
 #endif
 
             ApiReplayOptions  api_replay_options;

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -133,7 +133,7 @@ int main(int argc, const char** argv)
     }
 
 #if _WIN32
-    if(!arg_parser.IsOptionSet(kDisableProcessNameOverride))
+    if (!arg_parser.IsOptionSet(kDisableProcessNameOverride))
     {
         gfxrecon::util::InitializeProcessNameOverride();
     }
@@ -308,7 +308,7 @@ int main(int argc, const char** argv)
                     [](const char* message) { throw std::runtime_error(message); });
                 dx12_replay_consumer.SetFpsInfo(&fps_info);
 
-#if _WIN32       
+#if _WIN32
                 dx12_replay_consumer.SetProcessNameCallback(gfxrecon::util::ProcessNameOverrideCallback);
 #endif
 

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -202,7 +202,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --fwo <x,y>                     \tForce windowed mode if not already, and allow setting of a custom window location.");
     GFXRECON_WRITE_CONSOLE("                                  \t(Same as --force-windowed-origin)");
     GFXRECON_WRITE_CONSOLE("  --disable-process-name-override \tDisable the process name override functionality that sets the process name");
-    GFXRECON_WRITE_CONSOLE("                                  \tto the capture application name. This is enabled by default.");
+    GFXRECON_WRITE_CONSOLE("                                  \tto the capture application name.");
 #if defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
     GFXRECON_WRITE_CONSOLE("                                  \tdisplayed when abort() is called (Windows debug only).");

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -34,7 +34,8 @@ const char kOptions[] =
     "indices,--dcp,--discard-cached-psos,--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names,--"
     "dx12-ags-inject-markers,--offscreen-swapchain-frame-boundary,--wait-before-present,--dump-resources-before-draw,"
     "--dump-resources-modifiable-state-only,--pbi-all,--preload-measurement-range,--add-new-pipeline-caches,--"
-    "screenshot-ignore-FrameBoundaryANDROID,--deduplicate-device,--log-timestamps,--capture,--disable-process-name-override";
+    "screenshot-ignore-FrameBoundaryANDROID,--deduplicate-device,--log-timestamps,--capture,--disable-process-name-"
+    "override";
 const char kArguments[] =
     "--log-level,--log-file,--cpu-mask,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--screenshot-interval,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -199,13 +200,16 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE(
         "          \t\tThis can include vertex, index, const buffer, shader resource, render target,");
     GFXRECON_WRITE_CONSOLE("          \t\tand depth stencil resources. Resources are dumped after the drawcall.");
-    GFXRECON_WRITE_CONSOLE("  --fwo <x,y>                     \tForce windowed mode if not already, and allow setting of a custom window location.");
+    GFXRECON_WRITE_CONSOLE("  --fwo <x,y>                     \tForce windowed mode if not already, and allow setting "
+                           "of a custom window location.");
     GFXRECON_WRITE_CONSOLE("                                  \t(Same as --force-windowed-origin)");
-    GFXRECON_WRITE_CONSOLE("  --disable-process-name-override \tDisable the process name override functionality that sets the process name");
+    GFXRECON_WRITE_CONSOLE("  --disable-process-name-override \tDisable the process name override functionality that "
+                           "sets the process name");
     GFXRECON_WRITE_CONSOLE("                                  \tto the capture application name.");
 #if defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
-    GFXRECON_WRITE_CONSOLE("                                  \tdisplayed when abort() is called (Windows debug only).");
+    GFXRECON_WRITE_CONSOLE(
+        "                                  \tdisplayed when abort() is called (Windows debug only).");
 #endif
 #endif
     GFXRECON_WRITE_CONSOLE("")

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -34,7 +34,7 @@ const char kOptions[] =
     "indices,--dcp,--discard-cached-psos,--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names,--"
     "dx12-ags-inject-markers,--offscreen-swapchain-frame-boundary,--wait-before-present,--dump-resources-before-draw,"
     "--dump-resources-modifiable-state-only,--pbi-all,--preload-measurement-range,--add-new-pipeline-caches,--"
-    "screenshot-ignore-FrameBoundaryANDROID,--deduplicate-device,--log-timestamps,--capture";
+    "screenshot-ignore-FrameBoundaryANDROID,--deduplicate-device,--log-timestamps,--capture,--disable-process-name-override";
 const char kArguments[] =
     "--log-level,--log-file,--cpu-mask,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--screenshot-interval,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -199,12 +199,13 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE(
         "          \t\tThis can include vertex, index, const buffer, shader resource, render target,");
     GFXRECON_WRITE_CONSOLE("          \t\tand depth stencil resources. Resources are dumped after the drawcall.");
-    GFXRECON_WRITE_CONSOLE(
-        "  --fwo <x,y>\t\tForce windowed mode if not already, and allow setting of a custom window location.");
-    GFXRECON_WRITE_CONSOLE("          \t\t(Same as --force-windowed-origin)");
+    GFXRECON_WRITE_CONSOLE("  --fwo <x,y>                     \tForce windowed mode if not already, and allow setting of a custom window location.");
+    GFXRECON_WRITE_CONSOLE("                                  \t(Same as --force-windowed-origin)");
+    GFXRECON_WRITE_CONSOLE("  --disable-process-name-override \tDisable the process name override functionality that sets the process name");
+    GFXRECON_WRITE_CONSOLE("                                  \tto the capture application name. This is enabled by default.");
 #if defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tdisplayed when abort() is called (Windows debug only).");
+    GFXRECON_WRITE_CONSOLE("                                  \tdisplayed when abort() is called (Windows debug only).");
 #endif
 #endif
     GFXRECON_WRITE_CONSOLE("")

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -164,6 +164,7 @@ const char kDxAgsMarkRenderPasses[]            = "--dx12-ags-inject-markers";
 const char kBatchingMemoryUsageArgument[]      = "--batching-memory-usage";
 const char kDumpResourcesModifiableStateOnly[] = "--dump-resources-modifiable-state-only";
 const char kDumpResourcesBeforeDrawOption[]    = "--dump-resources-before-draw";
+const char kDisableProcessNameOverride[]       = "--disable-process-name-override";
 #endif
 
 const char kDumpResourcesArgument[]    = "--dump-resources";

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -1384,7 +1384,7 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     replay_options.do_device_deduplication      = arg_parser.IsOptionSet(kDeduplicateDevice);
 
     GetWaitBeforeFirstSubmit(arg_parser, replay_options.wait_before_first_submit);
-    replay_options.idle_before_submit = arg_parser.IsOptionSet(kIdleBeforeSubmit);
+    replay_options.idle_before_submit      = arg_parser.IsOptionSet(kIdleBeforeSubmit);
     replay_options.serialize_render_passes = arg_parser.IsOptionSet(kSerializeRenderPasses);
 
     GetFrameWarmUpOptions(arg_parser, replay_options.frame_warm_up_spirv_path, replay_options.frame_warm_up_load);


### PR DESCRIPTION
### What does this PR do? 
This PR effectively replaces the functionality in `scripts\gfxrecon-replay-renamed.py`. Currently supported only on Windows.

### How does this work? 

On Windows to get the current process name, apps call [GetModuleFilename](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew) with `NULL` `hModule`. This returns the current process name. Graphics drivers often rely on filename returned by this function to apply application-specific optimizations and settings.

On replay during initialization, Microsoft Detours is used to hook `GetModuleFilename` with our version. So when a graphics driver makes a call to GetModuleFilename(A/W), it gets redirected to our hooked version. 

When the replay consumer encounters a process exe name packet in the metadata, we set the original app name in process name override file via a callback from the consumer. The hooked version now returns the original app's exe name instead of `gfxrecon-replay.exe`. 

From the driver's perspective, it receives the original application's process name instead of the replay tool's name. This ensures that application-specific driver optimizations and profiles are correctly applied during replay.


### Why do this? 
Convenience. Ease of use. Invoking the player as usual, `gfxrecon-replay.exe <trace>`, should handle process name overrides. 