### PR TITLE
Fix trimming of zero-count secondary command buffers

### DIFF
--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -712,7 +712,14 @@ void VulkanStateTracker::TrackExecuteCommands(VkCommandBuffer        command_buf
                                               uint32_t               command_buffer_count,
                                               const VkCommandBuffer* command_buffers)
 {
-    assert((command_buffer != VK_NULL_HANDLE) && (command_buffers != nullptr));
+    assert(command_buffer != VK_NULL_HANDLE);
+
+    if (command_buffer_count == 0)
+    {
+        return;
+    }
+
+    assert(command_buffers != nullptr);
 
     auto primary_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
 


### PR DESCRIPTION
Trim feature is currently crashing in state tracker when a trace contained vkCmdExecuteCommands with commandBufferCount == 0 and pCommandBuffers == nullptr.
That is a valid Vulkan no-op, but VulkanStateTracker asserted that the command buffer array pointer must always be non-null.
