### PR TITLE
Refine file open error reporting

### DIFF
--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -67,7 +67,6 @@ bool FileProcessor::Initialize(const std::string& filename)
     }
     else
     {
-        GFXRECON_LOG_ERROR("Failed to open file %s", filename.c_str());
         error_state_ = kErrorOpeningFile;
     }
 
@@ -440,7 +439,6 @@ bool FileProcessor::SetActiveFile(const std::string& filename, bool execute_till
 
         if (!opened || !active_file->IsOpen())
         {
-            GFXRECON_LOG_ERROR("Failed to open file %s", filename.c_str());
             error_state_ = kErrorOpeningFile;
             return false;
         }

--- a/framework/util/file_input_stream.cpp
+++ b/framework/util/file_input_stream.cpp
@@ -107,6 +107,7 @@ bool FStreamFileInputStream::Open(const std::string& filename)
     }
     else
     {
+        GFXRECON_LOG_ERROR("Failed to open file '%s': %s", filename.c_str(), strerror(errno));
         last_read_status_ = util::platform::FileReadStatus::kError;
     }
 #endif

--- a/framework/util/json_util.cpp
+++ b/framework/util/json_util.cpp
@@ -370,7 +370,7 @@ static bool WriteBinaryFile(const std::string& filename, uint64_t data_size, con
     }
     else
     {
-        GFXRECON_LOG_ERROR("Failed to open file %s for writing.", filename.c_str());
+        GFXRECON_LOG_ERROR("Failed to open file %s for writing: %s.", filename.c_str(), strerror(errno));
     }
     return written_all;
 }


### PR DESCRIPTION
Centralize file-open failure logging in the lower-level stream and JSON write paths, where the platform error is still available.

Remove duplicate generic messages from FileProcessor and make open failures easier to diagnose.