### PR TITLE
fix: Return VulkanSemaphore from injected submit jobs

### DIFF
--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -237,9 +237,9 @@ decode::VulkanAddressReplacer::submit_asset_t::~submit_asset_t()
         {
             free_command_buffers_fn(device, command_pool, 1, &command_buffer);
         }
-        if (destroy_semaphore_fn != nullptr && signal_semaphore != VK_NULL_HANDLE)
+        if (destroy_semaphore_fn != nullptr && signal_semaphore.semaphore != VK_NULL_HANDLE)
         {
-            destroy_semaphore_fn(device, signal_semaphore, nullptr);
+            destroy_semaphore_fn(device, signal_semaphore.semaphore, nullptr);
         }
     }
 }
@@ -339,15 +339,16 @@ VulkanAddressReplacer::~VulkanAddressReplacer()
     }
 }
 
-VkSemaphore VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*            command_buffer_info,
-                                                         const std::span<VkDeviceAddress>          addresses_to_replace,
-                                                         const decode::VulkanDeviceAddressTracker& address_tracker,
-                                                         const std::span<graphics::VulkanSemaphore> wait_semaphores)
+graphics::VulkanSemaphore
+VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*             command_buffer_info,
+                                             const std::span<VkDeviceAddress>           addresses_to_replace,
+                                             const decode::VulkanDeviceAddressTracker&  address_tracker,
+                                             const std::span<graphics::VulkanSemaphore> wait_semaphores)
 {
     if (addresses_to_replace.empty())
     {
         // nothing to replace
-        return VK_NULL_HANDLE;
+        return graphics::VulkanSemaphore{ VK_NULL_HANDLE };
     }
 
     GFXRECON_LOG_INFO_ONCE("VulkanAddressReplacer::UpdateBufferAddresses(): Replay is adjusting "
@@ -377,7 +378,7 @@ VkSemaphore VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBuff
             {
                 GFXRECON_LOG_WARNING_ONCE(
                     "VulkanAddressReplacer::UpdateBufferAddresses: could not create required submit-assets");
-                return VK_NULL_HANDLE;
+                return graphics::VulkanSemaphore{ VK_NULL_HANDLE };
             }
 
             device_table_->ResetFences(device_, 1, &submit_asset.fence);
@@ -419,7 +420,7 @@ VkSemaphore VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBuff
             submit_info.commandBufferCount   = 1;
             submit_info.pCommandBuffers      = &submit_asset.command_buffer;
             submit_info.signalSemaphoreCount = 1;
-            submit_info.pSignalSemaphores    = &submit_asset.signal_semaphore;
+            submit_info.pSignalSemaphores    = &submit_asset.signal_semaphore.semaphore;
 
             // submit
             device_table_->QueueSubmit(queue_, 1, &submit_info, submit_asset.fence);
@@ -439,7 +440,7 @@ VkSemaphore VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBuff
         run_compute_replace(&fake_info, addresses_to_replace, address_tracker, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     }
 
-    return VK_NULL_HANDLE;
+    return graphics::VulkanSemaphore{ VK_NULL_HANDLE };
 }
 
 void VulkanAddressReplacer::ResolveBufferAddresses(VulkanCommandBufferInfo*                  command_buffer_info,
@@ -2221,12 +2222,12 @@ bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
     }
 
     // create a signal-semaphore
-    if (submit_asset.signal_semaphore == VK_NULL_HANDLE)
+    if (submit_asset.signal_semaphore.semaphore == VK_NULL_HANDLE)
     {
         VkSemaphoreCreateInfo semaphore_create_info = {};
         semaphore_create_info.sType                 = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-        VkResult result =
-            device_table_->CreateSemaphore(device_, &semaphore_create_info, nullptr, &submit_asset.signal_semaphore);
+        VkResult result                             = device_table_->CreateSemaphore(
+            device_, &semaphore_create_info, nullptr, &submit_asset.signal_semaphore.semaphore);
         if (result != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal semaphore creation failed");

--- a/framework/decode/vulkan_address_replacer.h
+++ b/framework/decode/vulkan_address_replacer.h
@@ -89,10 +89,10 @@ class VulkanAddressReplacer
      * @param   wait_semaphores      optional span of (timeline) wait-semaphores, along with their wait-values
      * @return  an optional Semaphore that will be signaled or VK_NULL_HANDLE
      */
-    VkSemaphore UpdateBufferAddresses(const VulkanCommandBufferInfo*             command_buffer_info,
-                                      const std::span<VkDeviceAddress>           addresses_to_replace,
-                                      const decode::VulkanDeviceAddressTracker&  address_tracker,
-                                      const std::span<graphics::VulkanSemaphore> wait_semaphores = {});
+    graphics::VulkanSemaphore UpdateBufferAddresses(const VulkanCommandBufferInfo*             command_buffer_info,
+                                                    const std::span<VkDeviceAddress>           addresses_to_replace,
+                                                    const decode::VulkanDeviceAddressTracker&  address_tracker,
+                                                    const std::span<graphics::VulkanSemaphore> wait_semaphores = {});
 
   private:
     /**
@@ -451,7 +451,7 @@ class VulkanAddressReplacer
         // actual payload
         VkCommandBuffer command_buffer   = VK_NULL_HANDLE;
         VkFence         fence            = VK_NULL_HANDLE;
-        VkSemaphore     signal_semaphore = VK_NULL_HANDLE;
+        graphics::VulkanSemaphore signal_semaphore{ VK_NULL_HANDLE };
 
         PFN_vkDestroyFence       destroy_fence_fn        = nullptr;
         PFN_vkFreeCommandBuffers free_command_buffers_fn = nullptr;

--- a/framework/decode/vulkan_frame_warm_up.cpp
+++ b/framework/decode/vulkan_frame_warm_up.cpp
@@ -263,7 +263,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     }
 
     VkSemaphoreCreateInfo semaphore_info = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
-    result = device_table->CreateSemaphore(device_, &semaphore_info, nullptr, &semaphore_);
+    result = device_table->CreateSemaphore(device_, &semaphore_info, nullptr, &semaphore_.semaphore);
 
     if (result != VK_SUCCESS)
     {
@@ -298,9 +298,9 @@ VulkanFrameWarmUp::~VulkanFrameWarmUp()
 
     if (device_table_ != nullptr && device_ != VK_NULL_HANDLE)
     {
-        if (semaphore_ != VK_NULL_HANDLE)
+        if (semaphore_.semaphore != VK_NULL_HANDLE)
         {
-            device_table_->DestroySemaphore(device_, semaphore_, nullptr);
+            device_table_->DestroySemaphore(device_, semaphore_.semaphore, nullptr);
         }
         if (buffer_memory_ != VK_NULL_HANDLE)
         {
@@ -362,10 +362,10 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(VulkanFrameWarmUp&& other) noexcept :
     other.pipeline_              = VK_NULL_HANDLE;
     other.buffer_                = VK_NULL_HANDLE;
     other.buffer_memory_         = VK_NULL_HANDLE;
-    other.semaphore_             = VK_NULL_HANDLE;
+    other.semaphore_             = graphics::VulkanSemaphore(VK_NULL_HANDLE);
 }
 
-VkSemaphore VulkanFrameWarmUp::WarmUp(const std::span<graphics::VulkanSemaphore> wait_semaphores)
+graphics::VulkanSemaphore VulkanFrameWarmUp::WarmUp(const std::span<graphics::VulkanSemaphore> wait_semaphores)
 {
     util::MarkInjectedCommandsHelper mark_injected_commands_helper;
 
@@ -394,7 +394,7 @@ VkSemaphore VulkanFrameWarmUp::WarmUp(const std::span<graphics::VulkanSemaphore>
     submit_info.pCommandBuffers    = &command_buffer_;
     // next_semaphore_index > 0 means we know how many of them we need from previous frame render
     submit_info.signalSemaphoreCount = 1;
-    submit_info.pSignalSemaphores    = &semaphore_;
+    submit_info.pSignalSemaphores    = &semaphore_.semaphore;
 
     VkResult result = device_table_->QueueSubmit(queue_, 1, &submit_info, VK_NULL_HANDLE);
 

--- a/framework/decode/vulkan_frame_warm_up.h
+++ b/framework/decode/vulkan_frame_warm_up.h
@@ -55,7 +55,7 @@ class VulkanFrameWarmUp
     VulkanFrameWarmUp(const VulkanFrameWarmUp&)            = delete;
     VulkanFrameWarmUp& operator=(const VulkanFrameWarmUp&) = delete;
 
-    VkSemaphore WarmUp(const std::span<graphics::VulkanSemaphore> wait_semaphores = {});
+    graphics::VulkanSemaphore WarmUp(const std::span<graphics::VulkanSemaphore> wait_semaphores = {});
 
   private:
     const graphics::VulkanDeviceTable* device_table_{ nullptr };
@@ -75,7 +75,7 @@ class VulkanFrameWarmUp
     VkPipeline            pipeline_{ VK_NULL_HANDLE };
     VkBuffer              buffer_{ VK_NULL_HANDLE };
     VkDeviceMemory        buffer_memory_{ VK_NULL_HANDLE };
-    VkSemaphore           semaphore_{ VK_NULL_HANDLE };
+    graphics::VulkanSemaphore semaphore_{ VK_NULL_HANDLE };
 };
 
 using VulkanPerDeviceFrameWarmUp = std::unordered_map<const VulkanDeviceInfo*, VulkanFrameWarmUp>;

--- a/framework/decode/vulkan_submit_job.cpp
+++ b/framework/decode/vulkan_submit_job.cpp
@@ -177,9 +177,9 @@ void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<
             // Execute each job function and gather injected wait-semaphores.
             for (const auto& job : jobs)
             {
-                VkSemaphore submit_semaphore = job(original_wait_semaphores);
-                GFXRECON_ASSERT(submit_semaphore != VK_NULL_HANDLE);
-                injected_wait_semaphores.push_back(submit_semaphore);
+                graphics::VulkanSemaphore submit_semaphore = job(original_wait_semaphores);
+                GFXRECON_ASSERT(submit_semaphore.semaphore != VK_NULL_HANDLE);
+                injected_wait_semaphores.push_back(submit_semaphore.semaphore);
             }
 
             // Replace the original waits with waits for the injected jobs.
@@ -246,13 +246,13 @@ void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<
             // Execute each job function and gather injected wait-semaphores.
             for (const auto& job : jobs)
             {
-                VkSemaphore submit_semaphore = job(original_wait_semaphores);
-                GFXRECON_ASSERT(submit_semaphore != VK_NULL_HANDLE);
+                graphics::VulkanSemaphore submit_semaphore = job(original_wait_semaphores);
+                GFXRECON_ASSERT(submit_semaphore.semaphore != VK_NULL_HANDLE);
 
                 VkSemaphoreSubmitInfo semaphore_info = {};
                 semaphore_info.sType                 = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
-                semaphore_info.semaphore             = submit_semaphore;
-                semaphore_info.value                 = 1;
+                semaphore_info.semaphore             = submit_semaphore.semaphore;
+                semaphore_info.value                 = submit_semaphore.timeline_value;
                 semaphore_info.stageMask             = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
                 injected_wait_semaphore_infos.push_back(semaphore_info);
             }

--- a/framework/decode/vulkan_submit_job.h
+++ b/framework/decode/vulkan_submit_job.h
@@ -41,7 +41,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
  * The callback receives the submit's original wait-semaphores and returns a semaphore that should be waited on by
  * the original submit-info.
  */
-typedef std::function<VkSemaphore(const std::span<graphics::VulkanSemaphore>)> VulkanSubmitJob;
+typedef std::function<graphics::VulkanSemaphore(const std::span<graphics::VulkanSemaphore>)> VulkanSubmitJob;
 
 /**
  * @brief   For each submit entry, multiple jobs can be registered.

--- a/framework/graphics/vulkan_semaphore_util.h
+++ b/framework/graphics/vulkan_semaphore_util.h
@@ -34,8 +34,9 @@ GFXRECON_BEGIN_NAMESPACE(graphics)
 
 struct VulkanSemaphore
 {
-    VkSemaphore semaphore;
-    uint64_t    timeline_value; // Only used for timeline semaphores, ignored for binary semaphores
+    VkSemaphore semaphore = VK_NULL_HANDLE;
+    /// Only used for timeline semaphores, ignored for binary semaphores
+    uint64_t timeline_value = 0;
 };
 
 /**


### PR DESCRIPTION
Carry the timeline value alongside the handle so injected waits use the semaphore's actual value instead of a hardcoded 1.