### PR TITLE
Fix missing CaptureReplay enablement for VK_EXT_buffer_device_address

### DIFF
--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -214,6 +214,7 @@ VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(const VulkanInstanceUtilI
             }
             break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT: // _not_ an alias of the above
             {
                 auto buffer_address_features =
                     reinterpret_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(current_struct);


### PR DESCRIPTION
For some reason, VK_EXT_buffer_device_address's enable struct is not an alias of the KHR and core structs. Therefore we need to handle it separately. It is probably too late to fix this in the spec, if it was in fact a mistake (it does look like it).