### PR TITLE
Add _WIN32 support for Windows platform detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ endif (UNIX AND NOT APPLE)
 add_library(windows_specific INTERFACE)
 
 target_compile_definitions(windows_specific INTERFACE
+        WIN32
         WIN32_LEAN_AND_MEAN
         NOMINMAX
         VK_USE_PLATFORM_WIN32_KHR


### PR DESCRIPTION
MSVC defines _WIN32 by default but not WIN32, causing Windows specific code to be excluded
Change #if defined(WIN32) to #if defined(WIN32) || defined(_WIN32) to support both macros"