### PR TITLE
Fix macOS build with SDK installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,7 +414,15 @@ if(MSVC)
 endif()
 
 add_library(vulkan_registry INTERFACE)
-target_include_directories(vulkan_registry SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include)
+if (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang)
+    # AppleClang implicitly adds /usr/local/include as a -I path, which takes precedence
+    # over -isystem paths. Add external/Vulkan-Headers as a normal -I path for the correct
+    # search order, then use --system-header-prefix to treat it as a system header for warnings
+    target_include_directories(vulkan_registry INTERFACE ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include)
+    target_compile_options(vulkan_registry INTERFACE --system-header-prefix vulkan/)
+else ()
+    target_include_directories(vulkan_registry SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include)
+endif()
 target_compile_definitions(vulkan_registry INTERFACE VK_NO_PROTOTYPES VK_ENABLE_BETA_EXTENSIONS)
 
 add_library(spirv_registry INTERFACE)


### PR DESCRIPTION
Due to a quirk in AppleClang, the header include order was incorrect and used Vulkan headers in /usr/local/include from the system global SDK install instead of the local copy in external/Vulkan-Headers/include.

Fixes #2296