### PR TITLE
refactor: Extract submit-info semaphore storage into helper classes

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -165,6 +165,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_resource_tracking_consumer.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_swapchain.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_swapchain.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_submit_info_helper.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_submit_info_helper.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_submit_job.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_submit_job.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_tracked_object_info.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -263,6 +263,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_resource_initializer.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_resource_tracking_consumer.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_resource_tracking_consumer.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_submit_info_helper.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_submit_info_helper.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_submit_job.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_submit_job.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_swapchain.h

--- a/framework/decode/vulkan_submit_info_helper.cpp
+++ b/framework/decode/vulkan_submit_info_helper.cpp
@@ -1,0 +1,262 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "decode/vulkan_submit_info_helper.h"
+#include "graphics/vulkan_struct_get_pnext.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+VulkanSubmitInfoHelper::VulkanSubmitInfoHelper(VkSubmitInfo& submit_info) : submit_info_(submit_info)
+{
+    CopyTimelineSemaphoreSubmitInfo();
+    CopyWaitSemaphores();
+    CopyWaitDstStageMasks();
+    CopyWaitValues();
+    CopySignalSemaphores();
+    CopySignalValues();
+}
+
+void VulkanSubmitInfoHelper::CopyWaitSemaphores()
+{
+    if (submit_info_.pWaitSemaphores != nullptr && submit_info_.waitSemaphoreCount > 0)
+    {
+        wait_semaphores_ =
+            std::vector(submit_info_.pWaitSemaphores, submit_info_.pWaitSemaphores + submit_info_.waitSemaphoreCount);
+    }
+
+    // Override wait semaphores pointer.
+    submit_info_.pWaitSemaphores = wait_semaphores_.data();
+}
+
+void VulkanSubmitInfoHelper::AddWaitSemaphore(VkSemaphore semaphore)
+{
+    wait_semaphores_.push_back(semaphore);
+    submit_info_.pWaitSemaphores    = wait_semaphores_.data();
+    submit_info_.waitSemaphoreCount = static_cast<uint32_t>(wait_semaphores_.size());
+
+    wait_dst_stage_masks_.push_back(VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+    submit_info_.pWaitDstStageMask = wait_dst_stage_masks_.data();
+
+    wait_semaphore_values_.push_back(0);
+
+    timeline_semaphore_info_.pWaitSemaphoreValues    = wait_semaphore_values_.data();
+    timeline_semaphore_info_.waitSemaphoreValueCount = static_cast<uint32_t>(wait_semaphore_values_.size());
+
+    GFXRECON_ASSERT(wait_semaphores_.size() == wait_semaphore_values_.size());
+}
+
+void VulkanSubmitInfoHelper::AddWaitSemaphore(const graphics::VulkanSemaphore& semaphore)
+{
+    AddWaitSemaphore(semaphore.semaphore);
+    wait_semaphore_values_.back() = semaphore.timeline_value;
+}
+
+void VulkanSubmitInfoHelper::AddWaitSemaphore(const VulkanInjectedSemaphore& semaphore)
+{
+    wait_semaphores_.push_back(semaphore.GetHandle());
+    submit_info_.pWaitSemaphores    = wait_semaphores_.data();
+    submit_info_.waitSemaphoreCount = static_cast<uint32_t>(wait_semaphores_.size());
+
+    wait_dst_stage_masks_.push_back(VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+    submit_info_.pWaitDstStageMask = wait_dst_stage_masks_.data();
+
+    wait_semaphore_values_.push_back(semaphore.GetTargetValue());
+
+    timeline_semaphore_info_.pWaitSemaphoreValues    = wait_semaphore_values_.data();
+    timeline_semaphore_info_.waitSemaphoreValueCount = static_cast<uint32_t>(wait_semaphore_values_.size());
+
+    GFXRECON_ASSERT(wait_semaphores_.size() == wait_semaphore_values_.size());
+}
+
+void VulkanSubmitInfoHelper::AddSignalSemaphore(const VulkanInjectedSemaphore& semaphore)
+{
+    signal_semaphores_.push_back(semaphore.GetHandle());
+    submit_info_.pSignalSemaphores    = signal_semaphores_.data();
+    submit_info_.signalSemaphoreCount = static_cast<uint32_t>(signal_semaphores_.size());
+
+    signal_semaphore_values_.push_back(semaphore.GetTargetValue());
+
+    timeline_semaphore_info_.pSignalSemaphoreValues    = signal_semaphore_values_.data();
+    timeline_semaphore_info_.signalSemaphoreValueCount = static_cast<uint32_t>(signal_semaphore_values_.size());
+
+    GFXRECON_ASSERT(signal_semaphores_.size() == signal_semaphore_values_.size());
+}
+
+void VulkanSubmitInfoHelper::CopySignalSemaphores()
+{
+    if (submit_info_.pSignalSemaphores != nullptr && submit_info_.signalSemaphoreCount > 0)
+    {
+        signal_semaphores_ = std::vector(submit_info_.pSignalSemaphores,
+                                         submit_info_.pSignalSemaphores + submit_info_.signalSemaphoreCount);
+    }
+
+    // Override signal semaphore pointer.
+    submit_info_.pSignalSemaphores = signal_semaphores_.data();
+}
+
+void VulkanSubmitInfoHelper::CopyWaitValues()
+{
+    auto& timeline_info = timeline_semaphore_info_;
+    if (timeline_info.waitSemaphoreValueCount > 0 && timeline_info.pWaitSemaphoreValues != nullptr)
+    {
+        wait_semaphore_values_ =
+            std::vector<uint64_t>(timeline_info.pWaitSemaphoreValues,
+                                  timeline_info.pWaitSemaphoreValues + timeline_info.waitSemaphoreValueCount);
+    }
+    else
+    {
+        wait_semaphore_values_ = std::vector<uint64_t>(submit_info_.waitSemaphoreCount, 0);
+    }
+
+    // Override any existing values pointer.
+    timeline_info.pWaitSemaphoreValues = wait_semaphore_values_.data();
+}
+
+void VulkanSubmitInfoHelper::CopySignalValues()
+{
+    VkTimelineSemaphoreSubmitInfo& timeline_info = timeline_semaphore_info_;
+    if (timeline_info.signalSemaphoreValueCount > 0 && timeline_info.pSignalSemaphoreValues != nullptr)
+    {
+        signal_semaphore_values_ =
+            std::vector<uint64_t>(timeline_info.pSignalSemaphoreValues,
+                                  timeline_info.pSignalSemaphoreValues + timeline_info.signalSemaphoreValueCount);
+    }
+    else
+    {
+        signal_semaphore_values_ = std::vector<uint64_t>(submit_info_.signalSemaphoreCount, 0);
+    }
+
+    // Override signal semaphore values.
+    timeline_info.pSignalSemaphoreValues = signal_semaphore_values_.data();
+}
+
+void VulkanSubmitInfoHelper::CopyWaitDstStageMasks()
+{
+    // Make sure there is injected storage for wait dst stage masks for this submit info.
+    if (submit_info_.pWaitDstStageMask != nullptr && submit_info_.waitSemaphoreCount > 0)
+    {
+        // Copy existing wait dst stage masks if they exist.
+        wait_dst_stage_masks_ = std::vector<VkPipelineStageFlags>(
+            submit_info_.pWaitDstStageMask, submit_info_.pWaitDstStageMask + submit_info_.waitSemaphoreCount);
+    }
+    else
+    {
+        // Otherwise, initialize wait dst stage masks with a valid default for each wait semaphore.
+        wait_dst_stage_masks_ =
+            std::vector<VkPipelineStageFlags>(submit_info_.waitSemaphoreCount, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+    }
+
+    // Override wait dst stage mask pointer.
+    submit_info_.pWaitDstStageMask = wait_dst_stage_masks_.data();
+}
+
+void VulkanSubmitInfoHelper::CopyTimelineSemaphoreSubmitInfo()
+{
+    if (auto* existing_info = graphics::vulkan_struct_get_pnext<VkTimelineSemaphoreSubmitInfo>(&submit_info_))
+    {
+        timeline_semaphore_info_ = *existing_info;
+    }
+    else
+    {
+        timeline_semaphore_info_ = VkTimelineSemaphoreSubmitInfo{ VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO };
+    }
+
+    // Insert owned timeline submit info, replacing any existing VkTimelineSemaphoreSubmitInfo.
+    graphics::vulkan_struct_add_pnext(&submit_info_, &timeline_semaphore_info_);
+}
+
+void VulkanSubmitInfoHelper::InjectSemaphore(VulkanInjectedSemaphore& semaphore)
+{
+    // Wait on the current value, then signal the next value on the same injected timeline semaphore.
+    AddWaitSemaphore(semaphore);
+    semaphore.IncreaseTargetValue();
+    AddSignalSemaphore(semaphore);
+}
+
+VulkanSubmitInfo2Helper::VulkanSubmitInfo2Helper(VkSubmitInfo2& submit_info2) : submit_info2_(submit_info2)
+{
+    CopyWaitSemaphoreInfos();
+    CopySignalSemaphoreInfos();
+}
+
+void VulkanSubmitInfo2Helper::CopyWaitSemaphoreInfos()
+{
+    if (submit_info2_.pWaitSemaphoreInfos != nullptr && submit_info2_.waitSemaphoreInfoCount > 0)
+    {
+        wait_semaphore_infos_ = std::vector(submit_info2_.pWaitSemaphoreInfos,
+                                            submit_info2_.pWaitSemaphoreInfos + submit_info2_.waitSemaphoreInfoCount);
+    }
+
+    // Override any existing wait semaphore pointer.
+    submit_info2_.pWaitSemaphoreInfos = wait_semaphore_infos_.data();
+}
+
+void VulkanSubmitInfo2Helper::CopySignalSemaphoreInfos()
+{
+    if (submit_info2_.pSignalSemaphoreInfos != nullptr && submit_info2_.signalSemaphoreInfoCount > 0)
+    {
+        signal_semaphore_infos_ =
+            std::vector(submit_info2_.pSignalSemaphoreInfos,
+                        submit_info2_.pSignalSemaphoreInfos + submit_info2_.signalSemaphoreInfoCount);
+    }
+
+    // Override any existing signal semaphore pointer.
+    submit_info2_.pSignalSemaphoreInfos = signal_semaphore_infos_.data();
+}
+
+void VulkanSubmitInfo2Helper::AddWaitSemaphore(VkSemaphoreSubmitInfo semaphore_info)
+{
+    std::vector<VkSemaphoreSubmitInfo>& wait_semaphores = wait_semaphore_infos_;
+    wait_semaphores.push_back(semaphore_info);
+    submit_info2_.pWaitSemaphoreInfos    = wait_semaphores.data();
+    submit_info2_.waitSemaphoreInfoCount = static_cast<uint32_t>(wait_semaphores.size());
+}
+
+void VulkanSubmitInfo2Helper::AddWaitSemaphore(const VulkanInjectedSemaphoreInfo& semaphore)
+{
+    std::vector<VkSemaphoreSubmitInfo>& wait_semaphores = wait_semaphore_infos_;
+    wait_semaphores.push_back(semaphore.info);
+    submit_info2_.pWaitSemaphoreInfos    = wait_semaphores.data();
+    submit_info2_.waitSemaphoreInfoCount = static_cast<uint32_t>(wait_semaphores.size());
+}
+
+void VulkanSubmitInfo2Helper::AddSignalSemaphore(const VulkanInjectedSemaphoreInfo& semaphore)
+{
+    std::vector<VkSemaphoreSubmitInfo>& signal_semaphores = signal_semaphore_infos_;
+    signal_semaphores.push_back(semaphore.info);
+    submit_info2_.pSignalSemaphoreInfos    = signal_semaphores.data();
+    submit_info2_.signalSemaphoreInfoCount = static_cast<uint32_t>(signal_semaphores.size());
+}
+
+void VulkanSubmitInfo2Helper::InjectSemaphore(VulkanInjectedSemaphoreInfo& semaphore_info)
+{
+    // Wait on the current value, then signal the next value on the same injected timeline semaphore.
+    AddWaitSemaphore(semaphore_info);
+    semaphore_info.info.value++;
+    semaphore_info.info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    semaphore_info.semaphore.IncreaseTargetValue();
+    AddSignalSemaphore(semaphore_info);
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_submit_info_helper.h
+++ b/framework/decode/vulkan_submit_info_helper.h
@@ -1,0 +1,203 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_VULKAN_SUBMIT_INFO_HELPER_H
+#define GFXRECON_VULKAN_SUBMIT_INFO_HELPER_H
+
+#include "graphics/vulkan_semaphore_util.h"
+#include "decode/vulkan_object_info.h"
+#include "util/defines.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+/**
+ * @brief   Executor-owned timeline semaphore used to order rewritten submit entries.
+ *
+ * `SerializeExecution()` creates one injected timeline semaphore for one `vkQueueSubmit()` call and reuses it for every
+ * submit entry in that call. Each rewritten submit waits on the semaphore's current `target_value`, then signals the
+ * next value. After all submits have been rewritten, `target_value` is the final value that must be reached before the
+ * executor can safely destroy the semaphore.
+ */
+class VulkanInjectedSemaphore
+{
+  private:
+    graphics::VulkanSemaphore semaphore_{ VK_NULL_HANDLE };
+
+    const VulkanDeviceInfo*            device_info_;
+    const graphics::VulkanDeviceTable* device_table_;
+
+  public:
+    bool        HasReachedTargetValue() const;
+    VkSemaphore GetHandle() const { return semaphore_.semaphore; }
+    uint64_t    GetTargetValue() const { return semaphore_.timeline_value; }
+    void        IncreaseTargetValue() { semaphore_.timeline_value++; }
+
+    VulkanInjectedSemaphore(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* table);
+    ~VulkanInjectedSemaphore();
+
+    VulkanInjectedSemaphore(const VulkanInjectedSemaphore&)            = delete;
+    VulkanInjectedSemaphore& operator=(const VulkanInjectedSemaphore&) = delete;
+
+    VulkanInjectedSemaphore(VulkanInjectedSemaphore&&);
+    VulkanInjectedSemaphore& operator=(VulkanInjectedSemaphore&&) noexcept;
+};
+
+/**
+ * @brief   Executor-owned timeline semaphore plus VkSubmitInfo2-compatible submit info.
+ *
+ * `info.value` is updated alongside `VulkanInjectedSemaphore::target_value` while rewriting a `VkSubmitInfo2` array so
+ * the same injected semaphore can be used for the wait and signal pair in each submit entry.
+ */
+struct VulkanInjectedSemaphoreInfo
+{
+    VulkanInjectedSemaphore semaphore;
+    VkSemaphoreSubmitInfo   info = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
+
+    VulkanInjectedSemaphoreInfo(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* table);
+};
+
+/**
+ * @brief   Original wait semaphores stripped from a submit before injected jobs run.
+ */
+struct VulkanSubmitSemaphores
+{
+    std::vector<graphics::VulkanSemaphore> semaphores;
+};
+
+class VulkanSubmitInfoHelper
+{
+  private:
+    VkSubmitInfo& submit_info_;
+
+    /// Backing storage for this submit's wait semaphores (binary semaphore handles).
+    std::vector<VkSemaphore> wait_semaphores_;
+
+    /// Backing storage for this submit's signal semaphores.
+    std::vector<VkSemaphore> signal_semaphores_;
+
+    /// Backing storage for this submit's timeline signal-semaphore values.
+    std::vector<uint64_t> signal_semaphore_values_;
+
+    /// Backing storage for this submit's timeline wait-semaphore values.
+    std::vector<uint64_t> wait_semaphore_values_;
+
+    /// Owned `VkTimelineSemaphoreSubmitInfo` inserted into this submit's pNext chain.
+    VkTimelineSemaphoreSubmitInfo timeline_semaphore_info_{ VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO };
+
+    /// Backing storage for this submit's wait dst stage masks.
+    std::vector<VkPipelineStageFlags> wait_dst_stage_masks_;
+
+    void CopyWaitSemaphores();
+    void CopyWaitDstStageMasks();
+    void CopyWaitValues();
+    void CopySignalSemaphores();
+    void CopySignalValues();
+    void CopyTimelineSemaphoreSubmitInfo();
+
+  public:
+    VulkanSubmitInfoHelper(VkSubmitInfo& submit_info);
+    ~VulkanSubmitInfoHelper() = default;
+
+    VulkanSubmitInfoHelper(const VulkanSubmitInfoHelper&)            = delete;
+    VulkanSubmitInfoHelper& operator=(const VulkanSubmitInfoHelper&) = delete;
+    VulkanSubmitInfoHelper(VulkanSubmitInfoHelper&&)                 = delete;
+    VulkanSubmitInfoHelper& operator=(VulkanSubmitInfoHelper&&)      = delete;
+
+    /**
+     * @brief Append a binary wait semaphore.
+     */
+    void AddWaitSemaphore(VkSemaphore semaphore);
+
+    /**
+     * @brief Append a VulkanSemaphore wait semaphore.
+     */
+    void AddWaitSemaphore(const graphics::VulkanSemaphore& semaphore);
+
+    /**
+     * @brief Append a timeline wait semaphore.
+     */
+    void AddWaitSemaphore(const VulkanInjectedSemaphore& semaphore);
+
+    /**
+     * @brief Append a timeline signal semaphore.
+     */
+    void AddSignalSemaphore(const VulkanInjectedSemaphore& semaphore);
+
+    /**
+     * @brief Append one timeline wait/signal pair to a VkSubmitInfo and advance the target value.
+     *
+     * The submit waits on `semaphore.target_value`, then signals `semaphore.target_value + 1`.
+     */
+    void InjectSemaphore(VulkanInjectedSemaphore& semaphore);
+};
+
+class VulkanSubmitInfo2Helper
+{
+  private:
+    VkSubmitInfo2& submit_info2_;
+
+    /// Injected waits for VkSubmitInfo2 (binary or timeline semaphore submit infos).
+    std::vector<VkSemaphoreSubmitInfo> wait_semaphore_infos_;
+
+    /// Injected signals for VkSubmitInfo2 (binary or timeline semaphore submit infos).
+    std::vector<VkSemaphoreSubmitInfo> signal_semaphore_infos_;
+
+    void CopyWaitSemaphoreInfos();
+    void CopySignalSemaphoreInfos();
+
+  public:
+    VulkanSubmitInfo2Helper(VkSubmitInfo2& submit_info2);
+    ~VulkanSubmitInfo2Helper() = default;
+
+    VulkanSubmitInfo2Helper(const VulkanSubmitInfo2Helper&)            = delete;
+    VulkanSubmitInfo2Helper& operator=(const VulkanSubmitInfo2Helper&) = delete;
+    VulkanSubmitInfo2Helper(VulkanSubmitInfo2Helper&&)                 = delete;
+    VulkanSubmitInfo2Helper& operator=(VulkanSubmitInfo2Helper&&)      = delete;
+
+    /**
+     * @brief Append a binary wait semaphore info to one VkSubmitInfo2.
+     */
+    void AddWaitSemaphore(VkSemaphoreSubmitInfo semaphore);
+
+    /**
+     * @brief Append a timeline wait semaphore info to one VkSubmitInfo2.
+     */
+    void AddWaitSemaphore(const VulkanInjectedSemaphoreInfo& semaphore);
+
+    /**
+     * @brief Append a timeline signal semaphore info to one VkSubmitInfo2.
+     */
+    void AddSignalSemaphore(const VulkanInjectedSemaphoreInfo& semaphore);
+
+    /**
+     * @brief Append one timeline wait/signal pair to a VkSubmitInfo2 and advance the target value.
+     *
+     * The submit waits on `semaphore_info.info.value`, then signals `semaphore_info.info.value + 1`.
+     */
+    void InjectSemaphore(VulkanInjectedSemaphoreInfo& semaphore_info);
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_VULKAN_SUBMIT_INFO_HELPER_H

--- a/framework/decode/vulkan_submit_job.cpp
+++ b/framework/decode/vulkan_submit_job.cpp
@@ -70,7 +70,8 @@ VulkanInjectedSemaphore::VulkanInjectedSemaphore(const VulkanDeviceInfo*        
     VkSemaphoreCreateInfo semaphore_create_info{ VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
     semaphore_create_info.pNext = &timeline_create_info;
 
-    VkResult result = device_table_->CreateSemaphore(device_info_->handle, &semaphore_create_info, nullptr, &handle_);
+    VkResult result =
+        device_table_->CreateSemaphore(device_info_->handle, &semaphore_create_info, nullptr, &semaphore_.semaphore);
     if (result != VK_SUCCESS) [[unlikely]]
     {
         GFXRECON_LOG_ERROR("Failed to create timeline semaphore for submit job execution: %s",
@@ -79,19 +80,16 @@ VulkanInjectedSemaphore::VulkanInjectedSemaphore(const VulkanDeviceInfo*        
 }
 
 VulkanInjectedSemaphore::VulkanInjectedSemaphore(VulkanInjectedSemaphore&& other) :
-    handle_{ other.handle_ }, target_value_{ other.target_value_ }, device_info_{ other.device_info_ }, device_table_{
-        other.device_table_
-    }
+    semaphore_{ other.semaphore_ }, device_info_{ other.device_info_ }, device_table_{ other.device_table_ }
 {
-    other.handle_ = VK_NULL_HANDLE;
+    other.semaphore_ = graphics::VulkanSemaphore(VK_NULL_HANDLE);
 }
 
 VulkanInjectedSemaphore& VulkanInjectedSemaphore::operator=(VulkanInjectedSemaphore&& other) noexcept
 {
     if (this != &other)
     {
-        std::swap(handle_, other.handle_);
-        std::swap(target_value_, other.target_value_);
+        std::swap(semaphore_, other.semaphore_);
         std::swap(device_info_, other.device_info_);
         std::swap(device_table_, other.device_table_);
     }
@@ -100,30 +98,30 @@ VulkanInjectedSemaphore& VulkanInjectedSemaphore::operator=(VulkanInjectedSemaph
 
 bool VulkanInjectedSemaphore::HasReachedTargetValue() const
 {
-    if (handle_ == VK_NULL_HANDLE)
+    if (semaphore_.semaphore == VK_NULL_HANDLE)
     {
         return false;
     }
 
     uint64_t read_value = 0;
-    VkResult result     = device_table_->GetSemaphoreCounterValue(device_info_->handle, handle_, &read_value);
+    VkResult result = device_table_->GetSemaphoreCounterValue(device_info_->handle, semaphore_.semaphore, &read_value);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("Failed to get timeline semaphore value for submit job execution: %s",
                            util::ToString(result).c_str());
     }
-    return result == VK_SUCCESS && read_value >= target_value_;
+    return result == VK_SUCCESS && read_value >= semaphore_.timeline_value;
 }
 
 VulkanInjectedSemaphore::~VulkanInjectedSemaphore()
 {
-    if (handle_ != VK_NULL_HANDLE)
+    if (semaphore_.semaphore != VK_NULL_HANDLE)
     {
         if (!HasReachedTargetValue())
         {
             GFXRECON_LOG_ERROR("Injected timeline semaphore has not reached its target value at destruction time.");
         }
-        device_table_->DestroySemaphore(device_info_->handle, handle_, nullptr);
+        device_table_->DestroySemaphore(device_info_->handle, semaphore_.semaphore, nullptr);
     }
 }
 
@@ -134,6 +132,32 @@ VulkanInjectedSemaphoreInfo::VulkanInjectedSemaphoreInfo(const VulkanDeviceInfo*
     GFXRECON_ASSERT(semaphore.GetHandle() != VK_NULL_HANDLE);
     info.semaphore = semaphore.GetHandle();
     info.stageMask = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT;
+}
+
+VulkanSubmitInfoHelper& VulkanSubmitJobExecution::GetSubmitInfoHelper(VkSubmitInfo& submit_info)
+{
+    auto it = submit_info_helpers_.find(&submit_info);
+    if (it == submit_info_helpers_.end())
+    {
+        auto [new_it, inserted] =
+            submit_info_helpers_.emplace(&submit_info, std::make_unique<VulkanSubmitInfoHelper>(submit_info));
+        GFXRECON_ASSERT(inserted);
+        it = new_it;
+    }
+    return *(it->second);
+}
+
+VulkanSubmitInfo2Helper& VulkanSubmitJobExecution::GetSubmitInfo2Helper(VkSubmitInfo2& submit_info2)
+{
+    auto it = submit_info2_helpers_.find(&submit_info2);
+    if (it == submit_info2_helpers_.end())
+    {
+        auto [new_it, inserted] =
+            submit_info2_helpers_.emplace(&submit_info2, std::make_unique<VulkanSubmitInfo2Helper>(submit_info2));
+        GFXRECON_ASSERT(inserted);
+        it = new_it;
+    }
+    return *(it->second);
 }
 
 void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<VkSubmitInfo> submit_infos)
@@ -147,7 +171,7 @@ void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<
 
     // Ensure that InjectBefore is not called multiple times for the same submit infos.
     GFXRECON_ASSERT(std::all_of(submit_infos.begin(), submit_infos.end(), [this](VkSubmitInfo& info) {
-        return !original_wait_semaphores_.contains(&info) && !injected_wait_semaphores_.contains(&info);
+        return !original_wait_semaphores_.contains(&info) && !submit_info_helpers_.contains(&info);
     }));
 
     // Gather original wait-semaphores for each submit and prepare storage for injected wait-semaphores.
@@ -172,32 +196,16 @@ void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<
         {
             VkSubmitInfo& submit_info              = submit_infos[submit_index];
             auto&         original_wait_semaphores = original_wait_semaphores_[&submit_info].semaphores;
-            auto&         injected_wait_semaphores = injected_wait_semaphores_[&submit_info];
+            auto&         submit_helper            = GetSubmitInfoHelper(submit_info);
 
             // Execute each job function and gather injected wait-semaphores.
             for (const auto& job : jobs)
             {
                 graphics::VulkanSemaphore submit_semaphore = job(original_wait_semaphores);
-                GFXRECON_ASSERT(submit_semaphore.semaphore != VK_NULL_HANDLE);
-                injected_wait_semaphores.push_back(submit_semaphore.semaphore);
-            }
-
-            // Replace the original waits with waits for the injected jobs.
-            submit_info.waitSemaphoreCount = static_cast<uint32_t>(injected_wait_semaphores.size());
-            submit_info.pWaitSemaphores    = injected_wait_semaphores.data();
-
-            // If waitSemaphoreCount was 0, pWaitDstStageMask might be nullptr.
-            // Make sure it points to valid data in all cases.
-            auto& wait_dst_stage_masks = GetWaitDstStageMasks(submit_info);
-            std::fill(wait_dst_stage_masks.begin(), wait_dst_stage_masks.end(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
-
-            submit_info.pWaitDstStageMask = wait_dst_stage_masks.data();
-
-            // The original waits were stripped, so any timeline wait values that described them must be removed too.
-            if (auto* timeline_info = graphics::vulkan_struct_get_pnext<VkTimelineSemaphoreSubmitInfo>(&submit_info))
-            {
-                timeline_info->waitSemaphoreValueCount = 0;
-                timeline_info->pWaitSemaphoreValues    = nullptr;
+                if (submit_semaphore.semaphore != VK_NULL_HANDLE)
+                {
+                    submit_helper.AddWaitSemaphore(submit_semaphore);
+                }
             }
         }
     }
@@ -214,7 +222,7 @@ void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<
 
     // Ensure that InjectBefore is not called multiple times for the same submit infos.
     GFXRECON_ASSERT(std::all_of(submit_infos.begin(), submit_infos.end(), [this](VkSubmitInfo2& info) {
-        return !original_wait_semaphores_.contains(&info) && !injected_wait_semaphore_infos_.contains(&info);
+        return !original_wait_semaphores_.contains(&info) && !submit_info2_helpers_.contains(&info);
     }));
 
     // Gather original wait-semaphores for each submit and prepare storage for injected wait-semaphores.
@@ -241,276 +249,25 @@ void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<
         {
             VkSubmitInfo2& submit_info                   = submit_infos[submit_index];
             auto&          original_wait_semaphores      = original_wait_semaphores_[&submit_info].semaphores;
-            auto&          injected_wait_semaphore_infos = injected_wait_semaphore_infos_[&submit_info];
+            auto&          submit_helper                 = GetSubmitInfo2Helper(submit_info);
 
             // Execute each job function and gather injected wait-semaphores.
             for (const auto& job : jobs)
             {
                 graphics::VulkanSemaphore submit_semaphore = job(original_wait_semaphores);
-                GFXRECON_ASSERT(submit_semaphore.semaphore != VK_NULL_HANDLE);
 
-                VkSemaphoreSubmitInfo semaphore_info = {};
-                semaphore_info.sType                 = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
-                semaphore_info.semaphore             = submit_semaphore.semaphore;
-                semaphore_info.value                 = submit_semaphore.timeline_value;
-                semaphore_info.stageMask             = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-                injected_wait_semaphore_infos.push_back(semaphore_info);
+                if (submit_semaphore.semaphore != VK_NULL_HANDLE)
+                {
+                    VkSemaphoreSubmitInfo semaphore_info = {};
+                    semaphore_info.sType                 = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+                    semaphore_info.semaphore             = submit_semaphore.semaphore;
+                    semaphore_info.value                 = submit_semaphore.timeline_value;
+                    semaphore_info.stageMask             = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+                    submit_helper.AddWaitSemaphore(semaphore_info);
+                }
             }
-
-            // Replace the original waits with waits for the injected jobs.
-            submit_info.waitSemaphoreInfoCount = static_cast<uint32_t>(injected_wait_semaphore_infos.size());
-            submit_info.pWaitSemaphoreInfos    = injected_wait_semaphore_infos.data();
         }
     }
-}
-
-std::vector<VkSemaphore>& VulkanSubmitJobExecution::GetWaitSemaphores(VkSubmitInfo& submit_info)
-{
-    if (!injected_wait_semaphores_.contains(&submit_info))
-    {
-        if (submit_info.pWaitSemaphores != nullptr && submit_info.waitSemaphoreCount > 0)
-        {
-
-            injected_wait_semaphores_[&submit_info] =
-                std::vector(submit_info.pWaitSemaphores, submit_info.pWaitSemaphores + submit_info.waitSemaphoreCount);
-        }
-        else
-        {
-            injected_wait_semaphores_[&submit_info] = std::vector<VkSemaphore>();
-        }
-
-        // Override wait semaphores pointer.
-        submit_info.pWaitSemaphores = injected_wait_semaphores_[&submit_info].data();
-    }
-    return injected_wait_semaphores_[&submit_info];
-}
-
-void VulkanSubmitJobExecution::AddWaitSemaphore(VkSubmitInfo& submit_info, const VulkanInjectedSemaphore& semaphore)
-{
-    std::vector<VkSemaphore>&          wait_semaphores                = GetWaitSemaphores(submit_info);
-    std::vector<VkPipelineStageFlags>& wait_dst_stage_masks           = GetWaitDstStageMasks(submit_info);
-    std::vector<uint64_t>&             wait_values                    = GetWaitValues(submit_info);
-    VkTimelineSemaphoreSubmitInfo&     timeline_semaphore_submit_info = GetTimelineSemaphoreSubmitInfo(submit_info);
-
-    wait_semaphores.push_back(semaphore.GetHandle());
-    submit_info.pWaitSemaphores    = wait_semaphores.data();
-    submit_info.waitSemaphoreCount = static_cast<uint32_t>(wait_semaphores.size());
-
-    wait_dst_stage_masks.push_back(VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
-    submit_info.pWaitDstStageMask = wait_dst_stage_masks.data();
-
-    wait_values.push_back(semaphore.GetTargetValue());
-
-    timeline_semaphore_submit_info.pWaitSemaphoreValues    = wait_values.data();
-    timeline_semaphore_submit_info.waitSemaphoreValueCount = static_cast<uint32_t>(wait_values.size());
-
-    GFXRECON_ASSERT(wait_semaphores.size() == wait_values.size());
-}
-
-void VulkanSubmitJobExecution::AddSignalSemaphore(VkSubmitInfo& submit_info, const VulkanInjectedSemaphore& semaphore)
-{
-    std::vector<VkSemaphore>&      signal_semaphores              = GetSignalSemaphores(submit_info);
-    std::vector<uint64_t>&         signal_values                  = GetSignalValues(submit_info);
-    VkTimelineSemaphoreSubmitInfo& timeline_semaphore_submit_info = GetTimelineSemaphoreSubmitInfo(submit_info);
-
-    signal_semaphores.push_back(semaphore.GetHandle());
-    submit_info.pSignalSemaphores    = signal_semaphores.data();
-    submit_info.signalSemaphoreCount = static_cast<uint32_t>(signal_semaphores.size());
-
-    signal_values.push_back(semaphore.GetTargetValue());
-
-    timeline_semaphore_submit_info.pSignalSemaphoreValues    = signal_values.data();
-    timeline_semaphore_submit_info.signalSemaphoreValueCount = static_cast<uint32_t>(signal_values.size());
-
-    GFXRECON_ASSERT(signal_semaphores.size() == signal_values.size());
-}
-
-void VulkanSubmitJobExecution::AddWaitSemaphore(VkSubmitInfo2&                     submit_info,
-                                                const VulkanInjectedSemaphoreInfo& semaphore)
-{
-    std::vector<VkSemaphoreSubmitInfo>& wait_semaphores = GetWaitSemaphoreInfos(submit_info);
-    wait_semaphores.push_back(semaphore.info);
-    submit_info.pWaitSemaphoreInfos    = wait_semaphores.data();
-    submit_info.waitSemaphoreInfoCount = static_cast<uint32_t>(wait_semaphores.size());
-}
-
-void VulkanSubmitJobExecution::AddSignalSemaphore(VkSubmitInfo2&                     submit_info,
-                                                  const VulkanInjectedSemaphoreInfo& semaphore)
-{
-    std::vector<VkSemaphoreSubmitInfo>& signal_semaphores = GetSignalSemaphoreInfos(submit_info);
-    signal_semaphores.push_back(semaphore.info);
-    submit_info.pSignalSemaphoreInfos    = signal_semaphores.data();
-    submit_info.signalSemaphoreInfoCount = static_cast<uint32_t>(signal_semaphores.size());
-}
-
-std::vector<VkSemaphore>& VulkanSubmitJobExecution::GetSignalSemaphores(VkSubmitInfo& submit_info)
-{
-    if (!injected_signal_semaphores_.contains(&submit_info))
-    {
-        if (submit_info.pSignalSemaphores != nullptr && submit_info.signalSemaphoreCount > 0)
-        {
-            injected_signal_semaphores_[&submit_info] = std::vector(
-                submit_info.pSignalSemaphores, submit_info.pSignalSemaphores + submit_info.signalSemaphoreCount);
-        }
-        else
-        {
-            injected_signal_semaphores_[&submit_info] = std::vector<VkSemaphore>();
-        }
-
-        // Override signal semaphore pointer.
-        submit_info.pSignalSemaphores = injected_signal_semaphores_[&submit_info].data();
-    }
-    return injected_signal_semaphores_[&submit_info];
-}
-
-std::vector<uint64_t>& VulkanSubmitJobExecution::GetWaitValues(VkSubmitInfo& submit_info)
-{
-    if (!injected_wait_semaphore_values_.contains(&submit_info))
-    {
-        VkTimelineSemaphoreSubmitInfo& timeline_info = GetTimelineSemaphoreSubmitInfo(submit_info);
-        if (timeline_info.waitSemaphoreValueCount > 0 && timeline_info.pWaitSemaphoreValues != nullptr)
-        {
-            injected_wait_semaphore_values_[&submit_info] =
-                std::vector<uint64_t>(timeline_info.pWaitSemaphoreValues,
-                                      timeline_info.pWaitSemaphoreValues + timeline_info.waitSemaphoreValueCount);
-        }
-        else
-        {
-            injected_wait_semaphore_values_[&submit_info] = std::vector<uint64_t>(submit_info.waitSemaphoreCount, 0);
-        }
-
-        // Override any existing values pointer.
-        timeline_info.pWaitSemaphoreValues = injected_wait_semaphore_values_[&submit_info].data();
-    }
-    return injected_wait_semaphore_values_[&submit_info];
-}
-
-std::vector<uint64_t>& VulkanSubmitJobExecution::GetSignalValues(VkSubmitInfo& submit_info)
-{
-    if (!injected_signal_semaphore_values_.contains(&submit_info))
-    {
-        VkTimelineSemaphoreSubmitInfo& timeline_info = GetTimelineSemaphoreSubmitInfo(submit_info);
-        if (timeline_info.signalSemaphoreValueCount > 0 && timeline_info.pSignalSemaphoreValues != nullptr)
-        {
-            injected_signal_semaphore_values_[&submit_info] =
-                std::vector<uint64_t>(timeline_info.pSignalSemaphoreValues,
-                                      timeline_info.pSignalSemaphoreValues + timeline_info.signalSemaphoreValueCount);
-        }
-        else
-        {
-            injected_signal_semaphore_values_[&submit_info] =
-                std::vector<uint64_t>(submit_info.signalSemaphoreCount, 0);
-        }
-
-        // Override signal semaphore values.
-        timeline_info.pSignalSemaphoreValues = injected_signal_semaphore_values_[&submit_info].data();
-    }
-    return injected_signal_semaphore_values_[&submit_info];
-}
-
-std::vector<VkPipelineStageFlags>& VulkanSubmitJobExecution::GetWaitDstStageMasks(VkSubmitInfo& submit_info)
-{
-    // Make sure there is injected storage for wait dst stage masks for this submit info.
-    if (!injected_wait_dst_stage_masks_.contains(&submit_info))
-    {
-        if (submit_info.pWaitDstStageMask != nullptr && submit_info.waitSemaphoreCount > 0)
-        {
-            // Copy existing wait dst stage masks if they exist.
-            injected_wait_dst_stage_masks_[&submit_info] = std::vector<VkPipelineStageFlags>(
-                submit_info.pWaitDstStageMask, submit_info.pWaitDstStageMask + submit_info.waitSemaphoreCount);
-        }
-        else
-        {
-            // Otherwise, initialize wait dst stage masks with a valid default for each wait semaphore.
-            injected_wait_dst_stage_masks_[&submit_info] =
-                std::vector<VkPipelineStageFlags>(submit_info.waitSemaphoreCount, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
-        }
-
-        // Override wait dst stage mask pointer.
-        submit_info.pWaitDstStageMask = injected_wait_dst_stage_masks_[&submit_info].data();
-    }
-
-    return injected_wait_dst_stage_masks_[&submit_info];
-}
-
-std::vector<VkSemaphoreSubmitInfo>& VulkanSubmitJobExecution::GetWaitSemaphoreInfos(VkSubmitInfo2& submit_info2)
-{
-    if (!injected_wait_semaphore_infos_.contains(&submit_info2))
-    {
-        if (submit_info2.pWaitSemaphoreInfos != nullptr && submit_info2.waitSemaphoreInfoCount > 0)
-        {
-            injected_wait_semaphore_infos_[&submit_info2] =
-                std::vector(submit_info2.pWaitSemaphoreInfos,
-                            submit_info2.pWaitSemaphoreInfos + submit_info2.waitSemaphoreInfoCount);
-        }
-        else
-        {
-            injected_wait_semaphore_infos_[&submit_info2] = std::vector<VkSemaphoreSubmitInfo>();
-        }
-
-        // Override any existing wait semaphore pointer.
-        submit_info2.pWaitSemaphoreInfos = injected_wait_semaphore_infos_[&submit_info2].data();
-    }
-    return injected_wait_semaphore_infos_[&submit_info2];
-}
-
-std::vector<VkSemaphoreSubmitInfo>& VulkanSubmitJobExecution::GetSignalSemaphoreInfos(VkSubmitInfo2& submit_info)
-{
-    if (!injected_signal_semaphore_infos_.contains(&submit_info))
-    {
-        if (submit_info.pSignalSemaphoreInfos != nullptr && submit_info.signalSemaphoreInfoCount > 0)
-        {
-            injected_signal_semaphore_infos_[&submit_info] =
-                std::vector(submit_info.pSignalSemaphoreInfos,
-                            submit_info.pSignalSemaphoreInfos + submit_info.signalSemaphoreInfoCount);
-        }
-        else
-        {
-            injected_signal_semaphore_infos_[&submit_info] = std::vector<VkSemaphoreSubmitInfo>();
-        }
-
-        // Override any existing signal semaphore pointer.
-        submit_info.pSignalSemaphoreInfos = injected_signal_semaphore_infos_[&submit_info].data();
-    }
-    return injected_signal_semaphore_infos_[&submit_info];
-}
-
-VkTimelineSemaphoreSubmitInfo& VulkanSubmitJobExecution::GetTimelineSemaphoreSubmitInfo(VkSubmitInfo& submit_info)
-{
-    if (!injected_timeline_semaphore_infos_.contains(&submit_info))
-    {
-        if (auto* existing_info = graphics::vulkan_struct_get_pnext<VkTimelineSemaphoreSubmitInfo>(&submit_info))
-        {
-            injected_timeline_semaphore_infos_[&submit_info] = *existing_info;
-        }
-        else
-        {
-            injected_timeline_semaphore_infos_[&submit_info] =
-                VkTimelineSemaphoreSubmitInfo{ VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO };
-        }
-
-        // Insert owned timeline submit info, replacing any existing VkTimelineSemaphoreSubmitInfo.
-        graphics::vulkan_struct_add_pnext(&submit_info, &injected_timeline_semaphore_infos_[&submit_info]);
-    }
-    return injected_timeline_semaphore_infos_[&submit_info];
-}
-
-void VulkanSubmitJobExecution::InjectSemaphore(VkSubmitInfo& submit_info, VulkanInjectedSemaphore& semaphore)
-{
-    // Wait on the current value, then signal the next value on the same injected timeline semaphore.
-    AddWaitSemaphore(submit_info, semaphore);
-    semaphore.IncreaseTargetValue();
-    AddSignalSemaphore(submit_info, semaphore);
-}
-
-void VulkanSubmitJobExecution::InjectSemaphore(VkSubmitInfo2& submit_info, VulkanInjectedSemaphoreInfo& semaphore_info)
-{
-    // Wait on the current value, then signal the next value on the same injected timeline semaphore.
-    AddWaitSemaphore(submit_info, semaphore_info);
-    semaphore_info.info.value++;
-    semaphore_info.info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-    semaphore_info.semaphore.IncreaseTargetValue();
-    AddSignalSemaphore(submit_info, semaphore_info);
 }
 
 void VulkanSubmitJobExecution::SerializeExecution(std::span<VkSubmitInfo> submit_infos)
@@ -531,7 +288,8 @@ void VulkanSubmitJobExecution::SerializeExecution(std::span<VkSubmitInfo> submit
     // One timeline semaphore serializes the whole submit array by advancing its value once per submit.
     for (VkSubmitInfo& submit_info : submit_infos)
     {
-        InjectSemaphore(submit_info, *injected_semaphore);
+        auto& submit_helper = GetSubmitInfoHelper(submit_info);
+        submit_helper.InjectSemaphore(*injected_semaphore);
     }
 }
 
@@ -553,7 +311,8 @@ void VulkanSubmitJobExecution::SerializeExecution(std::span<VkSubmitInfo2> submi
     // One timeline semaphore serializes the whole submit array by advancing its value once per submit.
     for (VkSubmitInfo2& submit_info2 : submit_infos2)
     {
-        InjectSemaphore(submit_info2, *injected_semaphore_info);
+        auto& submit_helper = GetSubmitInfo2Helper(submit_info2);
+        submit_helper.InjectSemaphore(*injected_semaphore_info);
     }
 }
 

--- a/framework/decode/vulkan_submit_job.h
+++ b/framework/decode/vulkan_submit_job.h
@@ -31,6 +31,7 @@
 #include "decode/vulkan_object_info.h"
 #include "graphics/vulkan_semaphore_util.h"
 #include "decode/common_object_info_table.h"
+#include "decode/vulkan_submit_info_helper.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -97,62 +98,7 @@ class VulkanSubmitJobPlan
     std::vector<VulkanSubmitJobs> submit_jobs_;
 };
 
-/**
- * @brief   Original wait semaphores stripped from a submit before injected jobs run.
- */
-struct VulkanSubmitSemaphores
-{
-    std::vector<graphics::VulkanSemaphore> semaphores;
-};
-
 class VulkanSubmitJobExecutor;
-
-/**
- * @brief   Executor-owned timeline semaphore used to order rewritten submit entries.
- *
- * `SerializeExecution()` creates one injected timeline semaphore for one `vkQueueSubmit()` call and reuses it for every
- * submit entry in that call. Each rewritten submit waits on the semaphore's current `target_value`, then signals the
- * next value. After all submits have been rewritten, `target_value` is the final value that must be reached before the
- * executor can safely destroy the semaphore.
- */
-class VulkanInjectedSemaphore
-{
-  private:
-    VkSemaphore handle_       = VK_NULL_HANDLE;
-    uint64_t    target_value_ = 0;
-
-    const VulkanDeviceInfo*            device_info_;
-    const graphics::VulkanDeviceTable* device_table_;
-
-  public:
-    bool        HasReachedTargetValue() const;
-    VkSemaphore GetHandle() const { return handle_; }
-    uint64_t    GetTargetValue() const { return target_value_; }
-    void        IncreaseTargetValue() { ++target_value_; }
-
-    VulkanInjectedSemaphore(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* table);
-    ~VulkanInjectedSemaphore();
-
-    VulkanInjectedSemaphore(const VulkanInjectedSemaphore&)            = delete;
-    VulkanInjectedSemaphore& operator=(const VulkanInjectedSemaphore&) = delete;
-
-    VulkanInjectedSemaphore(VulkanInjectedSemaphore&&);
-    VulkanInjectedSemaphore& operator=(VulkanInjectedSemaphore&&) noexcept;
-};
-
-/**
- * @brief   Executor-owned timeline semaphore plus VkSubmitInfo2-compatible submit info.
- *
- * `info.value` is updated alongside `VulkanInjectedSemaphore::target_value` while rewriting a `VkSubmitInfo2` array so
- * the same injected semaphore can be used for the wait and signal pair in each submit entry.
- */
-struct VulkanInjectedSemaphoreInfo
-{
-    VulkanInjectedSemaphore semaphore;
-    VkSemaphoreSubmitInfo   info = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
-
-    VulkanInjectedSemaphoreInfo(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* table);
-};
 
 /**
  * @brief   An execution for Vulkan submit jobs.
@@ -191,130 +137,6 @@ class VulkanSubmitJobExecution
     void InjectBefore(VulkanSubmitJobPlan plan, std::span<VkSubmitInfo2> submit_infos2);
 
     /**
-     * @brief   Access mutable wait-semaphore storage for one VkSubmitInfo.
-     *
-     * If executor-owned storage has not been created for this submit yet, the current wait semaphores from
-     * `submit_info` are copied into internal backing storage first.
-     *
-     * @param   submit_info      submit struct whose wait-semaphore storage should be accessed.
-     * @return  mutable vector owned by this executor and suitable for rewriting `submit_info` wait semaphores.
-     */
-    std::vector<VkSemaphore>& GetWaitSemaphores(VkSubmitInfo& submit_info);
-
-    /**
-     * @brief Append a timeline wait semaphore to one VkSubmitInfo.
-     */
-    void AddWaitSemaphore(VkSubmitInfo& submit_info, const VulkanInjectedSemaphore& semaphore);
-
-    /**
-     * @brief Append a timeline signal semaphore to one VkSubmitInfo.
-     */
-    void AddSignalSemaphore(VkSubmitInfo& submit_info, const VulkanInjectedSemaphore& semaphore);
-
-    /**
-     * @brief Append a timeline wait semaphore info to one VkSubmitInfo2.
-     */
-    void AddWaitSemaphore(VkSubmitInfo2& submit_info, const VulkanInjectedSemaphoreInfo& semaphore);
-
-    /**
-     * @brief Append a timeline signal semaphore info to one VkSubmitInfo2.
-     */
-    void AddSignalSemaphore(VkSubmitInfo2& submit_info, const VulkanInjectedSemaphoreInfo& semaphore);
-
-    /**
-     * @brief Access mutable signal-semaphore storage for a VkSubmitInfo.
-     *
-     * If executor-owned storage has not been created for this submit yet, the current signal semaphores from
-     * `submit_info` are copied into internal backing storage first.
-     *
-     * @param submit_info submit struct whose signal-semaphore storage should be accessed.
-     * @return mutable vector owned by this executor and suitable for rewriting `submit_info` signal semaphores.
-     */
-    std::vector<VkSemaphore>& GetSignalSemaphores(VkSubmitInfo& submit_info);
-
-    /**
-     * @brief Access mutable timeline signal-value storage for one VkSubmitInfo.
-     *
-     * If executor-owned storage has not been created for this submit yet, current signal values from
-     * `submit_info` are copied into internal backing storage first. If no timeline values exist, storage is initialized
-     * with zero values matching `signalSemaphoreCount` so counts remain aligned when a timeline signal is appended.
-     *
-     * @param submit_info submit struct whose signal-values storage should be accessed.
-     * @return mutable vector owned by this executor and suitable for rewriting `submit_info` signal values.
-     */
-    std::vector<uint64_t>& GetSignalValues(VkSubmitInfo& submit_info);
-
-    /**
-     * @brief   Access mutable wait-semaphore-info storage for one VkSubmitInfo2.
-     *
-     * If executor-owned storage has not been created for this submit yet, the current wait semaphore infos from
-     * `submit_info` are copied into internal backing storage first.
-     *
-     * @param   submit_info      submit struct whose wait-semaphore-info storage should be accessed.
-     * @return  mutable vector owned by this executor and suitable for rewriting `submit_info` wait semaphore infos.
-     */
-    std::vector<VkSemaphoreSubmitInfo>& GetWaitSemaphoreInfos(VkSubmitInfo2& submit_info);
-
-    /**
-     * @brief   Access mutable signal-semaphore-info storage for one VkSubmitInfo2.
-     *
-     * If executor-owned storage has not been created for this submit yet, the current signal semaphore infos from
-     * `submit_info` are copied into internal backing storage first.
-     *
-     * @param   submit_info      submit struct whose signal-semaphore-info storage should be accessed.
-     * @return  mutable vector owned by this executor and suitable for rewriting `submit_info` signal semaphore infos.
-     */
-    std::vector<VkSemaphoreSubmitInfo>& GetSignalSemaphoreInfos(VkSubmitInfo2& submit_info);
-
-    /**
-     * @brief  Access mutable wait dst stage mask storage for one VkSubmitInfo.
-     *
-     * If executor-owned storage has not been created for this submit yet, the current wait dst stage masks from
-     * `submit_info` are copied into internal backing storage first.
-     *
-     * @param   submit_info      submit struct whose wait dst stage masks should be accessed.
-     * @return  mutable vector owned by this executor and suitable for rewriting `submit_info` wait dst stage masks.
-     */
-    std::vector<VkPipelineStageFlags>& GetWaitDstStageMasks(VkSubmitInfo& submit_info);
-
-    /**
-     * @brief Access mutable timeline semaphore value storage for one VkSubmitInfo.
-     *
-     * If executor-owned storage has not been created for this submit yet, current wait values from `submit_info` are
-     * copied into internal backing storage first. If no timeline values exist, storage is initialized with zero values
-     * matching `waitSemaphoreCount` so counts remain aligned when a timeline wait is appended.
-     *
-     * @param  submit_info      submit struct whose timeline semaphore value storage should be accessed.
-     * @return mutable vector owned by this executor and suitable for rewriting `submit_info` timeline semaphore values.
-     */
-    std::vector<uint64_t>& GetWaitValues(VkSubmitInfo& submit_info);
-
-    /**
-     * @brief   Access mutable timeline semaphore submit info for one VkSubmitInfo.
-     *
-     * If executor-owned storage has not been created for this submit yet, an existing `VkTimelineSemaphoreSubmitInfo`
-     * is copied from the pNext chain or a new one is created and inserted into the chain.
-     *
-     * @param   submit_info      submit struct whose timeline semaphore submit info should be accessed.
-     * @return  mutable timeline semaphore submit info owned by this executor and suitable for rewriting `submit_info`.
-     */
-    VkTimelineSemaphoreSubmitInfo& GetTimelineSemaphoreSubmitInfo(VkSubmitInfo& submit_info);
-
-    /**
-     * @brief Append one timeline wait/signal pair to a VkSubmitInfo and advance the target value.
-     *
-     * The submit waits on `semaphore.target_value`, then signals `semaphore.target_value + 1`.
-     */
-    void InjectSemaphore(VkSubmitInfo& submit_info, VulkanInjectedSemaphore& semaphore);
-
-    /**
-     * @brief Append one timeline wait/signal pair to a VkSubmitInfo2 and advance the target value.
-     *
-     * The submit waits on `semaphore_info.info.value`, then signals `semaphore_info.info.value + 1`.
-     */
-    void InjectSemaphore(VkSubmitInfo2& submit_info, VulkanInjectedSemaphoreInfo& semaphore_info);
-
-    /**
      * @brief  SerializeExecution submit entries within one queue-submit call.
      *
      * Mutates the provided submit array to serialize execution order within one `vkQueueSubmit()` call. One injected
@@ -348,34 +170,16 @@ class VulkanSubmitJobExecution
      */
     void SubmitStandalone(VulkanSubmitJobPlan plan) const;
 
+    VulkanSubmitInfoHelper&  GetSubmitInfoHelper(VkSubmitInfo& submit_info);
+    VulkanSubmitInfo2Helper& GetSubmitInfo2Helper(VkSubmitInfo2& submit_info2);
+
     VulkanSubmitJobExecutor& executor_;
 
     /// Original waits stripped from each submit before injection, keyed by either `VkSubmitInfo*` or `VkSubmitInfo2*`.
     std::unordered_map<void*, VulkanSubmitSemaphores> original_wait_semaphores_;
 
-    /// Injected waits for VkSubmitInfo (binary semaphore handles), keyed by `VkSubmitInfo*`.
-    std::unordered_map<VkSubmitInfo*, std::vector<VkSemaphore>> injected_wait_semaphores_;
-
-    /// Signal semaphores of a VkSubmitInfo, keyed by `VkSubmitInfo*`.
-    std::unordered_map<VkSubmitInfo*, std::vector<VkSemaphore>> injected_signal_semaphores_;
-
-    /// Injected timeline signal semaphore values, keyed by `VkSubmitInfo*`.
-    std::unordered_map<VkSubmitInfo*, std::vector<uint64_t>> injected_signal_semaphore_values_;
-
-    /// Injected timeline wait semaphore values, keyed by `VkSubmitInfo*`.
-    std::unordered_map<VkSubmitInfo*, std::vector<uint64_t>> injected_wait_semaphore_values_;
-
-    /// Injected `VkTimelineSemaphoreSubmitInfo` keyed by `VkSubmitInfo*`.
-    std::unordered_map<VkSubmitInfo*, VkTimelineSemaphoreSubmitInfo> injected_timeline_semaphore_infos_;
-
-    /// Injected wait dst stage masks, keyed by `VkSubmitInfo*`.
-    std::unordered_map<VkSubmitInfo*, std::vector<VkPipelineStageFlags>> injected_wait_dst_stage_masks_;
-
-    /// Injected waits for VkSubmitInfo2 (binary or timeline semaphore submit infos), keyed by `VkSubmitInfo2*`.
-    std::unordered_map<VkSubmitInfo2*, std::vector<VkSemaphoreSubmitInfo>> injected_wait_semaphore_infos_;
-
-    /// Injected signals for VkSubmitInfo2 (binary or timeline semaphore submit infos), keyed by `VkSubmitInfo2*`.
-    std::unordered_map<VkSubmitInfo2*, std::vector<VkSemaphoreSubmitInfo>> injected_signal_semaphore_infos_;
+    std::unordered_map<VkSubmitInfo*, std::unique_ptr<VulkanSubmitInfoHelper>>   submit_info_helpers_;
+    std::unordered_map<VkSubmitInfo2*, std::unique_ptr<VulkanSubmitInfo2Helper>> submit_info2_helpers_;
 };
 
 /**


### PR DESCRIPTION
Move the per-submit semaphore backing storage out of `VulkanSubmitJobExecution` into dedicated `VulkanSubmitInfoHelper` and `VulkanSubmitInfo2Helper` classes. The executor now keeps one helper per submit instead of several parallel maps keyed by submit pointer.