### PR TITLE
Add appops write-settings to readme

### DIFF
--- a/HOWTO_android.md
+++ b/HOWTO_android.md
@@ -366,6 +366,7 @@ of legacy storage access:
 
 ```bash
 adb shell appops set com.lunarg.gfxreconstruct.replay android:legacy_storage allow
+adb shell appops write-settings
 ```
 
 ##### Android 11 and Newer
@@ -377,6 +378,7 @@ opens up:
 
 ```bash
 adb shell appops set com.lunarg.gfxreconstruct.replay MANAGE_EXTERNAL_STORAGE allow
+adb shell appops write-settings
 ```
 
 ### 9. Run the replay


### PR DESCRIPTION
On Android appops settings are not persisted across reboots unless they are explicitely written. Hence the adb shell appops set xxx commands in the HOWTO_android.md did work, but only until the device was rebooted. This simply adds the appops write-settings commands to the readme.