### PR TITLE
Simplify GetImageResourceSizesOptimal

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2266,34 +2266,27 @@ void VulkanCaptureManager::ProcessImportFdForImage(VkDevice device, VkImage imag
     using ImageResource = graphics::VulkanResourcesUtil::ImageResource;
     std::vector<ImageResource> image_resources;
 
-    auto write_init_image_cmd =
-        [this, &resource_util, device_wrapper](const ImageResource& img, const void* data, size_t num_bytes) {
-            // Combined size of all layers in a mip level.
-            std::vector<uint64_t> level_sizes;
+    auto write_init_image_cmd = [this, &resource_util, device_wrapper](
+                                    const ImageResource& img, const void* data, size_t num_bytes) {
+        // Combined size of all layers in a mip level.
+        std::vector<uint64_t> level_sizes;
 
-            uint64_t resource_size = resource_util.GetImageResourceSizesOptimal(img.format,
-                                                                                img.extent,
-                                                                                img.level_count,
-                                                                                img.layer_count,
-                                                                                img.tiling,
-                                                                                img.aspect,
-                                                                                nullptr,
-                                                                                &level_sizes,
-                                                                                true);
-            GFXRECON_ASSERT(resource_size == num_bytes);
+        uint64_t resource_size = resource_util.GetImageResourceSizesOptimal(
+            img.format, img.extent, img.level_count, img.layer_count, img.tiling, img.aspect, nullptr, &level_sizes);
+        GFXRECON_ASSERT(resource_size == num_bytes);
 
-            WriteBeginResourceInitCmd(device_wrapper->handle_id, resource_size, resource_size);
-            GetCommandWriter()->WriteInitImageCmd(api_family_,
-                                                  device_wrapper->handle_id,
-                                                  img.handle_id,
-                                                  img.aspect,
-                                                  img.layout,
-                                                  img.level_count,
-                                                  level_sizes,
-                                                  resource_size,
-                                                  data);
-            WriteEndResourceInitCmd(device_wrapper->handle_id);
-        };
+        WriteBeginResourceInitCmd(device_wrapper->handle_id, resource_size, resource_size);
+        GetCommandWriter()->WriteInitImageCmd(api_family_,
+                                              device_wrapper->handle_id,
+                                              img.handle_id,
+                                              img.aspect,
+                                              img.layout,
+                                              img.level_count,
+                                              level_sizes,
+                                              resource_size,
+                                              data);
+        WriteEndResourceInitCmd(device_wrapper->handle_id);
+    };
 
     uint32_t num_staging_bytes = 0;
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -3249,8 +3249,7 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
                                                                        wrapper->tiling,
                                                                        aspect,
                                                                        nullptr,
-                                                                       &snapshot_info.level_sizes,
-                                                                       true);
+                                                                       &snapshot_info.level_sizes);
                     }
 
                     if (snapshot_info.need_staging_copy)

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -903,8 +903,7 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkFormat             
                                                            VkImageTiling          tiling,
                                                            VkImageAspectFlagBits  aspect,
                                                            std::vector<uint64_t>* subresource_offsets,
-                                                           std::vector<uint64_t>* subresource_sizes,
-                                                           bool                   all_layers_per_level)
+                                                           std::vector<uint64_t>* subresource_sizes)
 {
     // Vulkan requires each VkBufferImageCopy::bufferOffset to satisfy format/aspect alignment.
     // Keep one shared alignment value here so all per-subresource offset math follows the same rule.
@@ -931,61 +930,45 @@ uint64_t VulkanResourcesUtil::GetImageResourceSizesOptimal(VkFormat             
         subresource_offsets->clear();
     }
 
-    uint64_t       resource_size     = 0;
-    uint32_t       subresource_idx   = 0;
-    const uint32_t subresource_count = all_layers_per_level ? mip_levels : (mip_levels * array_layers);
+    uint64_t resource_size   = 0;
+    uint32_t subresource_idx = 0;
 
     for (uint32_t m = 0; m < mip_levels; ++m)
     {
-        const VkExtent3D mip_extent = { std::max(1u, (extent.width >> m)),
-                                        std::max(1u, (extent.height >> m)),
-                                        std::max(1u, (extent.depth >> m)) };
-
         // Compute exact bytes copied for one tightly-packed region.
         VkImageToMemoryCopy copy_region{};
         copy_region.memoryRowLength                 = 0;
         copy_region.memoryImageHeight               = 0;
-        copy_region.imageExtent                     = mip_extent;
+        copy_region.imageExtent                     = graphics::ScaleToMipLevel(extent, m);
         copy_region.imageSubresource.aspectMask     = aspect;
         copy_region.imageSubresource.baseArrayLayer = 0;
-        copy_region.imageSubresource.layerCount     = all_layers_per_level ? array_layers : 1;
+        copy_region.imageSubresource.layerCount     = array_layers;
 
         const uint64_t tight_copy_size = GetBufferSizeFromCopyImage(copy_region, array_layers, format);
 
-        for (uint32_t l = 0; l < array_layers; ++l)
+        // Apply Vulkan alignment per subresource region offset.
+        resource_size = AlignBufferOffset(resource_size, copy_alignment);
+
+        if (subresource_offsets != nullptr)
         {
-            // Apply Vulkan alignment per subresource region offset.
-            resource_size = AlignBufferOffset(resource_size, copy_alignment);
-
-            if (subresource_offsets != nullptr)
-            {
-                subresource_offsets->push_back(resource_size);
-            }
-
-            const bool is_last_subresource = (subresource_idx + 1 == subresource_count);
-
-            // Preserve tight sizes for layer-by-layer callers, but emit padded per-level strides when
-            // all_layers_per_level=true so serialized level_sizes can reconstruct aligned offsets at replay.
-            uint64_t size_for_output = tight_copy_size;
-            if (all_layers_per_level && !is_last_subresource)
-            {
-                const uint64_t next_offset = AlignBufferOffset(resource_size + tight_copy_size, copy_alignment);
-                size_for_output            = next_offset - resource_size;
-            }
-
-            if (subresource_sizes != nullptr)
-            {
-                subresource_sizes->push_back(size_for_output);
-            }
-
-            resource_size += size_for_output;
-            ++subresource_idx;
-
-            if (all_layers_per_level)
-            {
-                break;
-            }
+            subresource_offsets->push_back(resource_size);
         }
+
+        uint64_t   size_for_output     = tight_copy_size;
+        const bool is_last_subresource = (subresource_idx + 1 == mip_levels);
+        if (!is_last_subresource)
+        {
+            const uint64_t next_offset = AlignBufferOffset(resource_size + tight_copy_size, copy_alignment);
+            size_for_output            = next_offset - resource_size;
+        }
+
+        if (subresource_sizes != nullptr)
+        {
+            subresource_sizes->push_back(size_for_output);
+        }
+
+        resource_size += size_for_output;
+        ++subresource_idx;
     }
 
     return resource_size;
@@ -1870,6 +1853,7 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
         }
         else if (resource_size == 0 || img.level_sizes == nullptr)
         {
+            GFXRECON_ASSERT(img.all_layers_per_level);
             resource_size = GetImageResourceSizesOptimal(tmp_data[i].use_blit ? dst_format : img.format,
                                                          tmp_data[i].use_blit ? tmp_data[i].scaled_extent : img.extent,
                                                          img.level_count,
@@ -1877,8 +1861,7 @@ VkResult VulkanResourcesUtil::ReadImageResources(const std::vector<ImageResource
                                                          img.tiling,
                                                          img.aspect,
                                                          nullptr,
-                                                         &tmp_data[i].level_sizes,
-                                                         img.all_layers_per_level);
+                                                         &tmp_data[i].level_sizes);
         }
 
         VkDeviceSize aligned_batch_offset = current_batch_size;

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -69,11 +69,7 @@ class VulkanResourcesUtil
     // The sizes are returned in the subresource_sizes vector and will be in the order:
     //    M0 L0 L1 ... La M1 L0 L1 ... La ... Mm L0 L1 ... La
     // Where M denotes the mip map levels and L the array layers.
-    // - With all_layers_per_level=false, each entry is the tightly-packed payload bytes for that subresource.
-    // - With all_layers_per_level=true, each entry is the serialized per-mip stride used by init-image commands;
-    //   intermediate entries may include padding so replay can reconstruct aligned buffer offsets.
     // The offsets will be returned in the subresource_offsets vector in the same manner.
-    // all_layers_per_level boolean determines if all array layer per mip map level will be accounted as one.
     //
     // Return value is the total size of the image.
     uint64_t GetImageResourceSizesOptimal(VkFormat               format,
@@ -82,9 +78,8 @@ class VulkanResourcesUtil
                                           uint32_t               array_layers,
                                           VkImageTiling          tiling,
                                           VkImageAspectFlagBits  aspect,
-                                          std::vector<uint64_t>* subresource_offsets  = nullptr,
-                                          std::vector<uint64_t>* subresource_sizes    = nullptr,
-                                          bool                   all_layers_per_level = false);
+                                          std::vector<uint64_t>* subresource_offsets = nullptr,
+                                          std::vector<uint64_t>* subresource_sizes   = nullptr);
 
     // Behaves exactly like GetImageResourceSizesOptimal but returns the image subresources sizes for a tightly packed
     // image with linear tiling (no hardware imposed alignments)


### PR DESCRIPTION
There are no callers that set all_layers_per_level to `false`.