### PR TITLE
Fix push-constants when pipeline is bound after vkCmdPushConstants

### DIFF
--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -641,6 +641,44 @@ void VulkanAddressReplacer::ProcessCmdPushConstants(const VulkanCommandBufferInf
     }
 }
 
+void VulkanAddressReplacer::ProcessCmdBindPipeline(VulkanCommandBufferInfo*                  command_buffer_info,
+                                                   const decode::VulkanDeviceAddressTracker& address_tracker)
+{
+    GFXRECON_ASSERT(command_buffer_info != nullptr);
+
+    if (command_buffer_info->push_constant_data.empty())
+    {
+        return;
+    }
+
+    // push_constant_data may hold capture-time addresses if vkCmdPushConstants was called before any pipeline was
+    // bound. work on a copy so we can detect whether patching actually changed anything.
+    auto push_constant_copy = command_buffer_info->push_constant_data;
+
+    // potentially sanitizes addresses
+    ProcessCmdPushConstants(command_buffer_info,
+                            command_buffer_info->push_constant_stage_flags,
+                            0,
+                            static_cast<uint32_t>(push_constant_copy.size()),
+                            push_constant_copy.data(),
+                            address_tracker);
+
+    if (push_constant_copy != command_buffer_info->push_constant_data)
+    {
+        GFXRECON_LOG_INFO_ONCE("VulkanAddressReplacer::ProcessCmdBindPipeline(): Replay is re-issuing "
+                               "push-constants to patch buffer-device-addresses recorded before pipeline bind");
+
+        util::MarkInjectedCommandsHelper injected_commands_helper;
+        device_table_->CmdPushConstants(command_buffer_info->handle,
+                                        command_buffer_info->push_constant_pipeline_layout,
+                                        command_buffer_info->push_constant_stage_flags,
+                                        0,
+                                        static_cast<uint32_t>(push_constant_copy.size()),
+                                        push_constant_copy.data());
+        command_buffer_info->push_constant_data = std::move(push_constant_copy);
+    }
+}
+
 void VulkanAddressReplacer::ProcessCmdBindDescriptorSets(VulkanCommandBufferInfo*               command_buffer_info,
                                                          VkPipelineBindPoint                    pipelineBindPoint,
                                                          uint32_t                               firstSet,

--- a/framework/decode/vulkan_address_replacer.h
+++ b/framework/decode/vulkan_address_replacer.h
@@ -150,6 +150,18 @@ class VulkanAddressReplacer
                                  const decode::VulkanDeviceAddressTracker& address_tracker);
 
     /**
+     * @brief   ProcessCmdBindPipeline patches any previously recorded push-constant data that may contain
+     *          unresolved capture-time buffer-device-addresses.
+     *          this is necessary when vkCmdPushConstants was called before vkCmdBindPipeline and a no-op otherwise.
+     *          Patching is achieved by injected a corrective vkCmdPushConstants into the command buffer.
+     *
+     * @param   command_buffer_info a provided VulkanCommandBufferInfo*
+     * @param   address_tracker     const reference to a VulkanDeviceAddressTracker, used for mapping device-addresses
+     */
+    void ProcessCmdBindPipeline(VulkanCommandBufferInfo*                  command_buffer_info,
+                                const decode::VulkanDeviceAddressTracker& address_tracker);
+
+    /**
      * @brief   ProcessCmdBindDescriptorSets will check the bound descriptor-sets for presence of buffer-references
      *          and collect all addresses that will require replacement.
      *

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10279,6 +10279,17 @@ void VulkanReplayConsumerBase::OverrideCmdBindPipeline(PFN_vkCmdBindPipeline    
         command_buffer_info->bound_pipelines[pipelineBindPoint] = pipeline_info->capture_id;
     }
     func(command_buffer, pipelineBindPoint, pipeline);
+
+    if (command_buffer_info != nullptr && pipeline_info != nullptr)
+    {
+        auto* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
+        if (device_info != nullptr && UseAddressReplacement(device_info))
+        {
+            const auto& address_tracker  = GetDeviceAddressTracker(device_info);
+            auto&       address_replacer = GetDeviceAddressReplacer(device_info);
+            address_replacer.ProcessCmdBindPipeline(command_buffer_info, address_tracker);
+        }
+    }
 }
 
 void VulkanReplayConsumerBase::OverrideCmdPushConstants(PFN_vkCmdPushConstants              func,


### PR DESCRIPTION
relevant when using '-m rebind'.
If an app calls vkCmdPushConstants before vkCmdBindPipeline, the address replacer had no pipeline to consult and emitted the original capture-time buffer-device-addresses verbatim. Fixed by adding ProcessCmdBindPipeline to VulkanAddressReplacer. re-process stored push-constant data against the newly bound pipeline and injects a corrective vkCmdPushConstants into the command buffer if anything got changed/corrected.

Fixes #2899