### PR TITLE
Fix bad `PointerDecoder` usage

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -7773,8 +7773,8 @@ VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceSurfaceFormatsKHR(
 {
     GFXRECON_ASSERT(physical_device_info != nullptr && surface_info != nullptr);
 
-    uint32_t*           surface_format_count = pSurfaceFormatCount->GetPointer();
-    VkSurfaceFormatKHR* surface_formats      = pSurfaceFormats->GetPointer();
+    uint32_t*           surface_format_count = pSurfaceFormatCount->GetOutputPointer();
+    VkSurfaceFormatKHR* surface_formats      = pSurfaceFormats->GetOutputPointer();
 
     VkResult result = func(physical_device_info->handle, surface_info->handle, surface_format_count, surface_formats);
 
@@ -7795,8 +7795,8 @@ VkResult VulkanReplayConsumerBase::OverrideGetPhysicalDeviceSurfaceFormats2KHR(
 {
     GFXRECON_ASSERT(physical_device_info != nullptr && surface_info != nullptr);
 
-    uint32_t*            surface_format_count = pSurfaceFormatCount->GetPointer();
-    VkSurfaceFormat2KHR* surface_formats      = pSurfaceFormats->GetPointer();
+    uint32_t*            surface_format_count = pSurfaceFormatCount->GetOutputPointer();
+    VkSurfaceFormat2KHR* surface_formats      = pSurfaceFormats->GetOutputPointer();
 
     VkResult result =
         func(physical_device_info->handle, surface_info->GetPointer(), surface_format_count, surface_formats);
@@ -12473,8 +12473,8 @@ VkResult VulkanReplayConsumerBase::OverrideGetPastPresentationTimingGOOGLE(
     {
         return func(device_info->handle,
                     swapchain_info->handle,
-                    pPresentationTimingCount->GetPointer(),
-                    pPresentationTimings->GetPointer());
+                    pPresentationTimingCount->GetOutputPointer(),
+                    pPresentationTimings->GetOutputPointer());
     }
     return VK_SUCCESS;
 }


### PR DESCRIPTION
For Vulkan function that follows the following usage:
```
// Get objectCount value from the driver
uint32_t objectCount;
vkGetObject(..., &objectCount, nullptr);

// Get objects from the driver
VkObject objects[objectCount]
vkGetObject(..., &objectCount, objects);
```

The override in VulkanReplayConsumer base should ALWAYS use the corresponding `GetOutputPointer()` for the replay time count/object and `GetPointer()` to get the capture time count/object.

Some functions were badly using `GetPointer()` for the replay time count/object leading to errors when using the queried lists.
