### PR TITLE
Fix fast-forwarding of `vkTransitionImageLayout[EXT]`

### DIFF
--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -1917,6 +1917,26 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBeginCommandBuffer>
 
 #endif // ENABLE_OPENXR_SUPPORT
 
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkTransitionImageLayout>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkTransitionImageLayout(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkTransitionImageLayoutEXT>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkTransitionImageLayout(result, args...);
+    }
+};
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -4455,5 +4455,19 @@ bool VulkanCaptureManager::IsValidFence(VkFence fence)
 
 #endif
 
+void VulkanCaptureManager::PostProcess_vkTransitionImageLayout(VkResult                               result,
+                                                               VkDevice                               device,
+                                                               uint32_t                               transitionCount,
+                                                               const VkHostImageLayoutTransitionInfo* pTransitions)
+{
+    if (result == VK_SUCCESS)
+    {
+        if (IsCaptureModeTrack())
+        {
+            state_tracker_->TrackTransitionImageLayout(transitionCount, pTransitions);
+        }
+    }
+}
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1747,6 +1747,11 @@ class VulkanCaptureManager : public ApiCaptureManager
     void OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);
 #endif
 
+    void PostProcess_vkTransitionImageLayout(VkResult                               result,
+                                             VkDevice                               device,
+                                             uint32_t                               transitionCount,
+                                             const VkHostImageLayoutTransitionInfo* pTransitions);
+
   protected:
     VulkanCaptureManager() : ApiCaptureManager(format::ApiFamilyId::ApiFamily_Vulkan) {}
 

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -4082,5 +4082,18 @@ void VulkanStateTracker::TrackBeginCommandBuffer(VkCommandBuffer command_buffer,
     }
 }
 
+void VulkanStateTracker::TrackTransitionImageLayout(uint32_t                               transitionCount,
+                                                    const VkHostImageLayoutTransitionInfo* pTransitions)
+{
+    for (uint32_t i = 0; i < transitionCount; ++i)
+    {
+        auto wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::ImageWrapper>(pTransitions[i].image);
+        if (wrapper != nullptr)
+        {
+            wrapper->current_layout = pTransitions[i].newLayout;
+        }
+    }
+}
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -764,6 +764,8 @@ class VulkanStateTracker
 
     void TrackBeginCommandBuffer(VkCommandBuffer command_buffer, VkCommandBufferUsageFlags flags);
 
+    void TrackTransitionImageLayout(uint32_t transitionCount, const VkHostImageLayoutTransitionInfo* pTransitions);
+
   private:
     template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
     void AddGroupHandles(ParentHandle                        parent_handle,


### PR DESCRIPTION
Fix `VkImage` layout tracking for which `vkTransitionImageLayout[EXT]` calls were forgotten.