### PR TITLE
[Frame looping] Unconditionally create command pools with VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT

### DIFF
--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -280,12 +280,12 @@ void VulkanReplayFrameLoopConsumer::ProcessCreateHardwareBufferCommand(
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(
-    const ApiCallInfo&                          call_info,
-    VkResult                                    returnValue,
-    format::HandleId                            device,
+    const ApiCallInfo&                                     call_info,
+    VkResult                                               returnValue,
+    format::HandleId                                       device,
     StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
-    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
-    HandlePointerDecoder<VkCommandPool>*        pCommandPool)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
+    HandlePointerDecoder<VkCommandPool>*                   pCommandPool)
 {
     if (frame_loop_info_.IsRepetition())
     {
@@ -298,7 +298,8 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(
     VkCommandPoolCreateInfo* create_info = pCreateInfo->GetPointer();
     create_info->flags |= VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 
-    VulkanReplayConsumer::Process_vkCreateCommandPool(call_info, returnValue, device, pCreateInfo, pAllocator, pCommandPool);
+    VulkanReplayConsumer::Process_vkCreateCommandPool(
+        call_info, returnValue, device, pCreateInfo, pAllocator, pCommandPool);
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -279,5 +279,27 @@ void VulkanReplayFrameLoopConsumer::ProcessCreateHardwareBufferCommand(
         device_id, memory_id, buffer_id, format, width, height, stride, usage, layers, plane_info);
 }
 
+void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(
+    const ApiCallInfo&                          call_info,
+    VkResult                                    returnValue,
+    format::HandleId                            device,
+    StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+    HandlePointerDecoder<VkCommandPool>*        pCommandPool)
+{
+    if (frame_loop_info_.IsLooping())
+    {
+        // Don't repeatedly recreate the command pool during the looping frame
+        return;
+    }
+
+    // Set VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT in order to prevent validation
+    // error regarding implicitly resetting the command buffer
+    VkCommandPoolCreateInfo* create_info = pCreateInfo->GetPointer();
+    create_info->flags |= VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+
+    VulkanReplayConsumer::Process_vkCreateCommandPool(call_info, returnValue, device, pCreateInfo, pAllocator, pCommandPool);
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -287,7 +287,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkCommandPool>*        pCommandPool)
 {
-    if (frame_loop_info_.IsLooping())
+    if (frame_loop_info_.IsRepetition())
     {
         // Don't repeatedly recreate the command pool during the looping frame
         return;

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -141,6 +141,13 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayConsumer
                                             uint32_t                                            layers,
                                             const std::vector<format::HardwareBufferPlaneInfo>& plane_info) override;
 
+    void Process_vkCreateCommandPool(const ApiCallInfo&                          call_info,
+                                     VkResult                                    returnValue,
+                                     format::HandleId                            device,
+                                     StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
+                                     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                                     HandlePointerDecoder<VkCommandPool>*        pCommandPool);
+
   private:
     graphics::FrameLoopInfo& frame_loop_info_;
 };

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -141,12 +141,12 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayConsumer
                                             uint32_t                                            layers,
                                             const std::vector<format::HardwareBufferPlaneInfo>& plane_info) override;
 
-    void Process_vkCreateCommandPool(const ApiCallInfo&                          call_info,
-                                     VkResult                                    returnValue,
-                                     format::HandleId                            device,
+    void Process_vkCreateCommandPool(const ApiCallInfo&                                     call_info,
+                                     VkResult                                               returnValue,
+                                     format::HandleId                                       device,
                                      StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
-                                     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
-                                     HandlePointerDecoder<VkCommandPool>*        pCommandPool) override;
+                                     StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
+                                     HandlePointerDecoder<VkCommandPool>*                   pCommandPool) override;
 
   private:
     graphics::FrameLoopInfo& frame_loop_info_;

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -146,7 +146,7 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayConsumer
                                      format::HandleId                            device,
                                      StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
                                      StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
-                                     HandlePointerDecoder<VkCommandPool>*        pCommandPool);
+                                     HandlePointerDecoder<VkCommandPool>*        pCommandPool) override;
 
   private:
     graphics::FrameLoopInfo& frame_loop_info_;


### PR DESCRIPTION
When looping a frame, used command buffers are implicitly reset each loop. This change forces all command pools to be created with `VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT` in order to work around this.