### PR TITLE
Fix debug build assertion error when advancing to next frame

### DIFF
--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -170,12 +170,6 @@ void Application::Run()
                 fps_info_->BeginFrame(frame_number);
             }
 
-            if (replay_event_sink_)
-            {
-                // Replay event plugin uses a 0-based frame index.
-                replay_event_sink_->FrameBegin(file_processor_->GetCurrentFrameNumber());
-            }
-
             // PlaySingleFrame() increments this->current_frame_number_ *if* there's an end-of-frame
             PlaySingleFrame();
 
@@ -198,11 +192,6 @@ void Application::Run()
                 {
                     file_processor_->WaitDecodersIdle();
                 }
-            }
-
-            if (replay_event_sink_)
-            {
-                replay_event_sink_->FrameEnd();
             }
         }
     }
@@ -232,6 +221,12 @@ bool Application::PlaySingleFrame()
 
     if (file_processor_)
     {
+        if (replay_event_sink_)
+        {
+            // Replay event plugin uses a 0-based frame index.
+            replay_event_sink_->FrameBegin(file_processor_->GetCurrentFrameNumber());
+        }
+
         success = file_processor_->ProcessNextFrame();
 
         if (success)
@@ -252,6 +247,11 @@ bool Application::PlaySingleFrame()
         else
         {
             running_ = false;
+        }
+
+        if (replay_event_sink_)
+        {
+            replay_event_sink_->FrameEnd();
         }
     }
 


### PR DESCRIPTION
Fix issue on debug builds of GFXR where advancing to the next frame (using rightarrow or n) causes an assertion error. This is due to the contexts that process keyboard inputs to call `application`'s `PlaySingleFrame()` eventually checking an assertion for `ReplayEventSink`'s member variable `frame_active_` even though it was never set to true with `FrameBegin`. 

One recommendation taken from Claude is to do the same as seen in the `application.cpp`'s loop to call `FrameBegin` and `FrameEnd`, except we move these calls to inside `PlaySingleFrame`.