### PR TITLE
VDR: Enable filtering out all descriptors

### DIFF
--- a/tools/replay/parse_dump_resources_cli.cpp
+++ b/tools/replay/parse_dump_resources_cli.cpp
@@ -34,6 +34,7 @@
 #include <cctype>
 #include <cstdint>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 #include <set>
@@ -337,6 +338,9 @@ static void ExtractIndexAndDescriptors(const json_iterator                  it,
 
         if (it->contains("Descriptors"))
         {
+            command_subresources.emplace(
+                std::piecewise_construct, std::forward_as_tuple(cmd_index), std::forward_as_tuple());
+
             const auto& subresources = it->at("Descriptors");
             for (const auto& sr : subresources)
             {


### PR DESCRIPTION
Providing an empty "Descriptors" array in the input json will filter out all descriptors for this call