### PR TITLE
Fix `OnVmaFreeDeviceMemory` attribute mismatch

### DIFF
--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -409,7 +409,8 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
 
   private:
     // VMA hook to clean our internal state (mutexes) when VMA clears blocks of memory
-    friend void VKAPI_CALL OnVmaFreeDeviceMemory(VmaAllocator, uint32_t, VkDeviceMemory, VkDeviceSize, void*);
+    friend VKAPI_ATTR void VKAPI_CALL
+    OnVmaFreeDeviceMemory(VmaAllocator, uint32_t, VkDeviceMemory, VkDeviceSize, void*);
 
     struct MemoryAllocInfo;
 


### PR DESCRIPTION
This function is defined in `vulkan_rebind_allocator.cpp` with the `VKAPI_ATTR` attribute, but is declared as a friend of the `VulkanRebindAllocator` class in the corresponding header file without the same attributes, which causes build issues on Android
