### PR TITLE
replay: Fixes to replay captures from vkd3d-proton with `-m rebind`

### DIFF
--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -662,6 +662,9 @@ void VulkanAddressReplacer::ProcessCmdBindDescriptorSets(VulkanCommandBufferInfo
     // map used to identify chained pointer-accesses (identical set/binding/offsets)
     std::set<set_key_t> dup_map;
 
+    const uint64_t first_bound_set = firstSet;
+    const uint64_t last_bound_set  = first_bound_set + descriptorSetCount;
+
     for (const auto& buffer_ref_info : pipeline_info->buffer_reference_infos)
     {
         if (buffer_ref_info.source != util::SpirVParsingUtil::BufferReferenceLocation::UNIFORM_BUFFER &&
@@ -670,7 +673,13 @@ void VulkanAddressReplacer::ProcessCmdBindDescriptorSets(VulkanCommandBufferInfo
             // non-buffer descriptor, handled elsewhere
             continue;
         }
-        GFXRECON_ASSERT(buffer_ref_info.set <= descriptorSetCount);
+
+        if (buffer_ref_info.set < first_bound_set || buffer_ref_info.set >= last_bound_set)
+        {
+            continue;
+        }
+
+        const uint32_t descriptor_set_index = buffer_ref_info.set - firstSet;
 
         set_key_t set_key = { static_cast<uint32_t>(buffer_ref_info.source),
                               buffer_ref_info.set,
@@ -679,7 +688,7 @@ void VulkanAddressReplacer::ProcessCmdBindDescriptorSets(VulkanCommandBufferInfo
 
         // we need a mutable pointer, to allow for in-place corrections
         auto* descriptor_set_info =
-            object_table_->GetVkDescriptorSetInfo(pDescriptorSets->GetPointer()[buffer_ref_info.set]);
+            object_table_->GetVkDescriptorSetInfo(pDescriptorSets->GetPointer()[descriptor_set_index]);
 
         if (descriptor_set_info == nullptr)
         {

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -600,8 +600,11 @@ void VulkanAddressReplacer::ProcessCmdPushConstants(const VulkanCommandBufferInf
                                                     const decode::VulkanDeviceAddressTracker& address_tracker)
 {
     GFXRECON_UNREFERENCED_PARAMETER(stage_flags);
-    GFXRECON_UNREFERENCED_PARAMETER(size);
     GFXRECON_ASSERT(command_buffer_info != nullptr && data != nullptr);
+
+    const uint64_t update_start = offset;
+    const uint64_t update_end   = update_start + size;
+
     for (const auto& [bind_point, pipeline_id] : command_buffer_info->bound_pipelines)
     {
         const auto* pipeline_info = object_table_->GetVkPipelineInfo(pipeline_id);
@@ -612,9 +615,17 @@ void VulkanAddressReplacer::ProcessCmdPushConstants(const VulkanCommandBufferInf
             {
                 if (buffer_ref_info.source == util::SpirVParsingUtil::BufferReferenceLocation::PUSH_CONSTANT_BLOCK)
                 {
+                    const uint64_t field_offset = buffer_ref_info.buffer_offset;
+                    const uint64_t field_end    = field_offset + sizeof(VkDeviceAddress);
+
+                    if (field_offset < update_start || field_end > update_end)
+                    {
+                        continue;
+                    }
+
                     // find addresses in push-constant memory and replace in-place.
-                    auto* address = reinterpret_cast<VkDeviceAddress*>(static_cast<uint8_t*>(data) + offset +
-                                                                       buffer_ref_info.buffer_offset);
+                    auto* address =
+                        reinterpret_cast<VkDeviceAddress*>(static_cast<uint8_t*>(data) + (field_offset - update_start));
 
                     auto* buffer_info = address_tracker.GetBufferByCaptureDeviceAddress(*address);
                     if (buffer_info != nullptr && buffer_info->replay_address != 0)

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -312,7 +312,12 @@ void VulkanRebindAllocator::DestroyBuffer(VkBuffer                     buffer,
                                           ResourceData                 allocator_data)
 {
     GFXRECON_UNREFERENCED_PARAMETER(allocation_callbacks);
-    GFXRECON_ASSERT(buffer != VK_NULL_HANDLE);
+
+    if (buffer == VK_NULL_HANDLE)
+    {
+        GFXRECON_ASSERT(allocator_data == 0);
+        return;
+    }
 
     if (allocator_data != 0)
     {
@@ -364,7 +369,12 @@ void VulkanRebindAllocator::DestroyImage(VkImage                      image,
                                          ResourceData                 allocator_data)
 {
     GFXRECON_UNREFERENCED_PARAMETER(allocation_callbacks);
-    GFXRECON_ASSERT(image != VK_NULL_HANDLE);
+
+    if (image == VK_NULL_HANDLE)
+    {
+        GFXRECON_ASSERT(allocator_data == 0);
+        return;
+    }
 
     if (allocator_data != 0)
     {

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -11909,7 +11909,8 @@ void VulkanReplayConsumerBase::OverrideUpdateDescriptorSets(
             const uint32_t binding = write->dstBinding;
             GFXRECON_ASSERT(dst_desc_set_info->descriptors.find(binding) != dst_desc_set_info->descriptors.end());
             auto& descriptor_set_binding_info = dst_desc_set_info->descriptors[binding];
-            GFXRECON_ASSERT(descriptor_set_binding_info.desc_type == write->descriptorType);
+            GFXRECON_ASSERT(descriptor_set_binding_info.desc_type == write->descriptorType ||
+                            descriptor_set_binding_info.desc_type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT);
 
             if (auto* inline_uniform_block_write =
                     graphics::vulkan_struct_get_pnext<VkWriteDescriptorSetInlineUniformBlock>(write);


### PR DESCRIPTION
Addresses issues described in https://github.com/LunarG/gfxreconstruct/issues/2949:

- `Assertion failed: 'descriptor_set_binding_info.desc_type == write->descriptorType'` - For mutable descriptor we can write any supported descriptor type.
  - Though this change doesn't handle potential issue when app would write different descriptor type at the same target idx. 
- Passing NULL to `::DestroyBuffer` and `::DestroyImage` in `VulkanRebindAllocator` should not assert since it's valid from VK perspective.
- `offset` in `CmdPushConstants` should be taken into account - push consts could be updated piece-wise, though this doesn't cover a case when a single uint64 address is being set with two push consts updates, 32b at a time.
- `firstSet` in `CmdBindDescriptorSets` should be taken into account.

Beside the above, the only change left to make replay with `-m rebind` work is treat uvec2 accesses in SPIRV as if they can be addresses, there is a draft commit to do this at https://github.com/werman/gfxreconstruct/commits/feature/better-BDA-rebind/ but I'm absolutely not confident regarding it, but with that change I was able to replay a trace of fairly complex game.

Why do I care about replaying vkd3d-proton traces with `-m rebind`? Without that I cannot make a RenderDoc capture from gfxreconstruct trace.

Also here is a demo that can reproduce BDA replaying issues: https://github.com/werman/vkd3d-proton/tree/test/gfxreconstruct-bda-demo (made on top of vkd3d-proton demos). Was with the following vkd3d options: `VKD3D_DISABLE_EXTENSIONS=VK_EXT_descriptor_buffer,VK_EXT_mesh_shader,VK_EXT_device_generated_commands,VK_NV_device_generated_commands,VK_NV_device_generated_commands_compute VKD3D_CONFIG=force_raw_va_cbv,nodxr`