### PR TITLE
Remove `TRANSFER_SRC_BIT` from virtual swapchain images

### DIFF
--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -85,8 +85,8 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainKHR(VkResult                    
     device_table_ = device_table;
 
     VkSwapchainCreateInfoKHR modified_create_info = *create_info;
-    modified_create_info.imageUsage =
-        modified_create_info.imageUsage | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+
+    modified_create_info.imageUsage = modified_create_info.imageUsage | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
     VkResult result = instance_table_->GetPhysicalDeviceSurfaceCapabilitiesKHR(
         physical_device, create_info->surface, &surfCapabilities);


### PR DESCRIPTION
At replay time, the `VulkanVirtualSwapchain` creates it's underlying swapchain by adding `VK_IMAGE_USAGE_TRANSFER_SRC_BIT` and `VK_IMAGE_USAGE_TRANSFER_DST_BIT`.

`DST` is necessary because of the copy from the virtual image to the actual swapchain image.
However, `SRC` is not useful, as the swapchain image are never read back. In particular, I think this was set for screenshot handling, but screenshot is done on the virtual image, not the actual swapchain image.
