### PR TITLE
gfxrecon-optimize: Fix handling of pipelines

### DIFF
--- a/framework/decode/vulkan_referenced_block_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_block_consumer_base.cpp
@@ -97,6 +97,21 @@ void VulkanReferencedBlockConsumerBase::Process_vkCreateRayTracingPipelinesKHR(
     }
 }
 
+void VulkanReferencedBlockConsumerBase::Process_vkDestroyPipeline(
+    const ApiCallInfo&                                   call_info,
+    format::HandleId                                     device,
+    format::HandleId                                     pipeline,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+
+    if (check_handle_id_unused(pipeline))
+    {
+        set_block_index_unused(call_info.index);
+    }
+}
+
 void VulkanReferencedBlockConsumerBase::Process_vkGetRayTracingShaderGroupHandlesKHR(const ApiCallInfo& call_info,
                                                                                      VkResult           returnValue,
                                                                                      format::HandleId   device,

--- a/framework/decode/vulkan_referenced_block_consumer_base.h
+++ b/framework/decode/vulkan_referenced_block_consumer_base.h
@@ -71,6 +71,11 @@ class VulkanReferencedBlockConsumerBase : public VulkanConsumer
         StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
         HandlePointerDecoder<VkPipeline>*                                pPipelines) override;
 
+    void Process_vkDestroyPipeline(const ApiCallInfo&                                   call_info,
+                                   format::HandleId                                     device,
+                                   format::HandleId                                     pipeline,
+                                   StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
+
     void Process_vkGetRayTracingShaderGroupHandlesKHR(const ApiCallInfo&       call_info,
                                                       VkResult                 returnValue,
                                                       format::HandleId         device,


### PR DESCRIPTION
vkDestroyPipeline is not handled in VulkanReferencedBlockConsumerBase which leaves calls to vkDestroyPipeline in the optimized file that reference nonexistent pipeline handles.