### PR TITLE
Fix RGB8 format handling in trim/dumpresources

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1237,6 +1237,11 @@ void VulkanReplayConsumerBase::ProcessInitImageCommand(format::HandleId         
                     copy_region.imageSubresource.baseArrayLayer = 0;
                     copy_region.imageSubresource.layerCount     = image_info->layer_count;
 
+                    const VkDeviceSize copy_alignment =
+                        graphics::GetBufferImageCopyOffsetAlignment(image_info->format, aspect);
+                    VkDeviceSize current_offset = 0;
+                    VkDeviceSize required_size  = 0;
+
                     assert(image_info->level_count == level_sizes.size());
 
                     for (uint32_t i = 0; i < image_info->level_count; ++i)
@@ -1246,8 +1251,47 @@ void VulkanReplayConsumerBase::ProcessInitImageCommand(format::HandleId         
                         copy_region.imageExtent.height        = std::max(1u, (image_info->extent.height >> i));
                         copy_region.imageExtent.depth         = std::max(1u, (image_info->extent.depth >> i));
 
+                        // Keep per-mip offsets valid even when level_sizes are tightly packed or
+                        // use non-power-of-two format alignments.
+                        //
+                        // For backward compatibility with older captures, this may be switched to
+                        // contiguous (legacy) offsets below when aligned offsets would exceed payload size.
+                        current_offset           = graphics::AlignBufferOffset(current_offset, copy_alignment);
+                        copy_region.bufferOffset = current_offset;
+
                         copy_regions.push_back(copy_region);
-                        copy_region.bufferOffset += level_sizes[i];
+                        required_size = std::max(required_size, current_offset + level_sizes[i]);
+                        current_offset += level_sizes[i];
+                    }
+
+                    if ((copy_alignment > 1) && (image_info->level_count > 1) && (required_size > data_size))
+                    {
+                        GFXRECON_LOG_WARNING(
+                            "InitImageCommand payload may use legacy capture mip packing incompatible "
+                            "with aligned replay offsets for image (ID = %" PRIu64 ", handle = 0x%" PRIx64
+                            ", format = %s, aspect = 0x%x): payload size = %" PRIu64
+                            ", aligned bytes required = %" PRIu64 ". Falling back to legacy contiguous mip offsets.",
+                            image_id,
+                            image,
+                            util::ToString<VkFormat>(image_info->format).c_str(),
+                            aspect,
+                            data_size,
+                            required_size);
+
+                        copy_regions.clear();
+                        current_offset = 0;
+
+                        for (uint32_t i = 0; i < image_info->level_count; ++i)
+                        {
+                            copy_region.imageSubresource.mipLevel = i;
+                            copy_region.imageExtent.width         = std::max(1u, (image_info->extent.width >> i));
+                            copy_region.imageExtent.height        = std::max(1u, (image_info->extent.height >> i));
+                            copy_region.imageExtent.depth         = std::max(1u, (image_info->extent.depth >> i));
+
+                            copy_region.bufferOffset = current_offset;
+                            copy_regions.push_back(copy_region);
+                            current_offset += level_sizes[i];
+                        }
                     }
                 }
             }

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -29,43 +29,12 @@
 #include "util/platform.h"
 #include "util/alignment_utils.h"
 
-#include "Vulkan-Utility-Libraries/vk_format_utils.h"
-
 #include <algorithm>
 #include <cassert>
 #include <limits>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
-
-static uint32_t FindBufferOffsetAlignmentForCopyBufferToImage(VkFormat format)
-{
-    uint32_t alignment = 0;
-    if (vkuFormatIsDepthOrStencil(format))
-    {
-        // Spec mandates an alignment of 4 for depth/stencil formats
-        alignment = 4;
-    }
-    else if (vkuFormatIsMultiplane(format))
-    {
-        // According to spec, for multiplanar formats the alignment is determined from the compatible format
-        VkFormat compatible_format = vkuFindMultiplaneCompatibleFormat(format, VK_IMAGE_ASPECT_PLANE_0_BIT);
-        GFXRECON_ASSERT(compatible_format != VK_FORMAT_UNDEFINED);
-        if (compatible_format != VK_FORMAT_UNDEFINED)
-        {
-            const VKU_FORMAT_INFO format_info = vkuGetFormatInfo(compatible_format);
-            alignment                         = format_info.block_size;
-        }
-    }
-    else
-    {
-        // In all other cases spec mandates an alignment of the format's block size.
-        const VKU_FORMAT_INFO format_info = vkuGetFormatInfo(format);
-        alignment                         = format_info.block_size;
-    }
-
-    return alignment;
-}
 
 VulkanResourceInitializer::VulkanResourceInitializer(const VulkanDeviceInfo*                 device_info,
                                                      VkDeviceSize                            total_copy_size,
@@ -282,8 +251,13 @@ VkResult VulkanResourceInitializer::InitializeImage(VkDeviceSize             dat
             if (staging_buffer_offset_ > 0)
             {
                 // Apply to offset any spec mandated alignment
-                const uint32_t alignment = FindBufferOffsetAlignmentForCopyBufferToImage(format);
-                staging_buffer_offset_   = util::platform::GetAlignedSize(staging_buffer_offset_, alignment);
+                //
+                // IMPORTANT: `util::platform::GetAlignedSize` uses bitwise math and only works for power-of-two
+                // alignments. Some legal Vulkan formats (for example RGB8) require alignment 3, which is not a
+                // power of two. Using the old helper with alignment=3 can produce offsets that are still misaligned
+                // to 3, triggering driver assertions when recording `vkCmdCopyBufferToImage`.
+                const VkDeviceSize alignment = graphics::GetBufferImageCopyOffsetAlignment(format, aspect);
+                staging_buffer_offset_       = graphics::AlignBufferOffset(staging_buffer_offset_, alignment);
 
                 // If data does not fit in the remaining portion of the staging buffer flush pending commands and reset
                 // staging buffer offset

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2272,7 +2272,6 @@ void VulkanCaptureManager::ProcessImportFdForImage(VkDevice device, VkImage imag
             std::vector<uint64_t> level_sizes;
 
             uint64_t resource_size = resource_util.GetImageResourceSizesOptimal(img.format,
-                                                                                img.type,
                                                                                 img.extent,
                                                                                 img.level_count,
                                                                                 img.layer_count,

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -3243,7 +3243,6 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
                     {
                         snapshot_info.resource_size =
                             resource_util.GetImageResourceSizesOptimal(wrapper->format,
-                                                                       wrapper->image_type,
                                                                        wrapper->extent,
                                                                        wrapper->mip_levels,
                                                                        wrapper->array_layers,

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -937,11 +937,9 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkFormat             
 
     for (uint32_t m = 0; m < mip_levels; ++m)
     {
-        const VkExtent3D mip_extent = {
-            std::max(1u, (extent.width >> m)),
-            std::max(1u, (extent.height >> m)),
-            std::max(1u, (extent.depth >> m))
-        };
+        const VkExtent3D mip_extent = { std::max(1u, (extent.width >> m)),
+                                        std::max(1u, (extent.height >> m)),
+                                        std::max(1u, (extent.depth >> m)) };
 
         // Compute exact bytes copied for one tightly-packed region.
         VkImageToMemoryCopy copy_region{};

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -897,7 +897,6 @@ VulkanResourcesUtil::~VulkanResourcesUtil()
 }
 
 uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkFormat               format,
-                                                           VkImageType            type,
                                                            const VkExtent3D&      extent,
                                                            uint32_t               mip_levels,
                                                            uint32_t               array_layers,
@@ -907,6 +906,10 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkFormat             
                                                            std::vector<uint64_t>* subresource_sizes,
                                                            bool                   all_layers_per_level)
 {
+    // Vulkan requires each VkBufferImageCopy::bufferOffset to satisfy format/aspect alignment.
+    // Keep one shared alignment value here so all per-subresource offset math follows the same rule.
+    const VkDeviceSize copy_alignment = GetBufferImageCopyOffsetAlignment(format, aspect);
+
     // Check whether the format is supported
     VkFormatProperties format_properties;
     instance_table_.GetPhysicalDeviceFormatProperties(physical_device_, format, &format_properties);
@@ -928,73 +931,63 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkFormat             
         subresource_offsets->clear();
     }
 
-    uint64_t resource_size = 0;
-
-    VkImageCreateInfo create_info     = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
-    create_info.pNext                 = nullptr;
-    create_info.flags                 = 0;
-    create_info.imageType             = type;
-    create_info.format                = GetImageAspectFormat(format, aspect);
-    create_info.extent                = extent;
-    create_info.mipLevels             = 1;
-    create_info.arrayLayers           = all_layers_per_level ? array_layers : 1;
-    create_info.samples               = VK_SAMPLE_COUNT_1_BIT;
-    create_info.tiling                = tiling;
-    create_info.usage                 = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    create_info.sharingMode           = VK_SHARING_MODE_EXCLUSIVE;
-    create_info.queueFamilyIndexCount = 0;
-    create_info.pQueueFamilyIndices   = nullptr;
-    create_info.initialLayout         = VK_IMAGE_LAYOUT_UNDEFINED;
+    uint64_t       resource_size     = 0;
+    uint32_t       subresource_idx   = 0;
+    const uint32_t subresource_count = all_layers_per_level ? mip_levels : (mip_levels * array_layers);
 
     for (uint32_t m = 0; m < mip_levels; ++m)
     {
-        create_info.extent.width  = std::max(1u, (extent.width >> m));
-        create_info.extent.height = std::max(1u, (extent.height >> m));
-        create_info.extent.depth  = std::max(1u, (extent.depth >> m));
+        const VkExtent3D mip_extent = {
+            std::max(1u, (extent.width >> m)),
+            std::max(1u, (extent.height >> m)),
+            std::max(1u, (extent.depth >> m))
+        };
 
-        VkImage  temp_image;
-        VkResult result = device_table_.CreateImage(device_, &create_info, nullptr, &temp_image);
-        if (result != VK_SUCCESS)
-        {
-            GFXRECON_LOG_ERROR("VulkanResourcesUtil::%s() Failed creating VkImage", __func__)
+        // Compute exact bytes copied for one tightly-packed region.
+        VkImageToMemoryCopy copy_region{};
+        copy_region.memoryRowLength                 = 0;
+        copy_region.memoryImageHeight               = 0;
+        copy_region.imageExtent                     = mip_extent;
+        copy_region.imageSubresource.aspectMask     = aspect;
+        copy_region.imageSubresource.baseArrayLayer = 0;
+        copy_region.imageSubresource.layerCount     = all_layers_per_level ? array_layers : 1;
 
-            if (subresource_offsets != nullptr)
-            {
-                subresource_offsets->clear();
-            }
-
-            if (subresource_sizes != nullptr)
-            {
-                subresource_sizes->clear();
-            }
-
-            return 0;
-        }
-
-        VkMemoryRequirements memory_requirements;
-        device_table_.GetImageMemoryRequirements(device_, temp_image, &memory_requirements);
+        const uint64_t tight_copy_size = GetBufferSizeFromCopyImage(copy_region, array_layers, format);
 
         for (uint32_t l = 0; l < array_layers; ++l)
         {
+            // Apply Vulkan alignment per subresource region offset.
+            resource_size = AlignBufferOffset(resource_size, copy_alignment);
+
             if (subresource_offsets != nullptr)
             {
                 subresource_offsets->push_back(resource_size);
             }
 
-            if (subresource_sizes != nullptr)
+            const bool is_last_subresource = (subresource_idx + 1 == subresource_count);
+
+            // Preserve tight sizes for layer-by-layer callers, but emit padded per-level strides when
+            // all_layers_per_level=true so serialized level_sizes can reconstruct aligned offsets at replay.
+            uint64_t size_for_output = tight_copy_size;
+            if (all_layers_per_level && !is_last_subresource)
             {
-                subresource_sizes->push_back(memory_requirements.size);
+                const uint64_t next_offset = AlignBufferOffset(resource_size + tight_copy_size, copy_alignment);
+                size_for_output            = next_offset - resource_size;
             }
 
-            resource_size += memory_requirements.size;
+            if (subresource_sizes != nullptr)
+            {
+                subresource_sizes->push_back(size_for_output);
+            }
+
+            resource_size += size_for_output;
+            ++subresource_idx;
 
             if (all_layers_per_level)
             {
                 break;
             }
         }
-
-        device_table_.DestroyImage(device_, temp_image, nullptr);
     }
 
     return resource_size;
@@ -1388,6 +1381,7 @@ void VulkanResourcesUtil::TransitionImageFromTransferOptimal(VkCommandBuffer    
 
 void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_buffer,
                                           VkImage                      image,
+                                          VkFormat                     format,
                                           VkBuffer                     buffer,
                                           VkDeviceSize                 buffer_offset,
                                           const VkExtent3D&            extent,
@@ -1409,12 +1403,14 @@ void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_b
     VkBufferImageCopy copy_region;
     copy_region.bufferRowLength             = 0; // Request tightly packed data.
     copy_region.bufferImageHeight           = 0; // Request tightly packed data.
-    copy_region.bufferOffset                = buffer_offset;
     copy_region.imageOffset.x               = 0;
     copy_region.imageOffset.y               = 0;
     copy_region.imageOffset.z               = 0;
     copy_region.imageSubresource.aspectMask = aspect;
     copy_region.imageSubresource.layerCount = all_layers_per_level ? array_layers : 1;
+
+    const VkDeviceSize copy_alignment = GetBufferImageCopyOffsetAlignment(format, aspect);
+    VkDeviceSize       current_offset = buffer_offset;
 
     uint32_t sr = 0;
     for (uint32_t m = 0; m < mip_levels; ++m)
@@ -1426,10 +1422,14 @@ void VulkanResourcesUtil::CopyImageBuffer(VkCommandBuffer              command_b
 
         for (uint32_t l = 0; l < array_layers; ++l)
         {
+            // Vulkan validates bufferOffset alignment per region. Align each subresource offset,
+            // not just the start of the staging buffer.
+            current_offset                              = AlignBufferOffset(current_offset, copy_alignment);
+            copy_region.bufferOffset                    = current_offset;
             copy_region.imageSubresource.baseArrayLayer = l;
             copy_regions.push_back(copy_region);
 
-            copy_region.bufferOffset += sizes[sr];
+            current_offset += sizes[sr];
             ++sr;
 
             if (all_layers_per_level)
@@ -1829,7 +1829,7 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
         }
     };
     std::vector<image_resource_tmp_data_t> tmp_data(image_resources.size());
-    uint32_t                               current_batch_size = 0;
+    VkDeviceSize                           current_batch_size = 0;
 
     // start with entire range
     std::vector<std::pair<uint32_t, uint32_t>> batch_ranges = { { 0, static_cast<uint32_t>(image_resources.size()) } };
@@ -1873,7 +1873,6 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
         else if (resource_size == 0 || img.level_sizes == nullptr)
         {
             resource_size = GetImageResourceSizesOptimal(tmp_data[i].use_blit ? dst_format : img.format,
-                                                         img.type,
                                                          tmp_data[i].use_blit ? tmp_data[i].scaled_extent : img.extent,
                                                          img.level_count,
                                                          img.layer_count,
@@ -1884,13 +1883,21 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
                                                          img.all_layers_per_level);
         }
 
+        VkDeviceSize aligned_batch_offset = current_batch_size;
+        if (!img.external_format)
+        {
+            const VkFormat     copy_format    = tmp_data[i].use_blit ? dst_format : img.format;
+            const VkDeviceSize copy_alignment = GetBufferImageCopyOffsetAlignment(copy_format, img.aspect);
+            aligned_batch_offset              = AlignBufferOffset(current_batch_size, copy_alignment);
+        }
+
         if (resource_size > staging_buffer_size)
         {
             // we need a bigger boat
             staging_buffer_size = resource_size;
         }
 
-        if (current_batch_size + resource_size > staging_buffer_size)
+        if (aligned_batch_offset + resource_size > staging_buffer_size)
         {
             // end current batch, start next
             auto& current_batch  = batch_ranges.back();
@@ -1898,6 +1905,10 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
 
             auto& next_batch   = batch_ranges.emplace_back(i, static_cast<uint32_t>(image_resources.size()));
             current_batch_size = 0;
+        }
+        else
+        {
+            current_batch_size = aligned_batch_offset;
         }
 
         tmp_data[i].resource_size  = resource_size;
@@ -2023,6 +2034,7 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
                 // Copy image to staging buffer
                 CopyImageBuffer(command_buffer,
                                 copy_image,
+                                tmp_data[i].use_blit ? dst_format : img.format,
                                 staging_buffer_.buffer,
                                 tmp_data[i].staging_offset,
                                 tmp_data[i].scaling_supported ? tmp_data[i].scaled_extent : img.extent,

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -64,17 +64,19 @@ class VulkanResourcesUtil
     VkResult CreateStagingBuffer(VkDeviceSize size);
 
     // Will return the size requirements and offsets for each subresource contained for an image with the specified
-    // attributes. Sizes and offsets are calculated in such a way that the each subresource will be tightly packed.
+    // attributes. Offsets are Vulkan-valid copy offsets for VkBufferImageCopy regions.
     //
     // The sizes are returned in the subresource_sizes vector and will be in the order:
     //    M0 L0 L1 ... La M1 L0 L1 ... La ... Mm L0 L1 ... La
     // Where M denotes the mip map levels and L the array layers.
+    // - With all_layers_per_level=false, each entry is the tightly-packed payload bytes for that subresource.
+    // - With all_layers_per_level=true, each entry is the serialized per-mip stride used by init-image commands;
+    //   intermediate entries may include padding so replay can reconstruct aligned buffer offsets.
     // The offsets will be returned in the subresource_offsets vector in the same manner.
     // all_layers_per_level boolean determines if all array layer per mip map level will be accounted as one.
     //
     // Return value is the total size of the image.
     uint64_t GetImageResourceSizesOptimal(VkFormat               format,
-                                          VkImageType            type,
                                           const VkExtent3D&      extent,
                                           uint32_t               mip_levels,
                                           uint32_t               array_layers,
@@ -238,6 +240,7 @@ class VulkanResourcesUtil
 
     void CopyImageBuffer(VkCommandBuffer              command_buffer,
                          VkImage                      image,
+                         VkFormat                     format,
                          VkBuffer                     buffer,
                          VkDeviceSize                 buffer_offset,
                          const VkExtent3D&            extent,

--- a/framework/graphics/vulkan_util.cpp
+++ b/framework/graphics/vulkan_util.cpp
@@ -23,6 +23,8 @@
 #include "graphics/vulkan_util.h"
 #include "graphics/vulkan_struct_get_pnext.h"
 
+#include "Vulkan-Utility-Libraries/vk_format_utils.h"
+
 #include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -51,6 +53,70 @@ void ReleaseLoader(util::platform::LibraryHandle loader_handle)
 bool ImageHasUsage(VkImageUsageFlags usage_flags, VkImageUsageFlagBits bit)
 {
     return (usage_flags & bit) == bit;
+}
+
+VkDeviceSize AlignBufferOffset(VkDeviceSize offset, VkDeviceSize alignment)
+{
+    // Vulkan only specifies alignments for buffer-image copies. Use modulo math so
+    // non-power-of-two alignments (e.g. 3-byte RGB formats) are handled correctly.
+    GFXRECON_ASSERT(alignment > 0);
+
+    if (alignment <= 1)
+    {
+        return offset;
+    }
+
+    const VkDeviceSize remainder = offset % alignment;
+    if (remainder == 0)
+    {
+        return offset;
+    }
+
+    return offset + (alignment - remainder);
+}
+
+VkDeviceSize GetBufferImageCopyOffsetAlignment(VkFormat format, VkImageAspectFlags aspect_mask)
+{
+    if (format == VK_FORMAT_UNDEFINED)
+    {
+        // Defensive fallback for external-format images where no concrete VkFormat is available.
+        return 1;
+    }
+
+    if (vkuFormatIsDepthOrStencil(format))
+    {
+        // Vulkan requires 4-byte bufferOffset alignment for depth/stencil image copies.
+        return 4;
+    }
+
+    if (vkuFormatIsMultiplane(format))
+    {
+        // For multiplane formats, alignment comes from the selected plane's compatible format.
+        VkImageAspectFlagBits plane_aspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
+        if ((aspect_mask & VK_IMAGE_ASPECT_PLANE_1_BIT) != 0)
+        {
+            plane_aspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
+        }
+        else if ((aspect_mask & VK_IMAGE_ASPECT_PLANE_2_BIT) != 0)
+        {
+            plane_aspect = VK_IMAGE_ASPECT_PLANE_2_BIT;
+        }
+
+        const VkFormat compatible_format = vkuFindMultiplaneCompatibleFormat(format, plane_aspect);
+        GFXRECON_ASSERT(compatible_format != VK_FORMAT_UNDEFINED);
+        if (compatible_format != VK_FORMAT_UNDEFINED)
+        {
+            const VKU_FORMAT_INFO format_info = vkuGetFormatInfo(compatible_format);
+            GFXRECON_ASSERT(format_info.block_size > 0);
+            return format_info.block_size;
+        }
+
+        return 1;
+    }
+
+    const VKU_FORMAT_INFO format_info = vkuGetFormatInfo(format);
+    GFXRECON_ASSERT(format_info.block_size > 0);
+    return format_info.block_size;
 }
 
 uint32_t FindTransferQueueFamilyIndex(const VulkanQueueFamilyFlags& families)

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -62,6 +62,18 @@ void ReleaseLoader(util::platform::LibraryHandle loader_handle);
 
 bool ImageHasUsage(VkImageUsageFlags usage_flags, VkImageUsageFlagBits bit);
 
+// Aligns a byte offset up to the next multiple of `alignment`.
+// Unlike util::platform::GetAlignedSize, this helper is safe for non-power-of-two alignments
+// (for example, 3-byte RGB formats).
+VkDeviceSize AlignBufferOffset(VkDeviceSize offset, VkDeviceSize alignment);
+
+// Returns the Vulkan-mandated VkBufferImageCopy::bufferOffset alignment for a format/aspect pair.
+// This must be applied to every copy region offset (not only the first one):
+// - depth/stencil formats => 4-byte alignment
+// - multiplane formats    => block size of the selected compatible plane format
+// - all other formats     => block size of the format
+VkDeviceSize GetBufferImageCopyOffsetAlignment(VkFormat format, VkImageAspectFlags aspect_mask);
+
 /**
  * @brief   copy_dispatch_table_from_device can be used if a command-buffer was not allocated through the loader,
  *          in order to assign the dispatch table from an existing VkDevice.


### PR DESCRIPTION
Current behavior
* image init offset logic is split across multiple paths and not consistently applied per VkBufferImageCopy region
* one path relied on a power of two alignment helper which is incorrect for some vulkan formats
* copy size command could use values that did not always map to actual tightly packed copy bytes
* this could produce invalid buffer offsets for some formats and lead to validation errors and corrupted image initialization

This change
* adds shared Vulkan copy layout helpers
 * AlignBufferOffset with modulo based align up valid for any positive alignment
 * GetBufferImageCopyOffsetAlignment covering depth stencil multiplane and regular format rules
* switches decode and replay init image offset construction to use the shared helpers
* updates copy region generation to align every region offset not only the initial staging offset
* updates image sizes and offsets to compute payload bytes from buffer image copy rules and produce aligned subresource offsets
* adds a fallback path for traces captured with previous implementation

Affects trimming and dump resource features