### PR TITLE
improve code style check

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -57,7 +57,7 @@ jobs:
         cmakeVersion: 3.24
     - name: Run build script
       run: |
-        if [ "${{ matrix.config.type }}" == "release" ]
+        if [ "${{ matrix.config.type }}" == "debug" ]
         then
           clang-format-14 --version
           git fetch origin ${{ github.base_ref }} # Fetch target branch to FETCH_HEAD for code style check.
@@ -140,6 +140,15 @@ jobs:
     - name: Set WindowsSDKVersion
       run:
         echo ("WindowsSDKVersion=10.0.26100.0\") >> $env:GITHUB_ENV
+    - name: Install clang-format
+      uses: aminya/setup-cpp@v1
+      with:
+        clang-format: 14.0.0
+    - name: Create clang-format-14 alias
+      shell: pwsh
+      run: |
+        $target = (Get-Command clang-format).Source
+        Copy-Item $target (Join-Path (Split-Path $target) "clang-format-14.exe")
     - name: Clone repository from merge of PR branch and dev branch
       uses: actions/checkout@v4
       with:
@@ -150,7 +159,13 @@ jobs:
         git diff --exit-code
     - name: Run build script
       run: |
-        python scripts\build.py --skip-check-code-style --config ${{ matrix.config.type }} --parallel 0 --test-apps
+        if ("${{ matrix.config.type }}" -eq "release") {
+          python scripts\build.py --skip-check-code-style --config ${{ matrix.config.type }} --parallel 0 --test-apps
+        } else {
+          clang-format-14 --version
+          git fetch origin ${{ github.base_ref }} # Fetch target branch to FETCH_HEAD for code style check.
+          python scripts\build.py --config ${{ matrix.config.type }} --check-code-style-base FETCH_HEAD --parallel 0 --test-apps
+        }
     - name: Run test app test cases
       id: test_apps
       run: |

--- a/cmake/CodeStyle.cmake
+++ b/cmake/CodeStyle.cmake
@@ -76,7 +76,7 @@ function(target_code_style_build_directives TARGET)
                     COMMAND "${PYTHON}" ${PROJECT_SOURCE_DIR}/scripts/check_code_style.py
                     --sourcefile ${TARGET_SRC_FILES} --base ${CHECK_CPP_CODE_STYLE_BASE}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-                    COMMENT "Check code style for ${TARGET}")
+                    COMMENT "Check code style for ${TARGET}" VERBATIM)
             add_dependencies(${TARGET} "${TARGET}CodeStyleCheck")
         endif()
     endif()

--- a/scripts/check_code_style.py
+++ b/scripts/check_code_style.py
@@ -38,14 +38,19 @@ def check_code_style(file_list, compare_base, style_script=None, style_config_di
     """
     git_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", compare_base]).strip()
     if git_branch == b'':
-        git_branch = "master"
+        git_branch = compare_base
+    else:
+        git_branch = str(git_branch, 'utf-8')
+
     if not style_script:
         # Look for the clang-format-diff.py script in the same directory as the calling script
         style_script = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), "clang-format-diff.py")
+
     if not style_config_dir:
         # Use the script directory's parent directory as the .clang-format file location
         style_config_dir = os.path.join(os.path.dirname(style_script), os.pardir)
-    diff_cmd = ["git", "diff", "-U0", str(git_branch, 'utf-8'), "--"] + file_list
+
+    diff_cmd = ["git", "diff", "-U0", git_branch, "--"] + file_list
     style_cmd = [sys.executable, style_script,"-p1","-style=file"]
     try:
         diff_process = subprocess.Popen(diff_cmd, stdout=subprocess.PIPE)


### PR DESCRIPTION
* escape parameters to code style CLI to survive vcxproj
* allow arbitrary hashes for code style check if run from CLI
* also run style check on Windows to pick up DirectX changes
* run code checks in GCC debug build job (presumably quicker)