### PR TITLE
Make GFXRECON_LOG_FATAL actually fatal on non-Android platforms

### DIFF
--- a/framework/decode/custom_dx12_struct_decoders.cpp
+++ b/framework/decode/custom_dx12_struct_decoders.cpp
@@ -1182,14 +1182,14 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_D3D12_PIP
 
                 if (type == format::kInvalidSubobjectType)
                 {
-                    GFXRECON_LOG_FATAL(
+                    GFXRECON_LOG_ERROR(
                         "A pipeline state subobject encoding indicates that the stream contained an unrecognized "
                         "subobject type during capture and the captured data is incomplete, which may cause replay to "
                         "fail.");
                 }
                 else
                 {
-                    GFXRECON_LOG_FATAL("Pipeline state subobject decoding encountered unrecognized subobject type "
+                    GFXRECON_LOG_ERROR("Pipeline state subobject decoding encountered unrecognized subobject type "
                                        "D3D12_PIPELINE_STATE_SUBOBJECT_TYPE = %d, which may cause replay to fail.",
                                        type);
                 }

--- a/framework/decode/custom_dx12_struct_decoders.cpp
+++ b/framework/decode/custom_dx12_struct_decoders.cpp
@@ -715,9 +715,8 @@ size_t DecodeStruct(const uint8_t*                                              
                 ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->NumBlocks));
             break;
         default:
-            GFXRECON_LOG_FATAL(
-                "Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
-                value->HeaderPostambleType);
+            GFXRECON_LOG_FATAL("Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
+                               value->HeaderPostambleType);
             break;
     }
 

--- a/framework/decode/custom_dx12_struct_decoders.cpp
+++ b/framework/decode/custom_dx12_struct_decoders.cpp
@@ -638,7 +638,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_D3D12_REN
             // These cases have no additional values to decode.
             break;
         default:
-            GFXRECON_LOG_FATAL_ONCE("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value->Type);
+            GFXRECON_LOG_FATAL("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value->Type);
             break;
     }
 
@@ -675,7 +675,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_D3D12_REN
             // These cases have no additional values to decode.
             break;
         default:
-            GFXRECON_LOG_FATAL_ONCE("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value->Type);
+            GFXRECON_LOG_FATAL("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value->Type);
             break;
     }
 
@@ -715,7 +715,7 @@ size_t DecodeStruct(const uint8_t*                                              
                 ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->NumBlocks));
             break;
         default:
-            GFXRECON_LOG_FATAL_ONCE(
+            GFXRECON_LOG_FATAL(
                 "Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
                 value->HeaderPostambleType);
             break;

--- a/framework/decode/custom_dx12_struct_decoders.cpp
+++ b/framework/decode/custom_dx12_struct_decoders.cpp
@@ -638,7 +638,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_D3D12_REN
             // These cases have no additional values to decode.
             break;
         default:
-            GFXRECON_LOG_FATAL("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value->Type);
+            GFXRECON_LOG_ERROR("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value->Type);
             break;
     }
 
@@ -675,7 +675,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_D3D12_REN
             // These cases have no additional values to decode.
             break;
         default:
-            GFXRECON_LOG_FATAL("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value->Type);
+            GFXRECON_LOG_ERROR("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value->Type);
             break;
     }
 
@@ -715,7 +715,7 @@ size_t DecodeStruct(const uint8_t*                                              
                 ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->NumBlocks));
             break;
         default:
-            GFXRECON_LOG_FATAL("Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
+            GFXRECON_LOG_ERROR("Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
                                value->HeaderPostambleType);
             break;
     }

--- a/framework/decode/custom_dx12_struct_decoders.cpp
+++ b/framework/decode/custom_dx12_struct_decoders.cpp
@@ -638,7 +638,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_D3D12_REN
             // These cases have no additional values to decode.
             break;
         default:
-            GFXRECON_LOG_ERROR("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value->Type);
+            GFXRECON_LOG_ERROR_ONCE("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value->Type);
             break;
     }
 
@@ -675,7 +675,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_D3D12_REN
             // These cases have no additional values to decode.
             break;
         default:
-            GFXRECON_LOG_ERROR("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value->Type);
+            GFXRECON_LOG_ERROR_ONCE("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value->Type);
             break;
     }
 
@@ -715,8 +715,9 @@ size_t DecodeStruct(const uint8_t*                                              
                 ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->NumBlocks));
             break;
         default:
-            GFXRECON_LOG_ERROR("Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
-                               value->HeaderPostambleType);
+            GFXRECON_LOG_ERROR_ONCE(
+                "Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
+                value->HeaderPostambleType);
             break;
     }
 

--- a/framework/decode/dx12_acceleration_structure_builder.cpp
+++ b/framework/decode/dx12_acceleration_structure_builder.cpp
@@ -47,7 +47,7 @@ void UpdateBufferSize(ID3D12Device*                         device,
         if (!buffer)
         {
             buffer_size = 0;
-            GFXRECON_LOG_FATAL("Failed to create a buffer of size %" PRIu64 " for building acceleration structures.",
+            GFXRECON_LOG_ERROR("Failed to create a buffer of size %" PRIu64 " for building acceleration structures.",
                                required_size);
         }
         else

--- a/framework/decode/dx12_decoder_base.cpp
+++ b/framework/decode/dx12_decoder_base.cpp
@@ -571,7 +571,7 @@ size_t Dx12DecoderBase::Decode_ID3D12Device_CheckFeatureSupport(format::HandleId
             // D3D12_FEATURE_SHADER_CACHE_ABI_SUPPORT has no corresponding structure.
             break;
         default:
-            GFXRECON_LOG_FATAL("Failed to decode ID3D12Device::CheckFeatureSupport pFeatureData parameter with "
+            GFXRECON_LOG_ERROR("Failed to decode ID3D12Device::CheckFeatureSupport pFeatureData parameter with "
                                "unrecognized D3D12_FEATURE type %d",
                                feature);
             break;
@@ -615,7 +615,7 @@ size_t Dx12DecoderBase::Decode_IDXGIFactory5_CheckFeatureSupport(format::HandleI
         }
         break;
         default:
-            GFXRECON_LOG_FATAL("Failed to decode IDXGIFactory5::CheckFeatureSupport pFeatureData parameter with "
+            GFXRECON_LOG_ERROR("Failed to decode IDXGIFactory5::CheckFeatureSupport pFeatureData parameter with "
                                "unrecognized DXGI_FEATURE type %d",
                                feature);
             break;

--- a/framework/decode/dx12_descriptor_map.cpp
+++ b/framework/decode/dx12_descriptor_map.cpp
@@ -81,7 +81,7 @@ void Dx12DescriptorMap::GetGpuAddress(D3D12_GPU_DESCRIPTOR_HANDLE& descriptor, b
     }
     else if (!get_result)
     {
-        GFXRECON_LOG_FATAL_ONCE("Failed to map GPU descriptor handle 0x%" PRIx64, descriptor.ptr);
+        GFXRECON_LOG_FATAL("Failed to map GPU descriptor handle 0x%" PRIx64, descriptor.ptr);
     }
 }
 

--- a/framework/decode/dx12_descriptor_map.cpp
+++ b/framework/decode/dx12_descriptor_map.cpp
@@ -68,7 +68,7 @@ void Dx12DescriptorMap::GetCpuAddress(D3D12_CPU_DESCRIPTOR_HANDLE& descriptor) c
 {
     if (!Get(descriptor.ptr, descriptor_cpu_addresses_))
     {
-        GFXRECON_LOG_FATAL("Failed to map CPU descriptor handle 0x%" PRIxPTR, descriptor.ptr);
+        GFXRECON_LOG_ERROR("Failed to map CPU descriptor handle 0x%" PRIxPTR, descriptor.ptr);
     }
 }
 
@@ -81,7 +81,7 @@ void Dx12DescriptorMap::GetGpuAddress(D3D12_GPU_DESCRIPTOR_HANDLE& descriptor, b
     }
     else if (!get_result)
     {
-        GFXRECON_LOG_FATAL("Failed to map GPU descriptor handle 0x%" PRIx64, descriptor.ptr);
+        GFXRECON_LOG_ERROR_ONCE("Failed to map GPU descriptor handle 0x%" PRIx64, descriptor.ptr);
     }
 }
 

--- a/framework/decode/dx12_dump_resources.cpp
+++ b/framework/decode/dx12_dump_resources.cpp
@@ -2054,7 +2054,6 @@ void Dx12DumpResources::CopyResourceAsyncRead(graphics::dx12::ID3D12FenceComPtr 
     {
         GFXRECON_LOG_FATAL(
             "Invalid fence value (UINT64_MAX). Device may have been removed. GFXR is unable to continue.");
-        return;
     }
     if (completed_value < fence_wait_value)
     {

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -209,7 +209,7 @@ T* GetExtraInfo(DxObjectInfo* info)
         return static_cast<T*>(info->extra_info.get());
     }
 
-    GFXRECON_LOG_FATAL("%s object does not have an associated info structure", T::kObjectType);
+    GFXRECON_LOG_ERROR("%s object does not have an associated info structure", T::kObjectType);
 
     return nullptr;
 }
@@ -222,7 +222,7 @@ const T* GetExtraInfo(const DxObjectInfo* info)
         return static_cast<T*>(info->extra_info.get());
     }
 
-    GFXRECON_LOG_FATAL("%s object does not have an associated info structure", T::kObjectType);
+    GFXRECON_LOG_ERROR("%s object does not have an associated info structure", T::kObjectType);
 
     return nullptr;
 }

--- a/framework/decode/dx12_pre_process_consumer.h
+++ b/framework/decode/dx12_pre_process_consumer.h
@@ -262,12 +262,12 @@ class Dx12PreProcessConsumer : public Dx12Consumer
     {
         if (track_submit_index_ <= dump_resources_target_.submit_index)
         {
-            GFXRECON_LOG_FATAL("The target submit index(%d) of dump resources is out of range(%d).",
+            GFXRECON_LOG_ERROR("The target submit index(%d) of dump resources is out of range(%d).",
                                dump_resources_target_.submit_index,
                                track_submit_index_);
             if (TEST_AVAILABLE_ARGS > 0)
             {
-                GFXRECON_LOG_FATAL("Although TEST_AVAILABLE_ARGS is enabled, it cann't find the available args that "
+                GFXRECON_LOG_ERROR("Although TEST_AVAILABLE_ARGS is enabled, it cann't find the available args that "
                                    "follow the original args.");
             }
             GFXRECON_ASSERT(track_submit_index_ > dump_resources_target_.submit_index);
@@ -796,7 +796,7 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                     }
                     else
                     {
-                        GFXRECON_LOG_FATAL("The target command index(%d) of dump resources is out of range(%d).",
+                        GFXRECON_LOG_ERROR("The target command index(%d) of dump resources is out of range(%d).",
                                            dump_resources_target_.command_index,
                                            NumCommandLists);
                         GFXRECON_ASSERT(NumCommandLists > dump_resources_target_.command_index);
@@ -894,7 +894,7 @@ class Dx12PreProcessConsumer : public Dx12Consumer
                         }
                         else
                         {
-                            GFXRECON_LOG_FATAL("The target draw call index(%d) of dump resources is out of range(%d).",
+                            GFXRECON_LOG_ERROR("The target draw call index(%d) of dump resources is out of range(%d).",
                                                dump_resources_target_.draw_call_index,
                                                all_draw_call_count);
                             GFXRECON_ASSERT(all_draw_call_count > dump_resources_target_.draw_call_index);

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -922,7 +922,6 @@ void Dx12ReplayConsumerBase::CheckReplayResult(const char* call_name, HRESULT ca
                 call_name,
                 enumutil::GetResultValueString(replay_result).c_str(),
                 enumutil::GetResultValueString(capture_result).c_str());
-            RaiseFatalError(enumutil::GetResultDescription(replay_result));
         }
         else
         {
@@ -3945,14 +3944,6 @@ IDXGIAdapter* Dx12ReplayConsumerBase::GetAdapter()
     return adapter_found;
 }
 
-void Dx12ReplayConsumerBase::RaiseFatalError(const char* message) const
-{
-    // TODO: Should there be a default action if no error handler has been provided?
-    if (fatal_error_handler_ != nullptr)
-    {
-        fatal_error_handler_(message);
-    }
-}
 
 // Helper to initialize the resource's D3D12ResourceInfo and set its is_reserved_resource = true.
 static void SetIsReservedResource(HandlePointerDecoder<void*>* resource)

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -425,7 +425,7 @@ void Dx12ReplayConsumerBase::ProcessCreateHeapAllocationCommand(uint64_t allocat
     }
     else
     {
-        GFXRECON_LOG_FATAL("Failed to create extertnal heap allocation (ID = %" PRIu64 ") of size %" PRIu64,
+        GFXRECON_LOG_ERROR("Failed to create extertnal heap allocation (ID = %" PRIu64 ") of size %" PRIu64,
                            allocation_id,
                            allocation_size);
     }
@@ -2433,7 +2433,7 @@ Dx12ReplayConsumerBase::OverrideOpenExistingHeapFromAddress(DxObjectInfo*       
     }
     else
     {
-        GFXRECON_LOG_FATAL("No heap allocation has been created for ID3D12Device3::OpenExistingHeapFromAddress "
+        GFXRECON_LOG_ERROR("No heap allocation has been created for ID3D12Device3::OpenExistingHeapFromAddress "
                            "allocation ID = %" PRIu64,
                            allocation_id);
     }
@@ -2504,7 +2504,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideOpenExistingHeapFromFileMapping(DxObject
     }
     else
     {
-        GFXRECON_LOG_FATAL("No heap allocation has been created for ID3D12Device3::OpenExistingHeapFromFileMapping "
+        GFXRECON_LOG_ERROR("No heap allocation has been created for ID3D12Device3::OpenExistingHeapFromFileMapping "
                            "allocation ID = %" PRIu64,
                            allocation_id);
     }
@@ -2550,7 +2550,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideOpenExistingHeapFromAddress1(DxObjectInf
     }
     else
     {
-        GFXRECON_LOG_FATAL("No heap allocation has been created for ID3D12Device13::OpenExistingHeapFromAddress1 "
+        GFXRECON_LOG_ERROR("No heap allocation has been created for ID3D12Device13::OpenExistingHeapFromAddress1 "
                            "allocation ID = %" PRIu64,
                            allocation_id);
     }
@@ -3741,7 +3741,7 @@ HANDLE Dx12ReplayConsumerBase::GetEventObject(uint64_t event_id, bool reset)
         }
         else
         {
-            GFXRECON_LOG_FATAL("Event creation failed for ID3D12Fence::SetEventOnCompletion");
+            GFXRECON_LOG_ERROR("Event creation failed for ID3D12Fence::SetEventOnCompletion");
         }
     }
 
@@ -5005,7 +5005,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideD3D12CreateVersionedRootSignatureDeseria
     Decoded_GUID                     pRootSignatureDeserializerInterface,
     PointerDecoder<uint64_t, void*>* ppRootSignatureDeserializer)
 {
-    GFXRECON_LOG_FATAL(
+    GFXRECON_LOG_ERROR(
         "Calling unsupported function D3D12CreateVersionedRootSignatureDeserializerFromSubobjectInLibrary");
     return E_NOTIMPL;
 }
@@ -5013,13 +5013,13 @@ HRESULT Dx12ReplayConsumerBase::OverrideD3D12CreateVersionedRootSignatureDeseria
 void Dx12ReplayConsumerBase::OverrideSetProgram(DxObjectInfo* replay_object_info,
                                                 StructPointerDecoder<Decoded_D3D12_SET_PROGRAM_DESC>* pDesc)
 {
-    GFXRECON_LOG_FATAL("Calling unsupported function ID3D12GraphicsCommandList10::SetProgram");
+    GFXRECON_LOG_ERROR("Calling unsupported function ID3D12GraphicsCommandList10::SetProgram");
 }
 
 void Dx12ReplayConsumerBase::OverrideDispatchGraph(DxObjectInfo* replay_object_info,
                                                    StructPointerDecoder<Decoded_D3D12_DISPATCH_GRAPH_DESC>* pDesc)
 {
-    GFXRECON_LOG_FATAL("Calling unsupported function ID3D12GraphicsCommandList10::DispatchGraph");
+    GFXRECON_LOG_ERROR("Calling unsupported function ID3D12GraphicsCommandList10::DispatchGraph");
 }
 
 HRESULT Dx12ReplayConsumerBase::OverrideCreateMetaCommand(DxObjectInfo*                device5_object_info,

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -73,11 +73,6 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     void SetAgsMarkerInjector(AGSContext* ags_context = nullptr);
 #endif
 
-    void SetFatalErrorHandler(std::function<void(const char*)> handler)
-    {
-        fatal_error_handler_ = handler;
-    }
-
     void SetFpsInfo(graphics::FpsInfo* fps_info)
     {
         fps_info_ = fps_info;
@@ -1279,8 +1274,6 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     LUID GetAdapterLuid(const LUID& capture_luid);
 
-    void RaiseFatalError(const char* message) const;
-
     uint64_t GetUniqueProxyWindowId()
     {
         return ++unique_proxy_window_id_counter_;
@@ -1383,7 +1376,6 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     std::unordered_map<uint64_t, HANDLE>                  event_objects_;
     std::unordered_map<uint64_t, LUID>                    adapter_luid_map_;
     std::unordered_map<uint64_t, void*>                   shared_handles_;
-    std::function<void(const char*)>                      fatal_error_handler_;
     Dx12DescriptorMap                                     descriptor_map_;
     graphics::Dx12GpuVaMap                                gpu_va_map_;
     std::unique_ptr<uint8_t[]>                            debug_message_;

--- a/framework/decode/dx12_resource_value_mapper.cpp
+++ b/framework/decode/dx12_resource_value_mapper.cpp
@@ -53,7 +53,7 @@ T* GetExtraInfo(HandlePointerDecoder<void*>* handle_ptr_decoder)
         return static_cast<T*>(object_info->extra_info.get());
     }
 
-    GFXRECON_LOG_FATAL("%s object does not have an associated info structure", T::kObjectType);
+    GFXRECON_LOG_ERROR("%s object does not have an associated info structure", T::kObjectType);
 
     return nullptr;
 }

--- a/framework/decode/openxr_replay_consumer_base.cpp
+++ b/framework/decode/openxr_replay_consumer_base.cpp
@@ -1453,7 +1453,6 @@ void OpenXrReplayConsumerBase::UpdateState_xrEnumerateSwapchainImages(
                            call_info.index,
                            call_info.thread_id,
                            util::ToString<XrResult>(result).c_str());
-        RaiseFatalError(enumutil::GetResultDescription(result));
     }
 }
 
@@ -1842,7 +1841,6 @@ void OpenXrReplayConsumerBase::CheckResult(const char*                func_name,
                                    util::ToString<XrResult>(replay).c_str(),
                                    util::ToString<XrResult>(original).c_str());
 
-                RaiseFatalError(enumutil::GetResultDescription(replay));
             }
             else
             {
@@ -1871,14 +1869,6 @@ void OpenXrReplayConsumerBase::CheckResult(const char*                func_name,
     }
 }
 
-void OpenXrReplayConsumerBase::RaiseFatalError(const char* message) const
-{
-    // TODO: Should there be a default action if no error handler has been provided?
-    if (fatal_error_handler_ != nullptr)
-    {
-        fatal_error_handler_(message);
-    }
-}
 
 openxr::GraphicsBinding OpenXrReplayConsumerBase::MakeGraphicsBinding(Decoded_XrSessionCreateInfo* create_info)
 {

--- a/framework/decode/openxr_replay_consumer_base.h
+++ b/framework/decode/openxr_replay_consumer_base.h
@@ -285,11 +285,6 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
                                         format::HandleId   swapchain,
                                         XrResult           replay_result);
 
-    void SetFatalErrorHandler(std::function<void(const char*)> handler)
-    {
-        fatal_error_handler_ = handler;
-    }
-
     const OpenXrReplayOptions options_;
 
   protected:
@@ -480,13 +475,10 @@ class OpenXrReplayConsumerBase : public OpenXrConsumer
                      bool                       assert_on_error = true);
 
   private:
-    void RaiseFatalError(const char* message) const;
-
     PFN_xrGetInstanceProcAddr                                   get_instance_proc_addr_;
     CommonObjectInfoTable*                                      object_info_table_;
     std::unordered_map<XrInstance, encode::OpenXrInstanceTable> instance_tables_;
     std::shared_ptr<application::Application>                   application_;
-    std::function<void(const char*)>                            fatal_error_handler_;
     graphics::FpsInfo*                                          fps_info_;
 
 #if defined(__ANDROID__)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1436,24 +1436,6 @@ void VulkanReplayConsumerBase::ClearRecaptureHandleIds()
     }
 }
 
-void VulkanReplayConsumerBase::SetFatalErrorHandler(std::function<void(const char*)> handler)
-{
-    fatal_error_handler_ = handler;
-    if (resource_dumper_)
-    {
-        resource_dumper_->DumpResourcesSetFatalErrorHandler(handler);
-    }
-}
-
-void VulkanReplayConsumerBase::RaiseFatalError(const char* message) const
-{
-    // TODO: Should there be a default action if no error handler has been provided?
-    if (fatal_error_handler_ != nullptr)
-    {
-        fatal_error_handler_(message);
-    }
-}
-
 void VulkanReplayConsumerBase::InitializeLoader()
 {
     loader_handle_ = graphics::InitializeLoader();
@@ -1476,7 +1458,6 @@ void VulkanReplayConsumerBase::InitializeLoader()
         GFXRECON_LOG_FATAL("Failed to load Vulkan runtime library; please ensure that the path to the Vulkan "
                            "loader (eg. %s) has been added to the appropriate system path",
                            graphics::kLoaderLibNames[0].c_str());
-        RaiseFatalError("Failed to load Vulkan runtime library");
     }
 }
 
@@ -1630,7 +1611,6 @@ void VulkanReplayConsumerBase::CheckResult(const char*                func_name,
                 // replay to attempt to continue for the case where an application may have queried for formats that it
                 // did not use.
                 GFXRECON_LOG_FATAL("%s. Replay cannot continue.", log_str);
-                RaiseFatalError(enumutil::GetResultDescription(replay));
             }
             else
             {
@@ -2491,8 +2471,6 @@ void VulkanReplayConsumerBase::InitializeResourceAllocator(const VulkanPhysicalD
     if (result < 0)
     {
         GFXRECON_LOG_FATAL("Failed to initialize memory allocator.  Replay cannot continue.");
-        RaiseFatalError(
-            "Replay has encountered a fatal error and cannot continue (failed to initialize memory allocator)");
     }
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -283,7 +283,6 @@ VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::
                 GFXRECON_LOG_FATAL("Could not open pipeline cache file '%s'. Error: '%s'",
                                    options_.save_pipeline_cache_filename.c_str(),
                                    strerror(error));
-                exit(-1);
             }
             util::platform::FileClose(file);
         }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -89,8 +89,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         gfxrecon::util::filepath::CheckReplayerName(info_record.AppName);
     }
 
-    void SetFatalErrorHandler(std::function<void(const char*)> handler);
-
     void SetFpsInfo(graphics::FpsInfo* fps_info) { fps_info_ = fps_info; }
 
     virtual void WaitDevicesIdle() override;
@@ -1697,8 +1695,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     //// End recapture members
 
   private:
-    void RaiseFatalError(const char* message) const;
-
     void InitializeLoader();
 
     void AddInstanceTable(VkInstance instance);
@@ -1947,7 +1943,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     graphics::InstanceDispatchTablesMap                                      instance_tables_;
     graphics::DeviceDispatchTablesMap                                        device_tables_;
     std::unordered_map<format::HandleId, format::HandleId>                   device_phy_id_map_;
-    std::function<void(const char*)>                                         fatal_error_handler_;
     std::shared_ptr<application::Application>                                application_;
     CommonObjectInfoTable*                                                   object_info_table_;
     bool                                                                     loading_trim_state_;

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -3224,7 +3224,7 @@ void VulkanReplayDumpResourcesBase::ProcessStateEndMarker()
         if (res != VK_SUCCESS)
         {
             Release();
-            GFXRECON_LOG_FATAL("Dumping transfer commands from state setup section failed failed (%s)",
+            GFXRECON_LOG_FATAL("Dumping transfer commands from state setup section failed (%s)",
                                util::ToString<VkResult>(res).c_str());
         }
 

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -2299,18 +2299,6 @@ void VulkanReplayDumpResourcesBase::OverrideCmdExecuteCommands(const ApiCallInfo
     }
 }
 
-void VulkanReplayDumpResourcesBase::DumpResourcesSetFatalErrorHandler(std::function<void(const char*)> handler)
-{
-    fatal_error_handler_ = handler;
-}
-
-void VulkanReplayDumpResourcesBase::RaiseFatalError(const char* message) const
-{
-    if (fatal_error_handler_ != nullptr)
-    {
-        fatal_error_handler_(message);
-    }
-}
 
 void VulkanReplayDumpResourcesBase::OverrideCmdBuildAccelerationStructuresKHR(
     const VulkanCommandBufferInfo*                                             original_command_buffer,
@@ -3236,9 +3224,8 @@ void VulkanReplayDumpResourcesBase::ProcessStateEndMarker()
         if (res != VK_SUCCESS)
         {
             Release();
-            RaiseFatalError(("Dumping transfer commands from state setup section failed failed (" +
-                             util::ToString<VkResult>(res) + ")")
-                                .c_str());
+            GFXRECON_LOG_FATAL("Dumping transfer commands from state setup section failed failed (%s)",
+                               util::ToString<VkResult>(res).c_str());
         }
 
         // ProcessStateEndMarker marks the end of the state setup section. If a TransferDumpingContext was assigned to

--- a/framework/decode/vulkan_replay_dump_resources.h
+++ b/framework/decode/vulkan_replay_dump_resources.h
@@ -518,8 +518,6 @@ class VulkanReplayDumpResourcesBase
         }
     }
 
-    void DumpResourcesSetFatalErrorHandler(std::function<void(const char*)> handler);
-
     // Handles population of acceleration_structures_context_ map. For each AS that is build an entry in that map is
     // created and the input buffers are cloned
     void OverrideCmdBuildAccelerationStructuresKHR(
@@ -789,8 +787,6 @@ class VulkanReplayDumpResourcesBase
     DumpResourcesAccelerationStructuresContext acceleration_structures_context_;
     bool                                       dump_as_build_input_buffers_;
 
-    std::function<void(const char*)> fatal_error_handler_;
-    void                             RaiseFatalError(const char* message) const;
 };
 
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_swapchain.cpp
+++ b/framework/decode/vulkan_swapchain.cpp
@@ -79,7 +79,6 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                             ori
         if (wsi_context == nullptr)
         {
             GFXRECON_LOG_FATAL("Failed to create wsi context. Replay cannot continue.");
-            return VK_ERROR_UNKNOWN;
         }
 
         auto* window_factory = wsi_context->GetWindowFactory();
@@ -87,7 +86,6 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                             ori
         if (window_factory == nullptr)
         {
             GFXRECON_LOG_FATAL("%s window factory creation failed. Replay cannot continue.", wsi_context->GetWsiName());
-            return VK_ERROR_UNKNOWN;
         }
 
         // By default, the created window will be automatically in full screen mode, and its location will be set to 0,0
@@ -105,7 +103,6 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                             ori
             // Failure to create a window is a fatal error.
             GFXRECON_LOG_FATAL("Failed to create %s window for use with surface creation. Replay cannot continue.",
                                wsi_context->GetWsiName());
-            return VK_ERROR_UNKNOWN;
         }
 
         window_factory->created_window_.emplace(window, window_index_);

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -200,7 +200,7 @@ bool CommonCaptureManager::LockedCreateInstance(ApiCaptureManager*           api
         success = Initialize(api_capture_singleton->GetApiFamily(), base_filename, trace_settings);
         if (!success)
         {
-            GFXRECON_LOG_FATAL("Failed to initialize CommonCaptureManager");
+            GFXRECON_LOG_ERROR("Failed to initialize CommonCaptureManager");
         }
     }
 
@@ -943,7 +943,7 @@ void CommonCaptureManager::CheckContinueCaptureForWriteMode(format::ApiFamilyId 
                 }
                 else
                 {
-                    GFXRECON_LOG_FATAL("Failed to initialize capture for trim range; capture has been disabled");
+                    GFXRECON_LOG_ERROR("Failed to initialize capture for trim range; capture has been disabled");
                     trim_enabled_ = false;
                     capture_mode_ = kModeDisabled;
                 }
@@ -1000,7 +1000,7 @@ void CommonCaptureManager::CheckStartCaptureForTrackMode(format::ApiFamilyId    
             }
             else
             {
-                GFXRECON_LOG_FATAL("Failed to initialize capture for trim range; capture has been disabled");
+                GFXRECON_LOG_ERROR("Failed to initialize capture for trim range; capture has been disabled");
                 trim_enabled_ = false;
                 capture_mode_ = kModeDisabled;
             }
@@ -1018,7 +1018,7 @@ void CommonCaptureManager::CheckStartCaptureForTrackMode(format::ApiFamilyId    
         }
         else
         {
-            GFXRECON_LOG_FATAL("Failed to initialize capture for hotkey trim trigger; capture has been disabled");
+            GFXRECON_LOG_ERROR("Failed to initialize capture for hotkey trim trigger; capture has been disabled");
             trim_enabled_ = false;
             capture_mode_ = kModeDisabled;
         }
@@ -1058,7 +1058,7 @@ void CommonCaptureManager::ActivateTrimmingDrawCalls(format::ApiFamilyId        
         }
         else
         {
-            GFXRECON_LOG_FATAL("Failed to initialize capture for trim draw calls; capture has been disabled");
+            GFXRECON_LOG_ERROR("Failed to initialize capture for trim draw calls; capture has been disabled");
             trim_enabled_ = false;
             capture_mode_ = kModeDisabled;
         }

--- a/framework/encode/custom_dx12_struct_encoders.cpp
+++ b/framework/encode/custom_dx12_struct_encoders.cpp
@@ -475,8 +475,9 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_SERIALIZED_RAYTRACING_A
             encoder->EncodeUInt32Value(value.NumBlocks);
             break;
         default:
-            GFXRECON_LOG_ERROR("Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
-                               value.HeaderPostambleType);
+            GFXRECON_LOG_ERROR_ONCE(
+                "Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
+                value.HeaderPostambleType);
             break;
     }
 }

--- a/framework/encode/custom_dx12_struct_encoders.cpp
+++ b/framework/encode/custom_dx12_struct_encoders.cpp
@@ -428,7 +428,7 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_RENDER_PASS_BEGINNING_A
             // These cases have no additional values to encode.
             break;
         default:
-            GFXRECON_LOG_FATAL_ONCE("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value.Type);
+            GFXRECON_LOG_FATAL("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value.Type);
             break;
     }
 }
@@ -453,7 +453,7 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_RENDER_PASS_ENDING_ACCE
             // These cases have no additional values to encode.
             break;
         default:
-            GFXRECON_LOG_FATAL_ONCE("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value.Type);
+            GFXRECON_LOG_FATAL("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value.Type);
             break;
     }
 }
@@ -475,7 +475,7 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_SERIALIZED_RAYTRACING_A
             encoder->EncodeUInt32Value(value.NumBlocks);
             break;
         default:
-            GFXRECON_LOG_FATAL_ONCE(
+            GFXRECON_LOG_FATAL(
                 "Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
                 value.HeaderPostambleType);
             break;

--- a/framework/encode/custom_dx12_struct_encoders.cpp
+++ b/framework/encode/custom_dx12_struct_encoders.cpp
@@ -475,9 +475,8 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_SERIALIZED_RAYTRACING_A
             encoder->EncodeUInt32Value(value.NumBlocks);
             break;
         default:
-            GFXRECON_LOG_FATAL(
-                "Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
-                value.HeaderPostambleType);
+            GFXRECON_LOG_FATAL("Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
+                               value.HeaderPostambleType);
             break;
     }
 }

--- a/framework/encode/custom_dx12_struct_encoders.cpp
+++ b/framework/encode/custom_dx12_struct_encoders.cpp
@@ -428,7 +428,7 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_RENDER_PASS_BEGINNING_A
             // These cases have no additional values to encode.
             break;
         default:
-            GFXRECON_LOG_ERROR("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value.Type);
+            GFXRECON_LOG_ERROR_ONCE("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value.Type);
             break;
     }
 }
@@ -453,7 +453,7 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_RENDER_PASS_ENDING_ACCE
             // These cases have no additional values to encode.
             break;
         default:
-            GFXRECON_LOG_ERROR("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value.Type);
+            GFXRECON_LOG_ERROR_ONCE("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value.Type);
             break;
     }
 }

--- a/framework/encode/custom_dx12_struct_encoders.cpp
+++ b/framework/encode/custom_dx12_struct_encoders.cpp
@@ -428,7 +428,7 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_RENDER_PASS_BEGINNING_A
             // These cases have no additional values to encode.
             break;
         default:
-            GFXRECON_LOG_FATAL("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value.Type);
+            GFXRECON_LOG_ERROR("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value.Type);
             break;
     }
 }
@@ -453,7 +453,7 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_RENDER_PASS_ENDING_ACCE
             // These cases have no additional values to encode.
             break;
         default:
-            GFXRECON_LOG_FATAL("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value.Type);
+            GFXRECON_LOG_ERROR("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value.Type);
             break;
     }
 }
@@ -475,7 +475,7 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_SERIALIZED_RAYTRACING_A
             encoder->EncodeUInt32Value(value.NumBlocks);
             break;
         default:
-            GFXRECON_LOG_FATAL("Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
+            GFXRECON_LOG_ERROR("Unrecognized D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER1 union type %u",
                                value.HeaderPostambleType);
             break;
     }

--- a/framework/encode/custom_dx12_struct_encoders.cpp
+++ b/framework/encode/custom_dx12_struct_encoders.cpp
@@ -913,7 +913,7 @@ void EncodeDXGIFeatureStruct(ParameterEncoder* encoder, void* feature_data, DXGI
             encoder->EncodeInt32Value(*reinterpret_cast<int32_t*>(feature_data));
             break;
         default:
-            GFXRECON_LOG_FATAL("Failed to encode IDXGIFactory5::CheckFeatureSupport pFeatureData parameter with "
+            GFXRECON_LOG_ERROR("Failed to encode IDXGIFactory5::CheckFeatureSupport pFeatureData parameter with "
                                "unrecognized DXGI_FEATURE type %d",
                                feature);
             break;

--- a/framework/encode/custom_openxr_api_call_encoders.cpp
+++ b/framework/encode/custom_openxr_api_call_encoders.cpp
@@ -55,7 +55,7 @@ static void RequireVulkanCaptureEnabled()
     VulkanCaptureManager* vulkan_capture_manager = VulkanCaptureManager::Get();
     if (!vulkan_capture_manager)
     {
-        GFXRECON_LOG_FATAL(
+        GFXRECON_LOG_ERROR(
             "Capture configuration error. Attempting OpenXR capture without Vulkan graphics API capture enabled.");
     }
     GFXRECON_ASSERT(vulkan_capture_manager != nullptr);

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -3033,7 +3033,7 @@ HRESULT D3D12CaptureManager::OverrideD3D12CreateVersionedRootSignatureDeserializ
     REFIID  pRootSignatureDeserializerInterface,
     void**  ppRootSignatureDeserializer)
 {
-    GFXRECON_LOG_FATAL(
+    GFXRECON_LOG_ERROR(
         "Calling unsupported function D3D12CreateVersionedRootSignatureDeserializerFromSubobjectInLibrary");
     return E_NOTIMPL;
 }
@@ -3520,10 +3520,11 @@ bool D3D12CaptureManager::TrimDrawCalls_ID3D12CommandQueue_ExecuteCommandLists(
     {
         if (num_lists <= trim_draw_calls.command_index)
         {
-            GFXRECON_LOG_FATAL("CAPTURE_DRAW_CALLS can't find the commandlist index(%d). It might be out of range(%d).",
+            GFXRECON_LOG_ERROR("CAPTURE_DRAW_CALLS can't find the commandlist index(%d). It might be out of range(%d).",
                                trim_draw_calls.command_index,
                                num_lists);
             GFXRECON_ASSERT(num_lists > trim_draw_calls.command_index);
+            return false;
         }
 
         auto target_cmdlist = lists[trim_draw_calls.command_index];
@@ -3535,10 +3536,11 @@ bool D3D12CaptureManager::TrimDrawCalls_ID3D12CommandQueue_ExecuteCommandLists(
 
         if (target_info->find_target_draw_call_count == 0)
         {
-            GFXRECON_LOG_FATAL("CAPTURE_DRAW_CALLS can't find the draw call indices(%d-%d). It might be out of range.",
+            GFXRECON_LOG_ERROR("CAPTURE_DRAW_CALLS can't find the draw call indices(%d-%d). It might be out of range.",
                                trim_draw_calls.draw_call_indices.first,
                                trim_draw_calls.draw_call_indices.last);
             GFXRECON_ASSERT(target_info->find_target_draw_call_count != 0);
+            return false;
         }
 
         if (target_info->find_target_draw_call_count !=
@@ -3556,11 +3558,12 @@ bool D3D12CaptureManager::TrimDrawCalls_ID3D12CommandQueue_ExecuteCommandLists(
             if (target_info->target_bundle_commandlist_info->find_target_draw_call_count == 0)
             {
 
-                GFXRECON_LOG_FATAL(
+                GFXRECON_LOG_ERROR(
                     "CAPTURE_DRAW_CALLS can't find the bundle draw call indices(%d-%d). It might be out of range.",
                     trim_draw_calls.bundle_draw_call_indices.first,
                     trim_draw_calls.bundle_draw_call_indices.last);
                 GFXRECON_ASSERT(target_info->target_bundle_commandlist_info->find_target_draw_call_count != 0);
+                return false;
             }
 
             if (target_info->target_bundle_commandlist_info->find_target_draw_call_count !=
@@ -3861,12 +3864,13 @@ D3D12CaptureManager::GetCommandListsForTrimDrawCalls(ID3D12CommandList_Wrapper* 
                 case graphics::dx12::Dx12DumpResourcePos::kDrawCall:
                     if (trim_draw_calls.draw_call_indices.first != trim_draw_calls.draw_call_indices.last)
                     {
-                        GFXRECON_LOG_FATAL("The target draw call is a ExecuteBundle. The draw call indices must be not "
+                        GFXRECON_LOG_ERROR("The target draw call is a ExecuteBundle. The draw call indices must be not "
                                            "a range(%d-%d).",
                                            trim_draw_calls.draw_call_indices.first,
                                            trim_draw_calls.draw_call_indices.last);
                         GFXRECON_ASSERT(trim_draw_calls.draw_call_indices.first ==
                                         trim_draw_calls.draw_call_indices.last);
+                        return {};
                     }
                     cmd_sets.insert(cmd_sets.end(),
                                     cmd_list_info->split_command_sets.begin(),

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -785,7 +785,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateDescriptorHeap(
         if (increment < sizeof(void*))
         {
             // The actual descriptor size is too small to store the pointer to the descriptor wrapper.
-            GFXRECON_LOG_FATAL("The descriptor increment size %u is too small to support descriptor wrapping",
+            GFXRECON_LOG_ERROR("The descriptor increment size %u is too small to support descriptor wrapping",
                                increment);
         }
 
@@ -3041,13 +3041,13 @@ HRESULT D3D12CaptureManager::OverrideD3D12CreateVersionedRootSignatureDeserializ
 void D3D12CaptureManager::OverrideID3D12GraphicsCommandList10_SetProgram(ID3D12GraphicsCommandList10_Wrapper* wrapper,
                                                                          const D3D12_SET_PROGRAM_DESC*        pDesc)
 {
-    GFXRECON_LOG_FATAL("Calling unsupported function ID3D12GraphicsCommandList10::SetProgram");
+    GFXRECON_LOG_ERROR("Calling unsupported function ID3D12GraphicsCommandList10::SetProgram");
 }
 
 void D3D12CaptureManager::OverrideID3D12GraphicsCommandList10_DispatchGraph(
     ID3D12GraphicsCommandList10_Wrapper* wrapper, const D3D12_DISPATCH_GRAPH_DESC* pDesc)
 {
-    GFXRECON_LOG_FATAL("Calling unsupported function ID3D12GraphicsCommandList10::DispatchGraph");
+    GFXRECON_LOG_ERROR("Calling unsupported function ID3D12GraphicsCommandList10::DispatchGraph");
 }
 
 void D3D12CaptureManager::PostProcess_ID3D12Device5_CreateStateObject(ID3D12Device5_Wrapper*         device5_wrapper,

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1733,7 +1733,7 @@ void Dx12StateWriter::WriteAccelerationStructuresState(
         }
         else
         {
-            GFXRECON_LOG_FATAL("Failed to map inputs data resource for writing trimmed state for acceleration "
+            GFXRECON_LOG_ERROR("Failed to map inputs data resource for writing trimmed state for acceleration "
                                "structures. The capture file will be invalid.");
             continue;
         }

--- a/framework/graphics/dx12_resource_data_util.cpp
+++ b/framework/graphics/dx12_resource_data_util.cpp
@@ -343,7 +343,7 @@ dx12::ID3D12ResourceComPtr Dx12ResourceDataUtil::GetStagingBuffer(CopyType type,
 
     if (FAILED(result))
     {
-        GFXRECON_LOG_FATAL("Failed to create a staging buffer of size %" PRIu64 " for copying resource data.",
+        GFXRECON_LOG_ERROR("Failed to create a staging buffer of size %" PRIu64 " for copying resource data.",
                            buffer_size);
 
         staging_buffers_[type]      = nullptr;

--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -77,7 +77,7 @@ ArgumentParser::ArgumentParser(bool               first_is_exe_name,
                 if (end_index == std::string::npos)
                 {
                     is_invalid_ = true;
-                    GFXRECON_LOG_ERROR("ArgumentParser command-line string contains unmatched quotes.", args);
+                    GFXRECON_LOG_ERROR("ArgumentParser command-line string contains unmatched quotes: %s", args);
                     return;
                 }
 

--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -77,7 +77,7 @@ ArgumentParser::ArgumentParser(bool               first_is_exe_name,
                 if (end_index == std::string::npos)
                 {
                     is_invalid_ = true;
-                    GFXRECON_LOG_FATAL("Error: ArgumentParser command-line string contains unmatched quotes.", args);
+                    GFXRECON_LOG_ERROR("ArgumentParser command-line string contains unmatched quotes.", args);
                     return;
                 }
 
@@ -259,7 +259,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
                 // be an invalid value.
                 invalid_values_present_.push_back(current_argument);
                 is_invalid_ = true;
-                GFXRECON_LOG_FATAL("Invalid command-line setting \'%s\'", current_argument.c_str());
+                GFXRECON_LOG_ERROR("Invalid command-line setting \'%s\'", current_argument.c_str());
             }
         }
         else

--- a/framework/util/logging.cpp
+++ b/framework/util/logging.cpp
@@ -25,8 +25,8 @@
 #include "util/date_time.h"
 
 #include <cstdarg>
+#include <cstdlib>
 #include <string>
-#include <cstring>
 #include <cstdio>
 
 #if defined(__ANDROID__)
@@ -228,7 +228,8 @@ void LoggingManager::UpdateDebugViewTarget(bool enabled)
 
 GFXRECON_END_NAMESPACE(logging)
 
-Log::Settings Log::settings_;
+Log::Settings      Log::settings_;
+Log::FatalCallback Log::fatal_callback_;
 
 std::string Log::ConvertFormatVaListToString(const std::string& format_string, va_list& var_args)
 {
@@ -277,6 +278,11 @@ void Log::UpdateLogManagerComponents(gfxrecon::util::logging::LoggingManager& lo
     {
         log_mgr.EnableIndentSupport();
     }
+}
+
+void Log::SetFatalCallback(FatalCallback callback)
+{
+    fatal_callback_ = std::move(callback);
 }
 
 void Log::Init(LoggingSeverity min_severity)
@@ -408,6 +414,18 @@ void Log::LogMessage(
         settings_.break_on_error)
     {
         platform::TriggerDebugBreak();
+    }
+
+    if (severity == LoggingSeverity::kFatal)
+    {
+        if (fatal_callback_)
+        {
+            fatal_callback_(non_indented_version.c_str());
+        }
+        else
+        {
+            std::abort();
+        }
     }
 }
 

--- a/framework/util/logging.cpp
+++ b/framework/util/logging.cpp
@@ -422,10 +422,9 @@ void Log::LogMessage(
         {
             fatal_callback_(non_indented_version.c_str());
         }
-        else
-        {
-            std::abort();
-        }
+
+        // guarantee LOG_FATAL is fatal
+        std::abort();
     }
 }
 

--- a/framework/util/logging.h
+++ b/framework/util/logging.h
@@ -107,7 +107,7 @@ class Log
     // NOTE: not thread-safe. must be called before any concurrent logging.
     static void SetFatalCallback(FatalCallback callback);
 
-    static void Release() {}
+    static void Release() { fatal_callback_ = {}; }
 
     static void LogMessage(
         LoggingSeverity severity, const char* file, const char* function, const char* line, const char* message, ...);

--- a/framework/util/logging.h
+++ b/framework/util/logging.h
@@ -321,7 +321,6 @@ GFXRECON_END_NAMESPACE(gfxrecon)
 
 // clang-format off
 #define GFXRECON_WRITE_CONSOLE_ONCE(message, ...) GFXRECON_LOG_ONCE(GFXRECON_WRITE_CONSOLE(message, ##__VA_ARGS__))
-#define GFXRECON_LOG_FATAL_ONCE(message, ...)     GFXRECON_LOG_ONCE(GFXRECON_LOG_FATAL(message, ##__VA_ARGS__))
 #define GFXRECON_LOG_ERROR_ONCE(message, ...)     GFXRECON_LOG_ONCE(GFXRECON_LOG_ERROR(message, ##__VA_ARGS__))
 #define GFXRECON_LOG_WARNING_ONCE(message, ...)   GFXRECON_LOG_ONCE(GFXRECON_LOG_WARNING(message, ##__VA_ARGS__))
 #define GFXRECON_LOG_INFO_ONCE(message, ...)      GFXRECON_LOG_ONCE(GFXRECON_LOG_INFO(message, ##__VA_ARGS__))

--- a/framework/util/logging.h
+++ b/framework/util/logging.h
@@ -29,6 +29,7 @@
 #include "util/platform.h"
 
 #include <array>
+#include <functional>
 #include <memory>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -97,9 +98,14 @@ class Log
         bool output_to_os_debug_string{ false }; // Windows-specific output messages to OutputDebugString
     };
 
+    using FatalCallback = std::function<void(const char*)>;
+
     static void Init(LoggingSeverity min_severity = LoggingSeverity::kInfo);
 
     static void UpdateWithSettings(const Settings& settings);
+
+    // NOTE: not thread-safe. must be called before any concurrent logging.
+    static void SetFatalCallback(FatalCallback callback);
 
     static void Release() {}
 
@@ -206,7 +212,8 @@ class Log
     static void        UpdateLogManagerComponents(gfxrecon::util::logging::LoggingManager& log_mgr);
     static std::string ConvertFormatVaListToString(const std::string& format_string, va_list& var_args);
 
-    static Settings settings_;
+    static Settings      settings_;
+    static FatalCallback fatal_callback_;
 };
 
 #ifdef GFXRECON_ENABLE_COMMAND_TRACE

--- a/framework/util/logging_targets.cpp
+++ b/framework/util/logging_targets.cpp
@@ -223,7 +223,7 @@ bool LoggingTargetFile::OpenFile()
     }
     else
     {
-        GFXRECON_LOG_FATAL("Failed opening log file %s with returned result %d", log_file_name_.c_str(), errno);
+        GFXRECON_LOG_ERROR("Failed opening log file %s with returned result %d", log_file_name_.c_str(), errno);
     }
 
     return success;

--- a/framework/util/test/main.cpp
+++ b/framework/util/test/main.cpp
@@ -456,12 +456,13 @@ TEST_CASE("FatalCallback invoked on LOG_FATAL", "[logging]")
     gfxrecon::util::Log::Init(gfxrecon::util::LoggingSeverity::kFatal);
 
     bool called = false;
-    gfxrecon::util::Log::SetFatalCallback([&called](const char*) { called = true; });
-    GFXRECON_LOG_FATAL("test fatal");
+    gfxrecon::util::Log::SetFatalCallback([&called](const char*) {
+        called = true;
+        throw std::runtime_error("abort intercepted");
+    });
+    REQUIRE_THROWS_AS(([] { GFXRECON_LOG_FATAL("test fatal"); }()), std::runtime_error);
     REQUIRE(called);
 
-    // `called` goes out of scope after this test; replace the lambda before it becomes a dangling reference.
-    gfxrecon::util::Log::SetFatalCallback([](const char*) {});
     gfxrecon::util::Log::Release();
 }
 
@@ -472,6 +473,5 @@ TEST_CASE("FatalCallback throw propagates", "[logging]")
 
     REQUIRE_THROWS_AS(([] { GFXRECON_LOG_FATAL("test fatal throw"); }()), std::runtime_error);
 
-    gfxrecon::util::Log::SetFatalCallback([](const char*) {});
     gfxrecon::util::Log::Release();
 }

--- a/framework/util/test/main.cpp
+++ b/framework/util/test/main.cpp
@@ -27,6 +27,8 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
+#include <stdexcept>
+
 #include "util/to_string.h"
 #include "util/strings.h"
 #include "util/date_time.h"
@@ -447,4 +449,29 @@ TEST_CASE("ExpandPathVariables", "[strings]")
 #endif
 
     Log::Release();
+}
+
+TEST_CASE("FatalCallback invoked on LOG_FATAL", "[logging]")
+{
+    gfxrecon::util::Log::Init(gfxrecon::util::LoggingSeverity::kFatal);
+
+    bool called = false;
+    gfxrecon::util::Log::SetFatalCallback([&called](const char*) { called = true; });
+    GFXRECON_LOG_FATAL("test fatal");
+    REQUIRE(called);
+
+    // `called` goes out of scope after this test; replace the lambda before it becomes a dangling reference.
+    gfxrecon::util::Log::SetFatalCallback([](const char*) {});
+    gfxrecon::util::Log::Release();
+}
+
+TEST_CASE("FatalCallback throw propagates", "[logging]")
+{
+    gfxrecon::util::Log::Init(gfxrecon::util::LoggingSeverity::kFatal);
+    gfxrecon::util::Log::SetFatalCallback([](const char* msg) { throw std::runtime_error(msg); });
+
+    REQUIRE_THROWS_AS(([] { GFXRECON_LOG_FATAL("test fatal throw"); }()), std::runtime_error);
+
+    gfxrecon::util::Log::SetFatalCallback([](const char*) {});
+    gfxrecon::util::Log::Release();
 }

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -82,8 +82,6 @@ void CreateResourceValueTrackingConsumer(
     // Create the replay consumer.
     dx12_replay_consumer = std::make_unique<decode::Dx12ResourceValueTrackingConsumer>(
         application, dx_replay_options, options.optimize_resource_values_experimental);
-    gfxrecon::util::Log::SetFatalCallback([](const char* message) { throw std::runtime_error(message); });
-
     if (options.optimize_resource_values_experimental)
     {
         dx12_replay_consumer->EnableReplayOfResourceValueCalls(false);

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -24,6 +24,7 @@
 #include "dx12_optimize_util.h"
 #include "block_skipping_file_processor.h"
 #include "dx12_resource_value_tracking_consumer.h"
+#include "util/logging.h"
 
 #include "dx12_file_optimizer.h"
 #include "decode/dx12_object_info.h"
@@ -81,7 +82,7 @@ void CreateResourceValueTrackingConsumer(
     // Create the replay consumer.
     dx12_replay_consumer = std::make_unique<decode::Dx12ResourceValueTrackingConsumer>(
         application, dx_replay_options, options.optimize_resource_values_experimental);
-    dx12_replay_consumer->SetFatalErrorHandler([](const char* message) { throw std::runtime_error(message); });
+    gfxrecon::util::Log::SetFatalCallback([](const char* message) { throw std::runtime_error(message); });
 
     if (options.optimize_resource_values_experimental)
     {

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -253,6 +253,7 @@ int main(int argc, const char** argv)
     int64_t start_time = gfxrecon::util::datetime::GetTimestamp();
 
     gfxrecon::util::Log::Init();
+    gfxrecon::util::Log::SetFatalCallback([](const char* message) { throw std::runtime_error(message); });
 
     gfxrecon::util::ArgumentParser arg_parser(argc, argv, kOptions, kArguments);
 

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2026 LunarG, Inc.
+** Copyright (c) 2018-2024 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -72,6 +72,7 @@ extern "C"
 void android_main(struct android_app* app)
 {
     gfxrecon::util::Log::Init();
+    gfxrecon::util::Log::SetFatalCallback([](const char* message) { throw std::runtime_error(message); });
     GFXRECON_WRITE_CONSOLE("====== Entering android_main");
 
     // Keep screen on while window is active.

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2018-2026 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -77,6 +77,7 @@ int main(int argc, const char** argv)
 
     // Default initialize logging to report issues while loading settings.
     gfxrecon::util::Log::Init(gfxrecon::decode::kDefaultLogLevel);
+    gfxrecon::util::Log::SetFatalCallback([](const char* message) { throw std::runtime_error(message); });
 
     std::vector<std::unique_ptr<gfxrecon::replay::ReplayFeatureBase>> features;
     gfxrecon::replay::LoadFeatures(features);

--- a/tools/replay/parse_dump_resources_cli.cpp
+++ b/tools/replay/parse_dump_resources_cli.cpp
@@ -502,7 +502,7 @@ bool parse_dump_resources_arg(gfxrecon::decode::VulkanReplayOptions& vulkan_repl
         // BeginCommandBuffer and QueueSubmit lists are expected to have the same length
         if (jargs[decode::DUMP_ARG_BEGIN_COMMAND_BUFFER].size() != jargs[decode::DUMP_ARG_QUEUE_SUBMIT].size())
         {
-            GFXRECON_LOG_FATAL("Malformed VDR input json: BeginCommandBuffer and QueueSubmit index lists are "
+            GFXRECON_LOG_ERROR("Malformed VDR input json: BeginCommandBuffer and QueueSubmit index lists are "
                                "expected to have the same length.");
             vulkan_replay_options.dumping_resources = false;
             return false;
@@ -519,7 +519,7 @@ bool parse_dump_resources_arg(gfxrecon::decode::VulkanReplayOptions& vulkan_repl
                           vulkan_replay_options.BeginCommandBufferQueueSubmit_Indices.end(),
                           new_pair) != vulkan_replay_options.BeginCommandBufferQueueSubmit_Indices.end())
             {
-                GFXRECON_LOG_FATAL("Malformed VDR input json: BeginCommandBuffer and QueueSubmit index pair (%" PRIu64
+                GFXRECON_LOG_ERROR("Malformed VDR input json: BeginCommandBuffer and QueueSubmit index pair (%" PRIu64
                                    ", %" PRIu64 ") already exist",
                                    bcb,
                                    qs);

--- a/tools/replay/replay_feature.h
+++ b/tools/replay/replay_feature.h
@@ -128,10 +128,7 @@ class ReplayFeature : public ReplayFeatureBase
         application_    = application;
     }
 
-    void FinalizeConsumer()
-    {
-        replay_consumer_->SetFatalErrorHandler([](const char* message) { throw std::runtime_error(message); });
-    }
+    void FinalizeConsumer() {}
 
     void RegisterConsumerAndDecoder(graphics::FpsInfo* fps_info)
     {

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -806,7 +806,6 @@ GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser, uint3
     {
         GFXRECON_LOG_FATAL("Invalid measurement frame range \"%s\". Must have format: <start_frame>-<end_frame>",
                            value.c_str());
-        std::abort();
     }
 
     for (std::string& num : values)
@@ -819,7 +818,6 @@ GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser, uint3
         {
             GFXRECON_LOG_FATAL("Invalid measurement frame range \"%s\", which contains non-numeric values",
                                value.c_str());
-            std::abort();
         }
     }
 
@@ -831,7 +829,6 @@ GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser, uint3
         GFXRECON_LOG_FATAL("Invalid measurement frame range \"%s\", where first frame is greater than or equal "
                            "to the last frame",
                            value.c_str());
-        std::abort();
     }
 
     if (start_frame_arg == 0)
@@ -839,7 +836,6 @@ GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser, uint3
         GFXRECON_LOG_FATAL("Invalid measurement frame range \"%s\", where first frame is 0 which is invalid in "
                            "GFXReconstruct (frame count starts at 1)",
                            value.c_str());
-        std::abort();
     }
 
     start_frame = start_frame_arg;
@@ -1330,9 +1326,8 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
         }
         else
         {
-            GFXRECON_LOG_FATAL("Unexpected value after '--skip-get-fence-status' : '%s'. Closing the program.",
+            GFXRECON_LOG_FATAL("Unexpected value after '--skip-get-fence-status': '%s'",
                                skip_get_fence_status.c_str());
-            abort();
         }
     }
 

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -1326,8 +1326,7 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
         }
         else
         {
-            GFXRECON_LOG_FATAL("Unexpected value after '--skip-get-fence-status': '%s'",
-                               skip_get_fence_status.c_str());
+            GFXRECON_LOG_FATAL("Unexpected value after '--skip-get-fence-status': '%s'", skip_get_fence_status.c_str());
         }
     }
 


### PR DESCRIPTION
- Add `Log::SetFatalCallback()`: on `kFatal`, invoke the callback, followed by a catch-all `std::abort()`.
- Remove the copy-pasted fatal_error_handler_/RaiseFatalError pattern from all four replay consumer classes
- tools set the callback once to throw std::runtime_error instead.

fixes #1024