### PR TITLE
Add first index to end of loop

### DIFF
--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1741,7 +1741,7 @@ void VulkanStateTracker::TrackQueryReset(VkCommandBuffer command_buffer,
     auto& query_pool_info =
         wrapper->recorded_queries[vulkan_wrappers::GetWrapper<vulkan_wrappers::QueryPoolWrapper>(query_pool)];
 
-    for (uint32_t i = first_query; i < query_count; ++i)
+    for (uint32_t i = first_query; i < first_query + query_count; ++i)
     {
         query_pool_info[i].active = false;
     }
@@ -1754,7 +1754,7 @@ void VulkanStateTracker::TrackQueryReset(VkQueryPool query_pool, uint32_t first_
     auto wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::QueryPoolWrapper>(query_pool);
     assert((first_query + query_count) <= wrapper->pending_queries.size());
 
-    for (uint32_t i = first_query; i < query_count; ++i)
+    for (uint32_t i = first_query; i < first_query + query_count; ++i)
     {
         wrapper->pending_queries[i].active = false;
     }


### PR DESCRIPTION
https://github.com/LunarG/gfxreconstruct/issues/2679 indicates the loop is incorrect according to the spec.

After testing, there are validation errors on replay as the query pools aren't reset.

GFXR does the following when setting the state for replay:
- Create query pools
- Reset query pools
- Start "dummy" queries for the queries in active states

This fix will result in states being accurate to how they were tracked. However, GFXR simply acknowledges that queries can still read the dummy queries on the first frame after loading the state. Perhaps this will be changed eventually.

Fixes https://github.com/LunarG/gfxreconstruct/issues/2679