### PR TITLE
Missing tool override for Vulkan 1.3 vkGetPhysicalDeviceToolProperties

### DIFF
--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -7051,7 +7051,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolProperties(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceToolProperties>::Dispatch(manager, physicalDevice, pToolCount, pToolProperties);
 
-    VkResult result = vulkan_wrappers::GetInstanceTable(physicalDevice)->GetPhysicalDeviceToolProperties(physicalDevice, pToolCount, pToolProperties);
+    VkResult result = manager->OverrideGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties);
     if (result < 0)
     {
         omit_output_data = true;

--- a/framework/generated/khronos_generators/vulkan_generators/capture_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/capture_overrides.json
@@ -8,6 +8,7 @@
         "vkCreateSampler": "manager->OverrideCreateSampler",
         "vkAllocateMemory": "manager->OverrideAllocateMemory",
         "vkGetPhysicalDeviceToolPropertiesEXT": "manager->OverrideGetPhysicalDeviceToolPropertiesEXT",
+        "vkGetPhysicalDeviceToolProperties": "manager->OverrideGetPhysicalDeviceToolPropertiesEXT",
         "vkCreateAccelerationStructureKHR": "manager->OverrideCreateAccelerationStructureKHR",
         "vkGetDeferredOperationResultKHR": "manager->OverrideGetDeferredOperationResultKHR",
         "vkDeferredOperationJoinKHR": "manager->OverrideDeferredOperationJoinKHR",


### PR DESCRIPTION
It does exist for vkGetPhysicalDeviceToolPropertiesEXT, though. Mapping the core handling to the EXT override now.