### PR TITLE
Fix renderpass image layout tracking in vulkan replay consumer

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -692,6 +692,9 @@ struct VulkanCommandBufferInfo : public VulkanPoolObjectInfo<VkCommandBuffer>
 {
     bool                                                      is_frame_boundary{ false };
     std::vector<format::HandleId>                             frame_buffer_ids;
+    format::HandleId                                          active_render_pass_id{ format::kNullHandleId };
+    format::HandleId                                          active_framebuffer_id{ format::kNullHandleId };
+    std::vector<format::HandleId>                             active_render_pass_attachment_image_view_ids;
     std::unordered_map<format::HandleId, VkImageLayout>       image_layout_barriers;
     std::unordered_map<VkPipelineBindPoint, format::HandleId> bound_pipelines;
     std::vector<uint8_t>                                      push_constant_data;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10117,6 +10117,9 @@ void VulkanReplayConsumerBase::ClearCommandBufferInfo(VulkanCommandBufferInfo* c
     GFXRECON_ASSERT(command_buffer_info != nullptr)
     command_buffer_info->is_frame_boundary = false;
     command_buffer_info->frame_buffer_ids.clear();
+    command_buffer_info->active_render_pass_id = format::kNullHandleId;
+    command_buffer_info->active_framebuffer_id = format::kNullHandleId;
+    command_buffer_info->active_render_pass_attachment_image_view_ids.clear();
     command_buffer_info->bound_pipelines.clear();
     command_buffer_info->push_constant_data.clear();
     command_buffer_info->push_constant_stage_flags     = 0;
@@ -10416,6 +10419,9 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
     auto       framebuffer_id        = render_pass_info_meta->framebuffer;
     auto       render_pass_id        = render_pass_info_meta->renderPass;
     command_buffer_info->frame_buffer_ids.push_back(framebuffer_id);
+    command_buffer_info->active_framebuffer_id = framebuffer_id;
+    command_buffer_info->active_render_pass_id = render_pass_id;
+    command_buffer_info->active_render_pass_attachment_image_view_ids.clear();
     command_buffer_info->in_rendering_scope = true;
 
     auto framebuffer_info = object_info_table_->GetVkFramebufferInfo(framebuffer_id);
@@ -10442,19 +10448,9 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
             attachment_image_view_ids = framebuffer_info->attachment_image_view_ids.data();
         }
 
-        for (size_t i = 0; i < render_pass_info->attachment_description_final_layouts.size(); ++i)
-        {
-            auto image_view_id   = attachment_image_view_ids[i];
-            auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
-            command_buffer_info->image_layout_barriers[image_view_info->image_id] =
-                render_pass_info->attachment_description_final_layouts[i];
-
-            const VulkanImageViewInfo* img_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
-            assert(image_view_info != nullptr);
-            VulkanImageInfo* img_info = object_info_table_->GetVkImageInfo(img_view_info->image_id);
-            assert(img_info);
-            img_info->intermediate_layout = render_pass_info->attachment_description_final_layouts[i];
-        }
+        command_buffer_info->active_render_pass_attachment_image_view_ids.assign(
+            attachment_image_view_ids,
+            attachment_image_view_ids + render_pass_info->attachment_description_final_layouts.size());
     }
 
     VkCommandBuffer command_buffer = command_buffer_info->handle;
@@ -10474,41 +10470,106 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
     auto       framebuffer_id        = render_pass_info_meta->framebuffer;
     auto       render_pass_id        = render_pass_info_meta->renderPass;
     command_buffer_info->frame_buffer_ids.push_back(framebuffer_id);
+    command_buffer_info->active_framebuffer_id = framebuffer_id;
+    command_buffer_info->active_render_pass_id = render_pass_id;
+    command_buffer_info->active_render_pass_attachment_image_view_ids.clear();
     command_buffer_info->in_rendering_scope = true;
 
     auto framebuffer_info = object_info_table_->GetVkFramebufferInfo(framebuffer_id);
     auto render_pass_info = object_info_table_->GetVkRenderPassInfo(render_pass_id);
     if ((render_pass_info != nullptr) && (framebuffer_info != nullptr))
     {
-        GFXRECON_ASSERT(framebuffer_info->attachment_image_view_ids.size() ==
-                        render_pass_info->attachment_description_final_layouts.size());
-
-        for (size_t i = 0; i < render_pass_info->attachment_description_final_layouts.size(); ++i)
+        const format::HandleId* attachment_image_view_ids = nullptr;
+        if ((framebuffer_info->framebuffer_flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) ==
+            VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT)
         {
-            auto image_view_id   = framebuffer_info->attachment_image_view_ids[i];
-            auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
-            command_buffer_info->image_layout_barriers[image_view_info->image_id] =
-                render_pass_info->attachment_description_final_layouts[i];
+            // The attachments for imageless framebuffers are provided in the pNext chain of
+            // vkCmdBeginRenderPass
+            const auto* attachment_begin_info = GetPNextMetaStruct<Decoded_VkRenderPassAttachmentBeginInfo>(
+                render_pass_begin_info_decoder->GetMetaStructPointer()->pNext);
 
-            const VulkanImageViewInfo* img_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
-            assert(image_view_info != nullptr);
-            VulkanImageInfo* img_info = object_info_table_->GetVkImageInfo(img_view_info->image_id);
-            assert(img_info);
-            img_info->intermediate_layout = render_pass_info->attachment_description_final_layouts[i];
+            GFXRECON_ASSERT(attachment_begin_info)
+            GFXRECON_ASSERT(attachment_begin_info->pAttachments.GetLength() ==
+                            render_pass_info->attachment_description_final_layouts.size());
+            attachment_image_view_ids = attachment_begin_info->pAttachments.GetPointer();
         }
+        else
+        {
+            GFXRECON_ASSERT(framebuffer_info->attachment_image_view_ids.size() ==
+                            render_pass_info->attachment_description_final_layouts.size());
+            attachment_image_view_ids = framebuffer_info->attachment_image_view_ids.data();
+        }
+
+        command_buffer_info->active_render_pass_attachment_image_view_ids.assign(
+            attachment_image_view_ids,
+            attachment_image_view_ids + render_pass_info->attachment_description_final_layouts.size());
     }
 
     VkCommandBuffer command_buffer = command_buffer_info->handle;
-
     func(command_buffer, render_pass_begin_info_decoder->GetPointer(), subpass_begin_info_decode->GetPointer());
+}
+
+void VulkanReplayConsumerBase::ApplyRenderPassFinalLayouts(VulkanCommandBufferInfo* command_buffer_info)
+{
+    GFXRECON_ASSERT(command_buffer_info != nullptr);
+
+    if ((command_buffer_info->active_render_pass_id == format::kNullHandleId) ||
+        (command_buffer_info->active_framebuffer_id == format::kNullHandleId))
+    {
+        return;
+    }
+
+    auto framebuffer_info = object_info_table_->GetVkFramebufferInfo(command_buffer_info->active_framebuffer_id);
+    auto render_pass_info = object_info_table_->GetVkRenderPassInfo(command_buffer_info->active_render_pass_id);
+    if ((render_pass_info == nullptr) || (framebuffer_info == nullptr))
+    {
+        return;
+    }
+
+    const format::HandleId* attachment_image_view_ids = nullptr;
+    if (!command_buffer_info->active_render_pass_attachment_image_view_ids.empty())
+    {
+        GFXRECON_ASSERT(command_buffer_info->active_render_pass_attachment_image_view_ids.size() ==
+                        render_pass_info->attachment_description_final_layouts.size());
+        attachment_image_view_ids = command_buffer_info->active_render_pass_attachment_image_view_ids.data();
+    }
+    else
+    {
+        GFXRECON_ASSERT(framebuffer_info->attachment_image_view_ids.size() ==
+                        render_pass_info->attachment_description_final_layouts.size());
+        attachment_image_view_ids = framebuffer_info->attachment_image_view_ids.data();
+    }
+
+    for (size_t i = 0; i < render_pass_info->attachment_description_final_layouts.size(); ++i)
+    {
+        auto image_view_id   = attachment_image_view_ids[i];
+        auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
+        if (image_view_info == nullptr)
+        {
+            continue;
+        }
+
+        command_buffer_info->image_layout_barriers[image_view_info->image_id] =
+            render_pass_info->attachment_description_final_layouts[i];
+
+        VulkanImageInfo* img_info = object_info_table_->GetVkImageInfo(image_view_info->image_id);
+        if (img_info != nullptr)
+        {
+            img_info->intermediate_layout = render_pass_info->attachment_description_final_layouts[i];
+        }
+    }
 }
 
 void VulkanReplayConsumerBase::OverrideCmdEndRenderPass(PFN_vkCmdEndRenderPass   func,
                                                         VulkanCommandBufferInfo* command_buffer_info)
 {
     GFXRECON_ASSERT(command_buffer_info != nullptr);
-    command_buffer_info->in_rendering_scope = false;
     func(command_buffer_info->handle);
+    ApplyRenderPassFinalLayouts(command_buffer_info);
+    command_buffer_info->active_render_pass_id = format::kNullHandleId;
+    command_buffer_info->active_framebuffer_id = format::kNullHandleId;
+    command_buffer_info->active_render_pass_attachment_image_view_ids.clear();
+    command_buffer_info->in_rendering_scope = false;
 }
 
 void VulkanReplayConsumerBase::OverrideCmdEndRenderPass2(
@@ -10517,8 +10578,12 @@ void VulkanReplayConsumerBase::OverrideCmdEndRenderPass2(
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
 {
     GFXRECON_ASSERT(command_buffer_info != nullptr);
-    command_buffer_info->in_rendering_scope = false;
     func(command_buffer_info->handle, pSubpassEndInfo->GetPointer());
+    ApplyRenderPassFinalLayouts(command_buffer_info);
+    command_buffer_info->active_render_pass_id = format::kNullHandleId;
+    command_buffer_info->active_framebuffer_id = format::kNullHandleId;
+    command_buffer_info->active_render_pass_attachment_image_view_ids.clear();
+    command_buffer_info->in_rendering_scope = false;
 }
 
 void VulkanReplayConsumerBase::OverrideCmdBeginRendering(

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10407,6 +10407,33 @@ void VulkanReplayConsumerBase::MaybeInjectExecutionBarrier(const VulkanCommandBu
     util::EndInjectedCommands();
 }
 
+std::vector<format::HandleId> VulkanReplayConsumerBase::GetRenderPassAttachmentImageViewIds(
+    const VulkanFramebufferInfo*                         framebuffer_info,
+    const VulkanRenderPassInfo*                          render_pass_info,
+    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder)
+{
+    const size_t attachment_count = render_pass_info->attachment_description_final_layouts.size();
+
+    const format::HandleId* attachment_image_view_ids = nullptr;
+    if ((framebuffer_info->framebuffer_flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) ==
+        VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT)
+    {
+        // The attachments for imageless framebuffers are provided in the pNext chain of vkCmdBeginRenderPass
+        const auto* attachment_begin_info = GetPNextMetaStruct<Decoded_VkRenderPassAttachmentBeginInfo>(
+            render_pass_begin_info_decoder->GetMetaStructPointer()->pNext);
+
+        GFXRECON_ASSERT(attachment_begin_info)
+        GFXRECON_ASSERT(attachment_begin_info->pAttachments.GetLength() == attachment_count);
+        attachment_image_view_ids = attachment_begin_info->pAttachments.GetPointer();
+    }
+    else
+    {
+        GFXRECON_ASSERT(framebuffer_info->attachment_image_view_ids.size() == attachment_count);
+        attachment_image_view_ids = framebuffer_info->attachment_image_view_ids.data();
+    }
+    return { attachment_image_view_ids, attachment_image_view_ids + attachment_count };
+}
+
 void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
     PFN_vkCmdBeginRenderPass                             func,
     VulkanCommandBufferInfo*                             command_buffer_info,
@@ -10428,29 +10455,8 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
     auto render_pass_info = object_info_table_->GetVkRenderPassInfo(render_pass_id);
     if ((render_pass_info != nullptr) && (framebuffer_info != nullptr))
     {
-        const format::HandleId* attachment_image_view_ids = nullptr;
-        if ((framebuffer_info->framebuffer_flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) ==
-            VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT)
-        {
-            // The attachments for imageless framebuffers are provided in the pNext chain of vkCmdBeginRenderPass
-            const auto* attachment_begin_info = GetPNextMetaStruct<Decoded_VkRenderPassAttachmentBeginInfo>(
-                render_pass_begin_info_decoder->GetMetaStructPointer()->pNext);
-
-            GFXRECON_ASSERT(attachment_begin_info)
-            GFXRECON_ASSERT(attachment_begin_info->pAttachments.GetLength() ==
-                            render_pass_info->attachment_description_final_layouts.size());
-            attachment_image_view_ids = attachment_begin_info->pAttachments.GetPointer();
-        }
-        else
-        {
-            GFXRECON_ASSERT(framebuffer_info->attachment_image_view_ids.size() ==
-                            render_pass_info->attachment_description_final_layouts.size());
-            attachment_image_view_ids = framebuffer_info->attachment_image_view_ids.data();
-        }
-
-        command_buffer_info->active_render_pass_attachment_image_view_ids.assign(
-            attachment_image_view_ids,
-            attachment_image_view_ids + render_pass_info->attachment_description_final_layouts.size());
+        command_buffer_info->active_render_pass_attachment_image_view_ids =
+            GetRenderPassAttachmentImageViewIds(framebuffer_info, render_pass_info, render_pass_begin_info_decoder);
     }
 
     VkCommandBuffer command_buffer = command_buffer_info->handle;
@@ -10479,30 +10485,8 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
     auto render_pass_info = object_info_table_->GetVkRenderPassInfo(render_pass_id);
     if ((render_pass_info != nullptr) && (framebuffer_info != nullptr))
     {
-        const format::HandleId* attachment_image_view_ids = nullptr;
-        if ((framebuffer_info->framebuffer_flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) ==
-            VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT)
-        {
-            // The attachments for imageless framebuffers are provided in the pNext chain of
-            // vkCmdBeginRenderPass
-            const auto* attachment_begin_info = GetPNextMetaStruct<Decoded_VkRenderPassAttachmentBeginInfo>(
-                render_pass_begin_info_decoder->GetMetaStructPointer()->pNext);
-
-            GFXRECON_ASSERT(attachment_begin_info)
-            GFXRECON_ASSERT(attachment_begin_info->pAttachments.GetLength() ==
-                            render_pass_info->attachment_description_final_layouts.size());
-            attachment_image_view_ids = attachment_begin_info->pAttachments.GetPointer();
-        }
-        else
-        {
-            GFXRECON_ASSERT(framebuffer_info->attachment_image_view_ids.size() ==
-                            render_pass_info->attachment_description_final_layouts.size());
-            attachment_image_view_ids = framebuffer_info->attachment_image_view_ids.data();
-        }
-
-        command_buffer_info->active_render_pass_attachment_image_view_ids.assign(
-            attachment_image_view_ids,
-            attachment_image_view_ids + render_pass_info->attachment_description_final_layouts.size());
+        command_buffer_info->active_render_pass_attachment_image_view_ids =
+            GetRenderPassAttachmentImageViewIds(framebuffer_info, render_pass_info, render_pass_begin_info_decoder);
     }
 
     VkCommandBuffer command_buffer = command_buffer_info->handle;
@@ -10513,8 +10497,8 @@ void VulkanReplayConsumerBase::ApplyRenderPassFinalLayouts(VulkanCommandBufferIn
 {
     GFXRECON_ASSERT(command_buffer_info != nullptr);
 
-    if ((command_buffer_info->active_render_pass_id == format::kNullHandleId) ||
-        (command_buffer_info->active_framebuffer_id == format::kNullHandleId))
+    if (command_buffer_info->active_render_pass_id == format::kNullHandleId ||
+        command_buffer_info->active_framebuffer_id == format::kNullHandleId)
     {
         return;
     }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10497,32 +10497,19 @@ void VulkanReplayConsumerBase::ApplyRenderPassFinalLayouts(VulkanCommandBufferIn
 {
     GFXRECON_ASSERT(command_buffer_info != nullptr);
 
-    if (command_buffer_info->active_render_pass_id == format::kNullHandleId ||
-        command_buffer_info->active_framebuffer_id == format::kNullHandleId)
+    const auto& attachment_image_view_ids = command_buffer_info->active_render_pass_attachment_image_view_ids;
+    if (attachment_image_view_ids.empty())
     {
         return;
     }
 
-    auto framebuffer_info = object_info_table_->GetVkFramebufferInfo(command_buffer_info->active_framebuffer_id);
     auto render_pass_info = object_info_table_->GetVkRenderPassInfo(command_buffer_info->active_render_pass_id);
-    if ((render_pass_info == nullptr) || (framebuffer_info == nullptr))
+    if (render_pass_info == nullptr)
     {
         return;
     }
 
-    const format::HandleId* attachment_image_view_ids = nullptr;
-    if (!command_buffer_info->active_render_pass_attachment_image_view_ids.empty())
-    {
-        GFXRECON_ASSERT(command_buffer_info->active_render_pass_attachment_image_view_ids.size() ==
-                        render_pass_info->attachment_description_final_layouts.size());
-        attachment_image_view_ids = command_buffer_info->active_render_pass_attachment_image_view_ids.data();
-    }
-    else
-    {
-        GFXRECON_ASSERT(framebuffer_info->attachment_image_view_ids.size() ==
-                        render_pass_info->attachment_description_final_layouts.size());
-        attachment_image_view_ids = framebuffer_info->attachment_image_view_ids.data();
-    }
+    GFXRECON_ASSERT(attachment_image_view_ids.size() == render_pass_info->attachment_description_final_layouts.size());
 
     for (size_t i = 0; i < render_pass_info->attachment_description_final_layouts.size(); ++i)
     {

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1392,6 +1392,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
                                     VkSubpassContents                                    contents);
 
+    void ApplyRenderPassFinalLayouts(VulkanCommandBufferInfo* command_buffer_info);
+
     void OverrideCmdEndRenderPass(PFN_vkCmdEndRenderPass func, VulkanCommandBufferInfo* command_buffer_info);
 
     void OverrideCmdEndRenderPass2(PFN_vkCmdEndRenderPass2                         func,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1392,6 +1392,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
                                     VkSubpassContents                                    contents);
 
+    std::vector<format::HandleId> GetRenderPassAttachmentImageViewIds(
+        const VulkanFramebufferInfo*                         framebuffer_info,
+        const VulkanRenderPassInfo*                          render_pass_info,
+        StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder);
+
     void ApplyRenderPassFinalLayouts(VulkanCommandBufferInfo* command_buffer_info);
 
     void OverrideCmdEndRenderPass(PFN_vkCmdEndRenderPass func, VulkanCommandBufferInfo* command_buffer_info);


### PR DESCRIPTION
Currently replay tracks render pass attachment finalLayout at vkCmdBeginRenderPass(2) and updates command-buffer image layout state before the render pass had actually ended. 
This is problematic because:
* finalLayout only becomes valid when the render pass ends
* tracking it at begin made replay think attachments had already left their in-pass layout
* tracked image layout can be wrong while a render pass was still active

This showed up as incorrect layout state for render pass attachments and resulted in visual corruptions in rebind path. 

This change:
* Keeps track of the active render pass, framebuffer, and resolved attachment image views during vkCmdBeginRenderPass(2)
* Applies attachment finalLayout to tracked image state only on vkCmdEndRenderPass(2).
