### PR TITLE
[Frame Looping] Manage fences that are signaled/waited-on during the looping frame

### DIFF
--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -419,25 +419,6 @@ void VulkanReplayFrameLoopConsumer::FixupDeviceFences(format::HandleId device, f
     }
 }
 
-void VulkanReplayFrameLoopConsumer::RemovePoolDanglingCreateDescriptors(format::HandleId descriptorPool)
-{
-    std::vector<format::HandleId> handles_to_delete;
-    handles_to_delete.reserve(dangling_create_descriptor_sets_.size());
-    for (format::HandleId handle : dangling_create_descriptor_sets_)
-    {
-        VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(handle);
-        if (info->pool_id == descriptorPool)
-        {
-            handles_to_delete.push_back(handle);
-        }
-    }
-
-    for (format::HandleId handle : handles_to_delete)
-    {
-        dangling_create_descriptor_sets_.erase(handle);
-    }
-}
-
 void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
     const ApiCallInfo&                              call_info,
     VkResult                                        returnValue,

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -420,15 +420,14 @@ void VulkanReplayFrameLoopConsumer::FixupDeviceFences(format::HandleId device, f
     }
 }
 
-void VulkanReplayFrameLoopConsumer::Process_vkAcquireNextImageKHR(
-    const ApiCallInfo&                          call_info,
-    VkResult                                    returnValue,
-    format::HandleId                            device,
-    format::HandleId                            swapchain,
-    uint64_t                                    timeout,
-    format::HandleId                            semaphore,
-    format::HandleId                            fence,
-    PointerDecoder<uint32_t>*                   pImageIndex)
+void VulkanReplayFrameLoopConsumer::Process_vkAcquireNextImageKHR(const ApiCallInfo&        call_info,
+                                                                  VkResult                  returnValue,
+                                                                  format::HandleId          device,
+                                                                  format::HandleId          swapchain,
+                                                                  uint64_t                  timeout,
+                                                                  format::HandleId          semaphore,
+                                                                  format::HandleId          fence,
+                                                                  PointerDecoder<uint32_t>* pImageIndex)
 {
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
     {

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -170,7 +170,10 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallI
     }
 
     VulkanReplayConsumer::Process_vkResetDescriptorPool(call_info, returnValue, device, descriptorPool, flags);
-    RemovePoolDanglingDescriptors(descriptorPool);
+
+    // For pools that contain dangling descriptor sets, this code will only be reached once,
+    // during the final iteration of the loop range.
+    RemovePoolDanglingCreateDescriptors(descriptorPool);
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -170,6 +170,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallI
     }
 
     VulkanReplayConsumer::Process_vkResetDescriptorPool(call_info, returnValue, device, descriptorPool, flags);
+    RemovePoolDanglingDescriptors(descriptorPool);
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -29,6 +29,20 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+#define CHECK_VK_RESULT(_res_, _func_)                                        \
+    {                                                                         \
+        VkResult _RES = (_res_);                                              \
+        if (_RES != VK_SUCCESS)                                               \
+        {                                                                     \
+            GFXRECON_LOG_ERROR("[%s:%u] synthetic call to %s failed with %s", \
+                               __FILE__,                                      \
+                               __LINE__,                                      \
+                               _func_,                                        \
+                               util::ToString(_RES).c_str());                 \
+            std::exit(-1);                                                    \
+        }                                                                     \
+    }
+
 void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(
     const ApiCallInfo&                                     call_info,
     VkResult                                               returnValue,
@@ -240,6 +254,197 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
 
     VulkanReplayConsumer::Process_vkFreeDescriptorSets(
         call_info, returnValue, device, descriptorPool, descriptorSetCount, pDescriptorSets);
+}
+
+void VulkanReplayFrameLoopConsumer::Process_vkWaitForFences(const ApiCallInfo&             call_info,
+                                                            VkResult                       returnValue,
+                                                            format::HandleId               device,
+                                                            uint32_t                       fenceCount,
+                                                            HandlePointerDecoder<VkFence>* pFences,
+                                                            VkBool32                       waitAll,
+                                                            uint64_t                       timeout)
+{
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    {
+        for (int i = 0; i < fenceCount; ++i)
+        {
+            if (!per_device_fence_tracking_.contains(device))
+            {
+                per_device_fence_tracking_[device] = {};
+            }
+            FenceTracking& t = per_device_fence_tracking_[device];
+
+            format::HandleId fence = pFences->GetPointer()[i];
+            if (t.waited_upon_fences_.contains(fence))
+            {
+                t.waited_upon_fences_[fence] += 1;
+            }
+            else
+            {
+                t.waited_upon_fences_[fence] = 1;
+            }
+            GFXRECON_LOG_DEBUG("VkFence with handle \"%" PRIu64 "\" has been waited on %" PRIu32 " times.",
+                               fence,
+                               t.waited_upon_fences_[fence]);
+        }
+    }
+
+    VulkanReplayConsumer::Process_vkWaitForFences(
+        call_info, returnValue, device, fenceCount, pFences, waitAll, timeout);
+}
+
+void VulkanReplayFrameLoopConsumer::Process_vkQueueSubmit(const ApiCallInfo&                          call_info,
+                                                          VkResult                                    returnValue,
+                                                          format::HandleId                            queue,
+                                                          uint32_t                                    submitCount,
+                                                          StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
+                                                          format::HandleId                            fence)
+{
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    {
+        // Collect fences submitted during the looping frame
+        VulkanFenceInfo* fence_info = GetObjectInfoTable().GetVkFenceInfo(fence);
+        if (fence_info != nullptr)
+        {
+            format::HandleId device = GetObjectInfoTable().GetVkQueueInfo(queue)->parent_id;
+            if (!per_device_fence_tracking_.contains(device))
+            {
+                per_device_fence_tracking_[device] = {};
+            }
+            FenceTracking& t = per_device_fence_tracking_[device];
+
+            if (t.signaled_fences_.contains(fence))
+            {
+                t.signaled_fences_[fence] += 1;
+            }
+            else
+            {
+                t.signaled_fences_[fence] = 1;
+            }
+            t.signaled_fences_[fence];
+            GFXRECON_LOG_DEBUG("VkFence with handle \"%" PRIu64 "\" has been signaled %" PRIu32 " times.",
+                               fence,
+                               t.signaled_fences_[fence]);
+        }
+    }
+
+    VulkanReplayConsumer::Process_vkQueueSubmit(call_info, returnValue, queue, submitCount, pSubmits, fence);
+}
+
+void VulkanReplayFrameLoopConsumer::FixupDeviceFences(format::HandleId device, format::HandleId queue)
+{
+    // Get fence tracking info associated with this VkDevice
+    if (!per_device_fence_tracking_.contains(device))
+    {
+        // No need to fixup fences if there weren't any
+        return;
+    }
+    FenceTracking& t = per_device_fence_tracking_[device];
+
+    VulkanObjectInfoTable&             table        = GetObjectInfoTable();
+    VkDevice                           vk_device    = table.GetVkDeviceInfo(device)->handle;
+    const graphics::VulkanDeviceTable* device_table = GetDeviceTable(vk_device);
+
+    // Gather fences that need to be synthetically waited on
+    std::vector<VkFence> manual_wait_fences;
+    manual_wait_fences.reserve(t.signaled_fences_.size());
+    for (auto [fence_id, signal_count] : t.signaled_fences_)
+    {
+        uint32_t wait_count = 0;
+        if (t.waited_upon_fences_.contains(fence_id))
+        {
+            wait_count = t.waited_upon_fences_[fence_id];
+        }
+
+        // Manually wait on the fence if it's signaled more times than it is waited upon
+        if (signal_count > wait_count)
+        {
+            GFXRECON_LOG_DEBUG("Will synthetically wait on fence %" PRIu64, fence_id);
+            VulkanFenceInfo* fence_info = table.GetVkFenceInfo(fence_id);
+            manual_wait_fences.push_back(fence_info->handle);
+        }
+    }
+
+    // Gather fences that need to be synthetically signaled
+    std::vector<VkFence> manual_signal_fences;
+    manual_signal_fences.reserve(t.signaled_fences_.size());
+    for (auto [fence_id, wait_count] : t.waited_upon_fences_)
+    {
+        uint32_t signal_count = 0;
+        if (t.signaled_fences_.contains(fence_id))
+        {
+            signal_count = t.signaled_fences_[fence_id];
+        }
+
+        // Manually signal fence if it's waited on more times than it is signaled
+        if (wait_count > signal_count)
+        {
+            GFXRECON_LOG_DEBUG("Will synthetically signal fence %" PRIu64, fence_id);
+            VulkanFenceInfo* fence_info = table.GetVkFenceInfo(fence_id);
+            manual_signal_fences.push_back(fence_info->handle);
+        }
+    }
+
+    VkResult result;
+
+    if (manual_wait_fences.size() > 0)
+    {
+        GFXRECON_LOG_DEBUG("Synthetically waiting on fences...");
+        result = device_table->WaitForFences(vk_device,
+                                             manual_wait_fences.size(),
+                                             manual_wait_fences.data(),
+                                             VK_TRUE,
+                                             std::numeric_limits<uint64_t>::max());
+        CHECK_VK_RESULT(result, "vkWaitForFences");
+
+        GFXRECON_LOG_DEBUG("Resetting synthetically waited on fences...");
+        result = device_table->ResetFences(vk_device, manual_wait_fences.size(), manual_wait_fences.data());
+        CHECK_VK_RESULT(result, "vkResetFences");
+    }
+
+    if (manual_signal_fences.size() > 0)
+    {
+        // Fences may have been waited on but not reset, so we reset the fences we're going
+        // to manually signal here just in case.
+        result = device_table->ResetFences(vk_device, manual_signal_fences.size(), manual_signal_fences.data());
+        CHECK_VK_RESULT(result, "vkResetFences");
+
+        GFXRECON_LOG_DEBUG("Synthetically signaling fences...");
+        for (VkFence fence : manual_signal_fences)
+        {
+            VulkanQueueInfo* queue_info = table.GetVkQueueInfo(queue);
+            result                      = device_table->QueueSubmit(queue_info->handle, 0, nullptr, fence);
+            CHECK_VK_RESULT(result, "vkDeviceWaitIdle");
+        }
+    }
+}
+
+void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
+    const ApiCallInfo&                              call_info,
+    VkResult                                        returnValue,
+    format::HandleId                                queue,
+    StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
+{
+    VulkanReplayConsumer::Process_vkQueuePresentKHR(call_info, returnValue, queue, pPresentInfo);
+
+    if (frame_loop_info_.IsLooping())
+    {
+        // Get device
+        CommonObjectInfoTable& table      = GetObjectInfoTable();
+        VulkanQueueInfo*       queue_info = table.GetVkQueueInfo(queue);
+        VkDevice               device     = queue_info->parent;
+        GFXRECON_ASSERT(device);
+        const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device);
+        GFXRECON_ASSERT(device_table);
+
+        VkResult result;
+
+        GFXRECON_LOG_DEBUG("Waiting for device to idle...");
+        result = device_table->DeviceWaitIdle(device);
+        CHECK_VK_RESULT(result, "vkDeviceWaitIdle");
+
+        FixupDeviceFences(queue_info->parent_id, queue);
+    }
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -170,10 +170,6 @@ void VulkanReplayFrameLoopConsumer::Process_vkResetDescriptorPool(const ApiCallI
     }
 
     VulkanReplayConsumer::Process_vkResetDescriptorPool(call_info, returnValue, device, descriptorPool, flags);
-
-    // For pools that contain dangling descriptor sets, this code will only be reached once,
-    // during the final iteration of the loop range.
-    RemovePoolDanglingCreateDescriptors(descriptorPool);
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkAllocateDescriptorSets(

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -419,6 +419,25 @@ void VulkanReplayFrameLoopConsumer::FixupDeviceFences(format::HandleId device, f
     }
 }
 
+void VulkanReplayFrameLoopConsumer::RemovePoolDanglingCreateDescriptors(format::HandleId descriptorPool)
+{
+    std::vector<format::HandleId> handles_to_delete;
+    handles_to_delete.reserve(dangling_create_descriptor_sets_.size());
+    for (format::HandleId handle : dangling_create_descriptor_sets_)
+    {
+        VulkanDescriptorSetInfo* info = GetObjectInfoTable().GetVkDescriptorSetInfo(handle);
+        if (info->pool_id == descriptorPool)
+        {
+            handles_to_delete.push_back(handle);
+        }
+    }
+
+    for (format::HandleId handle : handles_to_delete)
+    {
+        dangling_create_descriptor_sets_.erase(handle);
+    }
+}
+
 void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(
     const ApiCallInfo&                              call_info,
     VkResult                                        returnValue,

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -367,7 +367,7 @@ void VulkanReplayFrameLoopConsumer::FixupDeviceFences(format::HandleId device, f
 
     // Gather fences that need to be synthetically signaled
     std::vector<VkFence> manual_signal_fences;
-    manual_signal_fences.reserve(t.signaled_fences_.size());
+    manual_signal_fences.reserve(t.waited_upon_fences_.size());
     for (auto [fence_id, wait_count] : t.waited_upon_fences_)
     {
         uint32_t signal_count = 0;
@@ -389,7 +389,7 @@ void VulkanReplayFrameLoopConsumer::FixupDeviceFences(format::HandleId device, f
 
     if (manual_wait_fences.size() > 0)
     {
-        GFXRECON_LOG_DEBUG("Synthetically waiting on fences...");
+        GFXRECON_LOG_DEBUG("Synthetically waiting on %" PRIu64 " fences...", manual_wait_fences.size());
         result = device_table->WaitForFences(vk_device,
                                              manual_wait_fences.size(),
                                              manual_wait_fences.data(),
@@ -397,7 +397,7 @@ void VulkanReplayFrameLoopConsumer::FixupDeviceFences(format::HandleId device, f
                                              std::numeric_limits<uint64_t>::max());
         CHECK_VK_RESULT(result, "vkWaitForFences");
 
-        GFXRECON_LOG_DEBUG("Resetting synthetically waited on fences...");
+        GFXRECON_LOG_DEBUG("Resetting %" PRIu64 " synthetically waited on fences...", manual_wait_fences.size());
         result = device_table->ResetFences(vk_device, manual_wait_fences.size(), manual_wait_fences.data());
         CHECK_VK_RESULT(result, "vkResetFences");
     }
@@ -406,6 +406,7 @@ void VulkanReplayFrameLoopConsumer::FixupDeviceFences(format::HandleId device, f
     {
         // Fences may have been waited on but not reset, so we reset the fences we're going
         // to manually signal here just in case.
+        GFXRECON_LOG_DEBUG("Resetting fences to synthetically signal...");
         result = device_table->ResetFences(vk_device, manual_signal_fences.size(), manual_signal_fences.data());
         CHECK_VK_RESULT(result, "vkResetFences");
 
@@ -417,6 +418,47 @@ void VulkanReplayFrameLoopConsumer::FixupDeviceFences(format::HandleId device, f
             CHECK_VK_RESULT(result, "vkDeviceWaitIdle");
         }
     }
+}
+
+void VulkanReplayFrameLoopConsumer::Process_vkAcquireNextImageKHR(
+    const ApiCallInfo&                          call_info,
+    VkResult                                    returnValue,
+    format::HandleId                            device,
+    format::HandleId                            swapchain,
+    uint64_t                                    timeout,
+    format::HandleId                            semaphore,
+    format::HandleId                            fence,
+    PointerDecoder<uint32_t>*                   pImageIndex)
+{
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    {
+        // Collect fences used during the looping frame
+        VulkanFenceInfo* fence_info = GetObjectInfoTable().GetVkFenceInfo(fence);
+        if (fence_info != nullptr)
+        {
+            if (!per_device_fence_tracking_.contains(device))
+            {
+                per_device_fence_tracking_[device] = {};
+            }
+            FenceTracking& t = per_device_fence_tracking_[device];
+
+            if (t.signaled_fences_.contains(fence))
+            {
+                t.signaled_fences_[fence] += 1;
+            }
+            else
+            {
+                t.signaled_fences_[fence] = 1;
+            }
+            t.signaled_fences_[fence];
+            GFXRECON_LOG_DEBUG("VkFence with handle \"%" PRIu64 "\" has been signaled %" PRIu32 " times.",
+                               fence,
+                               t.signaled_fences_[fence]);
+        }
+    }
+
+    VulkanReplayConsumer::Process_vkAcquireNextImageKHR(
+        call_info, returnValue, device, swapchain, timeout, semaphore, fence, pImageIndex);
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -81,11 +81,39 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                       uint32_t                               descriptorSetCount,
                                       HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
 
+    void Process_vkWaitForFences(const ApiCallInfo&             call_info,
+                                 VkResult                       returnValue,
+                                 format::HandleId               device,
+                                 uint32_t                       fenceCount,
+                                 HandlePointerDecoder<VkFence>* pFences,
+                                 VkBool32                       waitAll,
+                                 uint64_t                       timeout) override;
+
+    void Process_vkQueueSubmit(const ApiCallInfo&                          call_info,
+                               VkResult                                    returnValue,
+                               format::HandleId                            queue,
+                               uint32_t                                    submitCount,
+                               StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
+                               format::HandleId                            fence) override;
+
+    void Process_vkQueuePresentKHR(const ApiCallInfo&                              call_info,
+                                   VkResult                                        returnValue,
+                                   format::HandleId                                queue,
+                                   StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
+
+    // Private declarations
   private:
     void RemovePoolDanglingCreateDescriptors(format::HandleId descriptorPool);
+    struct FenceTracking
+    {
+        std::unordered_map<format::HandleId, uint32_t> signaled_fences_;
+        std::unordered_map<format::HandleId, uint32_t> waited_upon_fences_;
+    };
+    void FixupDeviceFences(format::HandleId device, format::HandleId queue);
 
+    // Private data
   private:
-    graphics::FrameLoopInfo&             frame_loop_info_;
+    graphics::FrameLoopInfo& frame_loop_info_;
 
     /// A "dangling" resource is one that was either
     /// - created during the loop range but destroyed after it
@@ -94,6 +122,8 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
     std::unordered_set<format::HandleId> dangling_create_descriptor_sets_;
     std::unordered_set<format::HandleId> dangling_destroy_descriptor_pools_;
     std::unordered_set<format::HandleId> dangling_destroy_descriptor_sets_;
+
+    std::unordered_map<format::HandleId, FenceTracking> per_device_fence_tracking_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -96,6 +96,15 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
                                StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
                                format::HandleId                            fence) override;
 
+    void Process_vkAcquireNextImageKHR(const ApiCallInfo&        call_info,
+                                       VkResult                  returnValue,
+                                       format::HandleId          device,
+                                       format::HandleId          swapchain,
+                                       uint64_t                  timeout,
+                                       format::HandleId          semaphore,
+                                       format::HandleId          fence,
+                                       PointerDecoder<uint32_t>* pImageIndex) override;
+
     void Process_vkQueuePresentKHR(const ApiCallInfo&                              call_info,
                                    VkResult                                        returnValue,
                                    format::HandleId                                queue,


### PR DESCRIPTION
This PR is based on top of https://github.com/LunarG/gfxreconstruct/pull/2935 so it will need to be merged first.

In the case of naive looping, it is easy to see how a fence can be double-signaled or double-waited-on, so we need to handle those situations.

Regarding a fence that is used during the looping frame, there are three cases:

1. The fence is signaled as many times as it is waited upon
2. The fence is signaled more times than it is waited upon
3. The fence is signaled fewer times than it is waited upon

In the first case, no special handling is needed, as the final fence operation will put the fence in the state that the first fence operation expects.

In the second case, we need to synthetically wait-on the fence so that it's in the unsignaled state at the start of the next iteration of the looping frame.

In the third case, we need to synthetically signal the fence so that it's in the signaled state at the start of the next iteration of the looping frame.