### PR TITLE
Fix async pipeline creation when using VkPipelineCache

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -12021,8 +12021,8 @@ bool VulkanReplayConsumerBase::SkipPipelineCreationForCompileRequired(VkResult  
 
     if (original_result == VK_PIPELINE_COMPILE_REQUIRED)
     {
-        GFXRECON_LOG_WARNING("Skipping execution of VkPipeline creation due to original result being "
-                             "VK_PIPELINE_COMPILE_REQUIRED(_EXT). Returning VK_NULL_HANDLE for created pipeline.");
+        GFXRECON_LOG_WARNING_ONCE("Replay is skipping execution of VkPipeline creation due to original result(s) being "
+                                  "VK_PIPELINE_COMPILE_REQUIRED(_EXT). Returning VK_NULL_HANDLE for created pipeline.");
 
         VkPipeline* handles = pipelines->GetHandlePointer();
         for (uint32_t i = 0; i < pipelines->GetLength(); ++i)
@@ -12042,39 +12042,23 @@ void VulkanReplayConsumerBase::RemoveFailOnCompileRequiredFlags(T* create_infos,
                       std::is_same_v<T, VkRayTracingPipelineCreateInfoNV>,
                   "only Vk***PipelineCreateInfo types supported");
 
-    std::string pipeline_type_str;
+    constexpr const char* pipeline_type_name = std::is_same_v<T, VkGraphicsPipelineCreateInfo>  ? "graphics"
+                                               : std::is_same_v<T, VkComputePipelineCreateInfo> ? "compute"
+                                               : std::is_same_v<T, VkRayTracingPipelineCreateInfoKHR>
+                                                   ? "raytracing (KHR)"
+                                                   : "raytracing (NV)";
 
-    if constexpr (std::is_same_v<T, VkGraphicsPipelineCreateInfo>)
+    if (create_infos != nullptr)
     {
-        pipeline_type_str = "graphics pipeline";
-    }
-    else if constexpr (std::is_same_v<T, VkComputePipelineCreateInfo>)
-    {
-        pipeline_type_str = "compute pipeline";
-    }
-    else if constexpr (std::is_same_v<T, VkRayTracingPipelineCreateInfoKHR>)
-    {
-        pipeline_type_str = "raytracing pipeline (KHR)";
-    }
-    else if constexpr (std::is_same_v<T, VkRayTracingPipelineCreateInfoNV>)
-    {
-        pipeline_type_str = "raytracing pipeline (NV)";
-    }
-
-    if (create_infos == nullptr)
-    {
-        return;
-    }
-
-    for (uint32_t i = 0; i < create_info_count; ++i)
-    {
-        if (create_infos[i].flags & VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
+        for (uint32_t i = 0; i < create_info_count; ++i)
         {
-            create_infos[i].flags &= ~VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
-            GFXRECON_LOG_WARNING("Removed VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT flag from a %s - "
-                                 "create-info index: %u during replay.",
-                                 pipeline_type_str.c_str(),
-                                 i);
+            if (create_infos[i].flags & VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
+            {
+                create_infos[i].flags &= ~VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+                GFXRECON_LOG_WARNING_ONCE("Replay is removing VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT "
+                                          "flags for %s pipeline-creation calls",
+                                          pipeline_type_name);
+            }
         }
     }
 }
@@ -12581,7 +12565,8 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
     HandlePointerDecoder<VkPipeline>*                           pPipelines)
 {
     // avoid async operations if an externally synchronized pipeline-cache is used
-    bool avoid_async_op = pipeline_cache_info != nullptr && pipeline_cache_info->handle != VK_NULL_HANDLE;
+    bool avoid_async_op = pipeline_cache_info != nullptr && pipeline_cache_info->handle != VK_NULL_HANDLE &&
+                          pipeline_cache_info->requires_external_synchronization;
 
     // avoid async operations when VK_PIPELINE_COMPILE_REQUIRED was returned during capture
     avoid_async_op = avoid_async_op || SkipPipelineCreationForCompileRequired(returnValue, pPipelines);
@@ -12704,7 +12689,8 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
     HandlePointerDecoder<VkPipeline>*                                pPipelines)
 {
     // avoid async operations if an externally synchronized pipeline-cache is used
-    bool avoid_async_op = pipeline_cache_info != nullptr && pipeline_cache_info->handle != VK_NULL_HANDLE;
+    bool avoid_async_op = pipeline_cache_info != nullptr && pipeline_cache_info->handle != VK_NULL_HANDLE &&
+                          pipeline_cache_info->requires_external_synchronization;
 
     // avoid async operations when VK_PIPELINE_COMPILE_REQUIRED was returned during capture
     avoid_async_op = avoid_async_op || SkipPipelineCreationForCompileRequired(returnValue, pPipelines);


### PR DESCRIPTION
- a regression caused all pipelines using VkPipelineCache to compile sequentially
- was only required for VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT
-> fixed by properly applying 'requires_external_synchronization' flag

- reduce log-spam by demoting two WARNING to WARNING_ONCE