### PR TITLE
Fix condition for a warning, avoid misleading warnings/spam

### DIFF
--- a/framework/encode/vulkan_device_address_tracker.cpp
+++ b/framework/encode/vulkan_device_address_tracker.cpp
@@ -53,7 +53,8 @@ void encode::VulkanDeviceAddressTracker::TrackBuffer(const vulkan_wrappers::Buff
     {
         std::unique_lock lock(mutex_);
 
-        if (auto iter = buffer_addresses_.find(wrapper->address); iter != buffer_addresses_.end())
+        if (auto iter = buffer_addresses_.find(wrapper->address);
+            iter != buffer_addresses_.end() && iter->second.handle != wrapper->handle)
         {
             GFXRECON_LOG_WARNING("[VulkanDeviceAddressTracker] Buffer already exists for address: %" PRIu64
                                  ". Replacing old buffer: %p with new buffer: %p",


### PR DESCRIPTION
During capture we would spam these warnings:

`[gfxrecon] WARNING - [VulkanDeviceAddressTracker] Buffer already exists for address: 962072674304. Replacing old buffer: 0xcdecac0 with new buffer: 0xcdecac0`

which obviously make no sense, it's the same buffer. 
easy fix, we need to check if the handles are actually different.
that's important because VkBuffers can be repeatedly announced to the tracker, from different entrypoints (e.g. GetBufferDeviceAddress or GetAccelerationStructureAddress) or an application 'might' periodically query the same buffers per frame.