### PR TITLE
Restore synchronization on `vkGetQueryPoolResults` and `vkGetEventStatus`

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -82,6 +82,10 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 constexpr char kUnknownDeviceLabel[]  = "<Unknown>";
 constexpr char kValidationLayerName[] = "VK_LAYER_KHRONOS_validation";
 
+// vkGetEventStatus 'can' be used for synchronization, but cannot be (host-)waited on.
+// we poll until receiving VK_EVENT_SET, when the capture returned it.
+constexpr auto kGetEventStatusPollInterval = std::chrono::microseconds(100);
+
 const std::unordered_set<std::string> kSurfaceExtensions = {
     VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,  VK_MVK_IOS_SURFACE_EXTENSION_NAME,
     VK_MVK_MACOS_SURFACE_EXTENSION_NAME,    VK_KHR_MIR_SURFACE_EXTENSION_NAME,
@@ -4311,17 +4315,18 @@ VkResult VulkanReplayConsumerBase::OverrideGetEventStatus(PFN_vkGetEventStatus  
 
     VkResult result = func(device, event);
 
-    util::BeginInjectedCommands();
-
-    // If the query was successful at capture time, it MUST be successful at replay time, to avoid sync issues
-    while (original_result == VK_EVENT_SET && result == VK_EVENT_RESET)
+    // If the query was successful at capture time, it MUST be successful at replay time, to avoid sync issues.
+    // There is no host wait-primitive for events, so poll.
+    if (original_result == VK_EVENT_SET && result == VK_EVENT_RESET)
     {
-        std::this_thread::sleep_for(std::chrono::microseconds(100)); // Avoid true busy waiting
-        result = func(device, event);
+        util::BeginInjectedCommands();
+        while (result == VK_EVENT_RESET)
+        {
+            std::this_thread::sleep_for(kGetEventStatusPollInterval);
+            result = func(device, event);
+        }
+        util::EndInjectedCommands();
     }
-
-    util::EndInjectedCommands();
-
     return result;
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -69,8 +69,10 @@
 #include "Vulkan-Utility-Libraries/vk_format_utils.h"
 
 #include <algorithm>
+#include <chrono>
 #include <limits>
 #include <numeric>
+#include <thread>
 #include <unordered_set>
 #include <future>
 
@@ -93,7 +95,7 @@ const std::unordered_set<std::string> kSurfaceExtensions = {
 const std::unordered_set<std::string> kTrimStateSetupDeviceExtensions = { VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME };
 
 const std::unordered_set<std::string> kFunctionsAllowedToReturnDifferentCodeThanCapture = {
-    "vkSetDebugUtilsObjectNameEXT", "vkSetDebugUtilsObjectTagEXT", "vkGetQueryPoolResults", "vkGetEventStatus"
+    "vkSetDebugUtilsObjectNameEXT", "vkSetDebugUtilsObjectTagEXT"
 };
 
 // LUT containing an allow-list of differing Vulkan return-types (mapping: capture -> replay)
@@ -104,7 +106,8 @@ const std::unordered_map<VkResult, VkResult> kResultValuesAllowedDifferentCodeTh
     { VK_ERROR_OUT_OF_DATE_KHR, VK_SUCCESS },
     { VK_SUBOPTIMAL_KHR, VK_SUCCESS },
     { VK_ERROR_FORMAT_NOT_SUPPORTED, VK_SUCCESS },
-    { VK_ERROR_OUT_OF_POOL_MEMORY, VK_SUCCESS }
+    { VK_ERROR_OUT_OF_POOL_MEMORY, VK_SUCCESS },
+    { VK_EVENT_RESET, VK_EVENT_SET }
 };
 
 static VKAPI_ATTR VkBool32 VKAPI_CALL DebugReportCallback(VkDebugReportFlagsEXT      flags,
@@ -4296,6 +4299,32 @@ VkResult VulkanReplayConsumerBase::OverrideGetFenceStatus(PFN_vkGetFenceStatus  
     return result;
 }
 
+VkResult VulkanReplayConsumerBase::OverrideGetEventStatus(PFN_vkGetEventStatus    func,
+                                                          VkResult                original_result,
+                                                          const VulkanDeviceInfo* device_info,
+                                                          const VulkanEventInfo*  event_info)
+{
+    GFXRECON_ASSERT(device_info != nullptr && event_info != nullptr);
+
+    VkDevice device = device_info->handle;
+    VkEvent  event  = event_info->handle;
+
+    VkResult result = func(device, event);
+
+    util::BeginInjectedCommands();
+
+    // If the query was successful at capture time, it MUST be successful at replay time, to avoid sync issues
+    while (original_result == VK_EVENT_SET && result == VK_EVENT_RESET)
+    {
+        std::this_thread::sleep_for(std::chrono::microseconds(100)); // Avoid true busy waiting
+        result = func(device, event);
+    }
+
+    util::EndInjectedCommands();
+
+    return result;
+}
+
 VkResult VulkanReplayConsumerBase::OverrideGetQueryPoolResults(PFN_vkGetQueryPoolResults  func,
                                                                VkResult                   original_result,
                                                                const VulkanDeviceInfo*    device_info,
@@ -4313,6 +4342,12 @@ VkResult VulkanReplayConsumerBase::OverrideGetQueryPoolResults(PFN_vkGetQueryPoo
 
     VkDevice    device     = device_info->handle;
     VkQueryPool query_pool = query_pool_info->handle;
+
+    // If the query was successful at capture time, it MUST be successful at replay time, to avoid sync issues
+    if (original_result == VK_SUCCESS)
+    {
+        flags |= VK_QUERY_RESULT_WAIT_BIT;
+    }
 
     const VkResult result =
         func(device, query_pool, firstQuery, queryCount, dataSize, pData->GetOutputPointer(), stride, flags);

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -689,6 +689,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                     const VulkanDeviceInfo* device_info,
                                     const VulkanFenceInfo*  fence_info);
 
+    VkResult OverrideGetEventStatus(PFN_vkGetEventStatus    func,
+                                    VkResult                original_result,
+                                    const VulkanDeviceInfo* device_info,
+                                    const VulkanEventInfo*  event_info);
+
     VkResult OverrideGetQueryPoolResults(PFN_vkGetQueryPoolResults  func,
                                          VkResult                   original_result,
                                          const VulkanDeviceInfo*    device_info,

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -1243,10 +1243,10 @@ void VulkanReplayConsumer::Process_vkGetEventStatus(
     format::HandleId                            device,
     format::HandleId                            event)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
-    VkEvent in_event = MapHandle<VulkanEventInfo>(event, &CommonObjectInfoTable::GetVkEventInfo);
+    auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
+    auto in_event = GetObjectInfoTable().GetVkEventInfo(event);
 
-    VkResult replay_result = GetDeviceTable(in_device)->GetEventStatus(in_device, in_event);
+    VkResult replay_result = OverrideGetEventStatus(GetDeviceTable(in_device->handle)->GetEventStatus, returnValue, in_device, in_event);
     CheckResult("vkGetEventStatus", returnValue, replay_result, call_info);
 }
 

--- a/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
@@ -19,6 +19,7 @@
     "vkGetDeviceQueue2": "OverrideGetDeviceQueue2",
     "vkWaitForFences": "OverrideWaitForFences",
     "vkGetFenceStatus": "OverrideGetFenceStatus",
+    "vkGetEventStatus": "OverrideGetEventStatus",
     "vkGetQueryPoolResults": "OverrideGetQueryPoolResults",
     "vkQueueSubmit": "OverrideQueueSubmit",
     "vkQueueSubmit2": "OverrideQueueSubmit2",


### PR DESCRIPTION
PR #2723 removed busy-wait loops for cases where `vkGetQueryPoolResults` and `vkGetEventStatus` were successful at capture time but not at replay time.

It's true that busy looping is to be avoided, and that the former implementation was not even working anyway due to the "max retry" threshold.
However, we still need to make sure that the replayer doesn't break the synchronization scheme of the overall workload: if the original application was using `vkGetEventStatus` to make sure a Vulkan resource is not in use anymore before reusing it in further Vulkan calls, we need to make sure that any call to `vkGetEventStatus` that was successful at capture time is also successful at replay time (and the same for `vkGetQueryPoolResults`), the same way it is done for `vkGetFenceStatus`.

For `vkQueryPoolResults`, I propose to use `VK_QUERY_RESULT_WAIT_BIT`, which makes the request blocking.

For `vkGetEventStatus`, as there is no equivalent flag or `vkWaitForEvent` function, I propose to re-implement the busy-waiting with the following changes:
- No "max retry" anymore, it continues for as long as necessary
- A thread sleep of 100us between every "retry". At the time scale of a GPU, this is slow enough to avoid spamming the call millions of times, and fast enough to avoid stuttering the entire replay.

This is not a perfect solution, but this solution actually guarantees correct synchronization for single-threaded applications using these calls, and attempts to minimize the CPU impact of the busy-waiting.
