### PR TITLE
Update TrackUpdateDescriptorSetWithTemplate assert

### DIFF
--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1558,7 +1558,8 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
             {
                 auto& binding = wrapper->bindings[current_binding];
 
-                assert(binding.uniform_texel_buffer_views != nullptr);
+                GFXRECON_ASSERT(binding.uniform_texel_buffer_views != nullptr ||
+                                binding.storage_texel_buffer_views != nullptr);
 
                 // Check count for consecutive updates.
                 uint32_t current_writes = std::min(current_count, (binding.count - current_array_element));

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1558,9 +1558,6 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
             {
                 auto& binding = wrapper->bindings[current_binding];
 
-                GFXRECON_ASSERT(binding.uniform_texel_buffer_views != nullptr ||
-                                binding.storage_texel_buffer_views != nullptr);
-
                 // Check count for consecutive updates.
                 uint32_t current_writes = std::min(current_count, (binding.count - current_array_element));
 
@@ -1572,6 +1569,9 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                     GFXRECON_LOG_WARNING("%s() Descriptors mismatch: %u != %u", __func__, binding.type, entry.type);
                 }
                 const bool immutable_buffer = binding.type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+
+                GFXRECON_ASSERT(immutable_buffer ? binding.uniform_texel_buffer_views != nullptr
+                                                 : binding.storage_texel_buffer_views != nullptr);
 
                 format::HandleId* dst_view_ids = &binding.handle_ids[current_array_element];
                 VkBufferView*  dst_info = immutable_buffer ? &binding.uniform_texel_buffer_views[current_array_element]


### PR DESCRIPTION
Updates TrackUpdateDescriptorSetWithTemplate to instead check whether either `uniform_texel_buffer_views` or `storage_texel_buffer_views` is not `nullptr`.

While looking into [2880](https://github.com/LunarG/gfxreconstruct/issues/2880), running CS2 on debug mode on windows with NVIDIA RTX 5060 Laptop, I get caught on the assert where `uniform_texel_buffer_views` is `nullptr` even though it is currently processing the storage buffer instead as `immutable_buffer` was false, and `storage_texel_buffer_views` was valid.

It should not only be checking `uniform_texel_buffer_views`, but rather the one that will later be used in `dst_info` buffer view.  

This however still doesn't address issue 2880. 