### PR TITLE
Fix null dereferencing from pipeline cache file

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -285,7 +285,15 @@ void VulkanReplayConsumerBase::SavePipelineCachesToFile()
 {
     for (const auto& [handle_id, cache] : tracked_pipeline_caches_)
     {
-        SavePipelineCache(handle_id, cache.device_info, cache.vk_cache);
+        // When --load-pipeline-cache and --save-pipeline-cache point to the same file it is possible that entries in
+        // the tracked_pipeline_caches_ are left with device_info and vk_cache as null. When caches are loaded at the
+        // beginning from the cache file and the map is populated with new entries, the device_info and vk_cache member
+        // variables are default initialized to null. These entries are expected to be set when the cache is actually
+        // created when vkCreatePipelineCache is encountered.
+        if (cache.device_info != nullptr && cache.vk_cache != VK_NULL_HANDLE)
+        {
+            SavePipelineCache(handle_id, cache.device_info, cache.vk_cache);
+        }
     }
 
     tracked_pipeline_caches_.clear();
@@ -7511,6 +7519,7 @@ void VulkanReplayConsumerBase::OverrideDestroyPipelineCache(
     {
         if (save_pipeline_caches_to_file)
         {
+            GFXRECON_ASSERT(pipeline_cache_info->handle != VK_NULL_HANDLE);
             SavePipelineCache(pipeline_cache_info->capture_id, device_info, pipeline_cache_info->handle);
         }
 
@@ -12397,6 +12406,8 @@ void VulkanReplayConsumerBase::OverrideDestroyPipeline(
 
                 if (save_pipeline_caches_to_file)
                 {
+                    GFXRECON_ASSERT(itTracked->second.device_info != nullptr);
+                    GFXRECON_ASSERT(itTracked->second.vk_cache != VK_NULL_HANDLE);
                     SavePipelineCache(id, itTracked->second.device_info, itTracked->second.vk_cache);
                 }
                 auto device_table = GetDeviceTable(device_info->handle);
@@ -13024,6 +13035,8 @@ void VulkanReplayConsumerBase::SavePipelineCache(format::HandleId        id,
                                                  const VulkanDeviceInfo* device_info,
                                                  VkPipelineCache         pipelineCache)
 {
+    GFXRECON_ASSERT(device_info != nullptr);
+    GFXRECON_ASSERT(pipelineCache != VK_NULL_HANDLE);
     GFXRECON_ASSERT(save_pipeline_caches_to_file);
     GFXRECON_ASSERT(!options_.save_pipeline_cache_filename.empty());
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -256,44 +256,13 @@ VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::
         }
         background_queue_.set_num_threads(std::clamp<uint32_t>(num_threads, 0, std::thread::hardware_concurrency()));
     }
-
-    // --save-pipeline-cache and --load-pipeline-cache can point to the same file. Read the pipeline caches from the
-    // file before emptying the file
-    if (load_pipeline_caches_from_file)
-    {
-        LoadPipelineCachesFromFile();
-    }
-
-    // If we want to save a pipeline cache file, we do this to be sure the file exists, is empty, and optionally, is
-    // cached for faster access
-    if (save_pipeline_caches_to_file)
-    {
-        FILE*   file  = nullptr;
-        int32_t error = util::platform::FileOpen(&file, options_.save_pipeline_cache_filename.c_str(), "w");
-        if (error)
-        {
-            GFXRECON_LOG_FATAL("Could not open pipeline cache file '%s'. Error: '%s'",
-                               options_.save_pipeline_cache_filename.c_str(),
-                               strerror(error));
-            exit(-1);
-        }
-        util::platform::FileClose(file);
-    }
 }
 
 void VulkanReplayConsumerBase::SavePipelineCachesToFile()
 {
     for (const auto& [handle_id, cache] : tracked_pipeline_caches_)
     {
-        // When --load-pipeline-cache and --save-pipeline-cache point to the same file it is possible that entries in
-        // the tracked_pipeline_caches_ are left with device_info and vk_cache as null. When caches are loaded at the
-        // beginning from the cache file and the map is populated with new entries, the device_info and vk_cache member
-        // variables are default initialized to null. These entries are expected to be set when the cache is actually
-        // created when vkCreatePipelineCache is encountered.
-        if (cache.device_info != nullptr && cache.vk_cache != VK_NULL_HANDLE)
-        {
-            SavePipelineCache(handle_id, cache.device_info, cache.vk_cache);
-        }
+        SavePipelineCache(handle_id, cache);
     }
 
     tracked_pipeline_caches_.clear();
@@ -7371,6 +7340,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
 
     VkPipelineCacheCreateInfo override_create_info = *pCreateInfo->GetPointer();
     std::vector<uint8_t>      override_cache_data;
+    bool                      loaded_from_file = false;
 
     // If pipeline cache must not be loaded
     if (options_.omit_pipeline_cache_data)
@@ -7385,11 +7355,11 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
     }
     else if (load_pipeline_caches_from_file)
     {
-        const auto ppl_cache_entry = tracked_pipeline_caches_.find(*pPipelineCache->GetPointer());
-        if (ppl_cache_entry != tracked_pipeline_caches_.end() && !ppl_cache_entry->second.cache_data.empty())
+        loaded_from_file = LoadPipelineCacheFromFile(*pPipelineCache->GetPointer(), override_cache_data);
+        if (loaded_from_file)
         {
-            override_create_info.initialDataSize = ppl_cache_entry->second.cache_data.size();
-            override_create_info.pInitialData    = ppl_cache_entry->second.cache_data.data();
+            override_create_info.initialDataSize = override_cache_data.size();
+            override_create_info.pInitialData    = override_cache_data.data();
         }
         else
         {
@@ -7400,29 +7370,31 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
             override_create_info.pInitialData    = nullptr;
             tracked_pipeline_caches_.emplace(std::piecewise_construct,
                                              std::forward_as_tuple(*pPipelineCache->GetPointer()),
-                                             std::forward_as_tuple());
+                                             std::forward_as_tuple(nullptr, VK_NULL_HANDLE, true));
         }
     }
     else if ((override_create_info.pInitialData != nullptr) && (override_create_info.initialDataSize != 0))
     {
+        // Make sure that we don't go down this way if we are using external cache file. Otherwise things get too
+        // complicated
+        GFXRECON_ASSERT(!load_pipeline_caches_from_file);
+
         // This vkCreatePipelineCache call has initial pipeline cache data, the data is valid for capture time,
         // but it might not be valid for replay time if considering platform/driver version change. So in the
         // following process, we'll try to find corresponding replay time pipeline cache data.
-        auto capture_pipeline_cache_data_hash = gfxrecon::util::hash::GenerateCheckSum<uint32_t>(
-            reinterpret_cast<const uint8_t*>(override_create_info.pInitialData), override_create_info.initialDataSize);
-        size_t capture_pipeline_cache_data_size = override_create_info.initialDataSize;
+        const size_t capture_pipeline_cache_data_size = override_create_info.initialDataSize;
+        const auto   capture_pipeline_cache_data_hash = gfxrecon::util::hash::GenerateCheckSum<uint32_t>(
+            reinterpret_cast<const uint8_t*>(override_create_info.pInitialData), capture_pipeline_cache_data_size);
 
         object_info_table_->VisitVkPipelineCacheInfo([&](const VulkanPipelineCacheInfo* pipeline_cache_info) {
             GFXRECON_ASSERT(pipeline_cache_info != nullptr);
 
-            auto iterator = pipeline_cache_info->pipeline_cache_data.find(capture_pipeline_cache_data_hash);
-
+            const auto iterator = pipeline_cache_info->pipeline_cache_data.find(capture_pipeline_cache_data_hash);
             if (iterator != pipeline_cache_info->pipeline_cache_data.end())
             {
                 // We found pipeline cache data vector which has same hash value, will continue to check if it has
                 // same capture time pipeline cache data.
-                auto& cache_data = iterator->second;
-
+                const auto& cache_data = iterator->second;
                 for (auto& existing_cache_data : cache_data)
                 {
                     if (capture_pipeline_cache_data_size == existing_cache_data.capture_cache_data.size())
@@ -7456,7 +7428,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
     }
 
     // compare pipelineCacheUUID for replay-device and cache-data
-    if (!CheckPipelineCacheUUID(device_info, &override_create_info))
+    const bool uuid_matches = CheckPipelineCacheUUID(device_info, &override_create_info);
+    if (!uuid_matches)
     {
         GFXRECON_LOG_WARNING_ONCE("%s(): PipelineCache data was provided, but pipelineCacheUUIDs did not match. This "
                                   "requires a pipeline-recompilation and may cause unexpected delays.",
@@ -7472,24 +7445,26 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
                            GetAllocationCallbacks(pAllocator),
                            pPipelineCache->GetHandlePointer());
 
-    if (load_pipeline_caches_from_file && result == VK_SUCCESS)
-    {
-        // The entry must exist. It should have been either added by LoadPipelineCachesFromFile or by the check above
-        auto ppl_cache_entry = tracked_pipeline_caches_.find(*pPipelineCache->GetPointer());
-        GFXRECON_ASSERT(ppl_cache_entry != tracked_pipeline_caches_.end());
-
-        ppl_cache_entry->second.vk_cache    = *(pPipelineCache->GetHandlePointer());
-        ppl_cache_entry->second.device_info = device_info;
-    }
-
     // If we are creating a pipeline cache file, add this pipeline cache to the tracked list
-    if (save_pipeline_caches_to_file && result == VK_SUCCESS &&
-        (tracked_pipeline_caches_.find(*pPipelineCache->GetPointer()) == tracked_pipeline_caches_.end()))
+    if (save_pipeline_caches_to_file && result == VK_SUCCESS)
     {
-        tracked_pipeline_caches_.emplace(
-            std::piecewise_construct,
-            std::forward_as_tuple(*pPipelineCache->GetPointer()),
-            std::forward_as_tuple(TrackedPipelineCache{ device_info, *pPipelineCache->GetHandlePointer() }));
+        const format::HandleId id    = *pPipelineCache->GetPointer();
+        const bool             dirty = loaded_from_file ? !uuid_matches : true;
+        auto                   entry = tracked_pipeline_caches_.find(id);
+        if (entry != tracked_pipeline_caches_.end())
+        {
+            entry->second.device_info = device_info;
+            entry->second.vk_cache    = *pPipelineCache->GetHandlePointer();
+            entry->second.dirty       = dirty;
+        }
+        else
+        {
+            // If --load-pipeline-cache is not provided there willn't be an entry in the map
+            tracked_pipeline_caches_.emplace(
+                std::piecewise_construct,
+                std::forward_as_tuple(id),
+                std::forward_as_tuple(TrackedPipelineCache{ device_info, *pPipelineCache->GetHandlePointer(), dirty }));
+        }
     }
 
     // keep track if external synchronization is required
@@ -7517,17 +7492,15 @@ void VulkanReplayConsumerBase::OverrideDestroyPipelineCache(
     // If pipeline cache must be saved to a file
     if (save_pipeline_caches_to_file || load_pipeline_caches_from_file)
     {
+        const auto cache_entry = tracked_pipeline_caches_.find(pipeline_cache_info->capture_id);
+        GFXRECON_ASSERT(cache_entry != tracked_pipeline_caches_.end())
+        GFXRECON_ASSERT(pipeline_cache_info->handle != VK_NULL_HANDLE);
         if (save_pipeline_caches_to_file)
         {
-            GFXRECON_ASSERT(pipeline_cache_info->handle != VK_NULL_HANDLE);
-            SavePipelineCache(pipeline_cache_info->capture_id, device_info, pipeline_cache_info->handle);
+            SavePipelineCache(pipeline_cache_info->capture_id, cache_entry->second);
         }
 
-        const auto cache_entry = tracked_pipeline_caches_.find(pipeline_cache_info->capture_id);
-        if (cache_entry != tracked_pipeline_caches_.end())
-        {
-            tracked_pipeline_caches_.erase(cache_entry);
-        }
+        tracked_pipeline_caches_.erase(cache_entry);
     }
 
     func(device_info->handle, pipeline_cache_info->handle, GetAllocationCallbacks(pAllocator));
@@ -10013,7 +9986,6 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesNV(
                            pPipelines->GetHandlePointer());
 
     // If a pipeline cache was created, track it to know when to destroy it/save it to file
-
     if (pipelineCache != overridePipelineCache && result == VK_SUCCESS)
     {
         TrackNewPipelineCache(device_info,
@@ -12408,7 +12380,7 @@ void VulkanReplayConsumerBase::OverrideDestroyPipeline(
                 {
                     GFXRECON_ASSERT(itTracked->second.device_info != nullptr);
                     GFXRECON_ASSERT(itTracked->second.vk_cache != VK_NULL_HANDLE);
-                    SavePipelineCache(id, itTracked->second.device_info, itTracked->second.vk_cache);
+                    SavePipelineCache(id, itTracked->second);
                 }
                 auto device_table = GetDeviceTable(device_info->handle);
                 device_table->DestroyPipelineCache(
@@ -12988,7 +12960,7 @@ bool VulkanReplayConsumerBase::CheckPipelineCacheUUID(const VulkanDeviceInfo*   
     return true;
 }
 
-void VulkanReplayConsumerBase::LoadPipelineCachesFromFile()
+bool VulkanReplayConsumerBase::LoadPipelineCacheFromFile(format::HandleId id, std::vector<uint8_t>& cache_data)
 {
     FILE*   file  = nullptr;
     int32_t error = util::platform::FileOpen(&file, options_.load_pipeline_cache_filename.c_str(), "r");
@@ -12997,11 +12969,12 @@ void VulkanReplayConsumerBase::LoadPipelineCachesFromFile()
         GFXRECON_LOG_ERROR("Could not open pipeline cache file '%s' for loading. Error: '%s'",
                            options_.load_pipeline_cache_filename.c_str(),
                            strerror(error));
-        return;
+        return false;
     }
 
     format::HandleId idRead;
     uint64_t         cacheSizeRead;
+    bool             found = false;
 
     // As we don't have access to an EOF function, just check that the read was successful...
     while (util::platform::FileRead(&idRead, sizeof(format::HandleId), file))
@@ -13010,35 +12983,53 @@ void VulkanReplayConsumerBase::LoadPipelineCachesFromFile()
         {
             GFXRECON_LOG_WARNING("Pipeline cache file corrupted.");
             util::platform::FileClose(file);
-            return;
+            return false;
         }
 
-        auto new_entry = tracked_pipeline_caches_.emplace(
-            std::piecewise_construct, std::forward_as_tuple(idRead), std::forward_as_tuple());
-        // We expect one entry for each cache
-        GFXRECON_ASSERT(new_entry.second);
-
-        new_entry.first->second.cache_data.resize(cacheSizeRead);
-        if (!util::platform::FileRead(new_entry.first->second.cache_data.data(), cacheSizeRead, file))
+        if (id == idRead)
         {
-            new_entry.first->second.cache_data.clear();
-            GFXRECON_LOG_WARNING("Pipeline cache file corrupted.");
-            util::platform::FileClose(file);
-            return;
+            cache_data.resize(cacheSizeRead);
+            if (util::platform::FileRead(cache_data.data(), cacheSizeRead, file) != 1)
+            {
+                cache_data.clear();
+                GFXRECON_LOG_FATAL("Pipeline cache file corrupted.");
+                util::platform::FileClose(file);
+                return false;
+            }
+
+            // Add / update entry in tracked_pipeline_caches_ map.
+            tracked_pipeline_caches_[id] = TrackedPipelineCache{ nullptr, VK_NULL_HANDLE, true };
+            found                        = true;
+        }
+        else
+        {
+            if (!util::platform::FileSeek(file, static_cast<int64_t>(cacheSizeRead), util::platform::FileSeekCurrent))
+            {
+                GFXRECON_LOG_FATAL("Pipeline cache file corrupted.");
+                util::platform::FileClose(file);
+                return false;
+            }
         }
     }
 
+    if (!found)
+    {
+        GFXRECON_LOG_WARNING("Pipeline cache file entry not found: %u", id);
+    }
+
     util::platform::FileClose(file);
+    return found;
 }
 
-void VulkanReplayConsumerBase::SavePipelineCache(format::HandleId        id,
-                                                 const VulkanDeviceInfo* device_info,
-                                                 VkPipelineCache         pipelineCache)
+void VulkanReplayConsumerBase::SavePipelineCache(format::HandleId id, const TrackedPipelineCache& tracked_cache)
 {
-    GFXRECON_ASSERT(device_info != nullptr);
-    GFXRECON_ASSERT(pipelineCache != VK_NULL_HANDLE);
     GFXRECON_ASSERT(save_pipeline_caches_to_file);
     GFXRECON_ASSERT(!options_.save_pipeline_cache_filename.empty());
+
+    if (!tracked_cache.dirty)
+    {
+        return;
+    }
 
     FILE*   file  = nullptr;
     int32_t error = util::platform::FileOpen(&file, options_.save_pipeline_cache_filename.c_str(), "a");
@@ -13050,10 +13041,13 @@ void VulkanReplayConsumerBase::SavePipelineCache(format::HandleId        id,
         exit(-1);
     }
 
-    auto device_table = GetDeviceTable(device_info->handle);
+    GFXRECON_ASSERT(tracked_cache.device_info != nullptr);
+    GFXRECON_ASSERT(tracked_cache.vk_cache != VK_NULL_HANDLE);
+
+    auto device_table = GetDeviceTable(tracked_cache.device_info->handle);
 
     size_t cacheSize = 0;
-    device_table->GetPipelineCacheData(device_info->handle, pipelineCache, &cacheSize, nullptr);
+    device_table->GetPipelineCacheData(tracked_cache.device_info->handle, tracked_cache.vk_cache, &cacheSize, nullptr);
     if (cacheSize == 0)
     {
         GFXRECON_LOG_INFO("Attempted to save an empty pipeline cache.");
@@ -13062,7 +13056,8 @@ void VulkanReplayConsumerBase::SavePipelineCache(format::HandleId        id,
     }
 
     std::vector<char> buffer(cacheSize);
-    device_table->GetPipelineCacheData(device_info->handle, pipelineCache, &cacheSize, buffer.data());
+    device_table->GetPipelineCacheData(
+        tracked_cache.device_info->handle, tracked_cache.vk_cache, &cacheSize, buffer.data());
 
     uint64_t writtenCacheSize = static_cast<uint64_t>(cacheSize);
     util::platform::FileWrite(&id, sizeof(format::HandleId), file);
@@ -13083,15 +13078,18 @@ VkPipelineCache VulkanReplayConsumerBase::CreateNewPipelineCache(const VulkanDev
 
     if (load_pipeline_caches_from_file)
     {
-        const auto cache_entry = tracked_pipeline_caches_.find(id);
-        if (cache_entry != tracked_pipeline_caches_.end() && !cache_entry->second.cache_data.empty())
+        std::vector<uint8_t> pipelineCacheData;
+        const bool           loaded_from_file = LoadPipelineCacheFromFile(id, pipelineCacheData);
+        if (loaded_from_file)
         {
-            pipelineCacheCreateInfo.initialDataSize = cache_entry->second.cache_data.size();
-            pipelineCacheCreateInfo.pInitialData    = cache_entry->second.cache_data.data();
+            GFXRECON_ASSERT(!pipelineCacheData.empty());
+            pipelineCacheCreateInfo.initialDataSize = pipelineCacheData.size();
+            pipelineCacheCreateInfo.pInitialData    = pipelineCacheData.data();
         }
 
         // compare pipelineCacheUUID for replay-device and cache-data
-        if (!CheckPipelineCacheUUID(device_info, &pipelineCacheCreateInfo))
+        const bool uuid_matches = CheckPipelineCacheUUID(device_info, &pipelineCacheCreateInfo);
+        if (!uuid_matches)
         {
             GFXRECON_LOG_WARNING_ONCE(
                 "%s(): Trying to load externally provided pipeline-cache-data (%s), but pipelineCacheUUIDs do not "
@@ -13100,6 +13098,18 @@ VkPipelineCache VulkanReplayConsumerBase::CreateNewPipelineCache(const VulkanDev
                 options_.load_pipeline_cache_filename.c_str());
             pipelineCacheCreateInfo.initialDataSize = 0;
             pipelineCacheCreateInfo.pInitialData    = nullptr;
+        }
+
+        // Add new entry in tracked_pipeline_caches_ map
+        const auto cache_entry = tracked_pipeline_caches_.find(id);
+        GFXRECON_ASSERT(cache_entry == tracked_pipeline_caches_.end());
+        if (cache_entry == tracked_pipeline_caches_.end())
+        {
+            const bool cache_entry_dirty = loaded_from_file ? !uuid_matches : true;
+            tracked_pipeline_caches_.emplace(
+                std::piecewise_construct,
+                std::forward_as_tuple(id),
+                std::forward_as_tuple(TrackedPipelineCache{ nullptr, VK_NULL_HANDLE, cache_entry_dirty }));
         }
     }
 
@@ -13127,9 +13137,10 @@ void VulkanReplayConsumerBase::TrackNewPipelineCache(const VulkanDeviceInfo* dev
     auto cache_entry = tracked_pipeline_caches_.find(id);
     if (cache_entry == tracked_pipeline_caches_.end())
     {
-        tracked_pipeline_caches_.emplace(std::piecewise_construct,
-                                         std::forward_as_tuple(id),
-                                         std::forward_as_tuple(TrackedPipelineCache{ device_info, pipelineCache }));
+        tracked_pipeline_caches_.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(id),
+            std::forward_as_tuple(TrackedPipelineCache{ device_info, pipelineCache, true }));
     }
     else
     {

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1870,16 +1870,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
      */
     bool CheckPipelineCacheUUID(const VulkanDeviceInfo* device_info, const VkPipelineCacheCreateInfo* create_info);
 
-    void LoadPipelineCachesFromFile();
-    void SavePipelineCachesToFile();
-    void SavePipelineCache(format::HandleId id, const VulkanDeviceInfo* device_info, VkPipelineCache pipelineCache);
-    VkPipelineCache CreateNewPipelineCache(const VulkanDeviceInfo* device_info, format::HandleId id);
-    void            TrackNewPipelineCache(const VulkanDeviceInfo* device_info,
-                                          format::HandleId        id,
-                                          VkPipelineCache         pipelineCache,
-                                          VkPipeline*             pipelines,
-                                          size_t                  pipelineCount);
-
     bool IsExtensionBeingFaked(const char* extension);
 
     void DestroyInternalInstanceResources(const VulkanInstanceInfo* instance_info);
@@ -2045,11 +2035,21 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     {
         const VulkanDeviceInfo* device_info{ nullptr };
         VkPipelineCache         vk_cache{ VK_NULL_HANDLE };
-        std::vector<uint8_t>    cache_data;
+        bool                    dirty{ false };
     };
 
     std::unordered_map<format::HandleId, TrackedPipelineCache> tracked_pipeline_caches_;
     std::unordered_map<VkPipeline, format::HandleId>           pipeline_cache_correspondances_;
+
+    bool            LoadPipelineCacheFromFile(format::HandleId id, std::vector<uint8_t>& cache_data);
+    void            SavePipelineCachesToFile();
+    void            SavePipelineCache(format::HandleId id, const TrackedPipelineCache& tracked_cache);
+    VkPipelineCache CreateNewPipelineCache(const VulkanDeviceInfo* device_info, format::HandleId id);
+    void            TrackNewPipelineCache(const VulkanDeviceInfo* device_info,
+                                          format::HandleId        id,
+                                          VkPipelineCache         pipelineCache,
+                                          VkPipeline*             pipelines,
+                                          size_t                  pipelineCount);
 
     const bool save_pipeline_caches_to_file;
     const bool load_pipeline_caches_from_file;


### PR DESCRIPTION
When --load-pipeline-cache and --save-pipeline-cache point to the same file it is possible that entries in the tracked_pipeline_caches_ are left with device_info and vk_cache as null. When caches are loaded at the beginning from the cache file and the map is populated with new entries, the device_info and vk_cache member variables are default initialized to null. These entries are expected to be set when the cache is actually created when vkCreatePipelineCache is encountered.