### PR TITLE
Export sample count in dumped image subresource data in output JSON

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -469,8 +469,12 @@ VkResult DumpImage(DumpedImage&                         dumped_image,
                 const VkExtent3D subresource_extent        = graphics::ScaleToMipLevel(image_info->extent, mip);
                 const VkExtent3D subresource_scaled_extent = graphics::ScaleToMipLevel(scaled_extent, mip);
 
-                dumped_image.dumped_subresources.emplace_back(
-                    aspect, subresource_extent, subresource_scaled_extent, mip, layer);
+                dumped_image.dumped_subresources.emplace_back(aspect,
+                                                              subresource_extent,
+                                                              subresource_scaled_extent,
+                                                              static_cast<uint32_t>(image_info->sample_count),
+                                                              mip,
+                                                              layer);
 
                 const uint32_t sub_res_idx = mip * image_info->layer_count + layer;
                 const void*    offsetted_data =

--- a/framework/decode/vulkan_replay_dump_resources_delegate_dumped_resources.h
+++ b/framework/decode/vulkan_replay_dump_resources_delegate_dumped_resources.h
@@ -187,14 +187,14 @@ struct DumpedImage
         DumpedImageSubresource() = default;
 
         DumpedImageSubresource(
-            VkImageAspectFlagBits a, const VkExtent3D& e, const VkExtent3D& se, uint32_t le, uint32_t la) :
-            aspect(a),
-            extent(e), scaled_extent(se), level(le), layer(la)
+            VkImageAspectFlagBits a, const VkExtent3D& e, const VkExtent3D& se, uint32_t sc, uint32_t le, uint32_t la) :
+            aspect(a), extent(e), scaled_extent(se), sample_count(sc), level(le), layer(la)
         {}
 
         VkImageAspectFlagBits aspect{ VkImageAspectFlagBits(0) };
         VkExtent3D            extent{ 0, 0, 0 };
         VkExtent3D            scaled_extent{ 0, 0, 0 };
+        uint32_t              sample_count{ 0 };
         uint32_t              level{ 0 };
         uint32_t              layer{ 0 };
     };

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -186,9 +186,10 @@ void VulkanReplayDumpResourcesJson::InsertImageSubresourceInfo(nlohmann::ordered
     json_entry["dimensions"][1] = subresource.extent.height;
     json_entry["dimensions"][2] = subresource.extent.depth;
 
-    json_entry["mipLevel"]   = subresource.level;
-    json_entry["arrayLayer"] = subresource.layer;
-    json_entry["file"]       = subresource.filename;
+    json_entry["sampleCount"] = subresource.sample_count;
+    json_entry["mipLevel"]    = subresource.level;
+    json_entry["arrayLayer"]  = subresource.layer;
+    json_entry["file"]        = subresource.filename;
 
     if (separate_alpha && !dumped_raw && vkuFormatHasAlpha(format))
     {

--- a/vulkan_dump_resources.md
+++ b/vulkan_dump_resources.md
@@ -528,6 +528,7 @@ Here is an example of a json output file:
             720,
             1
           ],
+          "sampleCount": 1,
           "mipLevel": 0,
           "arrayLayer": 0,
           "file": "Draw_407_qs_461_bcb_399_att_0_aspect_color.bmp"
@@ -544,6 +545,7 @@ Here is an example of a json output file:
             720,
             1
           ],
+          "sampleCount": 1,
           "mipLevel": 0,
           "arrayLayer": 0,
           "file": "Draw_407_qs_461_bcb_399_depth_att_aspect_depth.bmp"
@@ -587,6 +589,7 @@ Here is an example of a json output file:
                   1,
                   1
                 ],
+                "sampleCount": 1,
                 "mipLevel": 0,
                 "arrayLayer": 0,
                 "file": "Image_68_qs_461_bcb_399_rp_0_aspect_color.bmp"
@@ -659,4 +662,3 @@ Raw binary files are created when the dumped resource is an image with a format 
 ### Buffer file output
 
 All buffers are dumped as raw binary files (`.bin`).
-


### PR DESCRIPTION
The sample count for an image is being collected, just not written out - this change fixes that.