### PR TITLE
Add DispatchSetEnvironmentVariablesCommand to openxr decoder

### DIFF
--- a/framework/decode/openxr_decoder_base.cpp
+++ b/framework/decode/openxr_decoder_base.cpp
@@ -74,6 +74,15 @@ void OpenXrDecoderBase::DispatchDisplayMessageCommand(format::ThreadId thread_id
     }
 }
 
+void OpenXrDecoderBase::DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                               const char*                                   env_string)
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessSetEnvironmentVariablesCommand(header, env_string);
+    }
+}
+
 void OpenXrDecoderBase::SetCurrentBlockIndex(uint64_t block_index)
 {
     for (auto consumer : consumers_)

--- a/framework/decode/openxr_decoder_base.h
+++ b/framework/decode/openxr_decoder_base.h
@@ -84,6 +84,9 @@ class OpenXrDecoderBase : public ApiDecoder
 
     virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) override;
 
+    virtual void DispatchSetEnvironmentVariablesCommand(const format::SetEnvironmentVariablesCommand& header,
+                                                        const char* env_string) override;
+
     virtual void SetCurrentBlockIndex(uint64_t block_index) override;
 
     virtual void DispatchViewRelativeLocation(format::ThreadId                    thread_id,


### PR DESCRIPTION
Openxr's decoder was missing the `DispatchSetEnvironmentVariablesCommand` which causes convert for `tutorial4_capture_frames_1_through_500.gfxr` to be missing block 2 completely, as it had meta function `SetEnvironmentVariablesCommand`.

Replicate the same `DispatchSetEnvironmentVariablesCommand` found in the vulkan decoder in the openxr decoder.