### PR TITLE
[Frame looping] Reset descriptor pools that are allocated from during the looping frame

### DIFF
--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -325,7 +325,6 @@ void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
     StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
 {
     // Get device
-    Decoded_VkPresentInfoKHR* meta       = pPresentInfo->GetMetaStructPointer();
     CommonObjectInfoTable&    table      = GetObjectInfoTable();
     VulkanQueueInfo*          queue_info = table.GetVkQueueInfo(queue);
     VkDevice                  device     = queue_info->parent;

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -302,5 +302,48 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(
         call_info, returnValue, device, pCreateInfo, pAllocator, pCommandPool);
 }
 
+void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
+    const ApiCallInfo&                          call_info,
+    VkResult                                    returnValue,
+    format::HandleId                            device,
+    StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
+    HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets)
+{
+    VulkanReplayConsumer::Process_vkAllocateDescriptorSets(call_info, returnValue, device, pAllocateInfo, pDescriptorSets);
+    if (frame_loop_info_.IsLooping())
+    {
+        VkDescriptorPool pool = pAllocateInfo->GetPointer()->descriptorPool;
+        active_descriptor_pools_.insert(pool);
+    }
+}
+
+void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
+    const ApiCallInfo&                          call_info,
+    VkResult                                    returnValue,
+    format::HandleId                            queue,
+    StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
+{
+    // Get device
+    Decoded_VkPresentInfoKHR *meta = pPresentInfo->GetMetaStructPointer();
+    CommonObjectInfoTable& table = GetObjectInfoTable();
+    const auto swapchain_info = table.GetVkSwapchainKHRInfo(meta->pSwapchains.GetPointer()[0]);
+    VkDevice device = swapchain_info->device_info->handle;
+    GFXRECON_ASSERT(device);
+    const graphics::VulkanDeviceTable *device_table = GetDeviceTable(device);
+    GFXRECON_ASSERT(device_table);
+
+    VulkanReplayConsumer::Process_vkQueuePresentKHR(call_info, returnValue, queue, pPresentInfo);
+
+    if (frame_loop_info_.IsLooping())
+    {
+        device_table->DeviceWaitIdle(device);
+        for (VkDescriptorPool pool : active_descriptor_pools_)
+        {
+            device_table->ResetDescriptorPool(device, pool, 0);
+        }
+        active_descriptor_pools_.clear();
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -325,10 +325,10 @@ void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
     StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
 {
     // Get device
-    Decoded_VkPresentInfoKHR* meta           = pPresentInfo->GetMetaStructPointer();
-    CommonObjectInfoTable&    table          = GetObjectInfoTable();
-    VulkanQueueInfo*          queue_info     = table.GetVkQueueInfo(queue);
-    VkDevice                  device         = queue_info->parent;
+    Decoded_VkPresentInfoKHR* meta       = pPresentInfo->GetMetaStructPointer();
+    CommonObjectInfoTable&    table      = GetObjectInfoTable();
+    VulkanQueueInfo*          queue_info = table.GetVkQueueInfo(queue);
+    VkDevice                  device     = queue_info->parent;
     GFXRECON_ASSERT(device);
     const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device);
     GFXRECON_ASSERT(device_table);

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -325,9 +325,9 @@ void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
     StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
 {
     // Get device
-    CommonObjectInfoTable&    table      = GetObjectInfoTable();
-    VulkanQueueInfo*          queue_info = table.GetVkQueueInfo(queue);
-    VkDevice                  device     = queue_info->parent;
+    CommonObjectInfoTable& table      = GetObjectInfoTable();
+    VulkanQueueInfo*       queue_info = table.GetVkQueueInfo(queue);
+    VkDevice               device     = queue_info->parent;
     GFXRECON_ASSERT(device);
     const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device);
     GFXRECON_ASSERT(device_table);

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -325,10 +325,10 @@ void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
     StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
 {
     // Get device
-    Decoded_VkPresentInfoKHR* meta = pPresentInfo->GetMetaStructPointer();
-    CommonObjectInfoTable&    table = GetObjectInfoTable();
+    Decoded_VkPresentInfoKHR* meta           = pPresentInfo->GetMetaStructPointer();
+    CommonObjectInfoTable&    table          = GetObjectInfoTable();
     const auto                swapchain_info = table.GetVkSwapchainKHRInfo(meta->pSwapchains.GetPointer()[0]);
-    VkDevice                  device = swapchain_info->device_info->handle;
+    VkDevice                  device         = swapchain_info->device_info->handle;
     GFXRECON_ASSERT(device);
     const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device);
     GFXRECON_ASSERT(device_table);

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -303,13 +303,14 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
-    const ApiCallInfo&                          call_info,
-    VkResult                                    returnValue,
-    format::HandleId                            device,
+    const ApiCallInfo&                                         call_info,
+    VkResult                                                   returnValue,
+    format::HandleId                                           device,
     StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
-    HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets)
+    HandlePointerDecoder<VkDescriptorSet>*                     pDescriptorSets)
 {
-    VulkanReplayConsumer::Process_vkAllocateDescriptorSets(call_info, returnValue, device, pAllocateInfo, pDescriptorSets);
+    VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
+        call_info, returnValue, device, pAllocateInfo, pDescriptorSets);
     if (frame_loop_info_.IsLooping())
     {
         VkDescriptorPool pool = pAllocateInfo->GetPointer()->descriptorPool;
@@ -318,18 +319,18 @@ void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
-    const ApiCallInfo&                          call_info,
-    VkResult                                    returnValue,
-    format::HandleId                            queue,
+    const ApiCallInfo&                              call_info,
+    VkResult                                        returnValue,
+    format::HandleId                                queue,
     StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
 {
     // Get device
-    Decoded_VkPresentInfoKHR *meta = pPresentInfo->GetMetaStructPointer();
-    CommonObjectInfoTable& table = GetObjectInfoTable();
-    const auto swapchain_info = table.GetVkSwapchainKHRInfo(meta->pSwapchains.GetPointer()[0]);
-    VkDevice device = swapchain_info->device_info->handle;
+    Decoded_VkPresentInfoKHR* meta = pPresentInfo->GetMetaStructPointer();
+    CommonObjectInfoTable&    table = GetObjectInfoTable();
+    const auto                swapchain_info = table.GetVkSwapchainKHRInfo(meta->pSwapchains.GetPointer()[0]);
+    VkDevice                  device = swapchain_info->device_info->handle;
     GFXRECON_ASSERT(device);
-    const graphics::VulkanDeviceTable *device_table = GetDeviceTable(device);
+    const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device);
     GFXRECON_ASSERT(device_table);
 
     VulkanReplayConsumer::Process_vkQueuePresentKHR(call_info, returnValue, queue, pPresentInfo);

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -327,8 +327,8 @@ void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
     // Get device
     Decoded_VkPresentInfoKHR* meta           = pPresentInfo->GetMetaStructPointer();
     CommonObjectInfoTable&    table          = GetObjectInfoTable();
-    const auto                swapchain_info = table.GetVkSwapchainKHRInfo(meta->pSwapchains.GetPointer()[0]);
-    VkDevice                  device         = swapchain_info->device_info->handle;
+    VulkanQueueInfo*          queue_info     = table.GetVkQueueInfo(queue);
+    VkDevice                  device         = queue_info->parent;
     GFXRECON_ASSERT(device);
     const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device);
     GFXRECON_ASSERT(device_table);

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -160,7 +160,7 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayConsumer
                                    StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
 
   private:
-    graphics::FrameLoopInfo& frame_loop_info_;
+    graphics::FrameLoopInfo&             frame_loop_info_;
     std::unordered_set<VkDescriptorPool> active_descriptor_pools_;
 };
 

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -147,9 +147,20 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayConsumer
                                      StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
                                      StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
                                      HandlePointerDecoder<VkCommandPool>*                   pCommandPool) override;
+    void Process_vkAllocateDescriptorSets(const ApiCallInfo&                          call_info,
+                                          VkResult                                    returnValue,
+                                          format::HandleId                            device,
+                                          StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
+                                          HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
+
+    void Process_vkQueuePresentKHR(const ApiCallInfo&                          call_info,
+                                   VkResult                                    returnValue,
+                                   format::HandleId                            queue,
+                                   StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
 
   private:
     graphics::FrameLoopInfo& frame_loop_info_;
+    std::unordered_set<VkDescriptorPool> active_descriptor_pools_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -147,15 +147,16 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayConsumer
                                      StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
                                      StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
                                      HandlePointerDecoder<VkCommandPool>*                   pCommandPool) override;
-    void Process_vkAllocateDescriptorSets(const ApiCallInfo&                          call_info,
-                                          VkResult                                    returnValue,
-                                          format::HandleId                            device,
-                                          StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
-                                          HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
 
-    void Process_vkQueuePresentKHR(const ApiCallInfo&                          call_info,
-                                   VkResult                                    returnValue,
-                                   format::HandleId                            queue,
+    void Process_vkAllocateDescriptorSets(const ApiCallInfo&                                         call_info,
+                                          VkResult                                                   returnValue,
+                                          format::HandleId                                           device,
+                                          StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
+                                          HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
+
+    void Process_vkQueuePresentKHR(const ApiCallInfo&                              call_info,
+                                   VkResult                                        returnValue,
+                                   format::HandleId                                queue,
                                    StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
 
   private:


### PR DESCRIPTION
This PR fixes the frame looping case where descriptor sets are allocated on the looping frame.

Descriptor pools that are allocated from are tracked, then reset after syncing with the device post vkQueuePresentKHR()