### PR TITLE
Change order of deferred operation pipeline wrapper setters

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1793,24 +1793,20 @@ void VulkanCaptureManager::DeferredOperationPostProcess(VkDevice               d
             auto pipeline_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::PipelineWrapper>(
                 deferred_operation_wrapper->pPipelines[i]);
 
-            if (deferred_operation_wrapper)
-            {
-                // We need to set device_id here because some hardware may not have the feature
-                // rayTracingPipelineShaderGroupHandleCaptureReplay so the device_id cannot be set by
-                // VulkanStateTracker::TrackRayTracingShaderGroupHandles
-                pipeline_wrapper->device_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceWrapper>(device);
-                pipeline_wrapper->deferred_operation.handle_id         = deferred_operation_wrapper->handle_id;
-                pipeline_wrapper->deferred_operation.create_call_id    = deferred_operation_wrapper->create_call_id;
-                pipeline_wrapper->deferred_operation.create_parameters = deferred_operation_wrapper->create_parameters;
-            }
+            // We need to set device_id here because some hardware may not have the feature
+            // rayTracingPipelineShaderGroupHandleCaptureReplay so the device_id cannot be set by
+            // VulkanStateTracker::TrackRayTracingShaderGroupHandles
+            pipeline_wrapper->device_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceWrapper>(device);
+            pipeline_wrapper->num_shader_group_handles     = deferred_operation_wrapper->create_infos[i].groupCount;
+            pipeline_wrapper->deferred_operation.handle_id = deferred_operation_wrapper->handle_id;
+            pipeline_wrapper->deferred_operation.create_call_id    = deferred_operation_wrapper->create_call_id;
+            pipeline_wrapper->deferred_operation.create_parameters = deferred_operation_wrapper->create_parameters;
 
             if (device_wrapper->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
             {
                 const uint32_t data_size =
                     device_wrapper->property_feature_info.property_shaderGroupHandleCaptureReplaySize *
                     deferred_operation_wrapper->create_infos[i].groupCount;
-
-                pipeline_wrapper->num_shader_group_handles = deferred_operation_wrapper->create_infos[i].groupCount;
 
                 std::vector<uint8_t> data(data_size);
                 result = device_table->GetRayTracingCaptureReplayShaderGroupHandlesKHR(

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -2146,7 +2146,11 @@ void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferW
     }
 
     state_table_.VisitWrappers([this, buffer_wrapper](vulkan_wrappers::AccelerationStructureKHRWrapper* acc_wrapper) {
-        GFXRECON_ASSERT(acc_wrapper != nullptr && acc_wrapper->buffer != nullptr);
+        GFXRECON_ASSERT(acc_wrapper != nullptr);
+        if (acc_wrapper->buffer == nullptr)
+        {
+            return;
+        }
         auto build_state_it = acc_wrapper->buffer->acceleration_structures.find(acc_wrapper->address);
 
         if (build_state_it != acc_wrapper->buffer->acceleration_structures.end() &&
@@ -2170,6 +2174,10 @@ void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferW
                 resource_util->second.ReadFromBufferResource(
                     buffer.handle, buffer.created_size, 0, buffer.queue_family_index, buffer.bytes);
             }
+        }
+        if (acc_wrapper->buffer == buffer_wrapper)
+        {
+            acc_wrapper->buffer = nullptr;
         }
     });
 


### PR DESCRIPTION
Motivated by https://github.com/LunarG/gfxreconstruct/issues/2674 when capturing "Doom: The Dark Ages" with trimming. There was an issue when writing a `vkGetRayTracingShaderGroupHandlesKHR` command with `data_size = 0`, which not only violates the Vulkan spec, but also causes an assertion error during replay in `VulkanReplayConsumerBase::OverrideGetRayTracingShaderGroupHandlesKHR` for having `pData` be null.

The writer's `data_size` is based off of the pipeline wrapper's `wrapper->num_shader_group_handles`, which happened to be 0. This was due to it not being set in `VulkanCaptureManager::DeferredOperationPostProcess` and defaulting to 0. However, why are we setting it in a `rayTracingPipelineShaderGroupHandleCaptureReplay` feature guard?

Move the set for `num_shader_group_handles` to be outside the feature guard, which also better mirrors the logic in `OverrideCreateRayTracingPipelinesKHR`.

Also remove the redundant `if (deferred_operation_wrapper)` guard.

This PR + https://github.com/LunarG/gfxreconstruct/pull/3015 should fix https://github.com/LunarG/gfxreconstruct/issues/2674.