### PR TITLE
replay: Add --serialize-queue-submissions option

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -797,6 +797,7 @@ usage: gfxrecon.py replay [-h] [-p LOCAL_FILE] [--version] [--log-level LEVEL]
                           [--idle-before-submit]
                           [--serialize-render-passes]
                           [--wait-before-frame MILLISECONDS]
+                          [--serialize-queue-submissions]
                           [file]
 
 Launch the replay tool.
@@ -1027,6 +1028,11 @@ options:
                         Wait for the specified amount of milliseconds before starting
                         to replay each frame. Default is 0 (no wait). (forwarded to
                         replay tool)
+  --serialize-queue-submissions
+                        Serialize submit entries within one `vkQueueSubmit` or
+                        `vkQueueSubmit2` call by adding semaphores between
+                        consecutive submits during replay.
+                        (forwarded to replay tool)
 ```
 
 The command will force-stop an active replay process before starting the replay

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -637,6 +637,7 @@ gfxrecon-replay         [-h | --help] [--version] [--cpu-mask <binary-mask>] [--
                         [--wait-before-first-submit MILLISECONDS]
                         [--idle-before-submit] [--serialize-render-passes]
                         [--wait-before-frame MILLISECONDS]
+                        [--serialize-queue-submissions]
 
 
 Required arguments:
@@ -890,6 +891,10 @@ Optional arguments:
               run before each frame replay. Default is 0 (disabled).
   --wait-before-frame <milliseconds>
               Specify a wait time in milliseconds before starting replay of each frame. Default is 0 (disabled).
+  --serialize-queue-submissions
+              Serialize submit entries within one `vkQueueSubmit` or
+              `vkQueueSubmit2` call by adding semaphores between consecutive
+              submits during replay.
 ```
 
 ### Frame Warm-Up

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -152,6 +152,7 @@ def CreateReplayParser():
     parser.add_argument('--frame-warm-up-spirv', metavar='DEVICE_FILE', help='Specify a user-provided SPIR-V compute shader for the warm-up pass. The shader must use entry point main and set 0, binding 0 as a storage buffer. Warm-up runs before the first submit of each replayed frame only when this option and a non-zero --frame-warm-up-load are both provided. (forwarded to replay tool)')
     parser.add_argument('--frame-warm-up-load', metavar='LOAD', default=0, help='Specify workload scale factor for a compute dispatch warm-up pass run before each frame replay. Default is 0 (disabled). (forwarded to replay tool)')
     parser.add_argument('--wait-before-frame', metavar='MILLISECONDS', default=0, help='Wait for the specified amount of milliseconds before starting to replay each frame. Default is 0 (no wait). (forwarded to replay tool)')
+    parser.add_argument('--serialize-queue-submissions', action='store_true', default=False, help='Serialize submit entries within one vkQueueSubmit or vkQueueSubmit2 call by adding semaphores between consecutive submits during replay. (forwarded to replay tool)')
 
     return parser
 
@@ -356,6 +357,9 @@ def MakeExtrasString(args):
     if args.frame_warm_up_load:
         arg_list.append('--frame-warm-up-load')
         arg_list.append('{}'.format(args.frame_warm_up_load))
+    
+    if args.serialize_queue_submissions:
+        arg_list.append('--serialize-queue-submissions')
 
     if args.wait_before_frame:
         arg_list.append('--wait-before-frame')

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4342,12 +4342,12 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
         }
     }
 
-    VulkanSubmitJobExecutor executor;
-    executor.InjectBefore(std::move(plan), pSubmits->GetSpan());
+    VulkanSubmitJobExecution execution = GetDeviceSubmitJobExecutor(device_info).CreateExecution();
+    execution.InjectBefore(std::move(plan), pSubmits->GetSpan());
 
     if (options_.serialize_queue_submissions)
     {
-        executor.SerializeExecution(pSubmits->GetSpan());
+        execution.SerializeExecution(pSubmits->GetSpan());
     }
 
     // Only attempt to filter imported semaphores if we know at least one has been imported.
@@ -4582,12 +4582,12 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
         }
     }
 
-    VulkanSubmitJobExecutor executor;
-    executor.InjectBefore(std::move(plan), pSubmits->GetSpan());
+    VulkanSubmitJobExecution execution = GetDeviceSubmitJobExecutor(device_info).CreateExecution();
+    execution.InjectBefore(std::move(plan), pSubmits->GetSpan());
 
     if (options_.serialize_queue_submissions)
     {
-        executor.SerializeExecution(pSubmits->GetSpan());
+        execution.SerializeExecution(pSubmits->GetSpan());
     }
 
     // Only attempt to filter imported semaphores if we know at least one has been imported.
@@ -11527,6 +11527,19 @@ VulkanFrameWarmUp& VulkanReplayConsumerBase::GetDeviceFrameWarmUp(const VulkanDe
                                                                               *object_info_table_,
                                                                               options_.frame_warm_up_spirv_path,
                                                                               options_.frame_warm_up_load) });
+    GFXRECON_ASSERT(success);
+    return new_it->second;
+}
+
+VulkanSubmitJobExecutor& VulkanReplayConsumerBase::GetDeviceSubmitJobExecutor(const VulkanDeviceInfo* device_info)
+{
+    if (auto it = device_submit_job_executors_.find(device_info); it != device_submit_job_executors_.end())
+    {
+        return it->second;
+    }
+
+    auto [new_it, success] = device_submit_job_executors_.insert(
+        { device_info, VulkanSubmitJobExecutor(device_info, GetDeviceTable(device_info->handle)) });
     GFXRECON_ASSERT(success);
     return new_it->second;
 }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4309,8 +4309,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
         GetDeviceTable(device_info->handle)->DeviceWaitIdle(device_info->handle);
     }
 
-    VulkanSubmitJobPlan     plan;
-    VulkanSubmitJobExecutor executor;
+    VulkanSubmitJobPlan plan;
 
     if (options_.frame_warm_up_load != 0 && !fps_info_->IsFirstSubmitDone())
     {
@@ -4343,7 +4342,13 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
         }
     }
 
+    VulkanSubmitJobExecutor executor;
     executor.InjectBefore(std::move(plan), pSubmits->GetSpan());
+
+    if (options_.serialize_queue_submissions)
+    {
+        executor.SerializeExecution(pSubmits->GetSpan());
+    }
 
     // Only attempt to filter imported semaphores if we know at least one has been imported.
     // If rendering is restricted to a specific surface, shadow semaphore and forward progress state will need to be
@@ -4544,8 +4549,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
         GetDeviceTable(device_info->handle)->DeviceWaitIdle(device_info->handle);
     }
 
-    VulkanSubmitJobPlan     plan;
-    VulkanSubmitJobExecutor executor;
+    VulkanSubmitJobPlan plan;
 
     if (options_.frame_warm_up_load != 0 && !fps_info_->IsFirstSubmitDone())
     {
@@ -4578,7 +4582,13 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
         }
     }
 
+    VulkanSubmitJobExecutor executor;
     executor.InjectBefore(std::move(plan), pSubmits->GetSpan());
+
+    if (options_.serialize_queue_submissions)
+    {
+        executor.SerializeExecution(pSubmits->GetSpan());
+    }
 
     // Only attempt to filter imported semaphores if we know at least one has been imported.
     // If rendering is restricted to a specific surface, shadow semaphore and forward progress state will need to be

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -302,7 +302,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     WaitDevicesIdle();
 
     // free replacer internal vulkan-resources
-    _device_address_replacers.clear();
+    device_address_replacers_.clear();
 
     // process queued async tasks
     background_queue_.join_all();
@@ -2132,7 +2132,7 @@ void VulkanReplayConsumerBase::InitializeReplayDumpResources()
     if (resource_dumper_ == nullptr)
     {
         resource_dumper_ = std::make_unique<VulkanReplayDumpResources>(
-            options_, object_info_table_, _device_address_trackers, instance_tables_, device_tables_);
+            options_, object_info_table_, device_address_trackers_, instance_tables_, device_tables_);
         GFXRECON_ASSERT(resource_dumper_);
     }
 }
@@ -3712,7 +3712,7 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
         }
 
         // free replacer internal vulkan-resources for the device
-        _device_address_replacers.erase(device_info);
+        device_address_replacers_.erase(device_info);
 
         // free potential swapchain-resources for the device
         GFXRECON_ASSERT(swapchain_)
@@ -11475,50 +11475,50 @@ void VulkanReplayConsumerBase::UpdateDescriptorSetInfoWithTemplate(
 VulkanDeviceAddressTracker&
 VulkanReplayConsumerBase::GetDeviceAddressTracker(const decode::VulkanDeviceInfo* device_info)
 {
-    auto it = _device_address_trackers.find(device_info);
-    if (it == _device_address_trackers.end())
+    if (auto it = device_address_trackers_.find(device_info); it != device_address_trackers_.end())
     {
-        auto [new_it, success] =
-            _device_address_trackers.insert({ device_info, VulkanDeviceAddressTracker(*object_info_table_) });
-        GFXRECON_ASSERT(success);
-        return new_it->second;
+        return it->second;
     }
-    return it->second;
+
+    auto [new_it, success] =
+        device_address_trackers_.insert({ device_info, VulkanDeviceAddressTracker(*object_info_table_) });
+    GFXRECON_ASSERT(success);
+    return new_it->second;
 }
 
 VulkanAddressReplacer& VulkanReplayConsumerBase::GetDeviceAddressReplacer(const decode::VulkanDeviceInfo* device_info)
 {
-    auto it = _device_address_replacers.find(device_info);
-    if (it == _device_address_replacers.end())
+    if (auto it = device_address_replacers_.find(device_info); it != device_address_replacers_.end())
     {
-        auto [new_it, success] =
-            _device_address_replacers.insert({ device_info,
-                                               VulkanAddressReplacer(device_info,
-                                                                     GetDeviceTable(device_info->handle),
-                                                                     GetInstanceTable(device_info->parent),
-                                                                     *object_info_table_) });
-        GFXRECON_ASSERT(success);
-        return new_it->second;
+        return it->second;
     }
-    return it->second;
+
+    auto [new_it, success] =
+        device_address_replacers_.insert({ device_info,
+                                           VulkanAddressReplacer(device_info,
+                                                                 GetDeviceTable(device_info->handle),
+                                                                 GetInstanceTable(device_info->parent),
+                                                                 *object_info_table_) });
+    GFXRECON_ASSERT(success);
+    return new_it->second;
 }
 
 VulkanFrameWarmUp& VulkanReplayConsumerBase::GetDeviceFrameWarmUp(const VulkanDeviceInfo* device_info)
 {
-    auto it = device_frame_warmups_.find(device_info);
-    if (it == device_frame_warmups_.end())
+    if (auto it = device_frame_warmups_.find(device_info); it != device_frame_warmups_.end())
     {
-        auto [new_it, success] = device_frame_warmups_.insert({ device_info,
-                                                                VulkanFrameWarmUp(device_info,
-                                                                                  GetDeviceTable(device_info->handle),
-                                                                                  GetInstanceTable(device_info->parent),
-                                                                                  *object_info_table_,
-                                                                                  options_.frame_warm_up_spirv_path,
-                                                                                  options_.frame_warm_up_load) });
-        GFXRECON_ASSERT(success);
-        return new_it->second;
+        return it->second;
     }
-    return it->second;
+
+    auto [new_it, success] = device_frame_warmups_.insert({ device_info,
+                                                            VulkanFrameWarmUp(device_info,
+                                                                              GetDeviceTable(device_info->handle),
+                                                                              GetInstanceTable(device_info->parent),
+                                                                              *object_info_table_,
+                                                                              options_.frame_warm_up_spirv_path,
+                                                                              options_.frame_warm_up_load) });
+    GFXRECON_ASSERT(success);
+    return new_it->second;
 }
 
 bool VulkanReplayConsumerBase::UseExtraDescriptorInfo(const VulkanDeviceInfo* device_info) const

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1967,8 +1967,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::string                                                              screenshot_file_prefix_;
     graphics::FpsInfo*                                                       fps_info_;
 
-    VulkanPerDeviceAddressTrackers  _device_address_trackers;
-    VulkanPerDeviceAddressReplacers _device_address_replacers;
+    VulkanPerDeviceAddressTrackers  device_address_trackers_;
+    VulkanPerDeviceAddressReplacers device_address_replacers_;
     VulkanPerDeviceFrameWarmUp      device_frame_warmups_;
 
     util::ThreadPool main_thread_queue_;

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -37,6 +37,7 @@
 #include "decode/common_object_info_table.h"
 #include "decode/vulkan_replay_options.h"
 #include "decode/vulkan_resource_allocator.h"
+#include "decode/vulkan_submit_job.h"
 #include "decode/vulkan_swapchain.h"
 #include "format/api_call_id.h"
 #include "format/platform_types.h"
@@ -1824,6 +1825,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     decode::VulkanDeviceAddressTracker& GetDeviceAddressTracker(const decode::VulkanDeviceInfo* device_info);
     decode::VulkanAddressReplacer&      GetDeviceAddressReplacer(const decode::VulkanDeviceInfo* device_info);
     VulkanFrameWarmUp&                  GetDeviceFrameWarmUp(const VulkanDeviceInfo* device_info);
+    VulkanSubmitJobExecutor&            GetDeviceSubmitJobExecutor(const VulkanDeviceInfo* device_info);
 
     /**
      * @brief   UseExtraDescriptorInfo returns true if additional information about layouts/descriptors/bindings etc.
@@ -1967,9 +1969,10 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::string                                                              screenshot_file_prefix_;
     graphics::FpsInfo*                                                       fps_info_;
 
-    VulkanPerDeviceAddressTrackers  device_address_trackers_;
-    VulkanPerDeviceAddressReplacers device_address_replacers_;
-    VulkanPerDeviceFrameWarmUp      device_frame_warmups_;
+    VulkanPerDeviceAddressTrackers    device_address_trackers_;
+    VulkanPerDeviceAddressReplacers   device_address_replacers_;
+    VulkanPerDeviceFrameWarmUp        device_frame_warmups_;
+    VulkanPerDeviceSubmitJobExecutors device_submit_job_executors_;
 
     util::ThreadPool main_thread_queue_;
     util::ThreadPool background_queue_;

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -192,6 +192,9 @@ struct VulkanReplayOptions : public ReplayOptions
     /// Milliseconds to wait before starting to replay each frame.
     uint32_t wait_before_frame{ 0 };
 
+    /// Serialize submit entries within one vkQueueSubmit/vkQueueSubmit2 call by chaining them with semaphores.
+    bool serialize_queue_submissions{ false };
+
     void MaybeWaitBeforeFirstSubmit() const;
     void MaybeWaitBeforeFrame() const;
 };

--- a/framework/decode/vulkan_submit_job.cpp
+++ b/framework/decode/vulkan_submit_job.cpp
@@ -70,7 +70,7 @@ VulkanInjectedSemaphore::VulkanInjectedSemaphore(const VulkanDeviceInfo*        
     VkSemaphoreCreateInfo semaphore_create_info{ VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
     semaphore_create_info.pNext = &timeline_create_info;
 
-    VkResult result = device_table_->CreateSemaphore(device_info_->handle, &semaphore_create_info, nullptr, &handle);
+    VkResult result = device_table_->CreateSemaphore(device_info_->handle, &semaphore_create_info, nullptr, &handle_);
     if (result != VK_SUCCESS) [[unlikely]]
     {
         GFXRECON_LOG_ERROR("Failed to create timeline semaphore for submit job execution: %s",
@@ -78,17 +78,37 @@ VulkanInjectedSemaphore::VulkanInjectedSemaphore(const VulkanDeviceInfo*        
     }
 }
 
+VulkanInjectedSemaphore::VulkanInjectedSemaphore(VulkanInjectedSemaphore&& other) :
+    handle_{ other.handle_ }, target_value_{ other.target_value_ }, device_info_{ other.device_info_ }, device_table_{
+        other.device_table_
+    }
+{
+    other.handle_ = VK_NULL_HANDLE;
+}
+
+VulkanInjectedSemaphore& VulkanInjectedSemaphore::operator=(VulkanInjectedSemaphore&& other) noexcept
+{
+    if (this != &other)
+    {
+        std::swap(handle_, other.handle_);
+        std::swap(target_value_, other.target_value_);
+        std::swap(device_info_, other.device_info_);
+        std::swap(device_table_, other.device_table_);
+    }
+    return *this;
+}
+
 bool VulkanInjectedSemaphore::HasReachedTargetValue() const
 {
-    if (handle == VK_NULL_HANDLE)
+    if (handle_ == VK_NULL_HANDLE)
     {
         return false;
     }
 
     VkSemaphoreWaitInfo wait_info = { VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO };
     wait_info.semaphoreCount      = 1;
-    wait_info.pSemaphores         = &handle;
-    wait_info.pValues             = &target_value;
+    wait_info.pSemaphores         = &handle_;
+    wait_info.pValues             = &target_value_;
     VkResult result               = device_table_->WaitSemaphores(device_info_->handle, &wait_info, 0);
     if (result != VK_SUCCESS && result != VK_TIMEOUT)
     {
@@ -100,13 +120,13 @@ bool VulkanInjectedSemaphore::HasReachedTargetValue() const
 
 VulkanInjectedSemaphore::~VulkanInjectedSemaphore()
 {
-    if (handle != VK_NULL_HANDLE)
+    if (handle_ != VK_NULL_HANDLE)
     {
         if (!HasReachedTargetValue())
         {
             GFXRECON_LOG_ERROR("Injected timeline semaphore has not reached its target value at destruction time.");
         }
-        device_table_->DestroySemaphore(device_info_->handle, handle, nullptr);
+        device_table_->DestroySemaphore(device_info_->handle, handle_, nullptr);
     }
 }
 
@@ -114,8 +134,8 @@ VulkanInjectedSemaphoreInfo::VulkanInjectedSemaphoreInfo(const VulkanDeviceInfo*
                                                          const graphics::VulkanDeviceTable* device_table) :
     semaphore{ device_info, device_table }
 {
-    GFXRECON_ASSERT(semaphore.handle != VK_NULL_HANDLE);
-    info.semaphore = semaphore.handle;
+    GFXRECON_ASSERT(semaphore.GetHandle() != VK_NULL_HANDLE);
+    info.semaphore = semaphore.GetHandle();
     info.stageMask = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT;
 }
 
@@ -259,14 +279,14 @@ void VulkanSubmitJobExecution::AddWaitSemaphore(VkSubmitInfo& submit_info, const
     std::vector<uint64_t>&             wait_values                    = GetWaitValues(submit_info);
     VkTimelineSemaphoreSubmitInfo&     timeline_semaphore_submit_info = GetTimelineSemaphoreSubmitInfo(submit_info);
 
-    wait_semaphores.push_back(semaphore.handle);
+    wait_semaphores.push_back(semaphore.GetHandle());
     submit_info.pWaitSemaphores    = wait_semaphores.data();
     submit_info.waitSemaphoreCount = static_cast<uint32_t>(wait_semaphores.size());
 
     wait_dst_stage_masks.push_back(VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
     submit_info.pWaitDstStageMask = wait_dst_stage_masks.data();
 
-    wait_values.push_back(semaphore.target_value);
+    wait_values.push_back(semaphore.GetTargetValue());
 
     timeline_semaphore_submit_info.pWaitSemaphoreValues    = wait_values.data();
     timeline_semaphore_submit_info.waitSemaphoreValueCount = static_cast<uint32_t>(wait_values.size());
@@ -280,11 +300,11 @@ void VulkanSubmitJobExecution::AddSignalSemaphore(VkSubmitInfo& submit_info, con
     std::vector<uint64_t>&         signal_values                  = GetSignalValues(submit_info);
     VkTimelineSemaphoreSubmitInfo& timeline_semaphore_submit_info = GetTimelineSemaphoreSubmitInfo(submit_info);
 
-    signal_semaphores.push_back(semaphore.handle);
+    signal_semaphores.push_back(semaphore.GetHandle());
     submit_info.pSignalSemaphores    = signal_semaphores.data();
     submit_info.signalSemaphoreCount = static_cast<uint32_t>(signal_semaphores.size());
 
-    signal_values.push_back(semaphore.target_value);
+    signal_values.push_back(semaphore.GetTargetValue());
 
     timeline_semaphore_submit_info.pSignalSemaphoreValues    = signal_values.data();
     timeline_semaphore_submit_info.signalSemaphoreValueCount = static_cast<uint32_t>(signal_values.size());
@@ -474,7 +494,7 @@ void VulkanSubmitJobExecution::InjectSemaphore(VkSubmitInfo& submit_info, Vulkan
 {
     // Wait on the current value, then signal the next value on the same injected timeline semaphore.
     AddWaitSemaphore(submit_info, semaphore);
-    semaphore.target_value++;
+    semaphore.IncreaseTargetValue();
     AddSignalSemaphore(submit_info, semaphore);
 }
 
@@ -484,7 +504,7 @@ void VulkanSubmitJobExecution::InjectSemaphore(VkSubmitInfo2& submit_info, Vulka
     AddWaitSemaphore(submit_info, semaphore_info);
     semaphore_info.info.value++;
     semaphore_info.info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-    semaphore_info.semaphore.target_value++;
+    semaphore_info.semaphore.IncreaseTargetValue();
     AddSignalSemaphore(submit_info, semaphore_info);
 }
 
@@ -546,7 +566,7 @@ VulkanInjectedSemaphore* VulkanSubmitJobExecutor::CreateTimelineSemaphore()
     PruneSignaledTimelineSemaphores();
 
     auto injected_semaphore = std::make_unique<VulkanInjectedSemaphore>(device_info_, device_table_);
-    if (injected_semaphore->handle == VK_NULL_HANDLE) [[unlikely]]
+    if (injected_semaphore->GetHandle() == VK_NULL_HANDLE) [[unlikely]]
     {
         return nullptr;
     }
@@ -559,7 +579,7 @@ VulkanInjectedSemaphoreInfo* VulkanSubmitJobExecutor::CreateTimelineSemaphoreInf
     PruneSignaledTimelineSemaphoreInfos();
 
     auto injected_semaphore_info = std::make_unique<VulkanInjectedSemaphoreInfo>(device_info_, device_table_);
-    if (injected_semaphore_info->semaphore.handle == VK_NULL_HANDLE) [[unlikely]]
+    if (injected_semaphore_info->semaphore.GetHandle() == VK_NULL_HANDLE) [[unlikely]]
     {
         return nullptr;
     }

--- a/framework/decode/vulkan_submit_job.cpp
+++ b/framework/decode/vulkan_submit_job.cpp
@@ -22,6 +22,7 @@
 
 #include "decode/vulkan_submit_job.h"
 #include "graphics/vulkan_struct_get_pnext.h"
+#include "generated/generated_vulkan_enum_to_string.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -54,7 +55,71 @@ bool VulkanSubmitJobPlan::HasJobsForIndex(uint32_t submit_index) const
     return jobs_for_index && !jobs_for_index->jobs.empty();
 }
 
-void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<VkSubmitInfo> submit_infos)
+VulkanInjectedSemaphore::VulkanInjectedSemaphore(const VulkanDeviceInfo*            device_info,
+                                                 const graphics::VulkanDeviceTable* device_table) :
+    device_info_{ device_info },
+    device_table_{ device_table }
+{
+    GFXRECON_ASSERT(device_info_ != nullptr);
+    GFXRECON_ASSERT(device_table_ != nullptr);
+
+    VkSemaphoreTypeCreateInfo timeline_create_info{ VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO };
+    timeline_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+    timeline_create_info.initialValue  = 0;
+
+    VkSemaphoreCreateInfo semaphore_create_info{ VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
+    semaphore_create_info.pNext = &timeline_create_info;
+
+    VkResult result = device_table_->CreateSemaphore(device_info_->handle, &semaphore_create_info, nullptr, &handle);
+    if (result != VK_SUCCESS) [[unlikely]]
+    {
+        GFXRECON_LOG_ERROR("Failed to create timeline semaphore for submit job execution: %s",
+                           util::ToString(result).c_str());
+    }
+}
+
+bool VulkanInjectedSemaphore::HasReachedTargetValue() const
+{
+    if (handle == VK_NULL_HANDLE)
+    {
+        return false;
+    }
+
+    VkSemaphoreWaitInfo wait_info = { VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO };
+    wait_info.semaphoreCount      = 1;
+    wait_info.pSemaphores         = &handle;
+    wait_info.pValues             = &target_value;
+    VkResult result               = device_table_->WaitSemaphores(device_info_->handle, &wait_info, 0);
+    if (result != VK_SUCCESS && result != VK_TIMEOUT)
+    {
+        GFXRECON_LOG_ERROR("Failed to wait on timeline semaphore for submit job execution: %s",
+                           util::ToString(result).c_str());
+    }
+    return result == VK_SUCCESS;
+}
+
+VulkanInjectedSemaphore::~VulkanInjectedSemaphore()
+{
+    if (handle != VK_NULL_HANDLE)
+    {
+        if (!HasReachedTargetValue())
+        {
+            GFXRECON_LOG_ERROR("Injected timeline semaphore has not reached its target value at destruction time.");
+        }
+        device_table_->DestroySemaphore(device_info_->handle, handle, nullptr);
+    }
+}
+
+VulkanInjectedSemaphoreInfo::VulkanInjectedSemaphoreInfo(const VulkanDeviceInfo*            device_info,
+                                                         const graphics::VulkanDeviceTable* device_table) :
+    semaphore{ device_info, device_table }
+{
+    GFXRECON_ASSERT(semaphore.handle != VK_NULL_HANDLE);
+    info.semaphore = semaphore.handle;
+    info.stageMask = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT;
+}
+
+void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<VkSubmitInfo> submit_infos)
 {
     // Ensure that InjectBefore is not called multiple times for the same submit infos.
     GFXRECON_ASSERT(std::all_of(submit_infos.begin(), submit_infos.end(), [this](VkSubmitInfo& info) {
@@ -93,16 +158,16 @@ void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<V
                 injected_wait_semaphores.push_back(submit_semaphore);
             }
 
-            // Inject wait-semaphore into submit-info.
+            // Replace the original waits with waits for the injected jobs.
             submit_info.waitSemaphoreCount = static_cast<uint32_t>(injected_wait_semaphores.size());
             submit_info.pWaitSemaphores    = injected_wait_semaphores.data();
 
             // If waitSemaphoreCount was 0, pWaitDstStageMask might be nullptr.
             // Make sure it points to valid data in all cases.
-            static VkPipelineStageFlags wait_stage_mask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-            submit_info.pWaitDstStageMask               = &wait_stage_mask;
+            auto& wait_dst_stage_masks    = GetWaitDstStageMasks(submit_info, true);
+            submit_info.pWaitDstStageMask = wait_dst_stage_masks.data();
 
-            // Handle potential timeline-semaphores in pnext-chain.
+            // The original waits were stripped, so any timeline wait values that described them must be removed too.
             if (auto* timeline_info = graphics::vulkan_struct_get_pnext<VkTimelineSemaphoreSubmitInfo>(&submit_info))
             {
                 timeline_info->waitSemaphoreValueCount = 0;
@@ -112,7 +177,7 @@ void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<V
     }
 }
 
-void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<VkSubmitInfo2> submit_infos)
+void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<VkSubmitInfo2> submit_infos)
 {
     // Ensure that InjectBefore is not called multiple times for the same submit infos.
     GFXRECON_ASSERT(std::all_of(submit_infos.begin(), submit_infos.end(), [this](VkSubmitInfo2& info) {
@@ -159,85 +224,384 @@ void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<V
                 injected_wait_semaphore_infos.push_back(semaphore_info);
             }
 
-            // Inject wait-semaphore into submit-info.
+            // Replace the original waits with waits for the injected jobs.
             submit_info.waitSemaphoreInfoCount = static_cast<uint32_t>(injected_wait_semaphore_infos.size());
             submit_info.pWaitSemaphoreInfos    = injected_wait_semaphore_infos.data();
         }
     }
 }
 
-std::vector<VkSemaphore>& VulkanSubmitJobExecutor::GetWaitSemaphores(VkSubmitInfo& submit_info)
+std::vector<VkSemaphore>& VulkanSubmitJobExecution::GetWaitSemaphores(VkSubmitInfo& submit_info)
 {
     if (!injected_wait_semaphores_.contains(&submit_info))
     {
-        injected_wait_semaphores_[&submit_info] =
-            std::vector(submit_info.pWaitSemaphores, submit_info.pWaitSemaphores + submit_info.waitSemaphoreCount);
+        if (submit_info.pWaitSemaphores != nullptr && submit_info.waitSemaphoreCount > 0)
+        {
+
+            injected_wait_semaphores_[&submit_info] =
+                std::vector(submit_info.pWaitSemaphores, submit_info.pWaitSemaphores + submit_info.waitSemaphoreCount);
+        }
+        else
+        {
+            injected_wait_semaphores_[&submit_info] = std::vector<VkSemaphore>();
+        }
+
+        // Override wait semaphores pointer.
+        submit_info.pWaitSemaphores = injected_wait_semaphores_[&submit_info].data();
     }
     return injected_wait_semaphores_[&submit_info];
 }
 
-std::vector<VkSemaphoreSubmitInfo>& VulkanSubmitJobExecutor::GetWaitSemaphores(VkSubmitInfo2& submit_info2)
+void VulkanSubmitJobExecution::AddWaitSemaphore(VkSubmitInfo& submit_info, const VulkanInjectedSemaphore& semaphore)
+{
+    std::vector<VkSemaphore>&          wait_semaphores                = GetWaitSemaphores(submit_info);
+    std::vector<VkPipelineStageFlags>& wait_dst_stage_masks           = GetWaitDstStageMasks(submit_info, true);
+    std::vector<uint64_t>&             wait_values                    = GetWaitValues(submit_info);
+    VkTimelineSemaphoreSubmitInfo&     timeline_semaphore_submit_info = GetTimelineSemaphoreSubmitInfo(submit_info);
+
+    wait_semaphores.push_back(semaphore.handle);
+    submit_info.pWaitSemaphores    = wait_semaphores.data();
+    submit_info.waitSemaphoreCount = static_cast<uint32_t>(wait_semaphores.size());
+
+    wait_dst_stage_masks.push_back(VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+    submit_info.pWaitDstStageMask = wait_dst_stage_masks.data();
+
+    wait_values.push_back(semaphore.target_value);
+
+    timeline_semaphore_submit_info.pWaitSemaphoreValues    = wait_values.data();
+    timeline_semaphore_submit_info.waitSemaphoreValueCount = static_cast<uint32_t>(wait_values.size());
+
+    GFXRECON_ASSERT(wait_semaphores.size() == wait_values.size());
+}
+
+void VulkanSubmitJobExecution::AddSignalSemaphore(VkSubmitInfo& submit_info, const VulkanInjectedSemaphore& semaphore)
+{
+    std::vector<VkSemaphore>&      signal_semaphores              = GetSignalSemaphores(submit_info);
+    std::vector<uint64_t>&         signal_values                  = GetSignalValues(submit_info);
+    VkTimelineSemaphoreSubmitInfo& timeline_semaphore_submit_info = GetTimelineSemaphoreSubmitInfo(submit_info);
+
+    signal_semaphores.push_back(semaphore.handle);
+    submit_info.pSignalSemaphores    = signal_semaphores.data();
+    submit_info.signalSemaphoreCount = static_cast<uint32_t>(signal_semaphores.size());
+
+    signal_values.push_back(semaphore.target_value);
+
+    timeline_semaphore_submit_info.pSignalSemaphoreValues    = signal_values.data();
+    timeline_semaphore_submit_info.signalSemaphoreValueCount = static_cast<uint32_t>(signal_values.size());
+
+    GFXRECON_ASSERT(signal_semaphores.size() == signal_values.size());
+}
+
+void VulkanSubmitJobExecution::AddWaitSemaphore(VkSubmitInfo2&                     submit_info,
+                                                const VulkanInjectedSemaphoreInfo& semaphore)
+{
+    std::vector<VkSemaphoreSubmitInfo>& wait_semaphores = GetWaitSemaphoreInfos(submit_info);
+    wait_semaphores.push_back(semaphore.info);
+    submit_info.pWaitSemaphoreInfos    = wait_semaphores.data();
+    submit_info.waitSemaphoreInfoCount = static_cast<uint32_t>(wait_semaphores.size());
+}
+
+void VulkanSubmitJobExecution::AddSignalSemaphore(VkSubmitInfo2&                     submit_info,
+                                                  const VulkanInjectedSemaphoreInfo& semaphore)
+{
+    std::vector<VkSemaphoreSubmitInfo>& signal_semaphores = GetSignalSemaphoreInfos(submit_info);
+    signal_semaphores.push_back(semaphore.info);
+    submit_info.pSignalSemaphoreInfos    = signal_semaphores.data();
+    submit_info.signalSemaphoreInfoCount = static_cast<uint32_t>(signal_semaphores.size());
+}
+
+std::vector<VkSemaphore>& VulkanSubmitJobExecution::GetSignalSemaphores(VkSubmitInfo& submit_info)
+{
+    if (!injected_signal_semaphores_.contains(&submit_info))
+    {
+        if (submit_info.pSignalSemaphores != nullptr && submit_info.signalSemaphoreCount > 0)
+        {
+            injected_signal_semaphores_[&submit_info] = std::vector(
+                submit_info.pSignalSemaphores, submit_info.pSignalSemaphores + submit_info.signalSemaphoreCount);
+        }
+        else
+        {
+            injected_signal_semaphores_[&submit_info] = std::vector<VkSemaphore>();
+        }
+
+        // Override signal semaphore pointer.
+        submit_info.pSignalSemaphores = injected_signal_semaphores_[&submit_info].data();
+    }
+    return injected_signal_semaphores_[&submit_info];
+}
+
+std::vector<uint64_t>& VulkanSubmitJobExecution::GetWaitValues(VkSubmitInfo& submit_info)
+{
+    if (!injected_wait_semaphore_values_.contains(&submit_info))
+    {
+        VkTimelineSemaphoreSubmitInfo& timeline_info = GetTimelineSemaphoreSubmitInfo(submit_info);
+        if (timeline_info.waitSemaphoreValueCount > 0 && timeline_info.pWaitSemaphoreValues != nullptr)
+        {
+            injected_wait_semaphore_values_[&submit_info] =
+                std::vector<uint64_t>(timeline_info.pWaitSemaphoreValues,
+                                      timeline_info.pWaitSemaphoreValues + timeline_info.waitSemaphoreValueCount);
+        }
+        else
+        {
+            injected_wait_semaphore_values_[&submit_info] = std::vector<uint64_t>(submit_info.waitSemaphoreCount, 0);
+        }
+
+        // Override any existing values pointer.
+        timeline_info.pWaitSemaphoreValues = injected_wait_semaphore_values_[&submit_info].data();
+    }
+    return injected_wait_semaphore_values_[&submit_info];
+}
+
+std::vector<uint64_t>& VulkanSubmitJobExecution::GetSignalValues(VkSubmitInfo& submit_info)
+{
+    if (!injected_signal_semaphore_values_.contains(&submit_info))
+    {
+        VkTimelineSemaphoreSubmitInfo& timeline_info = GetTimelineSemaphoreSubmitInfo(submit_info);
+        if (timeline_info.signalSemaphoreValueCount > 0 && timeline_info.pSignalSemaphoreValues != nullptr)
+        {
+            injected_signal_semaphore_values_[&submit_info] =
+                std::vector<uint64_t>(timeline_info.pSignalSemaphoreValues,
+                                      timeline_info.pSignalSemaphoreValues + timeline_info.signalSemaphoreValueCount);
+        }
+        else
+        {
+            injected_signal_semaphore_values_[&submit_info] =
+                std::vector<uint64_t>(submit_info.signalSemaphoreCount, 0);
+        }
+
+        // Override signal semaphore values.
+        timeline_info.pSignalSemaphoreValues = injected_signal_semaphore_values_[&submit_info].data();
+    }
+    return injected_signal_semaphore_values_[&submit_info];
+}
+
+std::vector<VkPipelineStageFlags>& VulkanSubmitJobExecution::GetWaitDstStageMasks(VkSubmitInfo& submit_info,
+                                                                                  bool          override)
+{
+    // Make sure there is injected storage for wait dst stage masks for this submit info.
+    if (!injected_wait_dst_stage_masks_.contains(&submit_info))
+    {
+        if (submit_info.pWaitDstStageMask != nullptr && submit_info.waitSemaphoreCount > 0)
+        {
+            // Copy existing wait dst stage masks if they exist.
+            injected_wait_dst_stage_masks_[&submit_info] = std::vector<VkPipelineStageFlags>(
+                submit_info.pWaitDstStageMask, submit_info.pWaitDstStageMask + submit_info.waitSemaphoreCount);
+        }
+        else
+        {
+            // Otherwise, initialize wait dst stage masks with a valid default for each wait semaphore.
+            injected_wait_dst_stage_masks_[&submit_info] =
+                std::vector<VkPipelineStageFlags>(submit_info.waitSemaphoreCount, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+        }
+
+        // Override wait dst stage mask pointer.
+        submit_info.pWaitDstStageMask = injected_wait_dst_stage_masks_[&submit_info].data();
+    }
+
+    if (override)
+    {
+        std::fill(injected_wait_dst_stage_masks_[&submit_info].begin(),
+                  injected_wait_dst_stage_masks_[&submit_info].end(),
+                  VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+    }
+
+    return injected_wait_dst_stage_masks_[&submit_info];
+}
+
+std::vector<VkSemaphoreSubmitInfo>& VulkanSubmitJobExecution::GetWaitSemaphoreInfos(VkSubmitInfo2& submit_info2)
 {
     if (!injected_wait_semaphore_infos_.contains(&submit_info2))
     {
-        injected_wait_semaphore_infos_[&submit_info2] = std::vector(
-            submit_info2.pWaitSemaphoreInfos, submit_info2.pWaitSemaphoreInfos + submit_info2.waitSemaphoreInfoCount);
+        if (submit_info2.pWaitSemaphoreInfos != nullptr && submit_info2.waitSemaphoreInfoCount > 0)
+        {
+            injected_wait_semaphore_infos_[&submit_info2] =
+                std::vector(submit_info2.pWaitSemaphoreInfos,
+                            submit_info2.pWaitSemaphoreInfos + submit_info2.waitSemaphoreInfoCount);
+        }
+        else
+        {
+            injected_wait_semaphore_infos_[&submit_info2] = std::vector<VkSemaphoreSubmitInfo>();
+        }
+
+        // Override any existing wait semaphore pointer.
+        submit_info2.pWaitSemaphoreInfos = injected_wait_semaphore_infos_[&submit_info2].data();
     }
     return injected_wait_semaphore_infos_[&submit_info2];
 }
 
-void VulkanSubmitJobExecutor::SerializeExecution(std::span<VkSubmitInfo> submit_infos)
+std::vector<VkSemaphoreSubmitInfo>& VulkanSubmitJobExecution::GetSignalSemaphoreInfos(VkSubmitInfo2& submit_info)
 {
-    // Each submit info should wait on semaphores signaled by the previous submit.
-    std::span<const VkSemaphore> previous_submit_signal_semaphores = {};
-
-    for (VkSubmitInfo& submit_info : submit_infos)
+    if (!injected_signal_semaphore_infos_.contains(&submit_info))
     {
-        if (!previous_submit_signal_semaphores.empty())
+        if (submit_info.pSignalSemaphoreInfos != nullptr && submit_info.signalSemaphoreInfoCount > 0)
         {
-            // This should work nicely with `InjectBefore` and just get the corresponding vector of injected semaphores.
-            // If `InjectBefore` was not called, this will create a new entry with the current semaphores.
-            auto& wait_semaphores = GetWaitSemaphores(submit_info);
-
-            // Append previous submit signal semaphores to the wait semaphores of the current submit.
-            wait_semaphores.insert(wait_semaphores.end(),
-                                   previous_submit_signal_semaphores.begin(),
-                                   previous_submit_signal_semaphores.end());
-
-            // Update submit info with the new wait semaphores pointer and count.
-            submit_info.waitSemaphoreCount = static_cast<uint32_t>(wait_semaphores.size());
-            submit_info.pWaitSemaphores    = wait_semaphores.data();
+            injected_signal_semaphore_infos_[&submit_info] =
+                std::vector(submit_info.pSignalSemaphoreInfos,
+                            submit_info.pSignalSemaphoreInfos + submit_info.signalSemaphoreInfoCount);
+        }
+        else
+        {
+            injected_signal_semaphore_infos_[&submit_info] = std::vector<VkSemaphoreSubmitInfo>();
         }
 
-        previous_submit_signal_semaphores = std::span(submit_info.pSignalSemaphores, submit_info.signalSemaphoreCount);
+        // Override any existing signal semaphore pointer.
+        submit_info.pSignalSemaphoreInfos = injected_signal_semaphore_infos_[&submit_info].data();
+    }
+    return injected_signal_semaphore_infos_[&submit_info];
+}
+
+VkTimelineSemaphoreSubmitInfo& VulkanSubmitJobExecution::GetTimelineSemaphoreSubmitInfo(VkSubmitInfo& submit_info)
+{
+    if (!injected_timeline_semaphore_infos_.contains(&submit_info))
+    {
+        if (auto* existing_info = graphics::vulkan_struct_get_pnext<VkTimelineSemaphoreSubmitInfo>(&submit_info))
+        {
+            injected_timeline_semaphore_infos_[&submit_info] = *existing_info;
+        }
+        else
+        {
+            injected_timeline_semaphore_infos_[&submit_info] =
+                VkTimelineSemaphoreSubmitInfo{ VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO };
+        }
+
+        // Insert owned timeline submit info, replacing any existing VkTimelineSemaphoreSubmitInfo.
+        graphics::vulkan_struct_add_pnext(&submit_info, &injected_timeline_semaphore_infos_[&submit_info]);
+    }
+    return injected_timeline_semaphore_infos_[&submit_info];
+}
+
+void VulkanSubmitJobExecution::InjectSemaphore(VkSubmitInfo& submit_info, VulkanInjectedSemaphore& semaphore)
+{
+    // Wait on the current value, then signal the next value on the same injected timeline semaphore.
+    AddWaitSemaphore(submit_info, semaphore);
+    semaphore.target_value++;
+    AddSignalSemaphore(submit_info, semaphore);
+}
+
+void VulkanSubmitJobExecution::InjectSemaphore(VkSubmitInfo2& submit_info, VulkanInjectedSemaphoreInfo& semaphore_info)
+{
+    // Wait on the current value, then signal the next value on the same injected timeline semaphore.
+    AddWaitSemaphore(submit_info, semaphore_info);
+    semaphore_info.info.value++;
+    semaphore_info.info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    semaphore_info.semaphore.target_value++;
+    AddSignalSemaphore(submit_info, semaphore_info);
+}
+
+void VulkanSubmitJobExecution::SerializeExecution(std::span<VkSubmitInfo> submit_infos)
+{
+    // No need to serialize fewer than two submits.
+    if (submit_infos.size() < 2)
+    {
+        return;
+    }
+
+    VulkanInjectedSemaphore* injected_semaphore = executor_.CreateTimelineSemaphore();
+    GFXRECON_ASSERT(injected_semaphore != nullptr);
+    if (injected_semaphore == nullptr) [[unlikely]]
+    {
+        return;
+    }
+
+    // One timeline semaphore serializes the whole submit array by advancing its value once per submit.
+    for (VkSubmitInfo& submit_info : submit_infos)
+    {
+        InjectSemaphore(submit_info, *injected_semaphore);
     }
 }
 
-void VulkanSubmitJobExecutor::SerializeExecution(std::span<VkSubmitInfo2> submit_infos2)
+void VulkanSubmitJobExecution::SerializeExecution(std::span<VkSubmitInfo2> submit_infos2)
 {
-    // Each submit info should wait on semaphores signaled by the previous submit.
-    std::span<const VkSemaphoreSubmitInfo> previous_submit_signal_semaphores = {};
-
-    for (VkSubmitInfo2& submit_info : submit_infos2)
+    // No need to serialize fewer than two submits.
+    if (submit_infos2.size() < 2)
     {
-        if (!previous_submit_signal_semaphores.empty())
+        return;
+    }
+
+    VulkanInjectedSemaphoreInfo* injected_semaphore_info = executor_.CreateTimelineSemaphoreInfo();
+    GFXRECON_ASSERT(injected_semaphore_info != nullptr);
+    if (injected_semaphore_info == nullptr) [[unlikely]]
+    {
+        return;
+    }
+
+    // One timeline semaphore serializes the whole submit array by advancing its value once per submit.
+    for (VkSubmitInfo2& submit_info2 : submit_infos2)
+    {
+        InjectSemaphore(submit_info2, *injected_semaphore_info);
+    }
+}
+
+VulkanSubmitJobExecutor::VulkanSubmitJobExecutor(const VulkanDeviceInfo*            device_info,
+                                                 const graphics::VulkanDeviceTable* device_table) :
+    device_info_(device_info),
+    device_table_(device_table)
+{
+    GFXRECON_ASSERT(device_info_ != nullptr);
+    GFXRECON_ASSERT(device_table_ != nullptr);
+}
+
+VulkanInjectedSemaphore* VulkanSubmitJobExecutor::CreateTimelineSemaphore()
+{
+    PruneSignaledTimelineSemaphores();
+
+    auto injected_semaphore = std::make_unique<VulkanInjectedSemaphore>(device_info_, device_table_);
+    if (injected_semaphore->handle == VK_NULL_HANDLE) [[unlikely]]
+    {
+        return nullptr;
+    }
+    injected_semaphores_.push_back(std::move(injected_semaphore));
+    return injected_semaphores_.back().get();
+}
+
+VulkanInjectedSemaphoreInfo* VulkanSubmitJobExecutor::CreateTimelineSemaphoreInfo()
+{
+    PruneSignaledTimelineSemaphoreInfos();
+
+    auto injected_semaphore_info = std::make_unique<VulkanInjectedSemaphoreInfo>(device_info_, device_table_);
+    if (injected_semaphore_info->semaphore.handle == VK_NULL_HANDLE) [[unlikely]]
+    {
+        return nullptr;
+    }
+    injected_semaphore_infos_.push_back(std::move(injected_semaphore_info));
+    return injected_semaphore_infos_.back().get();
+}
+
+void VulkanSubmitJobExecutor::PruneSignaledTimelineSemaphores()
+{
+    // Remove tracked timeline semaphores that have reached or exceeded their target value.
+    auto it = injected_semaphores_.begin();
+    while (it != injected_semaphores_.end())
+    {
+        auto& semaphore = *it;
+        if (semaphore->HasReachedTargetValue())
         {
-            // This should work nicely with `InjectBefore` and just get the corresponding vector of injected semaphore
-            // infos. If `InjectBefore` was not called, this will create a new entry with the current semaphores.
-            auto& wait_semaphore_infos = GetWaitSemaphores(submit_info);
-
-            // Append previous submit signal semaphore infos to the wait semaphore infos of the current submit.
-            wait_semaphore_infos.insert(wait_semaphore_infos.end(),
-                                        previous_submit_signal_semaphores.begin(),
-                                        previous_submit_signal_semaphores.end());
-
-            // Update submit info with the new wait semaphore infos pointer and count.
-            submit_info.waitSemaphoreInfoCount = static_cast<uint32_t>(wait_semaphore_infos.size());
-            submit_info.pWaitSemaphoreInfos    = wait_semaphore_infos.data();
+            it = injected_semaphores_.erase(it);
         }
+        else
+        {
+            // Semaphore is still pending, keep it tracked.
+            ++it;
+        }
+    }
+}
 
-        previous_submit_signal_semaphores =
-            std::span(submit_info.pSignalSemaphoreInfos, submit_info.signalSemaphoreInfoCount);
+void VulkanSubmitJobExecutor::PruneSignaledTimelineSemaphoreInfos()
+{
+    // Remove tracked timeline semaphores that have reached or exceeded their target value.
+    auto it = injected_semaphore_infos_.begin();
+    while (it != injected_semaphore_infos_.end())
+    {
+        auto& semaphore_info = *it;
+        if (semaphore_info->semaphore.HasReachedTargetValue())
+        {
+            it = injected_semaphore_infos_.erase(it);
+        }
+        else
+        {
+            // Semaphore is still pending, keep it tracked.
+            ++it;
+        }
     }
 }
 

--- a/framework/decode/vulkan_submit_job.cpp
+++ b/framework/decode/vulkan_submit_job.cpp
@@ -56,21 +56,20 @@ bool VulkanSubmitJobPlan::HasJobsForIndex(uint32_t submit_index) const
 
 void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<VkSubmitInfo> submit_infos)
 {
-    GFXRECON_ASSERT(original_wait_semaphores_.empty());
-    GFXRECON_ASSERT(injected_wait_semaphores_.empty());
+    // Ensure that InjectBefore is not called multiple times for the same submit infos.
+    GFXRECON_ASSERT(std::all_of(submit_infos.begin(), submit_infos.end(), [this](VkSubmitInfo& info) {
+        return !original_wait_semaphores_.contains(&info) && !injected_wait_semaphores_.contains(&info);
+    }));
 
     // Gather original wait-semaphores for each submit and prepare storage for injected wait-semaphores.
     auto& submit_jobs = plan.GetSubmitJobs();
     for (uint32_t submit_index = 0; submit_index < submit_infos.size(); ++submit_index)
     {
-        original_wait_semaphores_.emplace_back();
-        injected_wait_semaphores_.emplace_back();
-
         // Only gather original wait-semaphores if there are jobs to execute for this submit.
         if (plan.HasJobsForIndex(submit_index))
         {
-            original_wait_semaphores_[submit_index].semaphores =
-                graphics::StripWaitSemaphores(&submit_infos[submit_index]);
+            VkSubmitInfo& submit_info                          = submit_infos[submit_index];
+            original_wait_semaphores_[&submit_info].semaphores = graphics::StripWaitSemaphores(&submit_info);
         }
     }
 
@@ -82,8 +81,9 @@ void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<V
         // Only execute jobs if there are functions to execute for this submit.
         if (plan.HasJobsForIndex(submit_index))
         {
-            auto& original_wait_semaphores = original_wait_semaphores_[submit_index].semaphores;
-            auto& injected_wait_semaphores = injected_wait_semaphores_[submit_index];
+            VkSubmitInfo& submit_info              = submit_infos[submit_index];
+            auto&         original_wait_semaphores = original_wait_semaphores_[&submit_info].semaphores;
+            auto&         injected_wait_semaphores = injected_wait_semaphores_[&submit_info];
 
             // Execute each job function and gather injected wait-semaphores.
             for (const auto& job : jobs)
@@ -94,7 +94,6 @@ void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<V
             }
 
             // Inject wait-semaphore into submit-info.
-            auto& submit_info              = submit_infos[submit_index];
             submit_info.waitSemaphoreCount = static_cast<uint32_t>(injected_wait_semaphores.size());
             submit_info.pWaitSemaphores    = injected_wait_semaphores.data();
 
@@ -115,21 +114,22 @@ void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<V
 
 void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<VkSubmitInfo2> submit_infos)
 {
-    GFXRECON_ASSERT(original_wait_semaphores_.empty());
-    GFXRECON_ASSERT(injected_wait_semaphore_infos_.empty());
+    // Ensure that InjectBefore is not called multiple times for the same submit infos.
+    GFXRECON_ASSERT(std::all_of(submit_infos.begin(), submit_infos.end(), [this](VkSubmitInfo2& info) {
+        return !original_wait_semaphores_.contains(&info) && !injected_wait_semaphore_infos_.contains(&info);
+    }));
 
     // Gather original wait-semaphores for each submit and prepare storage for injected wait-semaphores.
     auto& submit_jobs = plan.GetSubmitJobs();
     for (uint32_t submit_index = 0; submit_index < submit_infos.size(); ++submit_index)
     {
-        original_wait_semaphores_.emplace_back();
-        injected_wait_semaphore_infos_.emplace_back();
+        VkSubmitInfo2& submit_info              = submit_infos[submit_index];
+        auto&          original_wait_semaphores = original_wait_semaphores_[&submit_info].semaphores;
 
         // Only gather original wait-semaphores if there are jobs to execute for this submit.
         if (plan.HasJobsForIndex(submit_index))
         {
-            original_wait_semaphores_[submit_index].semaphores =
-                graphics::StripWaitSemaphores(&submit_infos[submit_index]);
+            original_wait_semaphores = graphics::StripWaitSemaphores(&submit_info);
         }
     }
 
@@ -141,8 +141,9 @@ void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<V
         // Only execute jobs if there are functions to execute for this submit.
         if (plan.HasJobsForIndex(submit_index))
         {
-            auto& original_wait_semaphores      = original_wait_semaphores_[submit_index].semaphores;
-            auto& injected_wait_semaphore_infos = injected_wait_semaphore_infos_[submit_index];
+            VkSubmitInfo2& submit_info                   = submit_infos[submit_index];
+            auto&          original_wait_semaphores      = original_wait_semaphores_[&submit_info].semaphores;
+            auto&          injected_wait_semaphore_infos = injected_wait_semaphore_infos_[&submit_info];
 
             // Execute each job function and gather injected wait-semaphores.
             for (const auto& job : jobs)
@@ -159,10 +160,84 @@ void VulkanSubmitJobExecutor::InjectBefore(VulkanSubmitJobPlan plan, std::span<V
             }
 
             // Inject wait-semaphore into submit-info.
-            auto& submit_info                  = submit_infos[submit_index];
             submit_info.waitSemaphoreInfoCount = static_cast<uint32_t>(injected_wait_semaphore_infos.size());
             submit_info.pWaitSemaphoreInfos    = injected_wait_semaphore_infos.data();
         }
+    }
+}
+
+std::vector<VkSemaphore>& VulkanSubmitJobExecutor::GetWaitSemaphores(VkSubmitInfo& submit_info)
+{
+    if (!injected_wait_semaphores_.contains(&submit_info))
+    {
+        injected_wait_semaphores_[&submit_info] =
+            std::vector(submit_info.pWaitSemaphores, submit_info.pWaitSemaphores + submit_info.waitSemaphoreCount);
+    }
+    return injected_wait_semaphores_[&submit_info];
+}
+
+std::vector<VkSemaphoreSubmitInfo>& VulkanSubmitJobExecutor::GetWaitSemaphores(VkSubmitInfo2& submit_info2)
+{
+    if (!injected_wait_semaphore_infos_.contains(&submit_info2))
+    {
+        injected_wait_semaphore_infos_[&submit_info2] = std::vector(
+            submit_info2.pWaitSemaphoreInfos, submit_info2.pWaitSemaphoreInfos + submit_info2.waitSemaphoreInfoCount);
+    }
+    return injected_wait_semaphore_infos_[&submit_info2];
+}
+
+void VulkanSubmitJobExecutor::SerializeExecution(std::span<VkSubmitInfo> submit_infos)
+{
+    // Each submit info should wait on semaphores signaled by the previous submit.
+    std::span<const VkSemaphore> previous_submit_signal_semaphores = {};
+
+    for (VkSubmitInfo& submit_info : submit_infos)
+    {
+        if (!previous_submit_signal_semaphores.empty())
+        {
+            // This should work nicely with `InjectBefore` and just get the corresponding vector of injected semaphores.
+            // If `InjectBefore` was not called, this will create a new entry with the current semaphores.
+            auto& wait_semaphores = GetWaitSemaphores(submit_info);
+
+            // Append previous submit signal semaphores to the wait semaphores of the current submit.
+            wait_semaphores.insert(wait_semaphores.end(),
+                                   previous_submit_signal_semaphores.begin(),
+                                   previous_submit_signal_semaphores.end());
+
+            // Update submit info with the new wait semaphores pointer and count.
+            submit_info.waitSemaphoreCount = static_cast<uint32_t>(wait_semaphores.size());
+            submit_info.pWaitSemaphores    = wait_semaphores.data();
+        }
+
+        previous_submit_signal_semaphores = std::span(submit_info.pSignalSemaphores, submit_info.signalSemaphoreCount);
+    }
+}
+
+void VulkanSubmitJobExecutor::SerializeExecution(std::span<VkSubmitInfo2> submit_infos2)
+{
+    // Each submit info should wait on semaphores signaled by the previous submit.
+    std::span<const VkSemaphoreSubmitInfo> previous_submit_signal_semaphores = {};
+
+    for (VkSubmitInfo2& submit_info : submit_infos2)
+    {
+        if (!previous_submit_signal_semaphores.empty())
+        {
+            // This should work nicely with `InjectBefore` and just get the corresponding vector of injected semaphore
+            // infos. If `InjectBefore` was not called, this will create a new entry with the current semaphores.
+            auto& wait_semaphore_infos = GetWaitSemaphores(submit_info);
+
+            // Append previous submit signal semaphore infos to the wait semaphore infos of the current submit.
+            wait_semaphore_infos.insert(wait_semaphore_infos.end(),
+                                        previous_submit_signal_semaphores.begin(),
+                                        previous_submit_signal_semaphores.end());
+
+            // Update submit info with the new wait semaphore infos pointer and count.
+            submit_info.waitSemaphoreInfoCount = static_cast<uint32_t>(wait_semaphore_infos.size());
+            submit_info.pWaitSemaphoreInfos    = wait_semaphore_infos.data();
+        }
+
+        previous_submit_signal_semaphores =
+            std::span(submit_info.pSignalSemaphoreInfos, submit_info.signalSemaphoreInfoCount);
     }
 }
 

--- a/framework/decode/vulkan_submit_job.cpp
+++ b/framework/decode/vulkan_submit_job.cpp
@@ -105,17 +105,14 @@ bool VulkanInjectedSemaphore::HasReachedTargetValue() const
         return false;
     }
 
-    VkSemaphoreWaitInfo wait_info = { VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO };
-    wait_info.semaphoreCount      = 1;
-    wait_info.pSemaphores         = &handle_;
-    wait_info.pValues             = &target_value_;
-    VkResult result               = device_table_->WaitSemaphores(device_info_->handle, &wait_info, 0);
-    if (result != VK_SUCCESS && result != VK_TIMEOUT)
+    uint64_t read_value = 0;
+    VkResult result     = device_table_->GetSemaphoreCounterValue(device_info_->handle, handle_, &read_value);
+    if (result != VK_SUCCESS)
     {
-        GFXRECON_LOG_ERROR("Failed to wait on timeline semaphore for submit job execution: %s",
+        GFXRECON_LOG_ERROR("Failed to get timeline semaphore value for submit job execution: %s",
                            util::ToString(result).c_str());
     }
-    return result == VK_SUCCESS;
+    return result == VK_SUCCESS && read_value >= target_value_;
 }
 
 VulkanInjectedSemaphore::~VulkanInjectedSemaphore()

--- a/framework/decode/vulkan_submit_job.cpp
+++ b/framework/decode/vulkan_submit_job.cpp
@@ -181,7 +181,9 @@ void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<
 
             // If waitSemaphoreCount was 0, pWaitDstStageMask might be nullptr.
             // Make sure it points to valid data in all cases.
-            auto& wait_dst_stage_masks    = GetWaitDstStageMasks(submit_info, true);
+            auto& wait_dst_stage_masks = GetWaitDstStageMasks(submit_info);
+            std::fill(wait_dst_stage_masks.begin(), wait_dst_stage_masks.end(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+
             submit_info.pWaitDstStageMask = wait_dst_stage_masks.data();
 
             // The original waits were stripped, so any timeline wait values that described them must be removed too.
@@ -272,7 +274,7 @@ std::vector<VkSemaphore>& VulkanSubmitJobExecution::GetWaitSemaphores(VkSubmitIn
 void VulkanSubmitJobExecution::AddWaitSemaphore(VkSubmitInfo& submit_info, const VulkanInjectedSemaphore& semaphore)
 {
     std::vector<VkSemaphore>&          wait_semaphores                = GetWaitSemaphores(submit_info);
-    std::vector<VkPipelineStageFlags>& wait_dst_stage_masks           = GetWaitDstStageMasks(submit_info, true);
+    std::vector<VkPipelineStageFlags>& wait_dst_stage_masks           = GetWaitDstStageMasks(submit_info);
     std::vector<uint64_t>&             wait_values                    = GetWaitValues(submit_info);
     VkTimelineSemaphoreSubmitInfo&     timeline_semaphore_submit_info = GetTimelineSemaphoreSubmitInfo(submit_info);
 
@@ -392,8 +394,7 @@ std::vector<uint64_t>& VulkanSubmitJobExecution::GetSignalValues(VkSubmitInfo& s
     return injected_signal_semaphore_values_[&submit_info];
 }
 
-std::vector<VkPipelineStageFlags>& VulkanSubmitJobExecution::GetWaitDstStageMasks(VkSubmitInfo& submit_info,
-                                                                                  bool          override)
+std::vector<VkPipelineStageFlags>& VulkanSubmitJobExecution::GetWaitDstStageMasks(VkSubmitInfo& submit_info)
 {
     // Make sure there is injected storage for wait dst stage masks for this submit info.
     if (!injected_wait_dst_stage_masks_.contains(&submit_info))
@@ -413,13 +414,6 @@ std::vector<VkPipelineStageFlags>& VulkanSubmitJobExecution::GetWaitDstStageMask
 
         // Override wait dst stage mask pointer.
         submit_info.pWaitDstStageMask = injected_wait_dst_stage_masks_[&submit_info].data();
-    }
-
-    if (override)
-    {
-        std::fill(injected_wait_dst_stage_masks_[&submit_info].begin(),
-                  injected_wait_dst_stage_masks_[&submit_info].end(),
-                  VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
     }
 
     return injected_wait_dst_stage_masks_[&submit_info];

--- a/framework/decode/vulkan_submit_job.h
+++ b/framework/decode/vulkan_submit_job.h
@@ -115,18 +115,29 @@ class VulkanSubmitJobExecutor;
  * next value. After all submits have been rewritten, `target_value` is the final value that must be reached before the
  * executor can safely destroy the semaphore.
  */
-struct VulkanInjectedSemaphore
+class VulkanInjectedSemaphore
 {
-    VkSemaphore handle       = VK_NULL_HANDLE;
-    uint64_t    target_value = 0;
+  private:
+    VkSemaphore handle_       = VK_NULL_HANDLE;
+    uint64_t    target_value_ = 0;
 
     const VulkanDeviceInfo*            device_info_;
     const graphics::VulkanDeviceTable* device_table_;
 
-    bool HasReachedTargetValue() const;
+  public:
+    bool        HasReachedTargetValue() const;
+    VkSemaphore GetHandle() const { return handle_; }
+    uint64_t    GetTargetValue() const { return target_value_; }
+    void        IncreaseTargetValue() { ++target_value_; }
 
     VulkanInjectedSemaphore(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* table);
     ~VulkanInjectedSemaphore();
+
+    VulkanInjectedSemaphore(const VulkanInjectedSemaphore&)            = delete;
+    VulkanInjectedSemaphore& operator=(const VulkanInjectedSemaphore&) = delete;
+
+    VulkanInjectedSemaphore(VulkanInjectedSemaphore&&);
+    VulkanInjectedSemaphore& operator=(VulkanInjectedSemaphore&&) noexcept;
 };
 
 /**

--- a/framework/decode/vulkan_submit_job.h
+++ b/framework/decode/vulkan_submit_job.h
@@ -25,6 +25,8 @@
 
 #include <functional>
 #include <span>
+#include <vector>
+#include <unordered_map>
 
 #include "decode/vulkan_object_info.h"
 #include "graphics/vulkan_semaphore_util.h"
@@ -52,7 +54,7 @@ struct VulkanSubmitJobs
 /**
  * @brief   Stores pre-submit jobs grouped by submit index.
  *
- * Submit indices correspond to entries in the VkSubmitInfo/VkSubmitInfo2 arrays passed to VulkanSubmitJobExecutor.
+ * Submit indices correspond to entries in the VkSubmitInfo/VkSubmitInfo2 arrays passed to VulkanSubmitJobExecution.
  */
 class VulkanSubmitJobPlan
 {
@@ -96,28 +98,71 @@ class VulkanSubmitJobPlan
 };
 
 /**
- * @brief   Semaphore container used while rewriting submit wait lists.
+ * @brief   Original wait semaphores stripped from a submit before injected jobs run.
  */
 struct VulkanSubmitSemaphores
 {
     std::vector<graphics::VulkanSemaphore> semaphores;
 };
 
+class VulkanSubmitJobExecutor;
+
 /**
- * @brief   An executor for Vulkan submit jobs.
+ * @brief   Executor-owned timeline semaphore used to order rewritten submit entries.
+ *
+ * `SerializeExecution()` creates one injected timeline semaphore for one `vkQueueSubmit()` call and reuses it for every
+ * submit entry in that call. Each rewritten submit waits on the semaphore's current `target_value`, then signals the
+ * next value. After all submits have been rewritten, `target_value` is the final value that must be reached before the
+ * executor can safely destroy the semaphore.
+ */
+struct VulkanInjectedSemaphore
+{
+    VkSemaphore handle       = VK_NULL_HANDLE;
+    uint64_t    target_value = 0;
+
+    const VulkanDeviceInfo*            device_info_;
+    const graphics::VulkanDeviceTable* device_table_;
+
+    bool HasReachedTargetValue() const;
+
+    VulkanInjectedSemaphore(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* table);
+    ~VulkanInjectedSemaphore();
+};
+
+/**
+ * @brief   Executor-owned timeline semaphore plus VkSubmitInfo2-compatible submit info.
+ *
+ * `info.value` is updated alongside `VulkanInjectedSemaphore::target_value` while rewriting a `VkSubmitInfo2` array so
+ * the same injected semaphore can be used for the wait and signal pair in each submit entry.
+ */
+struct VulkanInjectedSemaphoreInfo
+{
+    VulkanInjectedSemaphore semaphore;
+    VkSemaphoreSubmitInfo   info = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
+
+    VulkanInjectedSemaphoreInfo(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* table);
+};
+
+/**
+ * @brief   An execution for Vulkan submit jobs.
  *
  * This is useful for both injecting new jobs and serializing submit entries within a single
  * `vkQueueSubmit()`/`vkQueueSubmit2()` call by making each `VkSubmitInfo`/`VkSubmitInfo2` wait on semaphores
  * signaled by the previous submit.
+ * Submit serialization uses one executor-owned timeline semaphore for the full submit array. Each submit waits on the
+ * current timeline value and signals the next value, so the timeline value advances once per submit entry.
  *
  * It does not preserve state across separate queue-submit calls.
  *
- * @note This object owns backing storage for pointers written into submit structs (semaphores).
+ * @note This object owns backing storage for pointers written into submit structs, including semaphore arrays, wait
+ *       stage masks, timeline values, and injected pNext structures.
  *       It must outlive the queue submit that consumes those structs.
  */
-class VulkanSubmitJobExecutor
+class VulkanSubmitJobExecution
 {
   public:
+    VulkanSubmitJobExecution(VulkanSubmitJobExecutor& executor) : executor_(executor) {}
+
     /**
      * @brief   Execute jobs and inject wait-semaphores into VkSubmitInfo.
      *
@@ -146,6 +191,49 @@ class VulkanSubmitJobExecutor
     std::vector<VkSemaphore>& GetWaitSemaphores(VkSubmitInfo& submit_info);
 
     /**
+     * @brief Append a timeline wait semaphore to one VkSubmitInfo.
+     */
+    void AddWaitSemaphore(VkSubmitInfo& submit_info, const VulkanInjectedSemaphore& semaphore);
+
+    /**
+     * @brief Append a timeline signal semaphore to one VkSubmitInfo.
+     */
+    void AddSignalSemaphore(VkSubmitInfo& submit_info, const VulkanInjectedSemaphore& semaphore);
+
+    /**
+     * @brief Append a timeline wait semaphore info to one VkSubmitInfo2.
+     */
+    void AddWaitSemaphore(VkSubmitInfo2& submit_info, const VulkanInjectedSemaphoreInfo& semaphore);
+
+    /**
+     * @brief Append a timeline signal semaphore info to one VkSubmitInfo2.
+     */
+    void AddSignalSemaphore(VkSubmitInfo2& submit_info, const VulkanInjectedSemaphoreInfo& semaphore);
+
+    /**
+     * @brief Access mutable signal-semaphore storage for a VkSubmitInfo.
+     *
+     * If executor-owned storage has not been created for this submit yet, the current signal semaphores from
+     * `submit_info` are copied into internal backing storage first.
+     *
+     * @param submit_info submit struct whose signal-semaphore storage should be accessed.
+     * @return mutable vector owned by this executor and suitable for rewriting `submit_info` signal semaphores.
+     */
+    std::vector<VkSemaphore>& GetSignalSemaphores(VkSubmitInfo& submit_info);
+
+    /**
+     * @brief Access mutable timeline signal-value storage for one VkSubmitInfo.
+     *
+     * If executor-owned storage has not been created for this submit yet, current signal values from
+     * `submit_info` are copied into internal backing storage first. If no timeline values exist, storage is initialized
+     * with zero values matching `signalSemaphoreCount` so counts remain aligned when a timeline signal is appended.
+     *
+     * @param submit_info submit struct whose signal-values storage should be accessed.
+     * @return mutable vector owned by this executor and suitable for rewriting `submit_info` signal values.
+     */
+    std::vector<uint64_t>& GetSignalValues(VkSubmitInfo& submit_info);
+
+    /**
      * @brief   Access mutable wait-semaphore-info storage for one VkSubmitInfo2.
      *
      * If executor-owned storage has not been created for this submit yet, the current wait semaphore infos from
@@ -154,14 +242,76 @@ class VulkanSubmitJobExecutor
      * @param   submit_info      submit struct whose wait-semaphore-info storage should be accessed.
      * @return  mutable vector owned by this executor and suitable for rewriting `submit_info` wait semaphore infos.
      */
-    std::vector<VkSemaphoreSubmitInfo>& GetWaitSemaphores(VkSubmitInfo2& submit_info);
+    std::vector<VkSemaphoreSubmitInfo>& GetWaitSemaphoreInfos(VkSubmitInfo2& submit_info);
+
+    /**
+     * @brief   Access mutable signal-semaphore-info storage for one VkSubmitInfo2.
+     *
+     * If executor-owned storage has not been created for this submit yet, the current signal semaphore infos from
+     * `submit_info` are copied into internal backing storage first.
+     *
+     * @param   submit_info      submit struct whose signal-semaphore-info storage should be accessed.
+     * @return  mutable vector owned by this executor and suitable for rewriting `submit_info` signal semaphore infos.
+     */
+    std::vector<VkSemaphoreSubmitInfo>& GetSignalSemaphoreInfos(VkSubmitInfo2& submit_info);
+
+    /**
+     * @brief  Access mutable wait dst stage mask storage for one VkSubmitInfo.
+     *
+     * If executor-owned storage has not been created for this submit yet, the current wait dst stage masks from
+     * `submit_info` are copied into internal backing storage first. If `override` is true, the backing storage is
+     * filled with `VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT`.
+     *
+     * @param   submit_info      submit struct whose wait dst stage masks should be accessed.
+     * @param   override         if true, existing masks will be overridden with `VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT`.
+     * @return  mutable vector owned by this executor and suitable for rewriting `submit_info` wait dst stage masks.
+     */
+    std::vector<VkPipelineStageFlags>& GetWaitDstStageMasks(VkSubmitInfo& submit_info, bool override = false);
+
+    /**
+     * @brief Access mutable timeline semaphore value storage for one VkSubmitInfo.
+     *
+     * If executor-owned storage has not been created for this submit yet, current wait values from `submit_info` are
+     * copied into internal backing storage first. If no timeline values exist, storage is initialized with zero values
+     * matching `waitSemaphoreCount` so counts remain aligned when a timeline wait is appended.
+     *
+     * @param  submit_info      submit struct whose timeline semaphore value storage should be accessed.
+     * @return mutable vector owned by this executor and suitable for rewriting `submit_info` timeline semaphore values.
+     */
+    std::vector<uint64_t>& GetWaitValues(VkSubmitInfo& submit_info);
+
+    /**
+     * @brief   Access mutable timeline semaphore submit info for one VkSubmitInfo.
+     *
+     * If executor-owned storage has not been created for this submit yet, an existing `VkTimelineSemaphoreSubmitInfo`
+     * is copied from the pNext chain or a new one is created and inserted into the chain.
+     *
+     * @param   submit_info      submit struct whose timeline semaphore submit info should be accessed.
+     * @return  mutable timeline semaphore submit info owned by this executor and suitable for rewriting `submit_info`.
+     */
+    VkTimelineSemaphoreSubmitInfo& GetTimelineSemaphoreSubmitInfo(VkSubmitInfo& submit_info);
+
+    /**
+     * @brief Append one timeline wait/signal pair to a VkSubmitInfo and advance the target value.
+     *
+     * The submit waits on `semaphore.target_value`, then signals `semaphore.target_value + 1`.
+     */
+    void InjectSemaphore(VkSubmitInfo& submit_info, VulkanInjectedSemaphore& semaphore);
+
+    /**
+     * @brief Append one timeline wait/signal pair to a VkSubmitInfo2 and advance the target value.
+     *
+     * The submit waits on `semaphore_info.info.value`, then signals `semaphore_info.info.value + 1`.
+     */
+    void InjectSemaphore(VkSubmitInfo2& submit_info, VulkanInjectedSemaphoreInfo& semaphore_info);
 
     /**
      * @brief  SerializeExecution submit entries within one queue-submit call.
      *
-     * Make each submit wait on semaphores signaled by the previous submit in the same
-     * `vkQueueSubmit()` call. This mutates the provided submit array to insert the
-     * necessary wait semaphores.
+     * Mutates the provided submit array to serialize execution order within one `vkQueueSubmit()` call. One injected
+     * timeline semaphore is added to every submit: each submit waits on the current timeline value and signals the next
+     * value. The first submit waits on the semaphore's initial value, and each subsequent submit waits for the value
+     * signaled by the previous submit.
      *
      * @param  submit_infos     submit array to mutate in place.
      */
@@ -170,23 +320,123 @@ class VulkanSubmitJobExecutor
     /**
      * @brief  SerializeExecution submit entries within one queue-submit call.
      *
-     * Make each submit wait on semaphores signaled by the previous submit in the same
-     * `vkQueueSubmit2()` call. This mutates the provided submit2 array to insert the
-     * necessary wait semaphore infos.
+     * Mutates the provided submit2 array to serialize execution order within one `vkQueueSubmit2()` call. One injected
+     * timeline semaphore is added to every submit: each submit waits on the current timeline value and signals the next
+     * value. The first submit waits on the semaphore's initial value, and each subsequent submit waits for the value
+     * signaled by the previous submit.
      *
      * @param  submit_infos2    submit2 array to mutate in place.
      */
     void SerializeExecution(std::span<VkSubmitInfo2> submit_infos2);
 
   private:
+    VulkanSubmitJobExecutor& executor_;
+
     /// Original waits stripped from each submit before injection, keyed by either `VkSubmitInfo*` or `VkSubmitInfo2*`.
     std::unordered_map<void*, VulkanSubmitSemaphores> original_wait_semaphores_;
 
     /// Injected waits for VkSubmitInfo (binary semaphore handles), keyed by `VkSubmitInfo*`.
     std::unordered_map<VkSubmitInfo*, std::vector<VkSemaphore>> injected_wait_semaphores_;
 
+    /// Signal semaphores of a VkSubmitInfo, keyed by `VkSubmitInfo*`.
+    std::unordered_map<VkSubmitInfo*, std::vector<VkSemaphore>> injected_signal_semaphores_;
+
+    /// Injected timeline signal semaphore values, keyed by `VkSubmitInfo*`.
+    std::unordered_map<VkSubmitInfo*, std::vector<uint64_t>> injected_signal_semaphore_values_;
+
+    /// Injected timeline wait semaphore values, keyed by `VkSubmitInfo*`.
+    std::unordered_map<VkSubmitInfo*, std::vector<uint64_t>> injected_wait_semaphore_values_;
+
+    /// Injected `VkTimelineSemaphoreSubmitInfo` keyed by `VkSubmitInfo*`.
+    std::unordered_map<VkSubmitInfo*, VkTimelineSemaphoreSubmitInfo> injected_timeline_semaphore_infos_;
+
+    /// Injected wait dst stage masks, keyed by `VkSubmitInfo*`.
+    std::unordered_map<VkSubmitInfo*, std::vector<VkPipelineStageFlags>> injected_wait_dst_stage_masks_;
+
     /// Injected waits for VkSubmitInfo2 (binary or timeline semaphore submit infos), keyed by `VkSubmitInfo2*`.
     std::unordered_map<VkSubmitInfo2*, std::vector<VkSemaphoreSubmitInfo>> injected_wait_semaphore_infos_;
+
+    /// Injected signals for VkSubmitInfo2 (binary or timeline semaphore submit infos), keyed by `VkSubmitInfo2*`.
+    std::unordered_map<VkSubmitInfo2*, std::vector<VkSemaphoreSubmitInfo>> injected_signal_semaphore_infos_;
+};
+
+/**
+ * @brief   Executor managing device resources for submit job execution.
+ *
+ * `VulkanSubmitJobExecutor` owns device-side resources used by `VulkanSubmitJobExecution`
+ * instances to implement injected jobs and serialization of submit entries.
+ * Create one executor per device and call `CreateExecution()` to obtain a short-lived
+ * execution object that borrows the executor for the duration of a single queue-submit call.
+ *
+ * The executor creates and destroys semaphores used for chaining submits and
+ * holds them so their handles remain valid while modified submit structures
+ * are in use. The executor must outlive any `VulkanSubmitJobExecution` and
+ * the actual `vkQueueSubmit`/`vkQueueSubmit2` call that consumes the modified
+ * submit arrays.
+ * Semaphores created for serialization remain tracked until their final target value has been reached; pruning checks
+ * that target value before destroying them.
+ *
+ * @note Instances are intended to be per-device and may be reused across
+ *       multiple queue-submit calls. `VulkanSubmitJobExecution` objects are
+ *       short-lived and are not safe to use after the executor is destroyed.
+ */
+class VulkanSubmitJobExecutor
+{
+  public:
+    /**
+     * @brief Construct a submit job executor for a device.
+     *
+     * @param device_info Pointer to VulkanDeviceInfo for the device this executor manages.
+     * @param device_table Pointer to the Vulkan device dispatch table used to create/destroy resources.
+     */
+    VulkanSubmitJobExecutor(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* device_table);
+
+    /**
+     * @brief Create a short-lived execution object for a single queue-submit call.
+     *
+     * The returned `VulkanSubmitJobExecution` borrows this executor and is intended to be used to
+     * inject job work and/or serialize submits for the duration of a single `vkQueueSubmit`/`vkQueueSubmit2` call.
+     *
+     * @return VulkanSubmitJobExecution execution object tied to this executor.
+     */
+    VulkanSubmitJobExecution CreateExecution() { return VulkanSubmitJobExecution(*this); }
+
+    /**
+     * @brief Create a timeline semaphore.
+     *
+     * Semaphores are stored internally and destroyed when their target value is reached or when the executor is
+     * destroyed. A serialization pass uses one created semaphore across all submits in that queue-submit call.
+     *
+     * @return A pointer to the `VulkanInjectedSemaphore` just created or `nullptr` on error.
+     */
+    VulkanInjectedSemaphore* CreateTimelineSemaphore();
+
+    /**
+     * @brief Create a timeline semaphore info.
+     *
+     * Semaphores are stored internally and destroyed when their target value is reached or when the executor is
+     * destroyed. A serialization pass uses one created semaphore across all submits in that queue-submit call.
+     *
+     * @return A pointer to the `VulkanInjectedSemaphoreInfo` just created or `nullptr` on error.
+     */
+    VulkanInjectedSemaphoreInfo* CreateTimelineSemaphoreInfo();
+
+    /**
+     * @brief Prunes timeline semaphores that have reached or exceeded their final target value.
+     */
+    void PruneSignaledTimelineSemaphores();
+
+    /**
+     * @brief Prunes timeline semaphore infos that have reached or exceeded their final target value.
+     */
+    void PruneSignaledTimelineSemaphoreInfos();
+
+  private:
+    const VulkanDeviceInfo*            device_info_  = nullptr;
+    const graphics::VulkanDeviceTable* device_table_ = nullptr;
+
+    std::vector<std::unique_ptr<VulkanInjectedSemaphore>>     injected_semaphores_;
+    std::vector<std::unique_ptr<VulkanInjectedSemaphoreInfo>> injected_semaphore_infos_;
 };
 
 using VulkanPerDeviceSubmitJobExecutors = std::unordered_map<const VulkanDeviceInfo*, VulkanSubmitJobExecutor>;

--- a/framework/decode/vulkan_submit_job.h
+++ b/framework/decode/vulkan_submit_job.h
@@ -28,6 +28,7 @@
 
 #include "decode/vulkan_object_info.h"
 #include "graphics/vulkan_semaphore_util.h"
+#include "decode/common_object_info_table.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -103,10 +104,16 @@ struct VulkanSubmitSemaphores
 };
 
 /**
- * @brief   Executes submit jobs and injects produced wait-semaphores into submit infos.
+ * @brief   An executor for Vulkan submit jobs.
  *
- * This object owns backing storage for pointers written into submit structs (semaphores).
- * It must outlive the queue submit that consumes those structs.
+ * This is useful for both injecting new jobs and serializing submit entries within a single
+ * `vkQueueSubmit()`/`vkQueueSubmit2()` call by making each `VkSubmitInfo`/`VkSubmitInfo2` wait on semaphores
+ * signaled by the previous submit.
+ *
+ * It does not preserve state across separate queue-submit calls.
+ *
+ * @note This object owns backing storage for pointers written into submit structs (semaphores).
+ *       It must outlive the queue submit that consumes those structs.
  */
 class VulkanSubmitJobExecutor
 {
@@ -127,16 +134,62 @@ class VulkanSubmitJobExecutor
      */
     void InjectBefore(VulkanSubmitJobPlan plan, std::span<VkSubmitInfo2> submit_infos2);
 
+    /**
+     * @brief   Access mutable wait-semaphore storage for one VkSubmitInfo.
+     *
+     * If executor-owned storage has not been created for this submit yet, the current wait semaphores from
+     * `submit_info` are copied into internal backing storage first.
+     *
+     * @param   submit_info      submit struct whose wait-semaphore storage should be accessed.
+     * @return  mutable vector owned by this executor and suitable for rewriting `submit_info` wait semaphores.
+     */
+    std::vector<VkSemaphore>& GetWaitSemaphores(VkSubmitInfo& submit_info);
+
+    /**
+     * @brief   Access mutable wait-semaphore-info storage for one VkSubmitInfo2.
+     *
+     * If executor-owned storage has not been created for this submit yet, the current wait semaphore infos from
+     * `submit_info` are copied into internal backing storage first.
+     *
+     * @param   submit_info      submit struct whose wait-semaphore-info storage should be accessed.
+     * @return  mutable vector owned by this executor and suitable for rewriting `submit_info` wait semaphore infos.
+     */
+    std::vector<VkSemaphoreSubmitInfo>& GetWaitSemaphores(VkSubmitInfo2& submit_info);
+
+    /**
+     * @brief  SerializeExecution submit entries within one queue-submit call.
+     *
+     * Make each submit wait on semaphores signaled by the previous submit in the same
+     * `vkQueueSubmit()` call. This mutates the provided submit array to insert the
+     * necessary wait semaphores.
+     *
+     * @param  submit_infos     submit array to mutate in place.
+     */
+    void SerializeExecution(std::span<VkSubmitInfo> submit_infos);
+
+    /**
+     * @brief  SerializeExecution submit entries within one queue-submit call.
+     *
+     * Make each submit wait on semaphores signaled by the previous submit in the same
+     * `vkQueueSubmit2()` call. This mutates the provided submit2 array to insert the
+     * necessary wait semaphore infos.
+     *
+     * @param  submit_infos2    submit2 array to mutate in place.
+     */
+    void SerializeExecution(std::span<VkSubmitInfo2> submit_infos2);
+
   private:
-    // Original waits stripped from each submit before injection.
-    std::vector<VulkanSubmitSemaphores> original_wait_semaphores_;
+    /// Original waits stripped from each submit before injection, keyed by either `VkSubmitInfo*` or `VkSubmitInfo2*`.
+    std::unordered_map<void*, VulkanSubmitSemaphores> original_wait_semaphores_;
 
-    // Injected waits for VkSubmitInfo (binary semaphore handles).
-    std::vector<std::vector<VkSemaphore>> injected_wait_semaphores_;
+    /// Injected waits for VkSubmitInfo (binary semaphore handles), keyed by `VkSubmitInfo*`.
+    std::unordered_map<VkSubmitInfo*, std::vector<VkSemaphore>> injected_wait_semaphores_;
 
-    // Injected waits for VkSubmitInfo2 (binary or timeline semaphore submit infos).
-    std::vector<std::vector<VkSemaphoreSubmitInfo>> injected_wait_semaphore_infos_;
+    /// Injected waits for VkSubmitInfo2 (binary or timeline semaphore submit infos), keyed by `VkSubmitInfo2*`.
+    std::unordered_map<VkSubmitInfo2*, std::vector<VkSemaphoreSubmitInfo>> injected_wait_semaphore_infos_;
 };
+
+using VulkanPerDeviceSubmitJobExecutors = std::unordered_map<const VulkanDeviceInfo*, VulkanSubmitJobExecutor>;
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_submit_job.h
+++ b/framework/decode/vulkan_submit_job.h
@@ -270,14 +270,12 @@ class VulkanSubmitJobExecution
      * @brief  Access mutable wait dst stage mask storage for one VkSubmitInfo.
      *
      * If executor-owned storage has not been created for this submit yet, the current wait dst stage masks from
-     * `submit_info` are copied into internal backing storage first. If `override` is true, the backing storage is
-     * filled with `VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT`.
+     * `submit_info` are copied into internal backing storage first.
      *
      * @param   submit_info      submit struct whose wait dst stage masks should be accessed.
-     * @param   override         if true, existing masks will be overridden with `VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT`.
      * @return  mutable vector owned by this executor and suitable for rewriting `submit_info` wait dst stage masks.
      */
-    std::vector<VkPipelineStageFlags>& GetWaitDstStageMasks(VkSubmitInfo& submit_info, bool override = false);
+    std::vector<VkPipelineStageFlags>& GetWaitDstStageMasks(VkSubmitInfo& submit_info);
 
     /**
      * @brief Access mutable timeline semaphore value storage for one VkSubmitInfo.

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -43,7 +43,7 @@ const char kArguments[] =
     "get-fence-status,--sgfr|--skip-get-fence-ranges,--dump-resources,--dump-resources-dir,--dump-resources-image-"
     "format,pbis,--pcj|--pipeline-creation-jobs,--save-pipeline-cache,--load-pipeline-cache,--quit-after-frame,--"
     "present-mode,--wait-before-first-submit,--idle-before-submit,--present-override,--serialize-render-passes,--frame-"
-    "warm-up-spirv,--frame-warm-up-load,--wait-before-frame,--loop-frame,--loop-count";
+    "warm-up-spirv,--frame-warm-up-load,--wait-before-frame,--loop-frame,--loop-count,--serialize-queue-submissions";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -86,6 +86,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--frame-warm-up-spirv <spirv-file>] [--frame-warm-up-load <load>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--idle-before-submit] [--pbi-all] [--pbis <index1,index2>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--serialize-render-passes] [--wait-before-frame <milliseconds>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--serialize-queue-submissions]");
 #if !defined(WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources <filename>.json]");
 #endif
@@ -387,6 +388,9 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --wait-before-frame <milliseconds>");
     GFXRECON_WRITE_CONSOLE("          \t\tWait for the specified amount of milliseconds before starting to replay");
     GFXRECON_WRITE_CONSOLE("          \t\teach frame. Default is 0 (no wait).");
+    GFXRECON_WRITE_CONSOLE("  --serialize-queue-submissions");
+    GFXRECON_WRITE_CONSOLE("          \t\tSerialize submit entries within one vkQueueSubmit/vkQueueSubmit2");
+    GFXRECON_WRITE_CONSOLE("          \t\tcall by adding semaphores between consecutive submits.");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("D3D12 only:")

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -166,10 +166,11 @@ const char kDumpResourcesModifiableStateOnly[] = "--dump-resources-modifiable-st
 const char kDumpResourcesBeforeDrawOption[]    = "--dump-resources-before-draw";
 #endif
 
-const char kDumpResourcesArgument[]    = "--dump-resources";
-const char kDumpResourcesDirArgument[] = "--dump-resources-dir";
-const char kFrameWarmUpSpirv[]         = "--frame-warm-up-spirv";
-const char kFrameWarmUpLoad[]          = "--frame-warm-up-load";
+const char kDumpResourcesArgument[]     = "--dump-resources";
+const char kDumpResourcesDirArgument[]  = "--dump-resources-dir";
+const char kFrameWarmUpSpirv[]          = "--frame-warm-up-spirv";
+const char kFrameWarmUpLoad[]           = "--frame-warm-up-load";
+const char kSerializeQueueSubmissions[] = "--serialize-queue-submissions";
 
 enum class WsiPlatform
 {
@@ -1383,8 +1384,9 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     replay_options.do_device_deduplication      = arg_parser.IsOptionSet(kDeduplicateDevice);
 
     GetWaitBeforeFirstSubmit(arg_parser, replay_options.wait_before_first_submit);
-    replay_options.idle_before_submit = arg_parser.IsOptionSet(kIdleBeforeSubmit);
-    replay_options.serialize_render_passes = arg_parser.IsOptionSet(kSerializeRenderPasses);
+    replay_options.idle_before_submit          = arg_parser.IsOptionSet(kIdleBeforeSubmit);
+    replay_options.serialize_render_passes     = arg_parser.IsOptionSet(kSerializeRenderPasses);
+    replay_options.serialize_queue_submissions = arg_parser.IsOptionSet(kSerializeQueueSubmissions);
 
     GetFrameWarmUpOptions(arg_parser, replay_options.frame_warm_up_spirv_path, replay_options.frame_warm_up_load);
     GetWaitBeforeFrame(arg_parser, replay_options.wait_before_frame);


### PR DESCRIPTION
Add a new replay option that serializes queue submissions by inserting semaphores so each submit waits for the previous, preventing concurrent execution of multiple submissions during replay.

Implement serialization in `VulkanSubmitJobExecutor` with `Serialize` overloads for `VkSubmitInfo` and `VkSubmitInfo2`, and call `Serialize` from `OverrideQueueSubmit`/`OverrideQueueSubmit2` when the option is set.

Wire the option through CLI parsers, replay_settings, and help text, and update desktop/android usage docs. Refactor submit executor storage to map submit pointers to semaphore storage to avoid multiple injections.