### PR TITLE
Add bind type guard for `dst_sampler_ids` in `TrackUpdateDescriptorSetWithTemplate`

### DIFF
--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1436,11 +1436,17 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                 assert((immutable_image && binding.images != nullptr) ||
                        (!immutable_image && binding.storage_images != nullptr));
 
-                format::HandleId*      dst_sampler_ids = &binding.sampler_ids[current_array_element];
-                format::HandleId*      dst_image_ids   = &binding.handle_ids[current_array_element];
-                VkDescriptorImageInfo* dst_info        = immutable_image ? &binding.images[current_array_element]
-                                                                         : &binding.storage_images[current_array_element];
-                const uint8_t*         src_address     = bytes + current_offset;
+                format::HandleId* dst_sampler_ids = nullptr;
+                if (binding.type == VK_DESCRIPTOR_TYPE_SAMPLER ||
+                    binding.type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+                {
+                    assert(binding.sampler_ids != nullptr);
+                    dst_sampler_ids = &binding.sampler_ids[current_array_element];
+                }
+                format::HandleId*      dst_image_ids = &binding.handle_ids[current_array_element];
+                VkDescriptorImageInfo* dst_info      = immutable_image ? &binding.images[current_array_element]
+                                                                       : &binding.storage_images[current_array_element];
+                const uint8_t*         src_address   = bytes + current_offset;
 
                 for (uint32_t i = 0; i < current_writes; ++i)
                 {

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1440,7 +1440,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                 if (binding.type == VK_DESCRIPTOR_TYPE_SAMPLER ||
                     binding.type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
                 {
-                    assert(binding.sampler_ids != nullptr);
+                    GFXRECON_ASSERT(binding.sampler_ids != nullptr);
                     dst_sampler_ids = &binding.sampler_ids[current_array_element];
                 }
                 format::HandleId*      dst_image_ids = &binding.handle_ids[current_array_element];


### PR DESCRIPTION
Add bind type guard for `dst_sampler_ids` as it was being unconditionally set even if we don't use it. Fixes #2880.

We see that later in this loop, we only utilize `dst_sampler_ids` if the binding types were `VK_DESCRIPTOR_TYPE_SAMPLER` or `VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER`.

Since it was being unconditionally assigned, there were cases where `binding.handle_ids` would be nullptr as it wasn't the corresponding binding type, resulting in https://github.com/LunarG/gfxreconstruct/issues/2880 as we try to index `binding.handle_ids`.



Interestingly, in my reproduction of https://github.com/LunarG/gfxreconstruct/issues/2880, this issue only occurs in my Arch Linux + AMD 6800XT system, while it wasn't caught in my Windows + NVIDIA 5060 system. 