### PR TITLE
replay: ignore VK_EXT_layer_settings during instance creation

### DIFF
--- a/framework/graphics/vulkan_feature_util.cpp
+++ b/framework/graphics/vulkan_feature_util.cpp
@@ -43,10 +43,9 @@ GFXRECON_BEGIN_NAMESPACE(feature_util)
 // enable the extension with no support present on the replay device (usually because the layer is
 // no longer there)
 std::set<std::string> kIgnorableExtensions = {
-    VK_EXT_TOOLING_INFO_EXTENSION_NAME,
-    VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
-    "VK_ANDROID_frame_boundary",
-    "VK_EXT_frame_boundary",
+    VK_EXT_TOOLING_INFO_EXTENSION_NAME,   VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
+    "VK_ANDROID_frame_boundary",          "VK_EXT_frame_boundary",
+    VK_EXT_LAYER_SETTINGS_EXTENSION_NAME,
 };
 
 VkResult GetInstanceLayers(PFN_vkEnumerateInstanceLayerProperties instance_layer_proc,


### PR DESCRIPTION
The extension can be provided by layers (e.g. VVL) active at capture time
but can be absent during replay, making --remove-unsupported necessary to avoid a fatal mismatch.
instead we can just safely ignore it, when unavailable.

fixes #2940