### PR TITLE
Add missing support for vkGetImageSubresourceLayout2 and vkCmdBindDescriptorSets2

### DIFF
--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -928,6 +928,29 @@ void VulkanResourceTrackingConsumer::Process_vkGetImageSubresourceLayout(
         pSubresource->GetPointer(), layout_capture_time, &subresource_layout_playback_time);
 }
 
+void VulkanResourceTrackingConsumer::Process_vkGetImageSubresourceLayout2(
+    const ApiCallInfo&                                  call_info,
+    format::HandleId                                    device,
+    format::HandleId                                    image,
+    StructPointerDecoder<Decoded_VkImageSubresource2>*  pSubresource,
+    StructPointerDecoder<Decoded_VkSubresourceLayout2>* pLayout)
+{
+    auto                 device_info = GetTrackedObjectInfoTable()->GetTrackedVkDeviceInfo(device);
+    auto                 image_info  = GetTrackedObjectInfoTable()->GetTrackedVkResourceInfo(image);
+    VkDevice             in_device   = device_info->GetHandleId();
+    VkImage              in_image    = image_info->GetImageReplayHandleId();
+    VkSubresourceLayout2 subresource_layout_playback_time;
+    auto                 layout_capture_time = pLayout->GetPointer();
+
+    GFXRECON_ASSERT(layout_capture_time);
+
+    GetDeviceTable(in_device)->GetImageSubresourceLayout2(
+        in_device, in_image, pSubresource->GetPointer(), &subresource_layout_playback_time);
+    image_info->SetImageSubresourceLayout(&pSubresource->GetPointer()->imageSubresource,
+                                          &layout_capture_time->subresourceLayout,
+                                          &subresource_layout_playback_time.subresourceLayout);
+}
+
 void VulkanResourceTrackingConsumer::Process_vkGetImageSubresourceLayout2KHR(
     const ApiCallInfo&                                     call_info,
     format::HandleId                                       device,

--- a/framework/decode/vulkan_resource_tracking_consumer.h
+++ b/framework/decode/vulkan_resource_tracking_consumer.h
@@ -193,6 +193,12 @@ class VulkanResourceTrackingConsumer : public VulkanConsumer
                                             StructPointerDecoder<Decoded_VkImageSubresource2KHR>*  pSubresource,
                                             StructPointerDecoder<Decoded_VkSubresourceLayout2KHR>* pLayout) override;
 
+    void Process_vkGetImageSubresourceLayout2(const ApiCallInfo&                                  call_info,
+                                              format::HandleId                                    device,
+                                              format::HandleId                                    image,
+                                              StructPointerDecoder<Decoded_VkImageSubresource2>*  pSubresource,
+                                              StructPointerDecoder<Decoded_VkSubresourceLayout2>* pLayout) override;
+
     void Process_vkGetPhysicalDeviceProperties(
         const ApiCallInfo&                                        call_info,
         format::HandleId                                          physicalDevice,

--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -1495,6 +1495,16 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndirect>
 };
 
 template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindDescriptorSets2>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdBindDescriptorSets2(args...);
+    }
+};
+
+template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirect>
 {
     template <typename... Args>

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -4025,7 +4025,16 @@ void VulkanCaptureManager::PostProcess_vkCmdBindDescriptorSets2KHR(
 {
     if (IsCaptureModeTrack())
     {
-        state_tracker_->TrackCmdBindDescriptorSets2KHR(commandBuffer, pBindDescriptorSetsInfo);
+        state_tracker_->TrackCmdBindDescriptorSets2(commandBuffer, pBindDescriptorSetsInfo);
+    }
+}
+
+void VulkanCaptureManager::PostProcess_vkCmdBindDescriptorSets2(
+    VkCommandBuffer commandBuffer, const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo)
+{
+    if (IsCaptureModeTrack())
+    {
+        state_tracker_->TrackCmdBindDescriptorSets2(commandBuffer, pBindDescriptorSetsInfo);
     }
 }
 

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1479,6 +1479,9 @@ class VulkanCaptureManager : public ApiCaptureManager
     void PostProcess_vkCmdBindDescriptorSets2KHR(VkCommandBuffer                    commandBuffer,
                                                  const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo);
 
+    void PostProcess_vkCmdBindDescriptorSets2(VkCommandBuffer                 commandBuffer,
+                                              const VkBindDescriptorSetsInfo* pBindDescriptorSetsInfo);
+
     void PostProcess_vkCmdCopyBuffer(VkCommandBuffer     commandBuffer,
                                      VkBuffer            srcBuffer,
                                      VkBuffer            dstBuffer,

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -2621,8 +2621,8 @@ void VulkanStateTracker::TrackCmdBindDescriptorSets(VkCommandBuffer        comma
     }
 }
 
-void VulkanStateTracker::TrackCmdBindDescriptorSets2KHR(VkCommandBuffer                    commandBuffer,
-                                                        const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo)
+void VulkanStateTracker::TrackCmdBindDescriptorSets2(VkCommandBuffer                    commandBuffer,
+                                                     const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo)
 {
     if (pBindDescriptorSetsInfo != nullptr && pBindDescriptorSetsInfo->pDescriptorSets != nullptr &&
         commandBuffer != VK_NULL_HANDLE)

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -511,9 +511,6 @@ class VulkanStateTracker
                                     uint32_t               dynamicOffsetCount,
                                     const uint32_t*        pDynamicOffsets);
 
-    void TrackCmdBindDescriptorSets2KHR(VkCommandBuffer                    commandBuffer,
-                                        const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo);
-
     void TrackCmdBindDescriptorSets2(VkCommandBuffer                 commandBuffer,
                                      const VkBindDescriptorSetsInfo* pBindDescriptorSetsInfo);
 

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -514,6 +514,9 @@ class VulkanStateTracker
     void TrackCmdBindDescriptorSets2KHR(VkCommandBuffer                    commandBuffer,
                                         const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo);
 
+    void TrackCmdBindDescriptorSets2(VkCommandBuffer                 commandBuffer,
+                                     const VkBindDescriptorSetsInfo* pBindDescriptorSetsInfo);
+
     void
     TrackCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline);
 


### PR DESCRIPTION
These two Vulkan 1.4 commands have support for their extension variants but lack similar support for their core command variants.