### PR TITLE
Better check in GetPhysicalDeviceSurfaceFormats(2)KHR

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -7673,7 +7673,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceSurfaceFormatsKHR(
 
     VkResult result = func(physical_device_info->handle, surface_info->handle, surface_format_count, surface_formats);
 
-    if (surface_formats != nullptr)
+    if (surface_formats != nullptr && result == VK_SUCCESS && *surface_format_count > 0)
     {
         physical_device_info->surface_formats = { surface_formats, surface_formats + *surface_format_count };
     }
@@ -7696,7 +7696,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceSurfaceFormats2KHR(
     VkResult result =
         func(physical_device_info->handle, surface_info->GetPointer(), surface_format_count, surface_formats);
 
-    if (surface_formats != nullptr)
+    if (surface_formats != nullptr && result == VK_SUCCESS && *surface_format_count > 0)
     {
         // init optional value
         physical_device_info->surface_formats.emplace();


### PR DESCRIPTION
- avoid initializing an std::optional when no information was returned
- attempts to correct wrong format-fallback-logic based on this std::optional