### PR TITLE
Support dx12 raytracing opacity micromap trimming

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -192,6 +192,7 @@ class ApiDecoder
     virtual void DispatchInitDx12AccelerationStructureCommand(
         const format::InitDx12AccelerationStructureCommandHeader&             command_header,
         const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const std::vector<uint8_t>&                                           build_inputs,
         const uint8_t*                                                        build_inputs_data) = 0;
 
     virtual void DispatchGetDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header){};

--- a/framework/decode/api_payload.h
+++ b/framework/decode/api_payload.h
@@ -416,10 +416,14 @@ struct InitDx12AccelerationStructureArgs
 
     format::InitDx12AccelerationStructureCommandHeader             command_header;
     std::vector<format::InitDx12AccelerationStructureGeometryDesc> geometry_descs;
+    std::vector<uint8_t>                                           inputs;
     const uint8_t*                                                 data;
 
-    auto GetTuple() const { return std::tie(command_header, geometry_descs, data); }
+    auto GetTuple() const { return std::tie(command_header, geometry_descs, inputs, data); }
 };
+template <>
+struct DispatchHasAllocGuard<InitDx12AccelerationStructureArgs> : std::true_type
+{};
 struct GetDxgiAdapterArgs
 {
     format::MetaDataId meta_data_id; // Needed by DispatchVisitor, but not ApiDecoder

--- a/framework/decode/block_parser.cpp
+++ b/framework/decode/block_parser.cpp
@@ -1276,8 +1276,13 @@ ParsedBlock& BlockParser::ParseMetaData(BlockBuffer& block_buffer)
                                  "Failed to read init subresource data meta-data block header");
         }
     }
-    else if (meta_data_type == format::MetaDataType::kInitDx12AccelerationStructureCommand)
+    else if (meta_data_type == format::MetaDataType::kInitDx12AccelerationStructureCommand_deprecated)
     {
+        GFXRECON_LOG_WARNING_ONCE(
+            "This capture contains a deprecated metacommand to create a Dx12AccelerationStructureCommand.  While still "
+            "supported, this "
+            "metacommand may not include new structure of the captured Dx12AccelerationStructureCommand.");
+
         // Parse command header.
         format::InitDx12AccelerationStructureCommandHeader header;
         success = block_buffer.Read(header.thread_id);
@@ -1287,14 +1292,15 @@ ParsedBlock& BlockParser::ParseMetaData(BlockBuffer& block_buffer)
         success = success && block_buffer.Read(header.inputs_type);
         success = success && block_buffer.Read(header.inputs_flags);
         success = success && block_buffer.Read(header.inputs_num_instance_descs);
-        success = success && block_buffer.Read(header.inputs_num_geometry_descs);
+        success = success && block_buffer.Read(header.inputs_geometry_descs_size);
         success = success && block_buffer.Read(header.inputs_data_size);
 
         // Parse geometry descs.
         std::vector<format::InitDx12AccelerationStructureGeometryDesc> geom_descs;
+        std::vector<uint8_t>                                           build_inputs_data;
         if (success)
         {
-            for (uint32_t i = 0; i < header.inputs_num_geometry_descs; ++i)
+            for (uint32_t i = 0; i < header.inputs_geometry_descs_size; ++i)
             {
                 format::InitDx12AccelerationStructureGeometryDesc geom_desc;
                 success = success && block_buffer.Read(geom_desc.geometry_type);
@@ -1314,6 +1320,53 @@ ParsedBlock& BlockParser::ParseMetaData(BlockBuffer& block_buffer)
         BlockBuffer::BlockSpan parameter_data;
         if (success)
         {
+            const char*         label       = "init DX12 acceleration structure deprecated meta-data block";
+            ParameterReadResult read_result = ReadParameterBuffer(label, block_buffer, header.inputs_data_size);
+            if (read_result.success)
+            {
+                auto* payload = Emplace<InitDx12AccelerationStructureArgs>(
+                    meta_data_id,
+                    read_result.uncompressed_size,
+                    header,
+                    geom_descs,
+                    build_inputs_data,
+                    reinterpret_cast<const uint8_t*>(read_result.buffer.data()));
+                return MakeCompressibleParsedBlock(block_buffer, read_result, payload);
+            }
+        }
+        else
+        {
+            HandleBlockReadError(kErrorReadingBlockHeader,
+                                 "Failed to read init DX12 acceleration structure deprecated meta-data block header");
+        }
+    }
+    else if (meta_data_type == format::MetaDataType::kInitDx12AccelerationStructureCommand2)
+    {
+        // Parse command header.
+        format::InitDx12AccelerationStructureCommandHeader header;
+        success = block_buffer.Read(header.thread_id);
+        success = success && block_buffer.Read(header.dest_acceleration_structure_data);
+        success = success && block_buffer.Read(header.copy_source_gpu_va);
+        success = success && block_buffer.Read(header.copy_mode);
+        success = success && block_buffer.Read(header.inputs_type);
+        success = success && block_buffer.Read(header.inputs_flags);
+        success = success && block_buffer.Read(header.inputs_num_instance_descs);
+        success = success && block_buffer.Read(header.inputs_geometry_descs_size);
+        success = success && block_buffer.Read(header.inputs_data_size);
+
+        // Parse build inputs.
+        std::vector<format::InitDx12AccelerationStructureGeometryDesc> geom_descs;
+        std::vector<uint8_t>                                           build_inputs_data;
+        size_t inputs_size = static_cast<size_t>(header.inputs_geometry_descs_size);
+        if (success && (inputs_size > 0))
+        {
+            build_inputs_data.resize(inputs_size);
+            success = success && block_buffer.ReadBytes(build_inputs_data.data(), inputs_size);
+        }
+
+        BlockBuffer::BlockSpan parameter_data;
+        if (success)
+        {
             const char*         label       = "init DX12 acceleration structure meta-data block";
             ParameterReadResult read_result = ReadParameterBuffer(label, block_buffer, header.inputs_data_size);
             if (read_result.success)
@@ -1323,6 +1376,7 @@ ParsedBlock& BlockParser::ParseMetaData(BlockBuffer& block_buffer)
                     read_result.uncompressed_size,
                     header,
                     geom_descs,
+                    build_inputs_data,
                     reinterpret_cast<const uint8_t*>(read_result.buffer.data()));
                 return MakeCompressibleParsedBlock(block_buffer, read_result, payload);
             }

--- a/framework/decode/custom_ags_decoder.h
+++ b/framework/decode/custom_ags_decoder.h
@@ -184,6 +184,7 @@ class AgsDecoder : public ApiDecoder
     virtual void DispatchInitDx12AccelerationStructureCommand(
         const format::InitDx12AccelerationStructureCommandHeader&             command_header,
         const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const std::vector<uint8_t>&                                           build_inputs,
         const uint8_t*                                                        build_inputs_data) override
     {}
 

--- a/framework/decode/dx12_acceleration_structure_builder.cpp
+++ b/framework/decode/dx12_acceleration_structure_builder.cpp
@@ -118,10 +118,11 @@ Dx12AccelerationStructureBuilder::Dx12AccelerationStructureBuilder(graphics::dx1
 
 // TODO: Consider batching multiple accel struct builds where possible.
 void Dx12AccelerationStructureBuilder::Build(
-    const graphics::Dx12GpuVaMap&                                         gpu_va_map,
-    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& init_geometry_descs,
-    const uint8_t*                                                        build_inputs_data)
+    const graphics::Dx12GpuVaMap&                                                       gpu_va_map,
+    const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               init_geometry_descs,
+    StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+    const uint8_t*                                                                      build_inputs_data)
 {
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC build_desc;
 
@@ -142,8 +143,16 @@ void Dx12AccelerationStructureBuilder::Build(
 
     if (build)
     {
-        SetupBuild(
-            gpu_va_map, command_header, init_geometry_descs, build_inputs_data, build_desc, use_temp_dest_buffer);
+        if ((build_inputs != nullptr) && (build_inputs->GetPointer() != nullptr))
+        {
+            SetupBuild2(gpu_va_map, command_header, build_inputs, build_inputs_data, build_desc, use_temp_dest_buffer);
+        }
+        else
+        {
+            SetupBuildDeprecated(
+                gpu_va_map, command_header, init_geometry_descs, build_inputs_data, build_desc, use_temp_dest_buffer);
+        }
+
         ExecuteBuild(gpu_va_map, build_desc);
     }
 
@@ -167,7 +176,7 @@ void Dx12AccelerationStructureBuilder::Build(
     }
 }
 
-void Dx12AccelerationStructureBuilder::SetupBuild(
+void Dx12AccelerationStructureBuilder::SetupBuildDeprecated(
     const graphics::Dx12GpuVaMap&                                         gpu_va_map,
     const format::InitDx12AccelerationStructureCommandHeader&             command_header,
     const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& init_geometry_descs,
@@ -190,7 +199,7 @@ void Dx12AccelerationStructureBuilder::SetupBuild(
 
     const uint8_t* final_data = build_inputs_data;
 
-    // In order for GetAccelerationStructureInputsBufferEntries to correctly process inputs buffer entries, a
+    // In order for GetAccelerationStructureInputsBufferEntriesDeprecated to correctly process inputs buffer entries, a
     // non-zero GPU VA must be set for values that will be used.
     const D3D12_GPU_VIRTUAL_ADDRESS kDefaultGpuVa = 1;
 
@@ -198,10 +207,10 @@ void Dx12AccelerationStructureBuilder::SetupBuild(
     temp_geometry_descs_.clear();
     if (inputs_desc.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL)
     {
-        temp_geometry_descs_.resize(command_header.inputs_num_geometry_descs);
+        temp_geometry_descs_.resize(command_header.inputs_geometry_descs_size);
 
-        inputs_desc.NumDescs = command_header.inputs_num_geometry_descs;
-        GFXRECON_ASSERT(command_header.inputs_num_geometry_descs == init_geometry_descs.size());
+        inputs_desc.NumDescs = command_header.inputs_geometry_descs_size;
+        GFXRECON_ASSERT(command_header.inputs_geometry_descs_size == init_geometry_descs.size());
         for (UINT i = 0; i < init_geometry_descs.size(); ++i)
         {
             const auto&                     init_geom_desc = init_geometry_descs[i];
@@ -262,8 +271,191 @@ void Dx12AccelerationStructureBuilder::SetupBuild(
     // Compute the required inputs buffer size and entry information.
     uint64_t                                       inputs_buffer_size = 0;
     std::vector<graphics::dx12::InputsBufferEntry> inputs_buffer_entries;
-    graphics::dx12::GetAccelerationStructureInputsBufferEntries(
+    graphics::dx12::GetAccelerationStructureInputsBufferEntriesDeprecated(
         inputs_desc, temp_geometry_descs_.data(), inputs_buffer_size, inputs_buffer_entries);
+
+    GFXRECON_ASSERT(inputs_buffer_size == command_header.inputs_data_size);
+
+    // Get required sizes and update buffers.
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuild_info;
+    device5_->GetRaytracingAccelerationStructurePrebuildInfo(&inputs_desc, &prebuild_info);
+    UpdateBufferSize(device5_,
+                     scratch_buffer_,
+                     scratch_buffer_size_,
+                     prebuild_info.ScratchDataSizeInBytes,
+                     D3D12_HEAP_TYPE_DEFAULT,
+                     D3D12_RESOURCE_STATE_COMMON,
+                     D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    UpdateBufferSize(device5_,
+                     inputs_buffer_,
+                     inputs_buffer_size_,
+                     command_header.inputs_data_size,
+                     D3D12_HEAP_TYPE_UPLOAD,
+                     D3D12_RESOURCE_STATE_GENERIC_READ,
+                     D3D12_RESOURCE_FLAG_NONE);
+
+    if (use_temp_dest_buffer)
+    {
+        UpdateBufferSize(device5_,
+                         temp_dest_buffer_,
+                         temp_dest_buffer_size_,
+                         prebuild_info.ResultDataMaxSizeInBytes,
+                         D3D12_HEAP_TYPE_DEFAULT,
+                         D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE,
+                         D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    }
+
+    // Write inputs data to resources.
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, command_header.inputs_data_size);
+    HRESULT hr =
+        MapSubresourceAndWriteData(inputs_buffer_, 0, static_cast<size_t>(command_header.inputs_data_size), final_data);
+    GFXRECON_ASSERT(SUCCEEDED(hr));
+
+    // Fix GPU VAs that point into buffers.
+    if (use_temp_dest_buffer)
+    {
+        build_desc.DestAccelerationStructureData = temp_dest_buffer_->GetGPUVirtualAddress();
+    }
+    build_desc.ScratchAccelerationStructureData  = scratch_buffer_->GetGPUVirtualAddress();
+    D3D12_GPU_VIRTUAL_ADDRESS inputs_buffer_base = inputs_buffer_->GetGPUVirtualAddress();
+    for (auto& inputs_buffer_entry : inputs_buffer_entries)
+    {
+        *inputs_buffer_entry.desc_gpu_va = inputs_buffer_base + inputs_buffer_entry.offset;
+    }
+}
+
+void Dx12AccelerationStructureBuilder::SetupBuild2(
+    const graphics::Dx12GpuVaMap&                                                       gpu_va_map,
+    const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+    StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+    const uint8_t*                                                                      build_inputs_data,
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC&                                 build_desc,
+    bool                                                                                use_temp_dest_buffer)
+{
+    if ((build_inputs == nullptr) || (build_inputs->GetPointer() == nullptr) || (build_inputs_data == nullptr))
+    {
+        GFXRECON_LOG_ERROR("Invalid build inputs for acceleration structure build. Build may fail.");
+        return;
+    }
+
+    // Build D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC from decoded data.
+    build_desc.DestAccelerationStructureData    = gpu_va_map.Map(command_header.dest_acceleration_structure_data);
+    auto& inputs_desc                           = build_desc.Inputs;
+    build_desc.SourceAccelerationStructureData  = 0;
+    build_desc.ScratchAccelerationStructureData = 0;
+
+    inputs_desc       = *(build_inputs->GetPointer());
+    inputs_desc.Type  = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE>(command_header.inputs_type);
+    inputs_desc.Flags = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS>(command_header.inputs_flags);
+
+    const uint8_t* final_data = build_inputs_data;
+
+    // In order for GetAccelerationStructureInputsBufferEntries2 to correctly process inputs buffer entries, a
+    // non-zero GPU VA must be set for values that will be used.
+    const D3D12_GPU_VIRTUAL_ADDRESS kDefaultGpuVa = 1;
+
+    // Reconstruct acceleration structure build descs.
+    if (inputs_desc.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL)
+    {
+        for (UINT i = 0; i < inputs_desc.NumDescs; ++i)
+        {
+            D3D12_RAYTRACING_GEOMETRY_DESC* geom_desc = nullptr;
+            if (inputs_desc.DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY)
+            {
+                GFXRECON_ASSERT(inputs_desc.pGeometryDescs != nullptr);
+                geom_desc = const_cast<D3D12_RAYTRACING_GEOMETRY_DESC*>(&inputs_desc.pGeometryDescs[i]);
+            }
+            else if (inputs_desc.DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS)
+            {
+                GFXRECON_ASSERT(inputs_desc.ppGeometryDescs != nullptr);
+                geom_desc = const_cast<D3D12_RAYTRACING_GEOMETRY_DESC*>(inputs_desc.ppGeometryDescs[i]);
+            }
+            else
+            {
+                GFXRECON_LOG_ERROR(
+                    "Unrecognized raytracing acceleration structure geometry desc layout (DescsLayout=%d).",
+                    inputs_desc.DescsLayout);
+                continue;
+            }
+
+            GFXRECON_ASSERT(geom_desc);
+            if (geom_desc->Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES)
+            {
+                auto& tris_desc                     = geom_desc->Triangles;
+                tris_desc.Transform3x4              = (tris_desc.Transform3x4 > 0) ? kDefaultGpuVa : 0;
+                tris_desc.IndexBuffer               = (tris_desc.IndexBuffer > 0) ? kDefaultGpuVa : 0;
+                tris_desc.VertexBuffer.StartAddress = kDefaultGpuVa;
+            }
+            else if (geom_desc->Type == D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS)
+            {
+                geom_desc->AABBs.AABBs.StartAddress = kDefaultGpuVa;
+            }
+            else if (geom_desc->Type == D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES)
+            {
+                if (geom_desc->OmmTriangles.pTriangles != nullptr)
+                {
+                    auto triangles_desc =
+                        const_cast<D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC*>(geom_desc->OmmTriangles.pTriangles);
+
+                    triangles_desc->Transform3x4              = (triangles_desc->Transform3x4 > 0) ? kDefaultGpuVa : 0;
+                    triangles_desc->IndexBuffer               = (triangles_desc->IndexBuffer > 0) ? kDefaultGpuVa : 0;
+                    triangles_desc->VertexBuffer.StartAddress = kDefaultGpuVa;
+                }
+
+                if (geom_desc->OmmTriangles.pOmmLinkage != nullptr)
+                {
+                    auto linkage_desc =
+                        const_cast<D3D12_RAYTRACING_GEOMETRY_OMM_LINKAGE_DESC*>(geom_desc->OmmTriangles.pOmmLinkage);
+                    linkage_desc->OpacityMicromapIndexBuffer.StartAddress =
+                        (linkage_desc->OpacityMicromapIndexBuffer.StartAddress > 0) ? kDefaultGpuVa : 0;
+                    linkage_desc->OpacityMicromapArray = gpu_va_map.Map(linkage_desc->OpacityMicromapArray);
+                }
+            }
+            else
+            {
+                GFXRECON_ASSERT(false && "Invalid D3D12_RAYTRACING_GEOMETRY_TYPE.");
+            }
+        }
+    }
+    else if (inputs_desc.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_ARRAY)
+    {
+        for (UINT i = 0; i < inputs_desc.NumDescs; ++i)
+        {
+            auto& omm_desc =
+                const_cast<D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC&>(inputs_desc.pOpacityMicromapArrayDesc[i]);
+            omm_desc.InputBuffer              = (omm_desc.InputBuffer > 0) ? kDefaultGpuVa : 0;
+            omm_desc.PerOmmDescs.StartAddress = (omm_desc.PerOmmDescs.StartAddress > 0) ? kDefaultGpuVa : 0;
+        }
+    }
+    else if (inputs_desc.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL)
+    {
+        inputs_desc.InstanceDescs = (inputs_desc.NumDescs > 0) ? kDefaultGpuVa : 0;
+
+        // Map GPU VAs in instance desc input data.
+        temp_instance_desc_input_data_.clear();
+        temp_instance_desc_input_data_.insert(temp_instance_desc_input_data_.end(),
+                                              build_inputs_data,
+                                              build_inputs_data + command_header.inputs_data_size);
+        constexpr auto address_stride = sizeof(D3D12_RAYTRACING_INSTANCE_DESC);
+        constexpr auto address_offset = offsetof(D3D12_RAYTRACING_INSTANCE_DESC, AccelerationStructure);
+        for (UINT i = 0; i < inputs_desc.NumDescs; ++i)
+        {
+            D3D12_GPU_VIRTUAL_ADDRESS* address = reinterpret_cast<D3D12_GPU_VIRTUAL_ADDRESS*>(
+                temp_instance_desc_input_data_.data() + i * address_stride + address_offset);
+            *address = gpu_va_map.Map(*address);
+        }
+        final_data = temp_instance_desc_input_data_.data();
+    }
+    else
+    {
+        GFXRECON_ASSERT(false && "Invalid D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE.");
+    }
+
+    // Compute the required inputs buffer size and entry information.
+    uint64_t                                       inputs_buffer_size = 0;
+    std::vector<graphics::dx12::InputsBufferEntry> inputs_buffer_entries;
+    graphics::dx12::GetAccelerationStructureInputsBufferEntries2(
+        inputs_desc, inputs_buffer_size, inputs_buffer_entries);
 
     GFXRECON_ASSERT(inputs_buffer_size == command_header.inputs_data_size);
 

--- a/framework/decode/dx12_acceleration_structure_builder.h
+++ b/framework/decode/dx12_acceleration_structure_builder.h
@@ -23,6 +23,7 @@
 #ifndef GFXRECON_DECODE_DX12_ACCELERATION_STRUCTURE_BUILDER_H
 #define GFXRECON_DECODE_DX12_ACCELERATION_STRUCTURE_BUILDER_H
 
+#include "decode/custom_dx12_struct_decoders.h"
 #include "graphics/dx12_gpu_va_map.h"
 #include "graphics/dx12_util.h"
 #include "format/format.h"
@@ -41,18 +42,26 @@ class Dx12AccelerationStructureBuilder
 
     virtual ~Dx12AccelerationStructureBuilder() {}
 
-    void Build(const graphics::Dx12GpuVaMap&                                         gpu_va_map,
-               const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-               const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& init_geometry_descs,
-               const uint8_t*                                                        build_inputs_data);
+    void Build(const graphics::Dx12GpuVaMap&                                                       gpu_va_map,
+               const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+               const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               init_geometry_descs,
+               StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+               const uint8_t*                                                                      build_inputs_data);
 
   private:
-    void SetupBuild(const graphics::Dx12GpuVaMap&                                         gpu_va_map,
-                    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-                    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& init_geometry_descs,
-                    const uint8_t*                                                        build_inputs_data,
-                    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC&                   build_desc,
-                    bool                                                                  use_temp_dest_buffer);
+    void SetupBuildDeprecated(const graphics::Dx12GpuVaMap&                                         gpu_va_map,
+                              const format::InitDx12AccelerationStructureCommandHeader&             command_header,
+                              const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& init_geometry_descs,
+                              const uint8_t*                                                        build_inputs_data,
+                              D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC&                   build_desc,
+                              bool use_temp_dest_buffer);
+
+    void SetupBuild2(const graphics::Dx12GpuVaMap&                                                       gpu_va_map,
+                     const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+                     StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+                     const uint8_t*                                      build_inputs_data,
+                     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC& build_desc,
+                     bool                                                use_temp_dest_buffer);
 
     void ExecuteBuild(const graphics::Dx12GpuVaMap&                       gpu_va_map,
                       D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC& build_desc);

--- a/framework/decode/dx12_consumer_base.h
+++ b/framework/decode/dx12_consumer_base.h
@@ -49,9 +49,10 @@ class Dx12ConsumerBase : public MetadataConsumerBase, public MarkerConsumerBase
     virtual bool IsComplete(uint64_t block_index) { return false; }
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                        build_inputs_data)
+        const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               geometry_descs,
+        StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+        const uint8_t*                                                                      build_inputs_data)
     {}
 
     virtual void ProcessDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header) {}

--- a/framework/decode/dx12_decoder_base.cpp
+++ b/framework/decode/dx12_decoder_base.cpp
@@ -298,11 +298,22 @@ void Dx12DecoderBase::DispatchInitSubresourceCommand(const format::InitSubresour
 void Dx12DecoderBase::DispatchInitDx12AccelerationStructureCommand(
     const format::InitDx12AccelerationStructureCommandHeader&             command_header,
     const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+    const std::vector<uint8_t>&                                           build_inputs,
     const uint8_t*                                                        build_inputs_data)
 {
+    size_t bytes_read  = 0;
+    size_t inputs_size = static_cast<size_t>(build_inputs.size());
+
+    StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS> inputs;
+    if (inputs_size > 0)
+    {
+        bytes_read += inputs.Decode((build_inputs.data() + bytes_read), (inputs_size - bytes_read));
+    }
+
     for (auto consumer : consumers_)
     {
-        consumer->ProcessInitDx12AccelerationStructureCommand(command_header, geometry_descs, build_inputs_data);
+        consumer->ProcessInitDx12AccelerationStructureCommand(
+            command_header, geometry_descs, &inputs, build_inputs_data);
     }
 }
 

--- a/framework/decode/dx12_decoder_base.h
+++ b/framework/decode/dx12_decoder_base.h
@@ -205,6 +205,7 @@ class Dx12DecoderBase : public ApiDecoder
     virtual void DispatchInitDx12AccelerationStructureCommand(
         const format::InitDx12AccelerationStructureCommandHeader&             command_header,
         const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const std::vector<uint8_t>&                                           build_inputs,
         const uint8_t*                                                        build_inputs_data) override;
 
     virtual void DispatchGetDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header) override;

--- a/framework/decode/dx12_json_consumer_base.cpp
+++ b/framework/decode/dx12_json_consumer_base.cpp
@@ -88,14 +88,15 @@ void Dx12JsonConsumerBase::ProcessInitSubresourceCommand(const format::InitSubre
 /// captures as part of establishing the GPU memory state at the start of the trimmed
 /// range.
 void Dx12JsonConsumerBase::ProcessInitDx12AccelerationStructureCommand(
-    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-    const uint8_t*                                                        build_inputs_data)
+    const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               geometry_descs,
+    StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+    const uint8_t*                                                                      build_inputs_data)
 {
     using util::FieldToJson;
 
     writer_->SetCurrentBlockIndex(block_index_);
-    auto& jdata = writer_->WriteMetaCommandStart("InitDx12AccelerationStructureCommand");
+    auto& jdata        = writer_->WriteMetaCommandStart("InitDx12AccelerationStructureCommand");
     jdata["thread_id"] = command_header.thread_id;
     // The GPU address D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC.DestAccelerationStructureData
     // is mapped from this during replay but we'll just dump the raw capture file value:
@@ -107,15 +108,23 @@ void Dx12JsonConsumerBase::ProcessInitDx12AccelerationStructureCommand(
     jdata["inputs_type"] = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE>(command_header.inputs_type);
     jdata["inputs_flags"] =
         static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS_t>(command_header.inputs_flags);
-    jdata["inputs_num_instance_descs"] = command_header.inputs_num_instance_descs;
-    jdata["inputs_num_geometry_descs"] = command_header.inputs_num_geometry_descs;
-    jdata["inputs_data_size"]          = command_header.inputs_data_size;
+    jdata["inputs_num_instance_descs"]  = command_header.inputs_num_instance_descs;
+    jdata["inputs_geometry_descs_size"] = command_header.inputs_geometry_descs_size;
+    jdata["inputs_data_size"]           = command_header.inputs_data_size;
     RepresentBinaryFile(*(this->writer_),
                         jdata[format::kNameData],
                         "initdx12accelerationstructurecommand.bin",
                         command_header.inputs_data_size,
                         build_inputs_data);
-    FieldToJson(jdata["geometry_descs"], geometry_descs.data(), geometry_descs.size());
+    if (geometry_descs.size() > 0)
+    {
+        FieldToJson(jdata["geometry_descs"], geometry_descs.data(), geometry_descs.size());
+    }
+    if ((build_inputs != nullptr) && (build_inputs->GetPointer() != nullptr))
+    {
+        FieldToJson(jdata["build_inputs"], build_inputs);
+    }
+
     writer_->WriteBlockEnd();
 }
 

--- a/framework/decode/dx12_json_consumer_base.h
+++ b/framework/decode/dx12_json_consumer_base.h
@@ -51,9 +51,10 @@ class Dx12JsonConsumerBase : public Dx12Consumer
     virtual void ProcessInitSubresourceCommand(const format::InitSubresourceCommandHeader& command_header,
                                                const uint8_t*                              data) override;
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                        build_inputs_data) override;
+        const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               geometry_descs,
+        StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+        const uint8_t*                                                                      build_inputs_data) override;
     virtual void
     ProcessFillMemoryResourceValueCommand(const format::FillMemoryResourceValueCommandHeader& command_header,
                                           const uint8_t*                                      data) override;

--- a/framework/decode/dx12_object_scanning_consumer.cpp
+++ b/framework/decode/dx12_object_scanning_consumer.cpp
@@ -156,9 +156,10 @@ void Dx12ObjectScanningConsumer::ProcessFillMemoryResourceValueCommand(
 }
 
 void Dx12ObjectScanningConsumer::ProcessInitDx12AccelerationStructureCommand(
-    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-    const uint8_t*                                                        build_inputs_data)
+    const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               geometry_descs,
+    StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+    const uint8_t*                                                                      build_inputs_data)
 {
     dxr_workload_ = true;
 }

--- a/framework/decode/dx12_object_scanning_consumer.h
+++ b/framework/decode/dx12_object_scanning_consumer.h
@@ -113,9 +113,10 @@ class Dx12ObjectScanningConsumer : public Dx12ObjectScanningConsumerBase
                                           const uint8_t*                                      data);
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                        build_inputs_data);
+        const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               geometry_descs,
+        StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+        const uint8_t*                                                                      build_inputs_data);
 
     void Process_ID3D12GraphicsCommandList_ExecuteIndirect(const ApiCallInfo& call_info,
                                                            format::HandleId   object_id,

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -741,9 +741,10 @@ void Dx12ReplayConsumerBase::ProcessInitializeMetaCommand(const format::Initiali
 }
 
 void Dx12ReplayConsumerBase::ProcessInitDx12AccelerationStructureCommand(
-    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-    const uint8_t*                                                        build_inputs_data)
+    const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               geometry_descs,
+    StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+    const uint8_t*                                                                      build_inputs_data)
 {
     if (!accel_struct_builder_)
     {
@@ -758,7 +759,7 @@ void Dx12ReplayConsumerBase::ProcessInitDx12AccelerationStructureCommand(
         accel_struct_builder_ = std::make_unique<Dx12AccelerationStructureBuilder>(device5);
     }
 
-    accel_struct_builder_->Build(gpu_va_map_, command_header, geometry_descs, build_inputs_data);
+    accel_struct_builder_->Build(gpu_va_map_, command_header, geometry_descs, build_inputs, build_inputs_data);
 
     dxr_workload_ = true;
 }

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -116,9 +116,10 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                const uint8_t*                              data) override;
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                        build_inputs_data) override;
+        const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               geometry_descs,
+        StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+        const uint8_t*                                                                      build_inputs_data) override;
 
     virtual void ProcessInitializeMetaCommand(const format::InitializeMetaCommand& command_header,
                                               const uint8_t*                       parameters_data) override;

--- a/framework/decode/dx12_stats_consumer.h
+++ b/framework/decode/dx12_stats_consumer.h
@@ -296,12 +296,14 @@ class Dx12StatsConsumer : public Dx12Consumer
     }
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                        build_inputs_data)
+        const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               geometry_descs,
+        StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+        const uint8_t*                                                                      build_inputs_data)
     {
         GFXRECON_UNREFERENCED_PARAMETER(command_header);
         GFXRECON_UNREFERENCED_PARAMETER(geometry_descs);
+        GFXRECON_UNREFERENCED_PARAMETER(build_inputs);
         GFXRECON_UNREFERENCED_PARAMETER(build_inputs_data);
         dxr_workload_ = true;
     }

--- a/framework/decode/info_decoder.h
+++ b/framework/decode/info_decoder.h
@@ -197,6 +197,7 @@ class InfoDecoder : public ApiDecoder
     virtual void DispatchInitDx12AccelerationStructureCommand(
         const format::InitDx12AccelerationStructureCommandHeader&             command_header,
         const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const std::vector<uint8_t>&                                           build_inputs,
         const uint8_t*                                                        build_inputs_data) override
     {}
 

--- a/framework/decode/openxr_decoder_base.h
+++ b/framework/decode/openxr_decoder_base.h
@@ -203,6 +203,7 @@ class OpenXrDecoderBase : public ApiDecoder
     virtual void DispatchInitDx12AccelerationStructureCommand(
         const format::InitDx12AccelerationStructureCommandHeader&             command_header,
         const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const std::vector<uint8_t>&                                           build_inputs,
         const uint8_t*                                                        build_inputs_data) override
     {}
 

--- a/framework/decode/stat_decoder_base.h
+++ b/framework/decode/stat_decoder_base.h
@@ -197,6 +197,7 @@ class StatDecoderBase : public ApiDecoder
     virtual void DispatchInitDx12AccelerationStructureCommand(
         const format::InitDx12AccelerationStructureCommandHeader&             command_header,
         const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const std::vector<uint8_t>&                                           build_inputs,
         const uint8_t*                                                        build_inputs_data) override
     {}
 

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -195,6 +195,7 @@ class VulkanDecoderBase : public ApiDecoder
     virtual void DispatchInitDx12AccelerationStructureCommand(
         const format::InitDx12AccelerationStructureCommandHeader&             command_header,
         const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
+        const std::vector<uint8_t>&                                           build_inputs,
         const uint8_t*                                                        build_inputs_data) override
     {}
 

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -190,14 +190,9 @@ struct DxAccelerationStructureBuildInfo
 
     // Build inputs.
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS inputs{};
+    std::shared_ptr<util::MemoryOutputStream>            inputs_parameters{};
 
-    // Save a copy of the inputs' geometry descs for bottom level accel structs.
-    std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> inputs_geometry_descs;
-
-    // Save a copy of the inputs' opacity micromap array descs for micromap level accel structs.
-    std::vector<D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC>                          inputs_omm_array_descs;
-    std::map<uint32_t, std::vector<D3D12_RAYTRACING_OPACITY_MICROMAP_HISTOGRAM_ENTRY>> inputs_omm_array_histograms;
-
+    // Inputs resource buffer and size.
     uint64_t                             input_data_size{ 0 };
     uint64_t                             input_data_header_size{ 0 };
     graphics::dx12::ID3D12ResourceComPtr input_data_resource{ nullptr };

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -770,29 +770,11 @@ void Dx12StateTracker::TrackBuildRaytracingAccelerationStructure(
 
         // Save build input arguments.
         build_info.inputs = desc->Inputs;
+        EncodeAccelerationStructureInputs(&desc->Inputs, build_info);
 
         build_info.is_tlas_with_array_of_pointers = false;
 
-        // Save a copy of the input's geometry desc pointers.
-        if (desc->Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL)
-        {
-            for (UINT i = 0; i < desc->Inputs.NumDescs; ++i)
-            {
-                if (desc->Inputs.DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY)
-                {
-                    build_info.inputs_geometry_descs.push_back(desc->Inputs.pGeometryDescs[i]);
-                }
-                else if (desc->Inputs.DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS)
-                {
-                    build_info.inputs_geometry_descs.push_back(*desc->Inputs.ppGeometryDescs[i]);
-                }
-            }
-
-            // The geometry desc pointers may be invalid when build_info is used in the future, so clear them here.
-            build_info.inputs.pGeometryDescs  = nullptr;
-            build_info.inputs.ppGeometryDescs = nullptr;
-        }
-        else if (desc->Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL)
+        if (desc->Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL)
         {
             // This code path adds support for top level AS builds where `DescsLayout ==
             // D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS`. Any top level AS build--regardless of DescLayout value--could
@@ -806,31 +788,18 @@ void Dx12StateTracker::TrackBuildRaytracingAccelerationStructure(
                 build_info.is_tlas_with_array_of_pointers = true;
             }
         }
-        else if (desc->Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_ARRAY)
-        {
-            for (UINT i = 0; i < desc->Inputs.NumDescs; ++i)
-            {
-                build_info.inputs_omm_array_descs.push_back(desc->Inputs.pOpacityMicromapArrayDesc[i]);
-
-                for (UINT j = 0; j < desc->Inputs.pOpacityMicromapArrayDesc[i].NumOmmHistogramEntries; ++j)
-                {
-                    build_info.inputs_omm_array_histograms[i].push_back(
-                        desc->Inputs.pOpacityMicromapArrayDesc[i].pOmmHistogram[j]);
-                }
-            }
-
-            // The opacity micromap array desc pointers may be invalid when build_info is used in the future.
-            build_info.inputs.pOpacityMicromapArrayDesc = nullptr;
-        }
 
         // Compute the required inputs buffer size and entry information.
         uint64_t                                       inputs_buffer_size = 0;
         std::vector<graphics::dx12::InputsBufferEntry> inputs_buffer_entries;
-        graphics::dx12::GetAccelerationStructureInputsBufferEntries(
-            build_info.inputs, build_info.inputs_geometry_descs.data(), inputs_buffer_size, inputs_buffer_entries);
+        graphics::dx12::GetAccelerationStructureInputsBufferEntries2(
+            const_cast<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS&>(desc->Inputs),
+            inputs_buffer_size,
+            inputs_buffer_entries);
 
         // TLAS builds shouldn't have more than one input buffer entry.
         GFXRECON_ASSERT((desc->Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL) ||
+                        (desc->Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_ARRAY) ||
                         (inputs_buffer_entries.size() <= 1));
 
         // Save input data to a secodary resource.

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1761,7 +1761,7 @@ void Dx12StateWriter::WriteAccelerationStructuresState(
         // Write header.
         format::InitDx12AccelerationStructureCommandHeader cmd;
         cmd.meta_header.meta_data_id = format::MakeMetaDataId(
-            format::ApiFamilyId::ApiFamily_D3D12, format::MetaDataType::kInitDx12AccelerationStructureCommand);
+            format::ApiFamilyId::ApiFamily_D3D12, format::MetaDataType::kInitDx12AccelerationStructureCommand2);
         cmd.meta_header.block_header.type    = format::BlockType::kMetaDataBlock;
         cmd.thread_id                        = thread_id_;
         cmd.dest_acceleration_structure_data = as_build.dest_gpu_va;
@@ -1780,26 +1780,19 @@ void Dx12StateWriter::WriteAccelerationStructuresState(
         cmd.inputs_flags = build_flags;
 
         // Get NumDescs and data sizes.
+        size_t inputs_parameters_size    = 0;
         size_t inputs_data_ptr_file_size = 0;
         cmd.inputs_data_size             = 0;
         cmd.inputs_num_instance_descs    = 0;
-        cmd.inputs_num_geometry_descs    = 0;
+        cmd.inputs_geometry_descs_size   = 0;
         if (write_build_data)
         {
-            cmd.inputs_data_size = as_build.input_data_size - as_build.input_data_header_size;
-            if (as_build.inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL)
-            {
-                cmd.inputs_num_geometry_descs = as_build.inputs.NumDescs;
-            }
-            else if (as_build.inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL)
-            {
-                cmd.inputs_num_instance_descs = as_build.inputs.NumDescs;
-            }
-            else
-            {
-                GFXRECON_ASSERT(false && "Invalid D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE.");
-            }
+            // Store the serialized build-inputs struct size in inputs_geometry_descs_size.
+            cmd.inputs_geometry_descs_size = static_cast<uint32_t>(as_build.inputs_parameters->GetDataSize());
+            GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, as_build.inputs_parameters->GetDataSize());
+            inputs_parameters_size = as_build.inputs_parameters->GetDataSize();
 
+            cmd.inputs_data_size = as_build.input_data_size - as_build.input_data_header_size;
             GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, cmd.inputs_data_size);
             inputs_data_ptr_file_size = static_cast<size_t>(cmd.inputs_data_size);
             if (compressor_ != nullptr)
@@ -1820,48 +1813,16 @@ void Dx12StateWriter::WriteAccelerationStructuresState(
 
         // Compute file block size and write header to file.
         cmd.meta_header.block_header.size =
-            format::GetMetaDataBlockBaseSize(cmd) +
-            (sizeof(format::InitDx12AccelerationStructureGeometryDesc) * cmd.inputs_num_geometry_descs) +
-            inputs_data_ptr_file_size;
+            format::GetMetaDataBlockBaseSize(cmd) + inputs_parameters_size + inputs_data_ptr_file_size;
         output_stream_->Write(&cmd, sizeof(cmd));
         accel_struct_file_bytes += sizeof(cmd);
 
-        // Write geometry and inputs data to file.
+        // Write inputs and inputs data to file.
         if (write_build_data)
         {
-            // Write geometry descs for BLAS.
-            if (as_build.inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL)
-            {
-                GFXRECON_ASSERT(as_build.inputs.NumDescs == as_build.inputs_geometry_descs.size());
-
-                for (const auto& geom : as_build.inputs_geometry_descs)
-                {
-                    format::InitDx12AccelerationStructureGeometryDesc geom_info;
-                    geom_info.geometry_type  = geom.Type;
-                    geom_info.geometry_flags = geom.Flags;
-                    if (geom.Type == D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS)
-                    {
-                        geom_info.aabbs_count  = geom.AABBs.AABBCount;
-                        geom_info.aabbs_stride = geom.AABBs.AABBs.StrideInBytes;
-                    }
-                    else if (geom.Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES)
-                    {
-                        geom_info.triangles_has_transform = (geom.Triangles.Transform3x4 == 0) ? 0 : 1;
-                        geom_info.triangles_index_format  = geom.Triangles.IndexFormat;
-                        geom_info.triangles_vertex_format = geom.Triangles.VertexFormat;
-                        geom_info.triangles_index_count =
-                            (geom.Triangles.IndexBuffer == 0) ? 0 : geom.Triangles.IndexCount;
-                        geom_info.triangles_vertex_count  = geom.Triangles.VertexCount;
-                        geom_info.triangles_vertex_stride = geom.Triangles.VertexBuffer.StrideInBytes;
-                    }
-                    else
-                    {
-                        GFXRECON_ASSERT(false && "Invalid D3D12_RAYTRACING_GEOMETRY_TYPE.");
-                    }
-                    output_stream_->Write(&geom_info, sizeof(geom_info));
-                    accel_struct_file_bytes += sizeof(geom_info);
-                }
-            }
+            // Write inputs encode data.
+            output_stream_->Write(as_build.inputs_parameters->GetData(), inputs_parameters_size);
+            accel_struct_file_bytes += inputs_parameters_size;
 
             // Write inputs data.
             output_stream_->Write(inputs_data_ptr, inputs_data_ptr_file_size);
@@ -1986,6 +1947,28 @@ void Dx12StateWriter::WriteAgsDriverExtensionsDX12CreateDevice(const AgsStateTab
     }
 }
 #endif // GFXRECON_AGS_SUPPORT
+
+void EncodeAccelerationStructureInputs(const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS* inputs,
+                                       DxAccelerationStructureBuildInfo&                           build_info)
+{
+    GFXRECON_ASSERT(inputs != nullptr);
+
+    util::MemoryOutputStream parameter_buffer{};
+    parameter_buffer.Clear();
+    ParameterEncoder encoder(&parameter_buffer);
+    EncodeStructPtr(&encoder, inputs);
+
+    if (parameter_buffer.GetDataSize() == 0)
+    {
+        GFXRECON_LOG_ERROR("Failed to encode acceleration structure build inputs for acceleration structure build "
+                           "destination VA = %" PRIu64 ". The VA will not be written to the trim state.",
+                           build_info.dest_gpu_va);
+        return;
+    }
+
+    build_info.inputs_parameters =
+        std::make_shared<util::MemoryOutputStream>(parameter_buffer.GetData(), parameter_buffer.GetDataSize());
+}
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/dx12_state_writer.h
+++ b/framework/encode/dx12_state_writer.h
@@ -28,6 +28,7 @@
 #include "encode/custom_ags_state_table.h"
 #endif // GFXRECON_AGS_SUPPORT
 #include "encode/parameter_encoder.h"
+#include "encode/dx12_object_wrapper_info.h"
 #include "format/format.h"
 #include "graphics/dx12_gpu_va_map.h"
 #include "graphics/dx12_resource_data_util.h"
@@ -233,6 +234,8 @@ class Dx12StateWriter
     std::vector<DxTileMappingInfo> temp_tile_mappings_;
 };
 
+void EncodeAccelerationStructureInputs(const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS* inputs,
+                                       DxAccelerationStructureBuildInfo&                           build_info);
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -151,7 +151,7 @@ enum class MetaDataType : uint16_t
     kCreateHeapAllocationCommand                        = 16,
     kInitSubresourceCommand                             = 17,
     kExeFileInfoCommand                                 = 18,
-    kInitDx12AccelerationStructureCommand               = 19,
+    kInitDx12AccelerationStructureCommand_deprecated    = 19,
     kFillMemoryResourceValueCommand                     = 20,
     kDxgiAdapterInfoCommand                             = 21,
     kDriverInfoCommand                                  = 22,
@@ -170,6 +170,7 @@ enum class MetaDataType : uint16_t
     kCreateHardwareBufferCommand                        = 35,
     kInitializeMetaCommand                              = 36,
     kSetOpaqueCaptureDescriptorDataCommand              = 37,
+    kInitDx12AccelerationStructureCommand2              = 38,
 
     //! reserve values with highest-bit for special purposes
     kBeginExperimentalReservedRange = 1U << 15U
@@ -626,13 +627,16 @@ struct InitDx12AccelerationStructureCommandHeader
     uint32_t       inputs_type{ 0 };
     uint32_t       inputs_flags{ 0 };
     uint32_t       inputs_num_instance_descs{ 0 }; ///< NumDescs for TLAS
-    uint32_t       inputs_num_geometry_descs{ 0 }; ///< NumDescs for BLAS
+    uint32_t       inputs_geometry_descs_size{ 0 };
     uint64_t       inputs_data_size{ 0 };
 
     // In the capture file, accel struct data is written in the following order:
     // InitDx12AccelerationStructureCommandHeader
-    // inputs_num_geometry_descs * InitDx12AccelerationStructureGeometryDesc
-    // build inputs data
+    // deprecated: inputs_geometry_descs_size is the numdescs for BLAS.
+    // deprecated: inputs_geometry_descs_size * InitDx12AccelerationStructureGeometryDesc
+    // now: inputs_geometry_descs_size is the size of the serialized
+    // D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS struct. now:
+    // D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS struct build inputs data
 };
 
 struct InitDx12AccelerationStructureGeometryDesc

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -442,10 +442,73 @@ ID3D12ResourceComPtr CreateBufferResource(ID3D12Device*         device,
     return resource;
 }
 
-void GetAccelerationStructureInputsBufferEntries(D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& inputs_desc,
-                                                 D3D12_RAYTRACING_GEOMETRY_DESC*                       geometry_descs,
-                                                 uint64_t&                       inputs_buffer_size,
-                                                 std::vector<InputsBufferEntry>& entries)
+static void GetRaytracingGeometryTriangleBufferEntries(D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC* triangles_desc,
+                                                       uint64_t&                                 inputs_buffer_size,
+                                                       std::vector<InputsBufferEntry>&           entries)
+{
+    if (triangles_desc->Transform3x4 != 0)
+    {
+        const uint64_t kTransform3x4Size = 3 * 4 * sizeof(float);
+        inputs_buffer_size =
+            util::platform::AlignValue<D3D12_RAYTRACING_TRANSFORM3X4_BYTE_ALIGNMENT>(inputs_buffer_size);
+        entries.push_back({ inputs_buffer_size, &triangles_desc->Transform3x4, kTransform3x4Size });
+        inputs_buffer_size += kTransform3x4Size;
+    }
+
+    if (triangles_desc->IndexCount != 0)
+    {
+        GFXRECON_ASSERT(triangles_desc->IndexBuffer != 0);
+
+        uint32_t index_size = 0;
+        switch (triangles_desc->IndexFormat)
+        {
+            case DXGI_FORMAT_R32_UINT:
+                index_size         = 4;
+                inputs_buffer_size = util::platform::AlignValue<4>(inputs_buffer_size);
+                break;
+            case DXGI_FORMAT_R16_UINT:
+                index_size         = 2;
+                inputs_buffer_size = util::platform::AlignValue<2>(inputs_buffer_size);
+                break;
+            default:
+                GFXRECON_LOG_ERROR("Invalid D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC::IndexFormat (IndexFormat=%d).",
+                                   triangles_desc->IndexFormat);
+                break;
+        }
+        const uint32_t indices_size = triangles_desc->IndexCount * index_size;
+        entries.push_back({ inputs_buffer_size, &triangles_desc->IndexBuffer, indices_size });
+        inputs_buffer_size += indices_size;
+    }
+
+    const uint64_t vertices_size = triangles_desc->VertexCount * triangles_desc->VertexBuffer.StrideInBytes;
+    if (vertices_size > 0)
+    {
+        GFXRECON_ASSERT(triangles_desc->VertexBuffer.StartAddress != 0);
+
+        // Vertex alignment must be a power of two and a multiple of the size of a single component of the
+        // vertex format. Current component sizes are 2 and 4 bytes, pad to 8 to future proof. If an
+        // alignment larger than 8 is ever needed, those types could be supported here.
+        const uint64_t kVertexAlignment = 8;
+
+        inputs_buffer_size = util::platform::AlignValue<kVertexAlignment>(inputs_buffer_size);
+        entries.push_back({ inputs_buffer_size, &triangles_desc->VertexBuffer.StartAddress, vertices_size });
+        inputs_buffer_size += vertices_size;
+    }
+    else
+    {
+        GFXRECON_LOG_DEBUG("D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC's vertex data has 0 byte size. "
+                           "(vertex count: %u, vertex stride in bytes: %" PRIu64
+                           "). Skipping acceleration structure input data for this desc.",
+                           triangles_desc->VertexCount,
+                           triangles_desc->VertexBuffer.StrideInBytes);
+    }
+}
+
+void GetAccelerationStructureInputsBufferEntriesDeprecated(
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& inputs_desc,
+    D3D12_RAYTRACING_GEOMETRY_DESC*                       geometry_descs,
+    uint64_t&                                             inputs_buffer_size,
+    std::vector<InputsBufferEntry>&                       entries)
 {
     inputs_buffer_size = 0;
     if (inputs_desc.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL)
@@ -459,63 +522,7 @@ void GetAccelerationStructureInputsBufferEntries(D3D12_BUILD_RAYTRACING_ACCELERA
             {
                 auto& triangles_desc = geom_desc->Triangles;
 
-                if (triangles_desc.Transform3x4 != 0)
-                {
-                    const uint64_t kTransform3x4Size = 3 * 4 * sizeof(float);
-                    inputs_buffer_size =
-                        util::platform::AlignValue<D3D12_RAYTRACING_TRANSFORM3X4_BYTE_ALIGNMENT>(inputs_buffer_size);
-                    entries.push_back({ inputs_buffer_size, &triangles_desc.Transform3x4, kTransform3x4Size });
-                    inputs_buffer_size += kTransform3x4Size;
-                }
-
-                if (triangles_desc.IndexCount != 0)
-                {
-                    GFXRECON_ASSERT(triangles_desc.IndexBuffer != 0);
-
-                    uint32_t index_size = 0;
-                    switch (triangles_desc.IndexFormat)
-                    {
-                        case DXGI_FORMAT_R32_UINT:
-                            index_size         = 4;
-                            inputs_buffer_size = util::platform::AlignValue<4>(inputs_buffer_size);
-                            break;
-                        case DXGI_FORMAT_R16_UINT:
-                            index_size         = 2;
-                            inputs_buffer_size = util::platform::AlignValue<2>(inputs_buffer_size);
-                            break;
-                        default:
-                            GFXRECON_LOG_ERROR(
-                                "Invalid D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC::IndexFormat (IndexFormat=%d).",
-                                triangles_desc.IndexFormat);
-                            break;
-                    }
-                    const uint32_t indices_size = triangles_desc.IndexCount * index_size;
-                    entries.push_back({ inputs_buffer_size, &triangles_desc.IndexBuffer, indices_size });
-                    inputs_buffer_size += indices_size;
-                }
-
-                const uint64_t vertices_size = triangles_desc.VertexCount * triangles_desc.VertexBuffer.StrideInBytes;
-                if (vertices_size > 0)
-                {
-                    GFXRECON_ASSERT(triangles_desc.VertexBuffer.StartAddress != 0);
-
-                    // Vertex alignment must be a power of two and a multiple of the size of a single component of the
-                    // vertex format. Current component sizes are 2 and 4 bytes, pad to 8 to future proof. If an
-                    // alignment larger than 8 is ever needed, those types could be supported here.
-                    const uint64_t kVertexAlignment = 8;
-
-                    inputs_buffer_size = util::platform::AlignValue<kVertexAlignment>(inputs_buffer_size);
-                    entries.push_back({ inputs_buffer_size, &triangles_desc.VertexBuffer.StartAddress, vertices_size });
-                    inputs_buffer_size += vertices_size;
-                }
-                else
-                {
-                    GFXRECON_LOG_DEBUG("D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC's vertex data has 0 byte size. "
-                                       "(vertex count: %u, vertex stride in bytes: %" PRIu64
-                                       "). Skipping acceleration structure input data for this desc.",
-                                       triangles_desc.VertexCount,
-                                       triangles_desc.VertexBuffer.StrideInBytes);
-                }
+                GetRaytracingGeometryTriangleBufferEntries(&triangles_desc, inputs_buffer_size, entries);
             }
             else if (geom_desc->Type == D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS)
             {
@@ -532,8 +539,7 @@ void GetAccelerationStructureInputsBufferEntries(D3D12_BUILD_RAYTRACING_ACCELERA
             }
             else
             {
-                GFXRECON_LOG_ERROR("Unrecognized raytracing acceleration geomtry type type (Type=%d).",
-                                   geom_desc->Type);
+                GFXRECON_LOG_ERROR("Unrecognized raytracing acceleration geometry type (Type=%d).", geom_desc->Type);
             }
         }
     }
@@ -549,6 +555,248 @@ void GetAccelerationStructureInputsBufferEntries(D3D12_BUILD_RAYTRACING_ACCELERA
             entry.offset      = 0;
             entry.size        = inputs_buffer_size;
             entries.push_back(entry);
+        }
+    }
+    else
+    {
+        GFXRECON_LOG_ERROR("Unrecognized raytracing acceleration structure inputs type (Type=%d).", inputs_desc.Type);
+    }
+}
+
+void GetAccelerationStructureInputsBufferEntries2(D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& inputs_desc,
+                                                  uint64_t&                       inputs_buffer_size,
+                                                  std::vector<InputsBufferEntry>& entries)
+{
+    inputs_buffer_size = 0;
+    if (inputs_desc.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL)
+    {
+        for (UINT i = 0; i < inputs_desc.NumDescs; ++i)
+        {
+            D3D12_RAYTRACING_GEOMETRY_DESC* geom_desc = nullptr;
+            if (inputs_desc.DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY)
+            {
+                GFXRECON_ASSERT(inputs_desc.pGeometryDescs != nullptr);
+                geom_desc = const_cast<D3D12_RAYTRACING_GEOMETRY_DESC*>(&inputs_desc.pGeometryDescs[i]);
+            }
+            else if (inputs_desc.DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS)
+            {
+                GFXRECON_ASSERT(inputs_desc.ppGeometryDescs != nullptr);
+                geom_desc = const_cast<D3D12_RAYTRACING_GEOMETRY_DESC*>(inputs_desc.ppGeometryDescs[i]);
+            }
+            else
+            {
+                GFXRECON_LOG_ERROR(
+                    "Unrecognized raytracing acceleration structure geometry desc layout (DescsLayout=%d).",
+                    inputs_desc.DescsLayout);
+                continue;
+            }
+
+            GFXRECON_ASSERT(geom_desc);
+
+            if (geom_desc->Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES)
+            {
+                auto& triangles_desc = geom_desc->Triangles;
+
+                GetRaytracingGeometryTriangleBufferEntries(&triangles_desc, inputs_buffer_size, entries);
+            }
+            else if (geom_desc->Type == D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS)
+            {
+                GFXRECON_ASSERT(geom_desc->AABBs.AABBs.StartAddress != 0);
+
+                auto&    aabbs_desc = geom_desc->AABBs;
+                uint64_t aabb_size =
+                    std::max(aabbs_desc.AABBs.StrideInBytes, static_cast<uint64_t>(sizeof(D3D12_RAYTRACING_AABB)));
+                const uint64_t aabbs_size = aabbs_desc.AABBCount * aabb_size;
+                inputs_buffer_size =
+                    util::platform::AlignValue<D3D12_RAYTRACING_AABB_BYTE_ALIGNMENT>(inputs_buffer_size);
+                entries.push_back({ inputs_buffer_size, &aabbs_desc.AABBs.StartAddress, aabbs_size });
+                inputs_buffer_size += aabbs_size;
+            }
+            else if (geom_desc->Type == D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES)
+            {
+                if (geom_desc->OmmTriangles.pTriangles != nullptr)
+                {
+                    auto triangles_desc =
+                        const_cast<D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC*>(geom_desc->OmmTriangles.pTriangles);
+
+                    GetRaytracingGeometryTriangleBufferEntries(triangles_desc, inputs_buffer_size, entries);
+                }
+
+                if (geom_desc->OmmTriangles.pOmmLinkage != nullptr)
+                {
+                    auto linkage_desc =
+                        const_cast<D3D12_RAYTRACING_GEOMETRY_OMM_LINKAGE_DESC*>(geom_desc->OmmTriangles.pOmmLinkage);
+
+                    // Determine the OMM index element size from the format.
+                    UINT index_element_size = 0;
+                    switch (linkage_desc->OpacityMicromapIndexFormat)
+                    {
+                        case DXGI_FORMAT_R8_UINT:
+                            index_element_size = 1;
+                            break;
+                        case DXGI_FORMAT_R16_UINT:
+                            index_element_size = 2;
+                            break;
+                        case DXGI_FORMAT_R32_UINT:
+                            index_element_size = 4;
+                            break;
+                        default:
+                            break; // DXGI_FORMAT_UNKNOWN or other: no index buffer to capture
+                    }
+
+                    if (index_element_size > 0 && linkage_desc->OpacityMicromapIndexBuffer.StartAddress != 0)
+                    {
+                        // There is one OMM index per triangle.
+                        UINT triangle_count = 0;
+                        if (geom_desc->OmmTriangles.pTriangles != nullptr)
+                        {
+                            const auto* tri = geom_desc->OmmTriangles.pTriangles;
+                            triangle_count  = (tri->IndexBuffer != 0) ? (tri->IndexCount / 3) : (tri->VertexCount / 3);
+                        }
+
+                        if (triangle_count > 0)
+                        {
+                            const UINT64 stride = (linkage_desc->OpacityMicromapIndexBuffer.StrideInBytes != 0)
+                                                      ? linkage_desc->OpacityMicromapIndexBuffer.StrideInBytes
+                                                      : static_cast<UINT64>(index_element_size);
+                            if ((stride % index_element_size) != 0)
+                            {
+                                GFXRECON_LOG_ERROR("Invalid OMM index buffer stride (%" PRIu64
+                                                   ") for index element size (%u).",
+                                                   stride,
+                                                   index_element_size);
+                                continue;
+                            }
+
+                            const uint64_t omm_index_size = static_cast<uint64_t>(triangle_count) * stride;
+                            inputs_buffer_size            = util::platform::AlignValue<4>(inputs_buffer_size);
+                            entries.push_back({ inputs_buffer_size,
+                                                &linkage_desc->OpacityMicromapIndexBuffer.StartAddress,
+                                                omm_index_size });
+                            inputs_buffer_size += omm_index_size;
+                        }
+                        else
+                        {
+                            GFXRECON_LOG_WARNING("Unable to determine triangle count for OMM_TRIANGLES geometry "
+                                                 "with a non-null OMM index buffer. The OMM index buffer will "
+                                                 "not be captured for trimming.");
+                        }
+                    }
+                }
+            }
+            else
+            {
+                GFXRECON_LOG_ERROR("Unrecognized raytracing acceleration geometry type (Type=%d).", geom_desc->Type);
+            }
+        }
+    }
+    else if (inputs_desc.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL)
+    {
+        if (inputs_desc.NumDescs > 0)
+        {
+            GFXRECON_ASSERT(inputs_desc.InstanceDescs != 0);
+
+            inputs_buffer_size = inputs_desc.NumDescs * sizeof(D3D12_RAYTRACING_INSTANCE_DESC);
+            InputsBufferEntry entry{};
+            entry.desc_gpu_va = &inputs_desc.InstanceDescs;
+            entry.offset      = 0;
+            entry.size        = inputs_buffer_size;
+            entries.push_back(entry);
+        }
+    }
+    else if (inputs_desc.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_ARRAY)
+    {
+        if (inputs_desc.pOpacityMicromapArrayDesc == nullptr)
+        {
+            return;
+        }
+
+        // Per spec, OMM array build uses exactly one CPU descriptor with DescsLayout=ARRAY.
+        if ((inputs_desc.NumDescs != 1) || (inputs_desc.DescsLayout != D3D12_ELEMENTS_LAYOUT_ARRAY))
+        {
+            GFXRECON_LOG_ERROR("Invalid OMM array build inputs (NumDescs=%u, DescsLayout=%d). Expected NumDescs=1 "
+                               "and DescsLayout=D3D12_ELEMENTS_LAYOUT_ARRAY.",
+                               inputs_desc.NumDescs,
+                               inputs_desc.DescsLayout);
+            return;
+        }
+
+        auto& omm_desc =
+            const_cast<D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC&>(inputs_desc.pOpacityMicromapArrayDesc[0]);
+        if ((omm_desc.NumOmmHistogramEntries > 0) && (omm_desc.pOmmHistogram == nullptr))
+        {
+            GFXRECON_LOG_ERROR("D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC has NumOmmHistogramEntries=%u "
+                               "with null pOmmHistogram.",
+                               omm_desc.NumOmmHistogramEntries);
+            return;
+        }
+
+        uint64_t total_omm_count = 0;
+        uint64_t omm_input_size  = 0;
+        for (UINT i = 0; i < omm_desc.NumOmmHistogramEntries; ++i)
+        {
+            total_omm_count += omm_desc.pOmmHistogram[i].Count;
+
+            auto& hist = omm_desc.pOmmHistogram[i];
+            if (hist.SubdivisionLevel > D3D12_RAYTRACING_OPACITY_MICROMAP_OC1_MAX_SUBDIVISION_LEVEL)
+            {
+                GFXRECON_LOG_ERROR("Invalid OMM histogram subdivision level (%u).", hist.SubdivisionLevel);
+                continue;
+            }
+
+            const uint64_t micro_triangles = 1ULL << (2 * hist.SubdivisionLevel);
+            uint64_t       bits_per_format = 0;
+            switch (hist.Format)
+            {
+                case D3D12_RAYTRACING_OPACITY_MICROMAP_FORMAT_OC1_2_STATE:
+                    bits_per_format = 1;
+                    break;
+                case D3D12_RAYTRACING_OPACITY_MICROMAP_FORMAT_OC1_4_STATE:
+                    bits_per_format = 2;
+                    break;
+                default:
+                    GFXRECON_LOG_ERROR("Invalid OMM histogram format (%d).", hist.Format);
+                    break;
+            }
+
+            if (bits_per_format == 0)
+            {
+                continue;
+            }
+
+            const uint64_t bytes_per_omm = util::platform::AlignValue<4>((micro_triangles * bits_per_format + 7) / 8);
+            omm_input_size += static_cast<uint64_t>(hist.Count) * bytes_per_omm;
+        }
+
+        GFXRECON_ASSERT(omm_input_size > 0);
+        if ((omm_desc.InputBuffer != 0) && (omm_input_size > 0))
+        {
+            inputs_buffer_size = util::platform::AlignValue<4>(inputs_buffer_size);
+            entries.push_back({ inputs_buffer_size, &omm_desc.InputBuffer, omm_input_size });
+            inputs_buffer_size += omm_input_size;
+        }
+
+        if (omm_desc.PerOmmDescs.StartAddress != 0)
+        {
+            const UINT64 per_omm_stride = (omm_desc.PerOmmDescs.StrideInBytes != 0)
+                                              ? omm_desc.PerOmmDescs.StrideInBytes
+                                              : static_cast<UINT64>(sizeof(D3D12_RAYTRACING_OPACITY_MICROMAP_DESC));
+
+            if ((per_omm_stride % 4) != 0)
+            {
+                GFXRECON_LOG_ERROR("Invalid PerOmmDescs stride (%" PRIu64 "). Stride must be 4-byte aligned.",
+                                   per_omm_stride);
+                return;
+            }
+
+            GFXRECON_ASSERT(total_omm_count > 0);
+            if (total_omm_count > 0)
+            {
+                const uint64_t per_omm_buffer_size = total_omm_count * per_omm_stride;
+                inputs_buffer_size                 = util::platform::AlignValue<4>(inputs_buffer_size);
+                entries.push_back({ inputs_buffer_size, &omm_desc.PerOmmDescs.StartAddress, per_omm_buffer_size });
+                inputs_buffer_size += per_omm_buffer_size;
+            }
         }
     }
     else

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -227,10 +227,15 @@ struct InputsBufferEntry
 // inputs are stored on GPU resources and referenced by the INPUTS desc. A non-const D3D12_RAYTRACING_GEOMETRY_DESC*
 // array must be provided as geometry_descs argument and will be referenced instead of
 // inputs_desc.pGeometries/ppGeometries.
-void GetAccelerationStructureInputsBufferEntries(D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& inputs_desc,
-                                                 D3D12_RAYTRACING_GEOMETRY_DESC*                       geometry_descs,
-                                                 uint64_t&                       inputs_buffer_size,
-                                                 std::vector<InputsBufferEntry>& entries);
+void GetAccelerationStructureInputsBufferEntriesDeprecated(
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& inputs_desc,
+    D3D12_RAYTRACING_GEOMETRY_DESC*                       geometry_descs,
+    uint64_t&                                             inputs_buffer_size,
+    std::vector<InputsBufferEntry>&                       entries);
+
+void GetAccelerationStructureInputsBufferEntries2(D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& inputs_desc,
+                                                  uint64_t&                       inputs_buffer_size,
+                                                  std::vector<InputsBufferEntry>& entries);
 
 // Get one pixel byte size for specific DXGI_FORMAT. The function is used by GetOneRowSizeByDXGIFormat
 // function.

--- a/tools/compress/compression_converter.cpp
+++ b/tools/compress/compression_converter.cpp
@@ -503,13 +503,27 @@ decode::FileTransformer::VisitResult CompressionConverter::WriteMetaData(const d
 decode::FileTransformer::VisitResult
 CompressionConverter::WriteMetaData(const decode::InitDx12AccelerationStructureArgs& args)
 {
-    GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) ==
-                    format::MetaDataType::kInitDx12AccelerationStructureCommand);
+    GFXRECON_ASSERT(
+        (format::GetMetaDataType(args.meta_data_id) ==
+         format::MetaDataType::kInitDx12AccelerationStructureCommand_deprecated) ||
+        (format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitDx12AccelerationStructureCommand2));
 
     // The header needs to be a copy as we are rewriting it below
     format::InitDx12AccelerationStructureCommandHeader                    init_cmd   = args.command_header;
     const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geom_descs = args.geometry_descs;
-    GFXRECON_ASSERT(args.geometry_descs.size() == init_cmd.inputs_num_geometry_descs);
+    if (format::GetMetaDataType(args.meta_data_id) ==
+        format::MetaDataType::kInitDx12AccelerationStructureCommand_deprecated)
+    {
+        GFXRECON_ASSERT(args.geometry_descs.size() == init_cmd.inputs_geometry_descs_size);
+    }
+
+    // D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS buffer
+    const uint8_t* build_inputs = args.inputs.data();
+    size_t         inputs_size  = args.inputs.size();
+    if (format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitDx12AccelerationStructureCommand2)
+    {
+        GFXRECON_ASSERT(inputs_size == init_cmd.inputs_geometry_descs_size);
+    }
 
     GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.inputs_data_size);
     size_t         data_size    = static_cast<size_t>(init_cmd.inputs_data_size);
@@ -518,9 +532,17 @@ CompressionConverter::WriteMetaData(const decode::InitDx12AccelerationStructureA
     PrepMetadataBlock(init_cmd.meta_header, args.meta_data_id, data_address, data_size);
 
     // Calculate size of packet with compressed or uncompressed data size.
-    init_cmd.meta_header.block_header.size =
-        format::GetMetaDataBlockBaseSize(init_cmd) + data_size +
-        (sizeof(format::InitDx12AccelerationStructureGeometryDesc) * init_cmd.inputs_num_geometry_descs);
+    if (format::GetMetaDataType(args.meta_data_id) ==
+        format::MetaDataType::kInitDx12AccelerationStructureCommand_deprecated)
+    {
+        init_cmd.meta_header.block_header.size =
+            format::GetMetaDataBlockBaseSize(init_cmd) + data_size +
+            (sizeof(format::InitDx12AccelerationStructureGeometryDesc) * init_cmd.inputs_geometry_descs_size);
+    }
+    if (format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitDx12AccelerationStructureCommand2)
+    {
+        init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + data_size + inputs_size;
+    }
 
     if (!WriteBytes(&init_cmd, sizeof(init_cmd)))
     {
@@ -528,7 +550,14 @@ CompressionConverter::WriteMetaData(const decode::InitDx12AccelerationStructureA
                               "Failed to write init DX12 acceleration structure meta-data block header");
         return kError;
     }
-    if (!WriteBytes(geom_descs.data(), sizeof(format::InitDx12AccelerationStructureGeometryDesc) * geom_descs.size()))
+    if ((geom_descs.size() > 0) &&
+        !WriteBytes(geom_descs.data(), sizeof(format::InitDx12AccelerationStructureGeometryDesc) * geom_descs.size()))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockHeader,
+                              "Failed to write init DX12 acceleration structure geometry block");
+        return kError;
+    }
+    if ((inputs_size > 0) && !WriteBytes(build_inputs, inputs_size))
     {
         HandleBlockWriteError(decode::kErrorWritingBlockHeader,
                               "Failed to write init DX12 acceleration structure geometry block");

--- a/tools/optimize/dx12_resource_value_tracking_consumer.cpp
+++ b/tools/optimize/dx12_resource_value_tracking_consumer.cpp
@@ -81,16 +81,17 @@ void Dx12ResourceValueTrackingConsumer::Process_ID3D12GraphicsCommandList4_CopyR
 }
 
 void Dx12ResourceValueTrackingConsumer::ProcessInitDx12AccelerationStructureCommand(
-    const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-    const uint8_t*                                                        build_inputs_data)
+    const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+    const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               geometry_descs,
+    StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+    const uint8_t*                                                                      build_inputs_data)
 {
     dxr_workload_ = true;
 
     if (replay_resource_value_calls_)
     {
         Dx12ReplayConsumer::ProcessInitDx12AccelerationStructureCommand(
-            command_header, geometry_descs, build_inputs_data);
+            command_header, geometry_descs, build_inputs, build_inputs_data);
     }
 }
 

--- a/tools/optimize/dx12_resource_value_tracking_consumer.h
+++ b/tools/optimize/dx12_resource_value_tracking_consumer.h
@@ -56,9 +56,10 @@ class Dx12ResourceValueTrackingConsumer : public Dx12ReplayConsumer
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE Mode) override;
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&             command_header,
-        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                        build_inputs_data) override;
+        const format::InitDx12AccelerationStructureCommandHeader&                           command_header,
+        const std::vector<format::InitDx12AccelerationStructureGeometryDesc>&               geometry_descs,
+        StructPointerDecoder<Decoded_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>* build_inputs,
+        const uint8_t*                                                                      build_inputs_data) override;
 
     virtual void OverrideExecuteIndirect(DxObjectInfo* command_list_object_info,
                                          DxObjectInfo* command_signature_object_info,


### PR DESCRIPTION
Support dx12 raytracing opacity micromap trimming, track in #2868

DX12 AS trim metadata payloads now include serialized D3D12 build-input
structs to preserve OMM and OMM-array behavior:
  - Add a new meta id kInitDx12AccelerationStructureCommand, deprecate the old.
  - Encode and write full AS build inputs from state tracking and writer paths.
  - Decode and route structured build inputs through DX12 consumers.
  - Update DX12 utility and builder logic for OMM triangles and OMM-array
      input buffer entry handling.