### PR TITLE
Fix gfxrecon-optimize: Prune debug-labels for unreferenced handle-ids

### DIFF
--- a/framework/decode/vulkan_referenced_block_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_block_consumer_base.cpp
@@ -119,5 +119,35 @@ void VulkanReferencedBlockConsumerBase::Process_vkGetRayTracingShaderGroupHandle
     }
 }
 
+void VulkanReferencedBlockConsumerBase::Process_vkSetDebugUtilsObjectNameEXT(
+    const ApiCallInfo&                                           call_info,
+    VkResult                                                     returnValue,
+    format::HandleId                                             device,
+    StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+
+    if (check_handle_id_unused(pNameInfo->GetMetaStructPointer()->objectHandle))
+    {
+        set_block_index_unused(call_info.index);
+    }
+}
+
+void VulkanReferencedBlockConsumerBase::Process_vkSetDebugUtilsObjectTagEXT(
+    const ApiCallInfo&                                          call_info,
+    VkResult                                                    returnValue,
+    format::HandleId                                            device,
+    StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+
+    if (check_handle_id_unused(pTagInfo->GetMetaStructPointer()->objectHandle))
+    {
+        set_block_index_unused(call_info.index);
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_referenced_block_consumer_base.h
+++ b/framework/decode/vulkan_referenced_block_consumer_base.h
@@ -80,6 +80,18 @@ class VulkanReferencedBlockConsumerBase : public VulkanConsumer
                                                       size_t                   dataSize,
                                                       PointerDecoder<uint8_t>* pData) override;
 
+    void Process_vkSetDebugUtilsObjectNameEXT(
+        const ApiCallInfo&                                           call_info,
+        VkResult                                                     returnValue,
+        format::HandleId                                             device,
+        StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo) override;
+
+    void
+    Process_vkSetDebugUtilsObjectTagEXT(const ApiCallInfo&                                          call_info,
+                                        VkResult                                                    returnValue,
+                                        format::HandleId                                            device,
+                                        StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo) override;
+
   protected:
     // check if a handle_id is not used throughout the entire capture
     bool check_handle_id_unused(format::HandleId handle_id) const { return unreferenced_ids_.contains(handle_id); }


### PR DESCRIPTION
When gfxrecon-optimize removes blocks for unreferenced resources
it shall also remove debug-utils calls referencing those resources.

fixes #2942
 