### PR TITLE
[Frame Looping] Rework solution for looped descriptor set allocations

### DIFF
--- a/framework/decode/handle_pointer_decoder.h
+++ b/framework/decode/handle_pointer_decoder.h
@@ -59,6 +59,8 @@ class HandlePointerDecoder
 
     const format::HandleId* GetPointer() const { return decoder_.GetPointer(); }
 
+    std::span<const format::HandleId> GetSpan() const { return decoder_.GetSpan(); }
+
     void SetExternalMemory(T* data, size_t capacity)
     {
         assert(handle_data_ == nullptr);

--- a/framework/decode/pointer_decoder.h
+++ b/framework/decode/pointer_decoder.h
@@ -33,6 +33,7 @@
 
 #include <cassert>
 #include <memory>
+#include <span>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -46,7 +47,11 @@ class PointerDecoder : public PointerDecoderBase
 
     T* GetPointer() { return data_; }
 
+    std::span<T> GetSpan() { return std::span(GetPointer(), GetLength()); }
+
     const T* GetPointer() const { return data_; }
+
+    std::span<const T> GetSpan() const { return std::span(GetPointer(), GetLength()); }
 
     size_t GetOutputLength() const { return output_len_; }
 

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -65,8 +65,8 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateDescriptorPool(
 
     if (frame_loop_info_.IsRepetition())
     {
-        // Skip allocation of dangling descriptor pools
-        if (dangling_descriptor_pools_.contains(pool_id))
+        // Skip allocation of descriptor pools with a dangling creation
+        if (dangling_create_descriptor_pools_.contains(pool_id))
         {
             return;
         }
@@ -78,7 +78,8 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateDescriptorPool(
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
     {
         // Gather descriptor pools that are created during the loop range
-        dangling_descriptor_pools_.insert(pool_id);
+        // We will delete any pools from this set that are destroyed during the loop range
+        dangling_create_descriptor_pools_.insert(pool_id);
     }
 }
 
@@ -90,7 +91,8 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
 {
     if (frame_loop_info_.IsRepetition() && !frame_loop_info_.IsFinalIteration())
     {
-        if (dangling_descriptor_pools_.contains(descriptorPool))
+        // Skip destruction of descriptor pools with a dangling destruction
+        if (dangling_destroy_descriptor_pools_.contains(descriptorPool))
         {
             return;
         }
@@ -98,29 +100,29 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
 
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
     {
-        if (!dangling_descriptor_pools_.contains(descriptorPool))
+        if (!dangling_create_descriptor_pools_.contains(descriptorPool))
         {
             // If this pool was not created during the loop range, ignore destroying it.
-            dangling_descriptor_pools_.insert(descriptorPool);
+            dangling_destroy_descriptor_pools_.insert(descriptorPool);
             return;
         }
         else
         {
-            // Created and destroyed during the loop range
-            dangling_descriptor_pools_.erase(descriptorPool);
+            // Created and destroyed during the loop range, not dangling
+            dangling_create_descriptor_pools_.erase(descriptorPool);
 
             // Check if this was the pool for any heretofore dangling descriptors
-            RemovePoolDanglingDescriptors(descriptorPool);
+            RemovePoolDanglingCreateDescriptors(descriptorPool);
         }
     }
     VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, device, descriptorPool, pAllocator);
 }
 
-void VulkanReplayFrameLoopConsumer::RemovePoolDanglingDescriptors(format::HandleId descriptorPool)
+void VulkanReplayFrameLoopConsumer::RemovePoolDanglingCreateDescriptors(format::HandleId descriptorPool)
 {
     std::vector<format::HandleId> handles_to_delete;
-    handles_to_delete.reserve(dangling_descriptor_sets_.size());
-    for (format::HandleId handle : dangling_descriptor_sets_)
+    handles_to_delete.reserve(dangling_create_descriptor_sets_.size());
+    for (format::HandleId handle : dangling_create_descriptor_sets_)
     {
         VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(handle);
         if (info != nullptr && info->pool_id == descriptorPool)
@@ -130,7 +132,7 @@ void VulkanReplayFrameLoopConsumer::RemovePoolDanglingDescriptors(format::Handle
     }
     for (format::HandleId handle : handles_to_delete)
     {
-        dangling_descriptor_sets_.erase(handle);
+        dangling_create_descriptor_sets_.erase(handle);
     }
 }
 
@@ -143,7 +145,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallI
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsFinalIteration())
     {
         // If any of the sets in this pool are dangling, skip pool reset
-        for (format::HandleId set_id : dangling_descriptor_sets_)
+        for (format::HandleId set_id : dangling_create_descriptor_sets_)
         {
             VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(set_id);
             if (info != nullptr && info->pool_id == descriptorPool)
@@ -154,7 +156,10 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallI
     }
 
     VulkanReplayConsumer::Process_vkResetDescriptorPool(call_info, returnValue, device, descriptorPool, flags);
-    RemovePoolDanglingDescriptors(descriptorPool);
+
+    // For pools that contain dangling descriptor sets, this code will only be reached once,
+    // during the final iteration of the loop range.
+    RemovePoolDanglingCreateDescriptors(descriptorPool);
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
@@ -169,7 +174,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
         // Skip allocation of dangling descriptor sets
         for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
-            if (dangling_descriptor_sets_.contains(set_handle))
+            if (dangling_create_descriptor_sets_.contains(set_handle))
             {
                 return;
             }
@@ -182,9 +187,10 @@ void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
     {
         // During first iteration of looping range, record which descriptor sets are allocated
+        // They will be removed from the set if they are freed during the loop range
         for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
-            dangling_descriptor_sets_.insert(set_handle);
+            dangling_create_descriptor_sets_.insert(set_handle);
         }
     }
 }
@@ -202,7 +208,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
         // then we want to omit their destruction
         for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
-            if (dangling_descriptor_sets_.contains(set_handle))
+            if (dangling_destroy_descriptor_sets_.contains(set_handle))
             {
                 return;
             }
@@ -213,15 +219,15 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
     {
         for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
-            if (dangling_descriptor_sets_.contains(set_handle))
+            if (dangling_create_descriptor_sets_.contains(set_handle))
             {
                 // Any descriptor set that was freed during the loop range is not dangling
-                dangling_descriptor_sets_.erase(set_handle);
+                dangling_create_descriptor_sets_.erase(set_handle);
             }
             else
             {
                 // Descriptor set freed during loop range but created before
-                dangling_descriptor_sets_.insert(set_handle);
+                dangling_destroy_descriptor_sets_.insert(set_handle);
                 return;
             }
         }

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -234,6 +234,10 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
         }
     }
 
+    // For pools that contain dangling descriptor sets, this code will only be reached once,
+    // during the final iteration of the loop range.
+    RemovePoolDanglingCreateDescriptors(descriptorPool);
+
     VulkanReplayConsumer::Process_vkFreeDescriptorSets(
         call_info, returnValue, device, descriptorPool, descriptorSetCount, pDescriptorSets);
 }

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -110,7 +110,20 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
             dangling_descriptor_pools_.erase(descriptorPool);
 
             // Check if this was the pool for any heretofore dangling descriptors
-            DeleteDanglingPoolDescriptorSets(descriptorPool);
+            std::vector<format::HandleId> handles_to_delete;
+            handles_to_delete.reserve(dangling_descriptor_sets_.size());
+            for (format::HandleId handle : dangling_descriptor_sets_)
+            {
+                VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(handle);
+                if (info->pool_id == descriptorPool)
+                {
+                    handles_to_delete.push_back(handle);
+                }
+            }
+            for (format::HandleId handle : handles_to_delete)
+            {
+                dangling_descriptor_sets_.erase(handle);
+            }
         }
     }
     VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, device, descriptorPool, pAllocator);
@@ -122,7 +135,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallI
                                                                   format::HandleId           descriptorPool,
                                                                   VkDescriptorPoolResetFlags flags)
 {
-    if (frame_loop_info_.IsRepetition())
+    if (frame_loop_info_.IsLooping())
     {
         // If any of the sets in this pool are dangling, skip pool reset
         for (format::HandleId set_id : dangling_descriptor_sets_)
@@ -133,13 +146,6 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallI
                 return;
             }
         }
-    }
-
-    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
-    {
-        // Reset descriptor pool means that the pool is still valid, but the allocated descriptor sets are not
-        // Check if this was the pool for any heretofore dangling descriptors
-        DeleteDanglingPoolDescriptorSets(descriptorPool);
     }
 
     VulkanReplayConsumer::Process_vkResetDescriptorPool(call_info, returnValue, device, descriptorPool, flags);
@@ -218,25 +224,6 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
 
     VulkanReplayConsumer::Process_vkFreeDescriptorSets(
         call_info, returnValue, device, descriptorPool, descriptorSetCount, pDescriptorSets);
-}
-
-void VulkanReplayFrameLoopConsumer::DeleteDanglingPoolDescriptorSets(format::HandleId descriptorPool)
-{
-    std::vector<format::HandleId> handles_to_delete;
-    handles_to_delete.reserve(dangling_descriptor_sets_.size());
-    for (format::HandleId handle : dangling_descriptor_sets_)
-    {
-        VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(handle);
-        if (info->pool_id == descriptorPool)
-        {
-            handles_to_delete.push_back(handle);
-        }
-    }
-
-    for (format::HandleId handle : handles_to_delete)
-    {
-        dangling_descriptor_sets_.erase(handle);
-    }
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -179,11 +179,11 @@ void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
     }
 }
 
-void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallInfo&                     call_info,
-                                                                 VkResult                               returnValue,
-                                                                 format::HandleId                       device,
-                                                                 format::HandleId                       descriptorPool,
-                                                                 uint32_t                               descriptorSetCount,
+void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallInfo& call_info,
+                                                                 VkResult           returnValue,
+                                                                 format::HandleId   device,
+                                                                 format::HandleId   descriptorPool,
+                                                                 uint32_t           descriptorSetCount,
                                                                  HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets)
 {
     if (frame_loop_info_.IsRepetition())

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -155,10 +155,9 @@ void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
     if (frame_loop_info_.IsRepetition())
     {
         // Skip allocation of dangling descriptor sets
-        const format::HandleId* set_handles = pDescriptorSets->GetPointer();
-        for (int i = 0; i < pDescriptorSets->GetLength(); ++i)
+        for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
-            if (dangling_descriptor_sets_.contains(set_handles[i]))
+            if (dangling_descriptor_sets_.contains(set_handle))
             {
                 return;
             }
@@ -171,10 +170,9 @@ void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
     {
         // During first iteration of looping range, record which descriptor sets are allocated
-        const format::HandleId* set_handles = pDescriptorSets->GetPointer();
-        for (int i = 0; i < pDescriptorSets->GetLength(); ++i)
+        for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
-            dangling_descriptor_sets_.insert(set_handles[i]);
+            dangling_descriptor_sets_.insert(set_handle);
         }
     }
 }
@@ -190,10 +188,9 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
     {
         // If any of the descriptor sets are _not_ in the dangling list,
         // then we want to omit their destruction
-        const format::HandleId* handles = pDescriptorSets->GetPointer();
-        for (int i = 0; i < descriptorSetCount; ++i)
+        for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
-            if (!dangling_descriptor_sets_.contains(handles[i]))
+            if (!dangling_descriptor_sets_.contains(set_handle))
             {
                 return;
             }
@@ -205,18 +202,17 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
 
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
     {
-        const format::HandleId* handles = pDescriptorSets->GetPointer();
-        for (int i = 0; i < descriptorSetCount; ++i)
+        for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
-            if (dangling_descriptor_sets_.contains(handles[i]))
+            if (dangling_descriptor_sets_.contains(set_handle))
             {
                 // Any descriptor set that was freed during the loop range is not dangling
-                dangling_descriptor_sets_.erase(handles[i]);
+                dangling_descriptor_sets_.erase(set_handle);
             }
             else
             {
                 // Descriptor set freed during loop range but created before
-                dangling_descriptor_sets_.insert(handles[i]);
+                dangling_descriptor_sets_.insert(set_handle);
             }
         }
     }

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -57,13 +57,14 @@ void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
     StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
     HandlePointerDecoder<VkDescriptorSet>*                     pDescriptorSets)
 {
+    if (frame_loop_info_.IsRepetition())
+    {
+        // Only allocate descriptor sets during the first iteration of the looping frame
+        return;
+    }
+
     VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
         call_info, returnValue, device, pAllocateInfo, pDescriptorSets);
-    if (frame_loop_info_.IsLooping())
-    {
-        VkDescriptorPool pool = pAllocateInfo->GetPointer()->descriptorPool;
-        active_descriptor_pools_.insert(pool);
-    }
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
@@ -81,16 +82,6 @@ void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
     GFXRECON_ASSERT(device_table);
 
     VulkanReplayConsumer::Process_vkQueuePresentKHR(call_info, returnValue, queue, pPresentInfo);
-
-    if (frame_loop_info_.IsLooping())
-    {
-        device_table->DeviceWaitIdle(device);
-        for (VkDescriptorPool pool : active_descriptor_pools_)
-        {
-            device_table->ResetDescriptorPool(device, pool, 0);
-        }
-        active_descriptor_pools_.clear();
-    }
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -53,32 +53,66 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(
         call_info, returnValue, device, pCreateInfo, pAllocator, pCommandPool);
 }
 
-void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
-    const ApiCallInfo&                          call_info,
-    format::HandleId                            device,
-    format::HandleId                            descriptorPool,
-    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+void VulkanReplayFrameLoopConsumer::Process_vkCreateDescriptorPool(
+    const ApiCallInfo&                                        call_info,
+    VkResult                                                  returnValue,
+    format::HandleId                                          device,
+    StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>*      pAllocator,
+    HandlePointerDecoder<VkDescriptorPool>*                   pDescriptorPool)
 {
-    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
-    {
-        // Check if this was the pool for any heretofore dangling descriptors
-        std::vector<format::HandleId> handles_to_delete;
-        handles_to_delete.reserve(dangling_descriptor_sets_.size());
-        for (format::HandleId handle : dangling_descriptor_sets_)
-        {
-            VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(handle);
-            if (info->pool_id == descriptorPool)
-            {
-                handles_to_delete.push_back(handle);
-            }
-        }
+    format::HandleId pool_id = *pDescriptorPool->GetPointer();
 
-        for (format::HandleId handle : handles_to_delete)
+    if (frame_loop_info_.IsRepetition())
+    {
+        // Skip allocation of dangling descriptor pools
+        if (dangling_descriptor_pools_.contains(pool_id))
         {
-            dangling_descriptor_sets_.erase(handle);
+            return;
         }
     }
 
+    VulkanReplayConsumer::Process_vkCreateDescriptorPool(
+        call_info, returnValue, device, pCreateInfo, pAllocator, pDescriptorPool);
+
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    {
+        // Gather descriptor pools that are created during the loop range
+        dangling_descriptor_pools_.insert(pool_id);
+    }
+}
+
+void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
+    const ApiCallInfo&                                   call_info,
+    format::HandleId                                     device,
+    format::HandleId                                     descriptorPool,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+{
+    if (frame_loop_info_.IsRepetition())
+    {
+        if (dangling_descriptor_pools_.contains(descriptorPool))
+        {
+            return;
+        }
+    }
+
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    {
+        if (!dangling_descriptor_pools_.contains(descriptorPool))
+        {
+            // If this pool was not created during the loop range, ignore destroying it.
+            dangling_descriptor_pools_.insert(descriptorPool);
+            return;
+        }
+        else
+        {
+            // Created and destroyed during the loop range
+            dangling_descriptor_pools_.erase(descriptorPool);
+    
+            // Check if this was the pool for any heretofore dangling descriptors
+            DeleteDanglingPoolDescriptorSets(descriptorPool);
+        }
+    }
     VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, device, descriptorPool, pAllocator);
 }
 
@@ -89,6 +123,25 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(
     format::HandleId                            descriptorPool,
     VkDescriptorPoolResetFlags                  flags)
 {
+    if (frame_loop_info_.IsRepetition())
+    {
+        // If any of the sets in this pool are dangling, skip pool reset
+        for (format::HandleId set_id : dangling_descriptor_sets_)
+        {
+            VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(set_id);
+            if (info->pool_id == descriptorPool)
+            {
+                return;
+            }
+        }
+    }
+
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    {
+        // Reset descriptor pool means that the pool is still valid, but the allocated descriptor sets are not
+        // Check if this was the pool for any heretofore dangling descriptors
+        DeleteDanglingPoolDescriptorSets(descriptorPool);
+    }
 
     VulkanReplayConsumer::Process_vkResetDescriptorPool(call_info, returnValue, device, descriptorPool, flags);
 }
@@ -142,7 +195,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(
         const format::HandleId* handles = pDescriptorSets->GetPointer();
         for (int i = 0; i < descriptorSetCount; ++i)
         {
-            if (dangling_descriptor_sets_.contains(handles[i]))
+            if (!dangling_descriptor_sets_.contains(handles[i]))
             {
                 return;
             }
@@ -157,9 +210,36 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(
         const format::HandleId* handles = pDescriptorSets->GetPointer();
         for (int i = 0; i < descriptorSetCount; ++i)
         {
-            // Any descriptor set that was freed during the loop range is not dangling
-            dangling_descriptor_sets_.erase(handles[i]);
+            if (dangling_descriptor_sets_.contains(handles[i]))
+            {
+                // Any descriptor set that was freed during the loop range is not dangling
+                dangling_descriptor_sets_.erase(handles[i]);
+            }
+            else
+            {
+                // Descriptor set freed during loop range but created before
+                dangling_descriptor_sets_.insert(handles[i]);
+            }
         }
+    }
+}
+
+void VulkanReplayFrameLoopConsumer::DeleteDanglingPoolDescriptorSets(format::HandleId descriptorPool)
+{
+    std::vector<format::HandleId> handles_to_delete;
+    handles_to_delete.reserve(dangling_descriptor_sets_.size());
+    for (format::HandleId handle : dangling_descriptor_sets_)
+    {
+        VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(handle);
+        if (info->pool_id == descriptorPool)
+        {
+            handles_to_delete.push_back(handle);
+        }
+    }
+
+    for (format::HandleId handle : handles_to_delete)
+    {
+        dangling_descriptor_sets_.erase(handle);
     }
 }
 
@@ -178,9 +258,6 @@ void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
     GFXRECON_ASSERT(device_table);
 
     VulkanReplayConsumer::Process_vkQueuePresentKHR(call_info, returnValue, queue, pPresentInfo);
-
-    // Fix up descriptor sets somehow
-
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -108,7 +108,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
         {
             // Created and destroyed during the loop range
             dangling_descriptor_pools_.erase(descriptorPool);
-    
+
             // Check if this was the pool for any heretofore dangling descriptors
             DeleteDanglingPoolDescriptorSets(descriptorPool);
         }
@@ -116,12 +116,11 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
     VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, device, descriptorPool, pAllocator);
 }
 
-void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(
-    const ApiCallInfo&                          call_info,
-    VkResult                                    returnValue,
-    format::HandleId                            device,
-    format::HandleId                            descriptorPool,
-    VkDescriptorPoolResetFlags                  flags)
+void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallInfo&                          call_info,
+                                                                  VkResult                                    returnValue,
+                                                                  format::HandleId                            device,
+                                                                  format::HandleId                            descriptorPool,
+                                                                  VkDescriptorPoolResetFlags                  flags)
 {
     if (frame_loop_info_.IsRepetition())
     {
@@ -180,13 +179,12 @@ void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
     }
 }
 
-void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(
-    const ApiCallInfo&                          call_info,
-    VkResult                                    returnValue,
-    format::HandleId                            device,
-    format::HandleId                            descriptorPool,
-    uint32_t                                    descriptorSetCount,
-    HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets)
+void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallInfo&                          call_info,
+                                                                 VkResult                                    returnValue,
+                                                                 format::HandleId                            device,
+                                                                 format::HandleId                            descriptorPool,
+                                                                 uint32_t                                    descriptorSetCount,
+                                                                 HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets)
 {
     if (frame_loop_info_.IsRepetition())
     {

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -116,11 +116,11 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
     VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, device, descriptorPool, pAllocator);
 }
 
-void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallInfo&                          call_info,
-                                                                  VkResult                                    returnValue,
-                                                                  format::HandleId                            device,
-                                                                  format::HandleId                            descriptorPool,
-                                                                  VkDescriptorPoolResetFlags                  flags)
+void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallInfo&         call_info,
+                                                                  VkResult                   returnValue,
+                                                                  format::HandleId           device,
+                                                                  format::HandleId           descriptorPool,
+                                                                  VkDescriptorPoolResetFlags flags)
 {
     if (frame_loop_info_.IsRepetition())
     {
@@ -179,12 +179,12 @@ void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
     }
 }
 
-void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallInfo&                          call_info,
-                                                                 VkResult                                    returnValue,
-                                                                 format::HandleId                            device,
-                                                                 format::HandleId                            descriptorPool,
-                                                                 uint32_t                                    descriptorSetCount,
-                                                                 HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets)
+void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallInfo&                     call_info,
+                                                                 VkResult                               returnValue,
+                                                                 format::HandleId                       device,
+                                                                 format::HandleId                       descriptorPool,
+                                                                 uint32_t                               descriptorSetCount,
+                                                                 HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets)
 {
     if (frame_loop_info_.IsRepetition())
     {

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -20,7 +20,6 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include "decode/vulkan_replay_frame_loop_consumer.h"
 #include "decode/custom_vulkan_struct_handle_mappers.h"
 
 #include "generated/generated_vulkan_replay_consumer.h"
@@ -62,6 +61,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateDescriptorPool(
     HandlePointerDecoder<VkDescriptorPool>*                   pDescriptorPool)
 {
     format::HandleId pool_id = *pDescriptorPool->GetPointer();
+    GFXRECON_ASSERT(pDescriptorPool != nullptr && pDescriptorPool->GetPointer() != nullptr);
 
     if (frame_loop_info_.IsRepetition())
     {
@@ -156,10 +156,6 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallI
     }
 
     VulkanReplayConsumer::Process_vkResetDescriptorPool(call_info, returnValue, device, descriptorPool, flags);
-
-    // For pools that contain dangling descriptor sets, this code will only be reached once,
-    // during the final iteration of the loop range.
-    RemovePoolDanglingCreateDescriptors(descriptorPool);
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
@@ -217,6 +213,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
 
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
     {
+        bool skip_call = false;
         for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
             if (dangling_create_descriptor_sets_.contains(set_handle))
@@ -228,30 +225,17 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
             {
                 // Descriptor set freed during loop range but created before
                 dangling_destroy_descriptor_sets_.insert(set_handle);
-                return;
+                skip_call = true;
             }
+        }
+        if (skip_call)
+        {
+            return;
         }
     }
 
     VulkanReplayConsumer::Process_vkFreeDescriptorSets(
         call_info, returnValue, device, descriptorPool, descriptorSetCount, pDescriptorSets);
-}
-
-void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
-    const ApiCallInfo&                              call_info,
-    VkResult                                        returnValue,
-    format::HandleId                                queue,
-    StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
-{
-    // Get device
-    CommonObjectInfoTable& table      = GetObjectInfoTable();
-    VulkanQueueInfo*       queue_info = table.GetVkQueueInfo(queue);
-    VkDevice               device     = queue_info->parent;
-    GFXRECON_ASSERT(device);
-    const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device);
-    GFXRECON_ASSERT(device_table);
-
-    VulkanReplayConsumer::Process_vkQueuePresentKHR(call_info, returnValue, queue, pPresentInfo);
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -197,11 +197,9 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
         }
     }
 
-    VulkanReplayConsumer::Process_vkFreeDescriptorSets(
-        call_info, returnValue, device, descriptorPool, descriptorSetCount, pDescriptorSets);
-
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
     {
+        bool any_dangling = false;
         for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
             if (dangling_descriptor_sets_.contains(set_handle))
@@ -213,9 +211,13 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
             {
                 // Descriptor set freed during loop range but created before
                 dangling_descriptor_sets_.insert(set_handle);
+                return;
             }
         }
     }
+
+    VulkanReplayConsumer::Process_vkFreeDescriptorSets(
+        call_info, returnValue, device, descriptorPool, descriptorSetCount, pDescriptorSets);
 }
 
 void VulkanReplayFrameLoopConsumer::DeleteDanglingPoolDescriptorSets(format::HandleId descriptorPool)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -20,6 +20,9 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
+#include "decode/vulkan_replay_frame_loop_consumer.h"
+#include "decode/custom_vulkan_struct_handle_mappers.h"
+
 #include "generated/generated_vulkan_replay_consumer.h"
 #include "generated/generated_vulkan_replay_frame_loop_consumer_base.h"
 #include "decode/vulkan_replay_frame_loop_consumer.h"
@@ -50,6 +53,46 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(
         call_info, returnValue, device, pCreateInfo, pAllocator, pCommandPool);
 }
 
+void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
+    const ApiCallInfo&                          call_info,
+    format::HandleId                            device,
+    format::HandleId                            descriptorPool,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+{
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    {
+        // Check if this was the pool for any heretofore dangling descriptors
+        std::vector<format::HandleId> handles_to_delete;
+        handles_to_delete.reserve(dangling_descriptor_sets_.size());
+        for (format::HandleId handle : dangling_descriptor_sets_)
+        {
+            VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(handle);
+            if (info->pool_id == descriptorPool)
+            {
+                handles_to_delete.push_back(handle);
+            }
+        }
+
+        for (format::HandleId handle : handles_to_delete)
+        {
+            dangling_descriptor_sets_.erase(handle);
+        }
+    }
+
+    VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, device, descriptorPool, pAllocator);
+}
+
+void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(
+    const ApiCallInfo&                          call_info,
+    VkResult                                    returnValue,
+    format::HandleId                            device,
+    format::HandleId                            descriptorPool,
+    VkDescriptorPoolResetFlags                  flags)
+{
+
+    VulkanReplayConsumer::Process_vkResetDescriptorPool(call_info, returnValue, device, descriptorPool, flags);
+}
+
 void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
     const ApiCallInfo&                                         call_info,
     VkResult                                                   returnValue,
@@ -59,12 +102,65 @@ void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
 {
     if (frame_loop_info_.IsRepetition())
     {
-        // Only allocate descriptor sets during the first iteration of the looping frame
-        return;
+        // Skip allocation of dangling descriptor sets
+        const format::HandleId* set_handles = pDescriptorSets->GetPointer();
+        for (int i = 0; i < pDescriptorSets->GetLength(); ++i)
+        {
+            if (dangling_descriptor_sets_.contains(set_handles[i]))
+            {
+                return;
+            }
+        }
     }
 
     VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
         call_info, returnValue, device, pAllocateInfo, pDescriptorSets);
+
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    {
+        // During first iteration of looping range, record which descriptor sets are allocated
+        const format::HandleId* set_handles = pDescriptorSets->GetPointer();
+        for (int i = 0; i < pDescriptorSets->GetLength(); ++i)
+        {
+            dangling_descriptor_sets_.insert(set_handles[i]);
+        }
+    }
+}
+
+void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(
+    const ApiCallInfo&                          call_info,
+    VkResult                                    returnValue,
+    format::HandleId                            device,
+    format::HandleId                            descriptorPool,
+    uint32_t                                    descriptorSetCount,
+    HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets)
+{
+    if (frame_loop_info_.IsRepetition())
+    {
+        // If any of the descriptor sets are _not_ in the dangling list,
+        // then we want to omit their destruction
+        const format::HandleId* handles = pDescriptorSets->GetPointer();
+        for (int i = 0; i < descriptorSetCount; ++i)
+        {
+            if (dangling_descriptor_sets_.contains(handles[i]))
+            {
+                return;
+            }
+        }
+    }
+
+    VulkanReplayConsumer::Process_vkFreeDescriptorSets(
+        call_info, returnValue, device, descriptorPool, descriptorSetCount, pDescriptorSets);
+
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    {
+        const format::HandleId* handles = pDescriptorSets->GetPointer();
+        for (int i = 0; i < descriptorSetCount; ++i)
+        {
+            // Any descriptor set that was freed during the loop range is not dangling
+            dangling_descriptor_sets_.erase(handles[i]);
+        }
+    }
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
@@ -82,6 +178,9 @@ void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
     GFXRECON_ASSERT(device_table);
 
     VulkanReplayConsumer::Process_vkQueuePresentKHR(call_info, returnValue, queue, pPresentInfo);
+
+    // Fix up descriptor sets somehow
+
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -88,7 +88,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
     format::HandleId                                     descriptorPool,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    if (frame_loop_info_.IsRepetition())
+    if (frame_loop_info_.IsRepetition() && !frame_loop_info_.IsFinalIteration())
     {
         if (dangling_descriptor_pools_.contains(descriptorPool))
         {
@@ -184,7 +184,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
                                                                  uint32_t           descriptorSetCount,
                                                                  HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets)
 {
-    if (frame_loop_info_.IsRepetition())
+    if (frame_loop_info_.IsRepetition() && !frame_loop_info_.IsFinalIteration())
     {
         // If any of the descriptor sets are _not_ in the dangling list,
         // then we want to omit their destruction

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -110,23 +110,28 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(
             dangling_descriptor_pools_.erase(descriptorPool);
 
             // Check if this was the pool for any heretofore dangling descriptors
-            std::vector<format::HandleId> handles_to_delete;
-            handles_to_delete.reserve(dangling_descriptor_sets_.size());
-            for (format::HandleId handle : dangling_descriptor_sets_)
-            {
-                VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(handle);
-                if (info->pool_id == descriptorPool)
-                {
-                    handles_to_delete.push_back(handle);
-                }
-            }
-            for (format::HandleId handle : handles_to_delete)
-            {
-                dangling_descriptor_sets_.erase(handle);
-            }
+            RemovePoolDanglingDescriptors(descriptorPool);
         }
     }
     VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, device, descriptorPool, pAllocator);
+}
+
+void VulkanReplayFrameLoopConsumer::RemovePoolDanglingDescriptors(format::HandleId descriptorPool)
+{
+    std::vector<format::HandleId> handles_to_delete;
+    handles_to_delete.reserve(dangling_descriptor_sets_.size());
+    for (format::HandleId handle : dangling_descriptor_sets_)
+    {
+        VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(handle);
+        if (info != nullptr && info->pool_id == descriptorPool)
+        {
+            handles_to_delete.push_back(handle);
+        }
+    }
+    for (format::HandleId handle : handles_to_delete)
+    {
+        dangling_descriptor_sets_.erase(handle);
+    }
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallInfo&         call_info,
@@ -135,13 +140,13 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallI
                                                                   format::HandleId           descriptorPool,
                                                                   VkDescriptorPoolResetFlags flags)
 {
-    if (frame_loop_info_.IsLooping())
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsFinalIteration())
     {
         // If any of the sets in this pool are dangling, skip pool reset
         for (format::HandleId set_id : dangling_descriptor_sets_)
         {
             VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(set_id);
-            if (info->pool_id == descriptorPool)
+            if (info != nullptr && info->pool_id == descriptorPool)
             {
                 return;
             }
@@ -149,6 +154,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallI
     }
 
     VulkanReplayConsumer::Process_vkResetDescriptorPool(call_info, returnValue, device, descriptorPool, flags);
+    RemovePoolDanglingDescriptors(descriptorPool);
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(
@@ -192,11 +198,11 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
 {
     if (frame_loop_info_.IsRepetition() && !frame_loop_info_.IsFinalIteration())
     {
-        // If any of the descriptor sets are _not_ in the dangling list,
+        // If any of the descriptor sets are in the dangling list,
         // then we want to omit their destruction
         for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
-            if (!dangling_descriptor_sets_.contains(set_handle))
+            if (dangling_descriptor_sets_.contains(set_handle))
             {
                 return;
             }
@@ -205,7 +211,6 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
 
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
     {
-        bool any_dangling = false;
         for (format::HandleId set_handle : pDescriptorSets->GetSpan())
         {
             if (dangling_descriptor_sets_.contains(set_handle))

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -55,18 +55,18 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                         format::HandleId                                          device,
                                         StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
                                         StructPointerDecoder<Decoded_VkAllocationCallbacks>*      pAllocator,
-                                        HandlePointerDecoder<VkDescriptorPool>*                   pDescriptorPool) override;
+                                        HandlePointerDecoder<VkDescriptorPool>* pDescriptorPool) override;
 
     void Process_vkDestroyDescriptorPool(const ApiCallInfo&                                   call_info,
                                          format::HandleId                                     device,
                                          format::HandleId                                     descriptorPool,
                                          StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
-    void Process_vkResetDescriptorPool(const ApiCallInfo&                          call_info,
-                                       VkResult                                    returnValue,
-                                       format::HandleId                            device,
-                                       format::HandleId                            descriptorPool,
-                                       VkDescriptorPoolResetFlags                  flags) override;
+    void Process_vkResetDescriptorPool(const ApiCallInfo&         call_info,
+                                       VkResult                   returnValue,
+                                       format::HandleId           device,
+                                       format::HandleId           descriptorPool,
+                                       VkDescriptorPoolResetFlags flags) override;
 
     void Process_vkAllocateDescriptorSets(const ApiCallInfo&                                         call_info,
                                           VkResult                                                   returnValue,
@@ -74,12 +74,12 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                           StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
                                           HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
 
-    void Process_vkFreeDescriptorSets(const ApiCallInfo&                          call_info,
-                                      VkResult                                    returnValue,
-                                      format::HandleId                            device,
-                                      format::HandleId                            descriptorPool,
-                                      uint32_t                                    descriptorSetCount,
-                                      HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
+    void Process_vkFreeDescriptorSets(const ApiCallInfo&                     call_info,
+                                      VkResult                               returnValue,
+                                      format::HandleId                       device,
+                                      format::HandleId                       descriptorPool,
+                                      uint32_t                               descriptorSetCount,
+                                      HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
 
     void Process_vkQueuePresentKHR(const ApiCallInfo&                              call_info,
                                    VkResult                                        returnValue,

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -50,11 +50,29 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                      StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
                                      HandlePointerDecoder<VkCommandPool>*                   pCommandPool) override;
 
+    void Process_vkDestroyDescriptorPool(const ApiCallInfo&                                   call_info,
+                                         format::HandleId                                     device,
+                                         format::HandleId                                     descriptorPool,
+                                         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
+
+    void Process_vkResetDescriptorPool(const ApiCallInfo&                          call_info,
+                                       VkResult                                    returnValue,
+                                       format::HandleId                            device,
+                                       format::HandleId                            descriptorPool,
+                                       VkDescriptorPoolResetFlags                  flags) override;
+
     void Process_vkAllocateDescriptorSets(const ApiCallInfo&                                         call_info,
                                           VkResult                                                   returnValue,
                                           format::HandleId                                           device,
                                           StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
                                           HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
+
+    void Process_vkFreeDescriptorSets(const ApiCallInfo&                          call_info,
+                                      VkResult                                    returnValue,
+                                      format::HandleId                            device,
+                                      format::HandleId                            descriptorPool,
+                                      uint32_t                                    descriptorSetCount,
+                                      HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
 
     void Process_vkQueuePresentKHR(const ApiCallInfo&                              call_info,
                                    VkResult                                        returnValue,
@@ -63,6 +81,8 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
 
   private:
     graphics::FrameLoopInfo&             frame_loop_info_;
+    std::unordered_set<format::HandleId> dangling_descriptor_pools_;
+    std::unordered_set<format::HandleId> dangling_descriptor_sets_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -63,7 +63,6 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
 
   private:
     graphics::FrameLoopInfo&             frame_loop_info_;
-    std::unordered_set<VkDescriptorPool> active_descriptor_pools_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -50,6 +50,13 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                      StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
                                      HandlePointerDecoder<VkCommandPool>*                   pCommandPool) override;
 
+    void Process_vkCreateDescriptorPool(const ApiCallInfo&                                        call_info,
+                                        VkResult                                                  returnValue,
+                                        format::HandleId                                          device,
+                                        StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
+                                        StructPointerDecoder<Decoded_VkAllocationCallbacks>*      pAllocator,
+                                        HandlePointerDecoder<VkDescriptorPool>*                   pDescriptorPool) override;
+
     void Process_vkDestroyDescriptorPool(const ApiCallInfo&                                   call_info,
                                          format::HandleId                                     device,
                                          format::HandleId                                     descriptorPool,
@@ -78,6 +85,9 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                    VkResult                                        returnValue,
                                    format::HandleId                                queue,
                                    StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
+
+  private:
+    void DeleteDanglingPoolDescriptorSets(format::HandleId descriptorPool);
 
   private:
     graphics::FrameLoopInfo&             frame_loop_info_;

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -91,6 +91,10 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
 
   private:
     graphics::FrameLoopInfo&             frame_loop_info_;
+
+    /// A "dangling" resource is one that was either
+    /// - created during the loop range but destroyed after it
+    /// - or created before the loop range but destroyed during it
     std::unordered_set<format::HandleId> dangling_descriptor_pools_;
     std::unordered_set<format::HandleId> dangling_descriptor_sets_;
 };

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -81,11 +81,6 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                       uint32_t                               descriptorSetCount,
                                       HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
 
-    void Process_vkQueuePresentKHR(const ApiCallInfo&                              call_info,
-                                   VkResult                                        returnValue,
-                                   format::HandleId                                queue,
-                                   StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
-
   private:
     void RemovePoolDanglingCreateDescriptors(format::HandleId descriptorPool);
 

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -87,6 +87,9 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                    StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
 
   private:
+    void RemovePoolDanglingDescriptors(format::HandleId descriptorPool);
+
+  private:
     graphics::FrameLoopInfo&             frame_loop_info_;
 
     /// A "dangling" resource is one that was either

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -87,7 +87,7 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                    StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
 
   private:
-    void RemovePoolDanglingDescriptors(format::HandleId descriptorPool);
+    void RemovePoolDanglingCreateDescriptors(format::HandleId descriptorPool);
 
   private:
     graphics::FrameLoopInfo&             frame_loop_info_;
@@ -95,8 +95,10 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
     /// A "dangling" resource is one that was either
     /// - created during the loop range but destroyed after it
     /// - or created before the loop range but destroyed during it
-    std::unordered_set<format::HandleId> dangling_descriptor_pools_;
-    std::unordered_set<format::HandleId> dangling_descriptor_sets_;
+    std::unordered_set<format::HandleId> dangling_create_descriptor_pools_;
+    std::unordered_set<format::HandleId> dangling_create_descriptor_sets_;
+    std::unordered_set<format::HandleId> dangling_destroy_descriptor_pools_;
+    std::unordered_set<format::HandleId> dangling_destroy_descriptor_sets_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -87,9 +87,6 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                    StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
 
   private:
-    void DeleteDanglingPoolDescriptorSets(format::HandleId descriptorPool);
-
-  private:
     graphics::FrameLoopInfo&             frame_loop_info_;
 
     /// A "dangling" resource is one that was either

--- a/framework/graphics/frame_loop_info.h
+++ b/framework/graphics/frame_loop_info.h
@@ -53,6 +53,8 @@ class FrameLoopInfo
     /// has already been played at least once and we are currently replaying it again.
     bool IsRepetition() const { return is_repetition_; }
 
+    bool IsFinalIteration() const { return loop_iterations_ == 1; }
+
     void     SetLooping(bool looping) { is_looping_ = looping; }
     uint32_t GetLoopFrame() const { return loop_frame_idx_; }
     uint32_t GetLoopIterations() const { return loop_iterations_; }

--- a/framework/graphics/frame_loop_info.h
+++ b/framework/graphics/frame_loop_info.h
@@ -53,6 +53,7 @@ class FrameLoopInfo
     /// has already been played at least once and we are currently replaying it again.
     bool IsRepetition() const { return is_repetition_; }
 
+    /// Returns true if this is the final iteration of the loop range
     bool IsFinalIteration() const { return loop_iterations_ == 1; }
 
     void     SetLooping(bool looping) { is_looping_ = looping; }


### PR DESCRIPTION
In my original solution, the code tracks which pools have been allocated from during the looping frame, and resets them after `vkQueuePresent()`. This solution has a flaw.

Example: Descriptor Pool 1 is used to allocate set A before the looping frame, then it allocates set B during the looping frame. Pool 1 will have been marked for reset because of set B's allocation, but when it is reset, set A goes along with it. If set A is used during the looping frame, this is invalid usage.

I realized that I was overthinking this, and we can simply skip allocating descriptor sets during repetitions of the looping frame in order to solve this issue in a simpler way, and without the flaw described above.

That's also to say, `Process_vkAllocateDescriptorSets()` can eventually just be generated like the rest of the resource allocating functions.