### PR TITLE
Change TEST_COMMIT to TEST_BRANCH for CI

### DIFF
--- a/ci/cloneTests.bat
+++ b/ci/cloneTests.bat
@@ -19,11 +19,11 @@
 @REM FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 @REM DEALINGS IN THE SOFTWARE.
 
-if not defined TEST_COMMIT (
+if not defined TEST_BRANCH (
     if exist test.ref (
-        set /p TEST_COMMIT=<test.ref
+        set /p TEST_BRANCH=<test.ref
     ) else (
-        set TEST_COMMIT=master
+        set TEST_BRANCH=master
     )
 )
 
@@ -43,7 +43,7 @@ goto :clone_tests
 cd VulkanTests
 git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
 git fetch origin
-git checkout %TEST_COMMIT% || exit /b
+git checkout %TEST_BRANCH% || exit /b
 git submodule update --init --recursive
 git describe --tags --always
 cd ..

--- a/ci/cloneTests.sh
+++ b/ci/cloneTests.sh
@@ -19,20 +19,20 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-if [ -z "${TEST_COMMIT:-}" ]; then
+if [ -z "${TEST_BRANCH:-}" ]; then
   if [ -f "test.ref" ]; then
-    IFS= read -r TEST_COMMIT < test.ref
+    IFS= read -r TEST_BRANCH < test.ref
   else
-    TEST_COMMIT="master"
+    TEST_BRANCH="master"
   fi
-  export TEST_COMMIT
+  export TEST_BRANCH
 fi
 
 git clone --verbose $TEST_REPO VulkanTests
 cd VulkanTests
 git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
 git fetch origin
-git checkout $TEST_COMMIT
+git checkout $TEST_BRANCH
 git submodule update --init --recursive
 git describe --tags --always
 cd ..

--- a/ci/runJob.bat
+++ b/ci/runJob.bat
@@ -49,11 +49,11 @@ git -C ci-gfxr-suites checkout %TEST_SUITE_BRANCH% || exit /b
 git -C ci-gfxr-suites submodule update --init --recursive
 git -C ci-gfxr-suites describe --tags --always
 
-if not defined TEST_COMMIT (
+if not defined TEST_BRANCH (
     if exist test.ref (
-        set /p TEST_COMMIT=<test.ref
+        set /p TEST_BRANCH=<test.ref
     ) else (
-        set TEST_COMMIT=master
+        set TEST_BRANCH=master
     )
 )
 
@@ -72,7 +72,7 @@ goto :clone_tests
 :clone_tests_done
 git -C VulkanTests config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
 git -C VulkanTests fetch origin
-git -C VulkanTests checkout %TEST_COMMIT% || exit /b
+git -C VulkanTests checkout %TEST_BRANCH% || exit /b
 git -C VulkanTests submodule update --init --recursive
 git -C VulkanTests describe --tags --always
 

--- a/ci/runJob.sh
+++ b/ci/runJob.sh
@@ -38,19 +38,19 @@ git -C ci-gfxr-suites checkout $TEST_SUITE_BRANCH
 git -C ci-gfxr-suites submodule update --init --recursive
 git -C ci-gfxr-suites describe --tags --always
 
-if [ -z "${TEST_COMMIT:-}" ]; then
+if [ -z "${TEST_BRANCH:-}" ]; then
   if [ -f "test.ref" ]; then
-    IFS= read -r TEST_COMMIT < test.ref
+    IFS= read -r TEST_BRANCH < test.ref
   else
-    TEST_COMMIT="master"
+    TEST_BRANCH="master"
   fi
-  export TEST_COMMIT
+  export TEST_BRANCH
 fi
 
 git clone --verbose $TEST_REPO VulkanTests
 git -C VulkanTests config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
 git -C VulkanTests fetch origin
-git -C VulkanTests checkout $TEST_COMMIT
+git -C VulkanTests checkout $TEST_BRANCH
 git -C VulkanTests submodule update --init --recursive
 git -C VulkanTests describe --tags --always
 

--- a/ci/runJobAndroid.sh
+++ b/ci/runJobAndroid.sh
@@ -38,19 +38,19 @@ git -C ci-gfxr-suites checkout $TEST_SUITE_BRANCH
 git -C ci-gfxr-suites submodule update --init --recursive
 git -C ci-gfxr-suites describe --tags --always
 
-if [ -z "${TEST_COMMIT:-}" ]; then
+if [ -z "${TEST_BRANCH:-}" ]; then
   if [ -f "test.ref" ]; then
-    IFS= read -r TEST_COMMIT < test.ref
+    IFS= read -r TEST_BRANCH < test.ref
   else
-    TEST_COMMIT="master"
+    TEST_BRANCH="master"
   fi
-  export TEST_COMMIT
+  export TEST_BRANCH
 fi
 
 git clone --verbose $TEST_REPO VulkanTests
 git -C VulkanTests config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
 git -C VulkanTests fetch origin
-git -C VulkanTests checkout $TEST_COMMIT
+git -C VulkanTests checkout $TEST_BRANCH
 git -C VulkanTests submodule update --init --recursive
 git -C VulkanTests describe --tags --always
 


### PR DESCRIPTION
Most CI scripts were using TEST_COMMIT but jenkinsfile.extended and jenkinsfile.manual define it as TEST_BRANCH. Values defined for a branch to test on VulkanTests were not being honored in jenkins.

cloneTests.bat:
cloneTests.sh:
runJob.bat:
runJob.sh:
runJobAndroid.sh:
- Change TEST_COMMIT to TEST_BRANCH