### PR TITLE
Add null check and set to acc_wrapper's associated buffer

### DIFF
--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -2146,7 +2146,11 @@ void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferW
     }
 
     state_table_.VisitWrappers([this, buffer_wrapper](vulkan_wrappers::AccelerationStructureKHRWrapper* acc_wrapper) {
-        GFXRECON_ASSERT(acc_wrapper != nullptr && acc_wrapper->buffer != nullptr);
+        GFXRECON_ASSERT(acc_wrapper != nullptr);
+        if (acc_wrapper->buffer == nullptr)
+        {
+            return;
+        }
         auto build_state_it = acc_wrapper->buffer->acceleration_structures.find(acc_wrapper->address);
 
         if (build_state_it != acc_wrapper->buffer->acceleration_structures.end() &&
@@ -2170,6 +2174,10 @@ void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferW
                 resource_util->second.ReadFromBufferResource(
                     buffer.handle, buffer.created_size, 0, buffer.queue_family_index, buffer.bytes);
             }
+        }
+        if (acc_wrapper->buffer == buffer_wrapper)
+        {
+            acc_wrapper->buffer = nullptr;
         }
     });
 


### PR DESCRIPTION
Issue when reproducing https://github.com/LunarG/gfxreconstruct/issues/2674. 

`acc_wrapper->buffer` is a dangling pointer to a wrapper buffer that is already deleted.

This is due to a case where we are destroying multiple buffers. Each time we attempt to destroy a buffer, we iterate through all acceleration structures to find ones that are associated to that buffer's wrapper to track input geometries. After finding these associated structures, we free the buffer wrapper. However, if we destroy multiple of these acceleration structure's buffers, such as on the second pass on a separate acceleration structure, since we `VisitWrappers` for all the acceleration structures, we hit the one where `acc_wrapper->buffer` is already deleted and is a dangling pointer, and therefore results in a read violation.

Instead of leaving `acc_wrapper->buffer` as dangling, set it as 'nullptr' which we can also later use to early exit out of processing this acceleration structure.

Unfortunately, https://github.com/LunarG/gfxreconstruct/issues/2674 is not completely resolved since although capture and replay is now possible, it is inconsistent with trimming. Trimming near the beginning of the capture before the loading indicator (orange star) seems to work, while trimming after seems to have a failing replay with an assertion failure 
```
Assertion failed: (device_info != nullptr) && (pipeline_info != nullptr) && (pData != nullptr) && (pData->GetOutputPointer() != nullptr), file C:\Github\gfxreconstruct\framework\decode\vulkan_replay_consumer_base.cpp, line 10047
```
which also seems to be related to raytracing.