### PR TITLE
Report failure reason for additional arguments

### DIFF
--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -35,7 +35,8 @@ GFXRECON_BEGIN_NAMESPACE(util)
 ArgumentParser::ArgumentParser(int32_t            argc,
                                const char** const argv,
                                const std::string& options,
-                               const std::string& arguments) : is_invalid_(false)
+                               const std::string& arguments) :
+    is_invalid_(false)
 {
     if (argc > 1 && nullptr != argv)
     {
@@ -53,7 +54,8 @@ ArgumentParser::ArgumentParser(int32_t            argc,
 ArgumentParser::ArgumentParser(bool               first_is_exe_name,
                                const char*        args,
                                const std::string& options,
-                               const std::string& arguments) : is_invalid_(false)
+                               const std::string& arguments) :
+    is_invalid_(false)
 {
     std::vector<std::string> command_line_args;
     size_t                   args_len = strlen(args);

--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -35,8 +35,7 @@ GFXRECON_BEGIN_NAMESPACE(util)
 ArgumentParser::ArgumentParser(int32_t            argc,
                                const char** const argv,
                                const std::string& options,
-                               const std::string& arguments) :
-    is_invalid_(false)
+                               const std::string& arguments) : is_invalid_(false)
 {
     if (argc > 1 && nullptr != argv)
     {
@@ -54,8 +53,7 @@ ArgumentParser::ArgumentParser(int32_t            argc,
 ArgumentParser::ArgumentParser(bool               first_is_exe_name,
                                const char*        args,
                                const std::string& options,
-                               const std::string& arguments) :
-    is_invalid_(false)
+                               const std::string& arguments) : is_invalid_(false)
 {
     std::vector<std::string> command_line_args;
     size_t                   args_len = strlen(args);
@@ -228,6 +226,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
                             // We're on the last argument, so add this to the invalid list.
                             invalid_values_present_.push_back(current_argument);
                             is_invalid_ = true;
+                            GFXRECON_LOG_FATAL("Invalid command-line setting \'%s\'", current_argument.c_str());
                         }
                         else
                         {

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -125,6 +125,10 @@ void android_main(struct android_app* app)
     }
     else if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() > 1))
     {
+        if (arg_parser.GetPositionalArgumentsCount() > 1)
+        {
+            GFXRECON_LOG_ERROR("Unexpected positional argument \'%s\'", arg_parser.GetPositionalArguments()[1].c_str());
+        }
         PrintUsage(kApplicationName);
         run = false;
     }

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -127,7 +127,8 @@ void android_main(struct android_app* app)
     {
         if (arg_parser.GetPositionalArgumentsCount() > 1)
         {
-            GFXRECON_LOG_ERROR("Unexpected positional argument \'%s\'", arg_parser.GetPositionalArguments()[1].c_str());
+            GFXRECON_LOG_ERROR("Too many inputs provided to command line starting with \'%s\'",
+                               arg_parser.GetPositionalArguments()[1].c_str());
         }
         PrintUsage(kApplicationName);
         run = false;

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -122,7 +122,8 @@ int main(int argc, const char** argv)
     {
         if (arg_parser.GetPositionalArgumentsCount() > 1)
         {
-            GFXRECON_LOG_ERROR("Unexpected positional argument \'%s\'", arg_parser.GetPositionalArguments()[1].c_str());
+            GFXRECON_LOG_ERROR("Too many inputs provided to command line starting with \'%s\'",
+                               arg_parser.GetPositionalArguments()[1].c_str());
         }
         else if (arg_parser.GetPositionalArgumentsCount() == 0)
         {

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -120,6 +120,14 @@ int main(int argc, const char** argv)
     }
     else if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 1))
     {
+        if (arg_parser.GetPositionalArgumentsCount() > 1)
+        {
+            GFXRECON_LOG_ERROR("Unexpected positional argument \'%s\'", arg_parser.GetPositionalArguments()[1].c_str());
+        }
+        else if (arg_parser.GetPositionalArgumentsCount() == 0)
+        {
+            GFXRECON_LOG_ERROR("Missing gfxr file argument");
+        }
         PrintUsage(argv[0]);
         gfxrecon::util::Log::Release();
         exit(-1);


### PR DESCRIPTION
When passing additional, unexpected arguments to the replay app, it did just show the command line help, but not actually issue any hint about the actual command line failure.

For example on Android, we treat a single space as argument separator.
Hence using 2 spaces, as in '--dump-resources-dir  /sdcard/output' did cause the issue, just showing the usage help without any hint of what detail failed.
Fixes the non reporting of the failure reason, now it fails with

Unexpected positional argument '/sdcard/output'
