### PR TITLE
extract: Split out API features

### DIFF
--- a/tools/extract/CMakeLists.txt
+++ b/tools/extract/CMakeLists.txt
@@ -31,24 +31,44 @@ add_executable(gfxrecon-extract "")
 target_sources(gfxrecon-extract
                PRIVATE
                    ${CMAKE_CURRENT_LIST_DIR}/main.cpp
-                    ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
-                    $<$<BOOL:WIN32>:${PROJECT_SOURCE_DIR}/version.rc>
-                    $<$<BOOL:WIN32>:${GFXRECON_WIN_MANIFEST}>
+                   ${CMAKE_CURRENT_LIST_DIR}/extract_feature.h
+                   ${CMAKE_CURRENT_LIST_DIR}/extract_d3d12_feature.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/extract_vulkan_feature.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/../tool_settings.h
+                   $<$<BOOL:WIN32>:${PROJECT_SOURCE_DIR}/version.rc>
+                   $<$<BOOL:WIN32>:${GFXRECON_WIN_MANIFEST}>
               )
 
 if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-      target_link_options(gfxrecon-extract PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+      target_link_options(gfxrecon-extract
+                          PUBLIC
+                              "LINKER:/Include:_gfxrecon_disable_popup_result"
+                          )
     else()
-      target_link_options(gfxrecon-extract PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+      target_link_options(gfxrecon-extract
+                          PUBLIC
+                              "LINKER:/Include:gfxrecon_disable_popup_result"
+                          )
     endif()
 endif()
 
-target_include_directories(gfxrecon-extract PUBLIC ${CMAKE_BINARY_DIR})
+target_include_directories(gfxrecon-extract
+                           PUBLIC
+                               ${CMAKE_CURRENT_LIST_DIR}/..
+                          )
 
-target_link_libraries(gfxrecon-extract gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific project_version)
+target_link_libraries(gfxrecon-extract
+                          gfxrecon_decode
+                          gfxrecon_graphics
+                          gfxrecon_format
+                          gfxrecon_util
+                          platform_specific
+                          project_version
+                      )
 
 common_build_directives(gfxrecon-extract)
 

--- a/tools/extract/extract_d3d12_feature.cpp
+++ b/tools/extract/extract_d3d12_feature.cpp
@@ -1,0 +1,203 @@
+/*
+** Copyright (c) 2020-2026 LunarG, Inc.
+** Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#if defined(D3D12_SUPPORT)
+
+#include "extract_feature.h"
+
+#include "decode/dx12_detection_consumer.h"
+#include "generated/generated_dx12_consumer.h"
+#include "generated/generated_dx12_decoder.h"
+#include "util/feature_module_registry.h"
+#include "util/file_path.h"
+#include "util/logging.h"
+#include "util/platform.h"
+
+#include <d3d12.h>
+
+#include <memory>
+#include <string>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(extract)
+
+class Dx12ExtractConsumer : public decode::Dx12Consumer
+{
+  public:
+    Dx12ExtractConsumer(const std::string& extract_dir) : extract_dir_(extract_dir) {}
+
+    virtual void Process_ID3D12Device_CreateGraphicsPipelineState(
+        const decode::ApiCallInfo&                                                        call_info,
+        format::HandleId                                                                  object_id,
+        HRESULT                                                                           return_value,
+        decode::StructPointerDecoder<decode::Decoded_D3D12_GRAPHICS_PIPELINE_STATE_DESC>* pDesc,
+        decode::Decoded_GUID                                                              riid,
+        decode::HandlePointerDecoder<void*>*                                              ppPipelineState) override
+    {
+        if ((return_value == S_OK) && (pDesc != nullptr) && !pDesc->IsNull() && (ppPipelineState != nullptr) &&
+            !ppPipelineState->IsNull())
+        {
+            uint64_t handle_id = *ppPipelineState->GetPointer();
+
+            WriteShaderBytecode(pDesc->GetPointer()->VS, handle_id, ".vso");
+            WriteShaderBytecode(pDesc->GetPointer()->PS, handle_id, ".pso");
+            WriteShaderBytecode(pDesc->GetPointer()->DS, handle_id, ".dso");
+            WriteShaderBytecode(pDesc->GetPointer()->HS, handle_id, ".hso");
+            WriteShaderBytecode(pDesc->GetPointer()->GS, handle_id, ".gso");
+        }
+    }
+
+    virtual void Process_ID3D12Device_CreateComputePipelineState(
+        const decode::ApiCallInfo&                                                       call_info,
+        format::HandleId                                                                 object_id,
+        HRESULT                                                                          return_value,
+        decode::StructPointerDecoder<decode::Decoded_D3D12_COMPUTE_PIPELINE_STATE_DESC>* pDesc,
+        decode::Decoded_GUID                                                             riid,
+        decode::HandlePointerDecoder<void*>*                                             ppPipelineState) override
+    {
+        if ((return_value == S_OK) && (pDesc != nullptr) && !pDesc->IsNull() && (ppPipelineState != nullptr) &&
+            !ppPipelineState->IsNull())
+        {
+            uint64_t handle_id = *ppPipelineState->GetPointer();
+            WriteShaderBytecode(pDesc->GetPointer()->CS, handle_id, ".cso");
+        }
+    }
+
+    virtual void Process_ID3D12Device5_CreateStateObject(
+        const decode::ApiCallInfo&                                             call_info,
+        format::HandleId                                                       object_id,
+        HRESULT                                                                return_value,
+        decode::StructPointerDecoder<decode::Decoded_D3D12_STATE_OBJECT_DESC>* pDesc,
+        decode::Decoded_GUID                                                   riid,
+        decode::HandlePointerDecoder<void*>*                                   ppStateObject) override
+    {
+        WriteDxilSubobjects(return_value, pDesc, ppStateObject);
+    }
+
+    virtual void Process_ID3D12Device7_AddToStateObject(
+        const decode::ApiCallInfo&                                             call_info,
+        format::HandleId                                                       object_id,
+        HRESULT                                                                return_value,
+        decode::StructPointerDecoder<decode::Decoded_D3D12_STATE_OBJECT_DESC>* pAddition,
+        format::HandleId                                                       pStateObjectToGrowFrom,
+        decode::Decoded_GUID                                                   riid,
+        decode::HandlePointerDecoder<void*>*                                   ppNewStateObject) override
+    {
+        WriteDxilSubobjects(return_value, pAddition, ppNewStateObject);
+    }
+
+  private:
+    void WriteShaderBytecode(const D3D12_SHADER_BYTECODE& bytecode, uint64_t handle_id, const char* extension)
+    {
+        if ((bytecode.BytecodeLength > 0) && (bytecode.pShaderBytecode != nullptr))
+        {
+            std::string file_name = "sh" + std::to_string(handle_id) + extension;
+            std::string file_path = util::filepath::Join(extract_dir_, file_name);
+
+            FILE*   fp     = nullptr;
+            int32_t result = util::platform::FileOpen(&fp, file_path.c_str(), "wb");
+            if (result == 0)
+            {
+                if (!util::platform::FileWrite(bytecode.pShaderBytecode, bytecode.BytecodeLength, fp))
+                {
+                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
+                }
+                util::platform::FileClose(fp);
+            }
+            else
+            {
+                GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
+            }
+        }
+    }
+
+    void WriteDxilSubobjects(HRESULT                                                                return_value,
+                             decode::StructPointerDecoder<decode::Decoded_D3D12_STATE_OBJECT_DESC>* pDesc,
+                             decode::HandlePointerDecoder<void*>*                                   ppStateObject)
+    {
+        if ((return_value == S_OK) && (pDesc != nullptr) && !pDesc->IsNull() && (ppStateObject != nullptr) &&
+            !ppStateObject->IsNull())
+        {
+            uint64_t handle_id  = *ppStateObject->GetPointer();
+            auto&    subobjects = pDesc->GetPointer()->pSubobjects;
+
+            for (uint32_t i = 0; i < pDesc->GetPointer()->NumSubobjects; i++)
+            {
+                if ((subobjects[i].pDesc == nullptr) || (subobjects[i].Type != D3D12_STATE_SUBOBJECT_TYPE_DXIL_LIBRARY))
+                {
+                    continue;
+                }
+
+                auto& dxil_lib = reinterpret_cast<const D3D12_DXIL_LIBRARY_DESC*>(subobjects[i].pDesc)->DXILLibrary;
+
+                std::string file_name = "sh" + std::to_string(handle_id) + "_" + std::to_string(i) + ".dxil";
+                std::string file_path = util::filepath::Join(extract_dir_, file_name);
+
+                FILE*   fp     = nullptr;
+                int32_t result = util::platform::FileOpen(&fp, file_path.c_str(), "wb");
+                if (result == 0)
+                {
+                    if (!util::platform::FileWrite(dxil_lib.pShaderBytecode, dxil_lib.BytecodeLength, fp))
+                    {
+                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
+                    }
+                    util::platform::FileClose(fp);
+                }
+                else
+                {
+                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
+                }
+            }
+        }
+    }
+
+    std::string extract_dir_;
+};
+
+class Dx12ExtractFeature : public ExtractFeatureBase
+{
+  public:
+    Dx12ExtractFeature() : detect_consumer_(decode::Dx12DetectionConsumer::kNoBlockLimit) {}
+
+    void Initialize(decode::FileProcessor& file_processor, const std::string& extract_dir) override
+    {
+        extract_consumer_ = std::make_unique<Dx12ExtractConsumer>(extract_dir);
+        decoder_.AddConsumer(&detect_consumer_);
+        decoder_.AddConsumer(extract_consumer_.get());
+        file_processor.AddDecoder(&decoder_);
+    }
+
+    bool WasDetected() const override { return detect_consumer_.WasD3D12APIDetected(); }
+
+  private:
+    decode::Dx12DetectionConsumer        detect_consumer_;
+    decode::Dx12Decoder                  decoder_;
+    std::unique_ptr<Dx12ExtractConsumer> extract_consumer_;
+};
+
+GFXR_UTIL_REGISTER_FEATURE_CREATOR(ExtractFeatureBase, Dx12ExtractFeature)
+
+GFXRECON_END_NAMESPACE(extract)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // D3D12_SUPPORT

--- a/tools/extract/extract_feature.h
+++ b/tools/extract/extract_feature.h
@@ -1,0 +1,46 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_EXTRACT_FEATURE_H
+#define GFXRECON_EXTRACT_FEATURE_H
+
+#include "decode/file_processor.h"
+#include "util/defines.h"
+
+#include <string>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(extract)
+
+class ExtractFeatureBase
+{
+  public:
+    virtual ~ExtractFeatureBase() = default;
+
+    virtual void Initialize(decode::FileProcessor& file_processor, const std::string& extract_dir) = 0;
+    virtual bool WasDetected() const                                                               = 0;
+};
+
+GFXRECON_END_NAMESPACE(extract)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_EXTRACT_FEATURE_H

--- a/tools/extract/extract_vulkan_feature.cpp
+++ b/tools/extract/extract_vulkan_feature.cpp
@@ -1,0 +1,207 @@
+/*
+** Copyright (c) 2020-2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "extract_feature.h"
+
+#include "decode/vulkan_detection_consumer.h"
+#include "generated/generated_vulkan_consumer.h"
+#include "generated/generated_vulkan_decoder.h"
+#include "util/feature_module_registry.h"
+#include "util/file_path.h"
+#include "util/logging.h"
+#include "util/platform.h"
+
+#include "vulkan/vulkan.h"
+
+#include <memory>
+#include <string>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(extract)
+
+class VulkanExtractConsumer : public decode::VulkanConsumer
+{
+  public:
+    VulkanExtractConsumer(const std::string& extract_dir) : extract_dir_(extract_dir) {}
+
+    virtual void
+    Process_vkCreateShaderModule(const decode::ApiCallInfo&                                              call_info,
+                                 VkResult                                                                returnValue,
+                                 format::HandleId                                                        shaderModule,
+                                 decode::StructPointerDecoder<decode::Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
+                                 decode::StructPointerDecoder<decode::Decoded_VkAllocationCallbacks>*,
+                                 decode::HandlePointerDecoder<VkShaderModule>* pShaderModule) override
+    {
+        if ((returnValue >= 0) && (pCreateInfo != nullptr) && !pCreateInfo->IsNull() && (pShaderModule != nullptr) &&
+            !pShaderModule->IsNull())
+        {
+            const uint32_t* orig_code = pCreateInfo->GetPointer()->pCode;
+            size_t          orig_size = pCreateInfo->GetPointer()->codeSize;
+            uint64_t        handle_id = *pShaderModule->GetPointer();
+            std::string     file_name = "sh" + std::to_string(handle_id);
+            std::string     file_path = util::filepath::Join(extract_dir_, file_name);
+
+            FILE*   fp     = nullptr;
+            int32_t result = util::platform::FileOpen(&fp, file_path.c_str(), "wb");
+            if (result == 0)
+            {
+                if (!util::platform::FileWrite(orig_code, orig_size, fp))
+                {
+                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
+                }
+                util::platform::FileClose(fp);
+            }
+            else
+            {
+                GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
+            }
+        }
+    }
+
+    virtual void
+    Process_vkCreateShadersEXT(const decode::ApiCallInfo&                                           call_info,
+                               VkResult                                                             returnValue,
+                               format::HandleId                                                     device,
+                               uint32_t                                                             createInfoCount,
+                               decode::StructPointerDecoder<decode::Decoded_VkShaderCreateInfoEXT>* pCreateInfos,
+                               decode::StructPointerDecoder<decode::Decoded_VkAllocationCallbacks>* pAllocator,
+                               decode::HandlePointerDecoder<VkShaderEXT>*                           pShaders) override
+    {
+        if ((returnValue >= 0) && (pCreateInfos != nullptr) && !pCreateInfos->IsNull() && (pShaders != nullptr) &&
+            !pShaders->IsNull())
+        {
+            for (size_t i = 0; i < createInfoCount; i++)
+            {
+                const void* orig_code = pCreateInfos->GetPointer()[i].pCode;
+                size_t      orig_size = pCreateInfos->GetPointer()[i].codeSize;
+                uint64_t    handle_id = pShaders->GetPointer()[i];
+                std::string file_name = "sh" + std::to_string(handle_id);
+                std::string file_path = util::filepath::Join(extract_dir_, file_name);
+
+                FILE*   fp     = nullptr;
+                int32_t result = util::platform::FileOpen(&fp, file_path.c_str(), "wb");
+                if (result == 0)
+                {
+                    if (!util::platform::FileWrite(orig_code, orig_size, fp))
+                    {
+                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
+                    }
+                    util::platform::FileClose(fp);
+                }
+                else
+                {
+                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
+                }
+            }
+        }
+    }
+
+    virtual void Process_vkCreateGraphicsPipelines(
+        const decode::ApiCallInfo&                                                  call_info,
+        VkResult                                                                    returnValue,
+        format::HandleId                                                            device,
+        format::HandleId                                                            pipelineCache,
+        uint32_t                                                                    createInfoCount,
+        decode::StructPointerDecoder<decode::Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
+        decode::StructPointerDecoder<decode::Decoded_VkAllocationCallbacks>*        pAllocator,
+        decode::HandlePointerDecoder<VkPipeline>*                                   pPipelines) override
+    {
+        if ((returnValue >= 0) && (pCreateInfos != nullptr) && !pCreateInfos->IsNull())
+        {
+            for (size_t create_info_index = 0; create_info_index < createInfoCount; create_info_index++)
+            {
+                auto& pipeline_create_info = pCreateInfos->GetPointer()[create_info_index];
+                for (size_t stage_index = 0; stage_index < pipeline_create_info.stageCount; stage_index++)
+                {
+                    auto& stage_create_info = pipeline_create_info.pStages[stage_index];
+                    if (stage_create_info.module != VK_NULL_HANDLE)
+                    {
+                        continue;
+                    }
+
+                    const void* pNext = stage_create_info.pNext;
+                    while (pNext != nullptr)
+                    {
+                        auto* base = reinterpret_cast<const VkBaseInStructure*>(pNext);
+                        if (base->sType == VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
+                        {
+                            auto*       create_info = reinterpret_cast<const VkShaderModuleCreateInfo*>(base);
+                            const void* orig_code   = create_info->pCode;
+                            size_t      orig_size   = create_info->codeSize;
+                            uint64_t    handle_id   = pPipelines->GetPointer()[create_info_index];
+                            std::string file_name =
+                                "sh" + std::to_string(handle_id) + "_" + std::to_string(stage_create_info.stage);
+                            std::string file_path = util::filepath::Join(extract_dir_, file_name);
+
+                            FILE*   fp     = nullptr;
+                            int32_t result = util::platform::FileOpen(&fp, file_path.c_str(), "wb");
+                            if (result == 0)
+                            {
+                                if (!util::platform::FileWrite(orig_code, orig_size, fp))
+                                {
+                                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete",
+                                                           file_name.c_str());
+                                }
+                                util::platform::FileClose(fp);
+                            }
+                            else
+                            {
+                                GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open",
+                                                       file_name.c_str());
+                            }
+                        }
+                        pNext = base->pNext;
+                    }
+                }
+            }
+        }
+    }
+
+  private:
+    std::string extract_dir_;
+};
+
+class VulkanExtractFeature : public ExtractFeatureBase
+{
+  public:
+    VulkanExtractFeature() : detect_consumer_(decode::VulkanDetectionConsumer::kNoBlockLimit) {}
+
+    void Initialize(decode::FileProcessor& file_processor, const std::string& extract_dir) override
+    {
+        extract_consumer_ = std::make_unique<VulkanExtractConsumer>(extract_dir);
+        decoder_.AddConsumer(&detect_consumer_);
+        decoder_.AddConsumer(extract_consumer_.get());
+        file_processor.AddDecoder(&decoder_);
+    }
+
+    bool WasDetected() const override { return detect_consumer_.WasVulkanAPIDetected(); }
+
+  private:
+    decode::VulkanDetectionConsumer        detect_consumer_;
+    decode::VulkanDecoder                  decoder_;
+    std::unique_ptr<VulkanExtractConsumer> extract_consumer_;
+};
+
+GFXR_UTIL_REGISTER_FEATURE_CREATOR(ExtractFeatureBase, VulkanExtractFeature)
+
+GFXRECON_END_NAMESPACE(extract)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/tools/extract/main.cpp
+++ b/tools/extract/main.cpp
@@ -21,30 +21,21 @@
 */
 
 #include PROJECT_VERSION_HEADER_FILE
+#include "tool_settings.h"
 
-#include "decode/decode_api_detection.h"
 #include "decode/file_processor.h"
-#include "format/format.h"
-#include "generated/generated_vulkan_consumer.h"
-#include "generated/generated_vulkan_decoder.h"
-#if defined(D3D12_SUPPORT)
-#include "generated/generated_dx12_consumer.h"
-#include "generated/generated_dx12_decoder.h"
-#endif
+#include "extract_feature.h"
 #include "util/argument_parser.h"
+#include "util/feature_module_registry.h"
 #include "util/file_path.h"
 #include "util/logging.h"
 
-#include "vulkan/vulkan.h"
-
 #include <cstdlib>
+#include <memory>
 #include <string>
+#include <vector>
 
-const char kHelpShortOption[]   = "-h";
-const char kHelpLongOption[]    = "--help";
-const char kVersionOption[]     = "--version";
 const char kDirectoryArgument[] = "--dir";
-const char kNoDebugPopup[]      = "--no-debug-popup";
 
 const char kOptions[]   = "-h|--help,--version,--no-debug-popup";
 const char kArguments[] = "--dir";
@@ -76,461 +67,17 @@ static void PrintUsage(const char* exe_name)
 #endif
 }
 
-static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
-{
-    if (arg_parser.IsOptionSet(kHelpShortOption) || arg_parser.IsOptionSet(kHelpLongOption))
-    {
-        PrintUsage(exe_name);
-        return true;
-    }
-
-    return false;
-}
-
-static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
-{
-    if (arg_parser.IsOptionSet(kVersionOption))
-    {
-        std::string app_name     = exe_name;
-        size_t      dir_location = app_name.find_last_of("/\\");
-
-        if (dir_location >= 0)
-        {
-            app_name.replace(0, dir_location + 1, "");
-        }
-
-        GFXRECON_WRITE_CONSOLE("%s version info:", app_name.c_str());
-        GFXRECON_WRITE_CONSOLE("  GFXReconstruct Version %s", GetProjectVersionString());
-        GFXRECON_WRITE_CONSOLE("  Vulkan Header Version %u.%u.%u",
-                               VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE),
-                               VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE),
-                               VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
-
-        return true;
-    }
-
-    return false;
-}
-
-class VulkanExtractConsumer : public gfxrecon::decode::VulkanConsumer
-{
-  public:
-    VulkanExtractConsumer(std::string& extract_dir) : extract_dir_(extract_dir) {}
-
-    virtual void Process_vkCreateShaderModule(
-        const gfxrecon::decode::ApiCallInfo&                                                        call_info,
-        VkResult                                                                                    returnValue,
-        gfxrecon::format::HandleId                                                                  shaderModule,
-        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
-        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*,
-        gfxrecon::decode::HandlePointerDecoder<VkShaderModule>* pShaderModule) override
-    {
-        if ((returnValue >= 0) && (pCreateInfo != nullptr) && !pCreateInfo->IsNull() && (pShaderModule != nullptr) &&
-            !pShaderModule->IsNull())
-        {
-            const uint32_t* orig_code = pCreateInfo->GetPointer()->pCode;
-            size_t          orig_size = pCreateInfo->GetPointer()->codeSize;
-            uint64_t        handle_id = *pShaderModule->GetPointer();
-            std::string     file_name = "sh" + std::to_string(handle_id);
-            std::string     file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-            FILE*   fp     = nullptr;
-            int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-            if (result == 0)
-            {
-                if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                {
-                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
-                }
-                gfxrecon::util::platform::FileClose(fp);
-            }
-            else
-            {
-                GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
-            }
-        }
-    }
-
-    virtual void Process_vkCreateShadersEXT(
-        const gfxrecon::decode::ApiCallInfo&                                                     call_info,
-        VkResult                                                                                 returnValue,
-        gfxrecon::format::HandleId                                                               device,
-        uint32_t                                                                                 createInfoCount,
-        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkShaderCreateInfoEXT>* pCreateInfos,
-        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>* pAllocator,
-        gfxrecon::decode::HandlePointerDecoder<VkShaderEXT>*                                     pShaders) override
-    {
-        if ((returnValue >= 0) && (pCreateInfos != nullptr) && !pCreateInfos->IsNull() && (pShaders != nullptr) &&
-            !pShaders->IsNull())
-        {
-            for (size_t i = 0; i < createInfoCount; i++)
-            {
-                const void* orig_code = pCreateInfos->GetPointer()[i].pCode;
-                size_t      orig_size = pCreateInfos->GetPointer()[i].codeSize;
-                uint64_t    handle_id = pShaders->GetPointer()[i];
-                std::string file_name = "sh" + std::to_string(handle_id);
-                std::string file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-                FILE*   fp     = nullptr;
-                int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-                if (result == 0)
-                {
-                    if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                    {
-                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
-                    }
-                    gfxrecon::util::platform::FileClose(fp);
-                }
-                else
-                {
-                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
-                }
-            }
-        }
-    }
-
-    virtual void Process_vkCreateGraphicsPipelines(
-        const gfxrecon::decode::ApiCallInfo&                                                            call_info,
-        VkResult                                                                                        returnValue,
-        gfxrecon::format::HandleId                                                                      device,
-        gfxrecon::format::HandleId                                                                      pipelineCache,
-        uint32_t                                                                                        createInfoCount,
-        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
-        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*        pAllocator,
-        gfxrecon::decode::HandlePointerDecoder<VkPipeline>* pPipelines) override
-    {
-        if ((returnValue >= 0) && (pCreateInfos != nullptr) && !pCreateInfos->IsNull())
-        {
-            for (size_t create_info_index = 0; create_info_index < createInfoCount; create_info_index++)
-            {
-                auto& pipeline_create_info = pCreateInfos->GetPointer()[create_info_index];
-                for (size_t stage_index = 0; stage_index < pipeline_create_info.stageCount; stage_index++)
-                {
-                    auto& stage_create_info = pipeline_create_info.pStages[stage_index];
-                    if (stage_create_info.module != VK_NULL_HANDLE)
-                        continue;
-
-                    const void* pNext = stage_create_info.pNext;
-                    while (pNext != nullptr)
-                    {
-                        auto* base = reinterpret_cast<const VkBaseInStructure*>(pNext);
-                        if (base->sType == VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
-                        {
-                            auto*       create_info = reinterpret_cast<const VkShaderModuleCreateInfo*>(base);
-                            const void* orig_code   = create_info->pCode;
-                            size_t      orig_size   = create_info->codeSize;
-                            uint64_t    handle_id   = pPipelines->GetPointer()[create_info_index];
-                            std::string file_name =
-                                "sh" + std::to_string(handle_id) + "_" + std::to_string(stage_create_info.stage);
-                            std::string file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-                            FILE*   fp     = nullptr;
-                            int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-                            if (result == 0)
-                            {
-                                if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                                {
-                                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete",
-                                                           file_name.c_str());
-                                }
-                                gfxrecon::util::platform::FileClose(fp);
-                            }
-                            else
-                            {
-                                GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open",
-                                                       file_name.c_str());
-                            }
-                        }
-                        pNext = base->pNext;
-                    }
-                }
-            }
-        }
-    }
-
-  private:
-    std::string extract_dir_;
-};
-
-#if defined(D3D12_SUPPORT)
-class Dx12ExtractConsumer : public gfxrecon::decode::Dx12Consumer
-{
-  public:
-    Dx12ExtractConsumer(std::string& extract_dir) : extract_dir_(extract_dir) {}
-
-    virtual void Process_ID3D12Device_CreateGraphicsPipelineState(
-        const gfxrecon::decode::ApiCallInfo& call_info,
-        gfxrecon::format::HandleId           object_id,
-        HRESULT                              return_value,
-        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_D3D12_GRAPHICS_PIPELINE_STATE_DESC>* pDesc,
-        gfxrecon::decode::Decoded_GUID                                                                        riid,
-        gfxrecon::decode::HandlePointerDecoder<void*>* ppPipelineState) override
-    {
-        if ((return_value == S_OK) && (pDesc != nullptr) && !pDesc->IsNull() && (ppPipelineState != nullptr) &&
-            !ppPipelineState->IsNull())
-        {
-            uint64_t handle_id = *ppPipelineState->GetPointer();
-
-            auto& vertex_shader = pDesc->GetPointer()->VS;
-            if ((vertex_shader.BytecodeLength > 0) && (vertex_shader.pShaderBytecode != nullptr))
-            {
-                const void* orig_code = vertex_shader.pShaderBytecode;
-                size_t      orig_size = vertex_shader.BytecodeLength;
-                std::string file_name = "sh" + std::to_string(handle_id) + ".vso";
-                std::string file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-                FILE*   fp     = nullptr;
-                int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-                if (result == 0)
-                {
-                    if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                    {
-                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
-                    }
-                    gfxrecon::util::platform::FileClose(fp);
-                }
-                else
-                {
-                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
-                }
-            }
-
-            auto& pixel_shader = pDesc->GetPointer()->PS;
-            if ((pixel_shader.BytecodeLength > 0) && (pixel_shader.pShaderBytecode != nullptr))
-            {
-                const void* orig_code = pixel_shader.pShaderBytecode;
-                size_t      orig_size = pixel_shader.BytecodeLength;
-                std::string file_name = "sh" + std::to_string(handle_id) + ".pso";
-                std::string file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-                FILE*   fp     = nullptr;
-                int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-                if (result == 0)
-                {
-                    if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                    {
-                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
-                    }
-                    gfxrecon::util::platform::FileClose(fp);
-                }
-                else
-                {
-                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
-                }
-            }
-
-            auto& domain_shader = pDesc->GetPointer()->DS;
-            if ((domain_shader.BytecodeLength > 0) && (domain_shader.pShaderBytecode != nullptr))
-            {
-                const void* orig_code = domain_shader.pShaderBytecode;
-                size_t      orig_size = domain_shader.BytecodeLength;
-                std::string file_name = "sh" + std::to_string(handle_id) + ".dso";
-                std::string file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-                FILE*   fp     = nullptr;
-                int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-                if (result == 0)
-                {
-                    if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                    {
-                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
-                    }
-                    gfxrecon::util::platform::FileClose(fp);
-                }
-                else
-                {
-                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
-                }
-            }
-
-            auto& hull_shader = pDesc->GetPointer()->HS;
-            if ((hull_shader.BytecodeLength > 0) && (hull_shader.pShaderBytecode != nullptr))
-            {
-                const void* orig_code = hull_shader.pShaderBytecode;
-                size_t      orig_size = hull_shader.BytecodeLength;
-                std::string file_name = "sh" + std::to_string(handle_id) + ".hso";
-                std::string file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-                FILE*   fp     = nullptr;
-                int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-                if (result == 0)
-                {
-                    if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                    {
-                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
-                    }
-                    gfxrecon::util::platform::FileClose(fp);
-                }
-                else
-                {
-                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
-                }
-            }
-
-            auto& geometry_shader = pDesc->GetPointer()->GS;
-            if ((geometry_shader.BytecodeLength > 0) && (geometry_shader.pShaderBytecode != nullptr))
-            {
-                const void* orig_code = geometry_shader.pShaderBytecode;
-                size_t      orig_size = geometry_shader.BytecodeLength;
-                std::string file_name = "sh" + std::to_string(handle_id) + ".gso";
-                std::string file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-                FILE*   fp     = nullptr;
-                int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-                if (result == 0)
-                {
-                    if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                    {
-                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
-                    }
-                    gfxrecon::util::platform::FileClose(fp);
-                }
-                else
-                {
-                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
-                }
-            }
-        }
-    }
-
-    virtual void Process_ID3D12Device_CreateComputePipelineState(
-        const gfxrecon::decode::ApiCallInfo& call_info,
-        gfxrecon::format::HandleId           object_id,
-        HRESULT                              return_value,
-        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_D3D12_COMPUTE_PIPELINE_STATE_DESC>* pDesc,
-        gfxrecon::decode::Decoded_GUID                                                                       riid,
-        gfxrecon::decode::HandlePointerDecoder<void*>* ppPipelineState) override
-    {
-        if ((return_value == S_OK) && (pDesc != nullptr) && !pDesc->IsNull() && (ppPipelineState != nullptr) &&
-            !ppPipelineState->IsNull())
-        {
-            uint64_t handle_id = *ppPipelineState->GetPointer();
-
-            auto& compute_shader = pDesc->GetPointer()->CS;
-            if ((compute_shader.BytecodeLength > 0) && (compute_shader.pShaderBytecode != nullptr))
-            {
-                const void* orig_code = compute_shader.pShaderBytecode;
-                size_t      orig_size = compute_shader.BytecodeLength;
-                std::string file_name = "sh" + std::to_string(handle_id) + ".cso";
-                std::string file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-                FILE*   fp     = nullptr;
-                int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-                if (result == 0)
-                {
-                    if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                    {
-                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete", file_name.c_str());
-                    }
-                    gfxrecon::util::platform::FileClose(fp);
-                }
-                else
-                {
-                    GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
-                }
-            }
-        }
-    }
-
-    virtual void Process_ID3D12Device5_CreateStateObject(
-        const gfxrecon::decode::ApiCallInfo&                                                       call_info,
-        gfxrecon::format::HandleId                                                                 object_id,
-        HRESULT                                                                                    return_value,
-        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_D3D12_STATE_OBJECT_DESC>* pDesc,
-        gfxrecon::decode::Decoded_GUID                                                             riid,
-        gfxrecon::decode::HandlePointerDecoder<void*>* ppStateObject) override
-    {
-        if ((return_value == S_OK) && (pDesc != nullptr) && !pDesc->IsNull() && (ppStateObject != nullptr) &&
-            !ppStateObject->IsNull())
-        {
-            uint64_t handle_id = *ppStateObject->GetPointer();
-
-            auto& subobjects = pDesc->GetPointer()->pSubobjects;
-            for (uint32_t i = 0; i < pDesc->GetPointer()->NumSubobjects; i++)
-            {
-                if ((subobjects[i].pDesc != nullptr) && (subobjects[i].Type == D3D12_STATE_SUBOBJECT_TYPE_DXIL_LIBRARY))
-                {
-                    auto& dxil_lib = reinterpret_cast<const D3D12_DXIL_LIBRARY_DESC*>(subobjects[i].pDesc)->DXILLibrary;
-
-                    const void* orig_code = dxil_lib.pShaderBytecode;
-                    size_t      orig_size = dxil_lib.BytecodeLength;
-                    std::string file_name = "sh" + std::to_string(handle_id) + "_" + std::to_string(i) + ".dxil";
-                    std::string file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-                    FILE*   fp     = nullptr;
-                    int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-                    if (result == 0)
-                    {
-                        if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                        {
-                            GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete",
-                                                   file_name.c_str());
-                        }
-                        gfxrecon::util::platform::FileClose(fp);
-                    }
-                    else
-                    {
-                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
-                    }
-                }
-            }
-        }
-    }
-
-    virtual void Process_ID3D12Device7_AddToStateObject(
-        const gfxrecon::decode::ApiCallInfo&                                                       call_info,
-        gfxrecon::format::HandleId                                                                 object_id,
-        HRESULT                                                                                    return_value,
-        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_D3D12_STATE_OBJECT_DESC>* pAddition,
-        gfxrecon::format::HandleId                     pStateObjectToGrowFrom,
-        gfxrecon::decode::Decoded_GUID                 riid,
-        gfxrecon::decode::HandlePointerDecoder<void*>* ppNewStateObject) override
-    {
-        if ((return_value == S_OK) && (pAddition != nullptr) && !pAddition->IsNull() && (ppNewStateObject != nullptr) &&
-            !ppNewStateObject->IsNull())
-        {
-            uint64_t handle_id = *ppNewStateObject->GetPointer();
-
-            auto& subobjects = pAddition->GetPointer()->pSubobjects;
-            for (uint32_t i = 0; i < pAddition->GetPointer()->NumSubobjects; i++)
-            {
-                if ((subobjects[i].pDesc != nullptr) && (subobjects[i].Type == D3D12_STATE_SUBOBJECT_TYPE_DXIL_LIBRARY))
-                {
-                    auto& dxil_lib = reinterpret_cast<const D3D12_DXIL_LIBRARY_DESC*>(subobjects[i].pDesc)->DXILLibrary;
-
-                    const void* orig_code = dxil_lib.pShaderBytecode;
-                    size_t      orig_size = dxil_lib.BytecodeLength;
-                    std::string file_name = "sh" + std::to_string(handle_id) + "_" + std::to_string(i) + ".dxil";
-                    std::string file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
-
-                    FILE*   fp     = nullptr;
-                    int32_t result = gfxrecon::util::platform::FileOpen(&fp, file_path.c_str(), "wb");
-                    if (result == 0)
-                    {
-                        if (!gfxrecon::util::platform::FileWrite(orig_code, orig_size, fp))
-                        {
-                            GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not complete",
-                                                   file_name.c_str());
-                        }
-                        gfxrecon::util::platform::FileClose(fp);
-                    }
-                    else
-                    {
-                        GFXRECON_WRITE_CONSOLE("Error while writing file %s: Could not open", file_name.c_str());
-                    }
-                }
-            }
-        }
-    }
-
-  private:
-    std::string extract_dir_;
-};
-#endif
-
 int main(int argc, const char** argv)
 {
     gfxrecon::util::Log::Init();
+
+    std::vector<std::unique_ptr<gfxrecon::extract::ExtractFeatureBase>> features;
+    for (const auto& creator :
+         gfxrecon::util::FeatureModuleRegistry<gfxrecon::extract::ExtractFeatureBase>::GetSingleton()
+             .GetRegisteredFeatureCreators())
+    {
+        features.push_back(creator());
+    }
 
     gfxrecon::util::ArgumentParser arg_parser(argc, argv, kOptions, kArguments);
 
@@ -568,7 +115,7 @@ int main(int argc, const char** argv)
         {
             extract_dir         = input_filename;
             size_t dir_location = extract_dir.find_last_of("/\\");
-            if (dir_location >= 0)
+            if (dir_location != std::string::npos)
             {
                 extract_dir.replace(0, dir_location + 1, "");
             }
@@ -594,48 +141,21 @@ int main(int argc, const char** argv)
             }
         }
 
-        bool detected_d3d12  = false;
-        bool detected_vulkan = false;
-        bool detected_openxr = false;
-        gfxrecon::decode::DetectAPIs(input_filename, detected_d3d12, detected_vulkan, detected_openxr);
-
-        if ((!detected_d3d12) && (!detected_vulkan))
+        for (auto& feature : features)
         {
-            // Detect with no block limit
-            gfxrecon::decode::DetectAPIs(input_filename, detected_d3d12, detected_vulkan, detected_openxr, true);
+            feature->Initialize(file_processor, extract_dir);
         }
 
-        if (detected_d3d12)
+        file_processor.ProcessAllFrames();
+
+        bool any_detected = false;
+        for (const auto& feature : features)
         {
-#if defined(D3D12_SUPPORT)
-            gfxrecon::decode::Dx12Decoder decoder;
-            Dx12ExtractConsumer           extract_consumer(extract_dir);
-
-            decoder.AddConsumer(&extract_consumer);
-
-            file_processor.AddDecoder(&decoder);
-            file_processor.ProcessAllFrames();
-#endif
+            any_detected |= feature->WasDetected();
         }
-        else if (detected_vulkan)
+        if (!any_detected)
         {
-            gfxrecon::decode::VulkanDecoder decoder;
-            VulkanExtractConsumer           extract_consumer(extract_dir);
-
-            decoder.AddConsumer(&extract_consumer);
-
-            file_processor.AddDecoder(&decoder);
-            file_processor.ProcessAllFrames();
-        }
-#ifdef ENABLE_OPENXR_SUPPORT
-        else if (detected_openxr)
-        {
-            GFXRECON_LOG_INFO("No extraction defined for OpenXR capture files");
-        }
-#endif
-        else
-        {
-            GFXRECON_LOG_ERROR("Could not detect graphics API. Aborting Extract.")
+            GFXRECON_LOG_ERROR("Could not detect graphics API. Aborting Extract.");
         }
 
         if (file_processor.GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)


### PR DESCRIPTION
Split out the API-specific functionality into separate feature classes (just like info and convert).

NOTE: This does not include OpenXR because it is not a graphics but a compositing API.  So that feature is intentionally left out.