### PR TITLE
Fix dynamic rendering resource dumps

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -1776,7 +1776,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBeginRendering(
         dc_context->GetDrawCallActiveCommandBuffers(first, last);
         for (CommandBufferIterator it = first; it < last; ++it)
         {
-            func(*it, pRenderingInfo->GetPointer());
+            dc_context->RecordCmdBeginRendering(*it, pRenderingInfo->GetPointer());
         }
     }
 
@@ -1815,12 +1815,14 @@ void VulkanReplayDumpResourcesBase::OverrideCmdEndRendering(const ApiCallInfo&  
         {
             dc_context->EndRendering();
         }
-
-        CommandBufferIterator first, last;
-        dc_context->GetDrawCallActiveCommandBuffers(first, last);
-        for (CommandBufferIterator it = first; it < last; ++it)
+        else
         {
-            func(*it);
+            CommandBufferIterator first, last;
+            dc_context->GetDrawCallActiveCommandBuffers(first, last);
+            for (CommandBufferIterator it = first; it < last; ++it)
+            {
+                dc_context->RecordCmdEndRendering(*it);
+            }
         }
     }
 

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -157,6 +157,55 @@ void DrawCallsDumpingContext::Release()
     current_cb_index_   = 0;
 }
 
+PFN_vkCmdBeginRendering DrawCallsDumpingContext::ResolveCmdBeginRendering() const
+{
+    if (device_table_->CmdBeginRendering != graphics::noop::vkCmdBeginRendering)
+    {
+        return device_table_->CmdBeginRendering;
+    }
+
+    if (device_table_->CmdBeginRenderingKHR != graphics::noop::vkCmdBeginRenderingKHR)
+    {
+        return device_table_->CmdBeginRenderingKHR;
+    }
+
+    return nullptr;
+}
+
+PFN_vkCmdEndRendering DrawCallsDumpingContext::ResolveCmdEndRendering() const
+{
+    if (device_table_->CmdEndRendering != graphics::noop::vkCmdEndRendering)
+    {
+        return device_table_->CmdEndRendering;
+    }
+
+    if (device_table_->CmdEndRenderingKHR != graphics::noop::vkCmdEndRenderingKHR)
+    {
+        return device_table_->CmdEndRenderingKHR;
+    }
+
+    return nullptr;
+}
+
+void DrawCallsDumpingContext::RecordCmdBeginRendering(VkCommandBuffer        command_buffer,
+                                                      const VkRenderingInfo* rendering_info) const
+{
+    const PFN_vkCmdBeginRendering cmd_begin_rendering = ResolveCmdBeginRendering();
+    if (cmd_begin_rendering != nullptr)
+    {
+        cmd_begin_rendering(command_buffer, rendering_info);
+    }
+}
+
+void DrawCallsDumpingContext::RecordCmdEndRendering(VkCommandBuffer command_buffer) const
+{
+    const PFN_vkCmdEndRendering cmd_end_rendering = ResolveCmdEndRendering();
+    if (cmd_end_rendering != nullptr)
+    {
+        cmd_end_rendering(command_buffer);
+    }
+}
+
 DrawCallsDumpingContext::DrawCallParams* DrawCallsDumpingContext::InsertNewDrawParameters(
     uint64_t index, uint32_t vertex_count, uint32_t instance_count, uint32_t first_vertex, uint32_t first_instance)
 {
@@ -1002,7 +1051,7 @@ void DrawCallsDumpingContext::FinalizeCommandBuffer(DrawCallsDumpingContext::Dra
     }
     else if (current_render_pass_type_ == RenderPassType::kDynamicRendering)
     {
-        device_table_->CmdEndRenderingKHR(current_command_buffer);
+        RecordCmdEndRendering(current_command_buffer);
 
         // Transition render targets into TRANSFER_SRC_OPTIMAL
         assert(current_renderpass_ == render_targets_.size() - 1);
@@ -3403,7 +3452,7 @@ void DrawCallsDumpingContext::EndRendering()
     size_t cmd_buf_idx = current_cb_index_;
     for (auto it = first; it < last; ++it, ++cmd_buf_idx)
     {
-        device_table_->CmdEndRendering(*it);
+        RecordCmdEndRendering(*it);
     }
 
     ++current_renderpass_;

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -173,6 +173,10 @@ class DrawCallsDumpingContext
 
     void EndRendering();
 
+    void RecordCmdBeginRendering(VkCommandBuffer command_buffer, const VkRenderingInfo* rendering_info) const;
+
+    void RecordCmdEndRendering(VkCommandBuffer command_buffer) const;
+
     void BindVertexBuffers(uint64_t                                    index,
                            uint32_t                                    firstBinding,
                            const std::vector<const VulkanBufferInfo*>& buffer_infos,
@@ -290,6 +294,10 @@ class DrawCallsDumpingContext
     void ReleaseIndirectParams();
 
     void ResetFetchedIndirectParams();
+
+    PFN_vkCmdBeginRendering ResolveCmdBeginRendering() const;
+
+    PFN_vkCmdEndRendering ResolveCmdEndRendering() const;
 
     VkResult BackUpMutableResources(VkQueue queue);
 


### PR DESCRIPTION
Prevent insertion of two EndRendering commands when dumping resources of dynamic rendering traces

Use Begin/EndRendering aliases for internal calls when one is available but the other isn't