### PR TITLE
Fix --wsi auto side effects

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2891,7 +2891,8 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
         }
     }
 
-    std::string capture_surface_extension;
+    // In case there is more than one replay surface
+    std::vector<std::string> capture_surface_extensions;
 
     // Transfer requested extensions to filtered extension
     for (uint32_t i = 0; i < replay_create_info->enabledExtensionCount; ++i)
@@ -2906,9 +2907,7 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
             {
                 if (!override_wsi_extensions)
                 {
-                    application_->InitializeWsiContext(current_extension);
-                    capture_surface_extension = current_extension;
-                    modified_extensions.push_back(current_extension);
+                    capture_surface_extensions.push_back(current_extension);
                 }
             }
             else
@@ -2923,7 +2922,7 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
     if (graphics::feature_util::GetInstanceExtensions(instance_extension_proc, &available_extensions) == VK_SUCCESS)
     {
         // only set a wsi if there was one on the capture device
-        bool surface_at_capture_time = !capture_surface_extension.empty();
+        bool surface_at_capture_time = !capture_surface_extensions.empty();
 
         if (!override_wsi_extensions && surface_at_capture_time &&
             options_.swapchain_option != util::SwapchainOption::kOffscreen)
@@ -2933,15 +2932,20 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
                 application_->GetWsiContexts();
 
             // Try to use the same WSI as at capture time
-            if (graphics::feature_util::IsSupportedExtension(available_extensions, capture_surface_extension.c_str()))
+            for (auto capture_surface_extension : capture_surface_extensions)
             {
-                const auto itr_surface_extension = kSurfaceExtensions.find(capture_surface_extension);
-
-                // check if corresponding compositor exists on replay device
-                if (itr_surface_extension != kSurfaceExtensions.end() && wsi_contexts.contains(*itr_surface_extension))
+                if (graphics::feature_util::IsSupportedExtension(available_extensions,
+                                                                 capture_surface_extension.c_str()))
                 {
-                    modified_extensions.push_back(itr_surface_extension->c_str());
-                    picked_surface = true;
+                    const auto itr_surface_extension = kSurfaceExtensions.find(capture_surface_extension);
+
+                    // check if corresponding compositor exists on replay device
+                    if (wsi_contexts.find(*itr_surface_extension) != wsi_contexts.end() ||
+                        application_->InitializeWsiContext(itr_surface_extension->c_str()))
+                    {
+                        picked_surface = true;
+                        modified_extensions.push_back(itr_surface_extension->c_str());
+                    }
                 }
             }
 
@@ -2958,8 +2962,14 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
                             application_->InitializeWsiContext(itr_surface_extension->c_str()))
                         {
                             modified_extensions.push_back(itr_surface_extension->c_str());
-                            GFXRECON_LOG_WARNING("--wsi auto: could not find surface: %s, instead using: %s",
-                                                 capture_surface_extension.c_str(),
+                            std::string all_capture_surface_extensions = std::string("");
+                            for (std::string ext : capture_surface_extensions)
+                            {
+                                all_capture_surface_extensions += ext;
+                                all_capture_surface_extensions += ", ";
+                            }
+                            GFXRECON_LOG_WARNING("--wsi auto: could not find surface: %sinstead using: %s",
+                                                 all_capture_surface_extensions.c_str(),
                                                  itr_surface_extension->c_str());
                             picked_surface = true;
                             break;
@@ -2982,7 +2992,7 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
                 "WSI was specified, but no surface was available at capture time, option will be ignored");
         }
 
-        if (surface_at_capture_time)
+        if (surface_at_capture_time || override_wsi_extensions)
         {
             // If a WSI was specified by CLI but there was none at capture time, it's possible to end up with a surface
             // extension without having VK_KHR_surface. Check for that and fix that.


### PR DESCRIPTION
Currently `--wsi auto` (default flag) is adding all surface extensions from the replay and trying to initialize their compositors. This is done to deal with an edge case of where multiple WSIs are available in the caputre. However, when compositors are not available on the replay device, the surface extensions are not removed leading to the application breaking during the `vkCreateInstance` call with `VK_ERROR_EXTENSION_NOT_PRESENT`. This makes `--remove-unsupported` a required option to replay the trace.

The change that creates this behaviour is introduced in PR #2736, while testing the fix I could not reproduce the issue with `vulkaninfo` that originally prompted this change.

Instead of adding all the surface extensions from the replay and then removing some if they are not available. This change proposes to add them if they are available, by going through all the capture time surface extensions and checking if they are available and then adding them.