### PR TITLE
VDR: Handle vkQueueSubmit2[KHR]

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4536,6 +4536,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
 }
 
 VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2                           func,
+                                                        uint64_t                                     index,
                                                         VkResult                                     original_result,
                                                         const VulkanQueueInfo*                       queue_info,
                                                         uint32_t                                     submitCount,
@@ -4719,8 +4720,17 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
         current_submits_span = std::span(modified_submit_infos.data(), modified_submit_infos.size());
     }
 
-    result = func(
-        queue_info->handle, static_cast<uint32_t>(current_submits_span.size()), current_submits_span.data(), fence);
+    if (options_.dumping_resources && resource_dumper_->MustDumpQueueSubmitIndex(index))
+    {
+        auto* device_table = GetDeviceTable(queue_info->handle);
+        GFXRECON_ASSERT(device_table != nullptr);
+        resource_dumper_->QueueSubmit2(current_submits_span, *device_table, queue_info, fence, index);
+    }
+    else
+    {
+        result = func(
+            queue_info->handle, static_cast<uint32_t>(current_submits_span.size()), current_submits_span.data(), fence);
+    }
 
     // The result to report to the event sink might be different from the
     // result of the actual QueueSubmit call if synchronization is enabled.

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -710,6 +710,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                  const VulkanFenceInfo*                      fence_info);
 
     VkResult OverrideQueueSubmit2(PFN_vkQueueSubmit2                           func,
+                                  uint64_t                                     index,
                                   VkResult                                     original_result,
                                   const VulkanQueueInfo*                       queue_info,
                                   uint32_t                                     submitCount,

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -1847,9 +1847,72 @@ void VulkanReplayDumpResourcesBase::OverrideCmdEndRenderingKHR(const ApiCallInfo
 
 VkResult VulkanReplayDumpResourcesBase::QueueSubmit(std::span<const VkSubmitInfo>      submit_infos,
                                                     const graphics::VulkanDeviceTable& device_table,
-                                                    const VulkanQueueInfo*             queue_info,
+                                                    const VulkanQueueInfo*             queue,
                                                     VkFence                            fence,
-                                                    uint64_t                           qs_index)
+                                                    uint64_t                           index)
+{
+    // Losslessly widen each VkSubmitInfo into a VkSubmitInfo2 and forward to the canonical QueueSubmit2 implementation.
+    std::vector<VkSubmitInfo2>                          submit_infos_2(submit_infos.size());
+    std::vector<std::vector<VkSemaphoreSubmitInfo>>     wait_semaphores(submit_infos.size());
+    std::vector<std::vector<VkCommandBufferSubmitInfo>> command_buffers(submit_infos.size());
+    std::vector<std::vector<VkSemaphoreSubmitInfo>>     signal_semaphores(submit_infos.size());
+
+    for (size_t i = 0; i < submit_infos.size(); ++i)
+    {
+        const VkSubmitInfo& submit_info = submit_infos[i];
+
+        // Wait semaphores. The per-semaphore wait stage moves from pWaitDstStageMask into VkSemaphoreSubmitInfo.
+        wait_semaphores[i].resize(submit_info.waitSemaphoreCount);
+        for (uint32_t j = 0; j < submit_info.waitSemaphoreCount; ++j)
+        {
+            wait_semaphores[i][j] = VkSemaphoreSubmitInfo{
+                VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
+                nullptr,
+                submit_info.pWaitSemaphores[j],
+                0, // value (binary semaphore; timeline values via VkTimelineSemaphoreSubmitInfo are not translated)
+                submit_info.pWaitDstStageMask ? static_cast<VkPipelineStageFlags2>(submit_info.pWaitDstStageMask[j])
+                                              : VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
+                0
+            };
+        }
+
+        // Command buffers
+        command_buffers[i].resize(submit_info.commandBufferCount);
+        for (uint32_t j = 0; j < submit_info.commandBufferCount; ++j)
+        {
+            command_buffers[i][j] = VkCommandBufferSubmitInfo{
+                VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO, nullptr, submit_info.pCommandBuffers[j], 0
+            };
+        }
+
+        // Signal semaphores. A VkSubmitInfo signals once all submitted work completes, i.e. at ALL_COMMANDS.
+        signal_semaphores[i].resize(submit_info.signalSemaphoreCount);
+        for (uint32_t j = 0; j < submit_info.signalSemaphoreCount; ++j)
+        {
+            signal_semaphores[i][j] = VkSemaphoreSubmitInfo{ VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO, nullptr,
+                                                             submit_info.pSignalSemaphores[j],        0,
+                                                             VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,    0 };
+        }
+
+        submit_infos_2[i] = VkSubmitInfo2{ VK_STRUCTURE_TYPE_SUBMIT_INFO_2,
+                                           submit_info.pNext,
+                                           0,
+                                           static_cast<uint32_t>(wait_semaphores[i].size()),
+                                           wait_semaphores[i].size() ? wait_semaphores[i].data() : nullptr,
+                                           static_cast<uint32_t>(command_buffers[i].size()),
+                                           command_buffers[i].size() ? command_buffers[i].data() : nullptr,
+                                           static_cast<uint32_t>(signal_semaphores[i].size()),
+                                           signal_semaphores[i].size() ? signal_semaphores[i].data() : nullptr };
+    }
+
+    return QueueSubmit2(submit_infos_2, device_table, queue, fence, index);
+}
+
+VkResult VulkanReplayDumpResourcesBase::QueueSubmit2(std::span<const VkSubmitInfo2>     submit_infos,
+                                                     const graphics::VulkanDeviceTable& device_table,
+                                                     const VulkanQueueInfo*             queue_info,
+                                                     VkFence                            fence,
+                                                     uint64_t                           qs_index)
 {
 #define CHECK_VK_ERROR(_res_, _func_)                                                                               \
     if (_res_ != VK_SUCCESS)                                                                                        \
@@ -1870,25 +1933,26 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(std::span<const VkSubmitInfo
     const size_t submit_count = submit_infos.size();
     for (size_t si = 0; si < submit_count; ++si)
     {
-        std::vector<VkCommandBuffer> submit_cbs;
-        VkResult                     res = VK_SUCCESS;
+        std::vector<VkCommandBufferSubmitInfo> submit_cbs;
+        VkResult                               res = VK_SUCCESS;
 
-        // For each VkSubmitInfo we shall create a different fence. The provided fence will be used only in the last
-        // VkSubmitInfo. If none is provided then we will create one.
+        // For each VkSubmitInfo2 we shall create a different fence. The provided fence will be used only in the last
+        // VkSubmitInfo2. If none is provided then we will create one.
         const bool     last_submit_info  = (si == submit_count - 1);
         const bool     create_temp_fence = (!last_submit_info) || (last_submit_info && (fence == VK_NULL_HANDLE));
         TemporaryFence submission_fence(create_temp_fence ? VK_NULL_HANDLE : fence, queue_info->parent, device_table);
 
-        VkSubmitInfo modified_submit_info = submit_infos[si];
-        for (uint32_t cb = 0; cb < submit_infos[si].commandBufferCount; ++cb)
+        VkSubmitInfo2 modified_submit_info = submit_infos[si];
+        for (uint32_t cb = 0; cb < submit_infos[si].commandBufferInfoCount; ++cb)
         {
-            const bool            last_cmd_buf   = (cb == submit_infos[si].commandBufferCount - 1);
-            const VkCommandBuffer command_buffer = submit_infos[si].pCommandBuffers[cb];
+            const bool            last_cmd_buf   = (cb == submit_infos[si].commandBufferInfoCount - 1);
+            const VkCommandBuffer command_buffer = submit_infos[si].pCommandBufferInfos[cb].commandBuffer;
 
             // The command_buffer (primary) is not marked for dumping
             if (cb_bcb_map_.find(command_buffer) == cb_bcb_map_.end())
             {
-                submit_cbs.push_back(command_buffer);
+                submit_cbs.push_back(VkCommandBufferSubmitInfo{
+                    VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO, nullptr, command_buffer, 0 });
 
                 // Look for transfer contexts from secondaries. This case can happen when command_buffer is a primary
                 // which is not marked for dumping but contains vkCmdExecuteCommands with secondaries that are marked to
@@ -1913,7 +1977,8 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(std::span<const VkSubmitInfo
                     {
                         transfer_contexts.emplace(std::make_pair(static_cast<Index>(si), static_cast<Index>(cb)),
                                                   transf_context);
-                        submit_cbs.push_back(command_buffer);
+                        submit_cbs.push_back(VkCommandBufferSubmitInfo{
+                            VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO, nullptr, command_buffer, 0 });
                         has_transfer_or_dispatch = true;
                     }
                 }
@@ -1925,7 +1990,10 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(std::span<const VkSubmitInfo
                                               dispatch_context);
                     // Dispatch/RayTracing context uses a clone command buffer. We submit that one instead of the
                     // original.
-                    submit_cbs.push_back(dispatch_context->GetDispatchRaysCommandBuffer());
+                    submit_cbs.push_back(VkCommandBufferSubmitInfo{ VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO,
+                                                                    nullptr,
+                                                                    dispatch_context->GetDispatchRaysCommandBuffer(),
+                                                                    0 });
                     has_transfer_or_dispatch = true;
                 }
 
@@ -1935,10 +2003,10 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(std::span<const VkSubmitInfo
                     // Submit previous command buffers from this VkSubmitInfo before dumping draw calls
                     if (!submit_cbs.empty())
                     {
-                        modified_submit_info.commandBufferCount = static_cast<uint32_t>(submit_cbs.size());
-                        modified_submit_info.pCommandBuffers    = submit_cbs.data();
-                        res                                     = device_table.QueueSubmit(
-                            queue_info->handle, 1, &modified_submit_info, submission_fence.handle);
+                        modified_submit_info.commandBufferInfoCount = static_cast<uint32_t>(submit_cbs.size());
+                        modified_submit_info.pCommandBufferInfos    = submit_cbs.data();
+                        res                                         = SubmitInfo2OnQueue(
+                            device_table, queue_info->handle, modified_submit_info, submission_fence.handle);
                         CHECK_VK_ERROR(res, "QueueSubmit")
 
                         // The fence might be reused. Wait and reset
@@ -1955,10 +2023,10 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(std::span<const VkSubmitInfo
                         }
 
                         // The semaphores have been used up by the submission. Don't use them again.
-                        modified_submit_info.waitSemaphoreCount   = 0;
-                        modified_submit_info.pWaitSemaphores      = nullptr;
-                        modified_submit_info.signalSemaphoreCount = 0;
-                        modified_submit_info.pSignalSemaphores    = nullptr;
+                        modified_submit_info.waitSemaphoreInfoCount   = 0;
+                        modified_submit_info.pWaitSemaphoreInfos      = nullptr;
+                        modified_submit_info.signalSemaphoreInfoCount = 0;
+                        modified_submit_info.pSignalSemaphoreInfos    = nullptr;
                         submit_cbs.clear();
                     }
 
@@ -1967,17 +2035,18 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(std::span<const VkSubmitInfo
                     CHECK_VK_ERROR(res, "DumpDrawCalls")
 
                     // The semaphores have been used up by the submission. Don't use them again.
-                    modified_submit_info.waitSemaphoreCount   = 0;
-                    modified_submit_info.pWaitSemaphores      = nullptr;
-                    modified_submit_info.signalSemaphoreCount = 0;
-                    modified_submit_info.pSignalSemaphores    = nullptr;
+                    modified_submit_info.waitSemaphoreInfoCount   = 0;
+                    modified_submit_info.pWaitSemaphoreInfos      = nullptr;
+                    modified_submit_info.signalSemaphoreInfoCount = 0;
+                    modified_submit_info.pSignalSemaphoreInfos    = nullptr;
 
                     // Insert original command buffer in the vector for submission. If has_transfer_or_dispatch is true
                     // then the command buffer has already been submitted
                     if (!has_transfer_or_dispatch)
                     {
                         GFXRECON_ASSERT(submit_cbs.empty());
-                        submit_cbs.push_back(command_buffer);
+                        submit_cbs.push_back(VkCommandBufferSubmitInfo{
+                            VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO, nullptr, command_buffer, 0 });
                     }
                 }
             }
@@ -1985,9 +2054,9 @@ VkResult VulkanReplayDumpResourcesBase::QueueSubmit(std::span<const VkSubmitInfo
 
         if (!submit_cbs.empty())
         {
-            modified_submit_info.commandBufferCount = static_cast<uint32_t>(submit_cbs.size());
-            modified_submit_info.pCommandBuffers    = submit_cbs.data();
-            res = device_table.QueueSubmit(queue_info->handle, 1, &modified_submit_info, submission_fence.handle);
+            modified_submit_info.commandBufferInfoCount = static_cast<uint32_t>(submit_cbs.size());
+            modified_submit_info.pCommandBufferInfos    = submit_cbs.data();
+            res = SubmitInfo2OnQueue(device_table, queue_info->handle, modified_submit_info, submission_fence.handle);
             CHECK_VK_ERROR(res, "QueueSubmit")
 
             res = submission_fence.Wait();

--- a/framework/decode/vulkan_replay_dump_resources.h
+++ b/framework/decode/vulkan_replay_dump_resources.h
@@ -517,6 +517,12 @@ class VulkanReplayDumpResourcesBase
                          VkFence                            fence,
                          uint64_t                           index);
 
+    VkResult QueueSubmit2(std::span<const VkSubmitInfo2>     submit_infos_2,
+                          const graphics::VulkanDeviceTable& device_table,
+                          const VulkanQueueInfo*             queue,
+                          VkFence                            fence,
+                          uint64_t                           index);
+
     bool MustDumpQueueSubmitIndex(uint64_t index) const;
 
     bool IsRecording() const { return active_contexts_; }

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -2121,5 +2121,57 @@ void CopyBufferAndBarrier(VkCommandBuffer                    command_buffer,
                                     nullptr);
 }
 
+VkResult SubmitInfo2OnQueue(const graphics::VulkanDeviceTable& device_table,
+                            VkQueue                            queue,
+                            const VkSubmitInfo2&               submit_info_2,
+                            VkFence                            fence)
+{
+    // Check if the implementation supports either vkQueueSubmit2 (Vulkan 1.3) or vkQueueSubmit2KHR
+    // (VK_KHR_synchronization2). In either case submit directly without converting
+    if (device_table.QueueSubmit2 != graphics::noop::vkQueueSubmit2)
+    {
+        return device_table.QueueSubmit2(queue, 1, &submit_info_2, fence);
+    }
+    else if (device_table.QueueSubmit2KHR != graphics::noop::vkQueueSubmit2KHR)
+    {
+        return device_table.QueueSubmit2KHR(queue, 1, &submit_info_2, fence);
+    }
+
+    // Otherwise fall back to vkQueueSubmit. The per-semaphore stage masks are only meaningful for queue-side
+    // synchronization, which is irrelevant here because the dump-resources submits are serialized with host fence
+    // waits.
+    std::vector<VkSemaphore>          wait_semaphores(submit_info_2.waitSemaphoreInfoCount);
+    std::vector<VkPipelineStageFlags> wait_stage_masks(submit_info_2.waitSemaphoreInfoCount);
+    for (uint32_t i = 0; i < submit_info_2.waitSemaphoreInfoCount; ++i)
+    {
+        wait_semaphores[i]  = submit_info_2.pWaitSemaphoreInfos[i].semaphore;
+        wait_stage_masks[i] = static_cast<VkPipelineStageFlags>(submit_info_2.pWaitSemaphoreInfos[i].stageMask);
+    }
+
+    std::vector<VkCommandBuffer> command_buffers(submit_info_2.commandBufferInfoCount);
+    for (uint32_t i = 0; i < submit_info_2.commandBufferInfoCount; ++i)
+    {
+        command_buffers[i] = submit_info_2.pCommandBufferInfos[i].commandBuffer;
+    }
+
+    std::vector<VkSemaphore> signal_semaphores(submit_info_2.signalSemaphoreInfoCount);
+    for (uint32_t i = 0; i < submit_info_2.signalSemaphoreInfoCount; ++i)
+    {
+        signal_semaphores[i] = submit_info_2.pSignalSemaphoreInfos[i].semaphore;
+    }
+
+    const VkSubmitInfo submit_info{ VK_STRUCTURE_TYPE_SUBMIT_INFO,
+                                    submit_info_2.pNext,
+                                    submit_info_2.waitSemaphoreInfoCount,
+                                    submit_info_2.waitSemaphoreInfoCount ? wait_semaphores.data() : nullptr,
+                                    submit_info_2.waitSemaphoreInfoCount ? wait_stage_masks.data() : nullptr,
+                                    submit_info_2.commandBufferInfoCount,
+                                    submit_info_2.commandBufferInfoCount ? command_buffers.data() : nullptr,
+                                    submit_info_2.signalSemaphoreInfoCount,
+                                    submit_info_2.signalSemaphoreInfoCount ? signal_semaphores.data() : nullptr };
+
+    return device_table.QueueSubmit(queue, 1, &submit_info, fence);
+}
+
 GFXRECON_END_NAMESPACE(gfxrecon)
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_dump_resources_common.h
+++ b/framework/decode/vulkan_replay_dump_resources_common.h
@@ -159,6 +159,15 @@ void ShaderStageFlagsToStageNames(VkShaderStageFlags flags, std::vector<std::str
 
 std::vector<VkPipelineBindPoint> ShaderStageFlagsToPipelineBindPoints(VkShaderStageFlags flags);
 
+// Submit a single VkSubmitInfo2 to the queue using vkQueueSubmit2 when it is available. On devices that do not support
+// synchronization2, the submit info is converted into a VkSubmitInfo and submitted via vkQueueSubmit. The
+// dump-resources submissions are serialized with host fence waits, so the wait-stage masks lost during down-conversion
+// do not affect correctness.
+VkResult SubmitInfo2OnQueue(const graphics::VulkanDeviceTable& device_table,
+                            VkQueue                            queue,
+                            const VkSubmitInfo2&               submit_info_2,
+                            VkFence                            fence);
+
 // Inject a CmdCopyBuffer(command_buffer, src, dst, regions.count(), regions.size()) into the provided command buffer
 // followed by the appropriate pipeline barrier
 void CopyBufferAndBarrier(VkCommandBuffer                    command_buffer,

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -1144,10 +1144,10 @@ bool DrawCallsDumpingContext::ShouldHandleExecuteCommands(uint64_t index) const
     return secondaries_.find(index) != secondaries_.end();
 }
 
-VkResult DrawCallsDumpingContext::DumpDrawCalls(VkQueue             queue,
-                                                const VkSubmitInfo& submit_info,
-                                                Index               submit_info_index,
-                                                Index               submit_info_cmd_buf_index)
+VkResult DrawCallsDumpingContext::DumpDrawCalls(VkQueue              queue,
+                                                const VkSubmitInfo2& submit_info,
+                                                Index                submit_info_index,
+                                                Index                submit_info_cmd_buf_index)
 {
     const size_t n_drawcalls = command_buffers_.size();
 
@@ -1159,18 +1159,24 @@ VkResult DrawCallsDumpingContext::DumpDrawCalls(VkQueue             queue,
     // Dump render targets
     for (size_t cb = 0; cb < n_drawcalls; ++cb)
     {
-        VkSubmitInfo si;
-        si.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-        si.pNext                = submit_info.pNext;
-        si.waitSemaphoreCount   = !cb ? submit_info.waitSemaphoreCount : 0;
-        si.pWaitSemaphores      = !cb ? submit_info.pWaitSemaphores : nullptr;
-        si.pWaitDstStageMask    = !cb ? submit_info.pWaitDstStageMask : nullptr;
-        si.commandBufferCount   = 1;
-        si.pCommandBuffers      = &command_buffers_[cb];
-        si.signalSemaphoreCount = (cb == (n_drawcalls - 1)) ? submit_info.signalSemaphoreCount : 0;
-        si.pSignalSemaphores    = (cb == (n_drawcalls - 1)) ? submit_info.pSignalSemaphores : nullptr;
+        const VkCommandBufferSubmitInfo cb_info{
+            VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO, nullptr, command_buffers_[cb], 0 /* deviceMask */
+        };
 
-        VkResult res = device_table_->QueueSubmit(queue, 1, &si, submission_fence.handle);
+        // Forward the original submit's wait semaphores only on the first clone and its signal semaphores only on the
+        // last clone, so the application-visible synchronization is preserved across the split submissions.
+        VkSubmitInfo2 si{};
+        si.sType                    = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
+        si.pNext                    = submit_info.pNext;
+        si.flags                    = submit_info.flags;
+        si.waitSemaphoreInfoCount   = !cb ? submit_info.waitSemaphoreInfoCount : 0;
+        si.pWaitSemaphoreInfos      = !cb ? submit_info.pWaitSemaphoreInfos : nullptr;
+        si.commandBufferInfoCount   = 1;
+        si.pCommandBufferInfos      = &cb_info;
+        si.signalSemaphoreInfoCount = (cb == (n_drawcalls - 1)) ? submit_info.signalSemaphoreInfoCount : 0;
+        si.pSignalSemaphoreInfos    = (cb == (n_drawcalls - 1)) ? submit_info.pSignalSemaphoreInfos : nullptr;
+
+        VkResult res = SubmitInfo2OnQueue(*device_table_, queue, si, submission_fence.handle);
         if (res != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR(

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.h
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.h
@@ -205,10 +205,10 @@ class DrawCallsDumpingContext
 
     uint32_t GetDrawCallActiveCommandBuffers(CommandBufferIterator& first, CommandBufferIterator& last) const;
 
-    VkResult DumpDrawCalls(VkQueue             queue,
-                           const VkSubmitInfo& submit_info,
-                           Index               submit_info_index,
-                           Index               submit_info_cmd_buf_index);
+    VkResult DumpDrawCalls(VkQueue              queue,
+                           const VkSubmitInfo2& submit_info,
+                           Index                submit_info_index,
+                           Index                submit_info_cmd_buf_index);
 
     VkResult DumpRenderTargetAttachments(uint64_t                  cmd_buf_index,
                                          DrawCallParams&           dc_params,

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -3158,7 +3158,7 @@ void VulkanReplayConsumer::Process_vkQueueSubmit2(
     MapStructArrayHandles(pSubmits->GetMetaStructPointer(), pSubmits->GetLength(), GetObjectInfoTable());
     auto in_fence = GetObjectInfoTable().GetVkFenceInfo(fence);
 
-    VkResult replay_result = OverrideQueueSubmit2(GetDeviceTable(in_queue->handle)->QueueSubmit2, returnValue, in_queue, submitCount, pSubmits, in_fence);
+    VkResult replay_result = OverrideQueueSubmit2(GetDeviceTable(in_queue->handle)->QueueSubmit2, call_info.index, returnValue, in_queue, submitCount, pSubmits, in_fence);
     CheckResult("vkQueueSubmit2", returnValue, replay_result, call_info);
 }
 
@@ -6260,7 +6260,7 @@ void VulkanReplayConsumer::Process_vkQueueSubmit2KHR(
     MapStructArrayHandles(pSubmits->GetMetaStructPointer(), pSubmits->GetLength(), GetObjectInfoTable());
     auto in_fence = GetObjectInfoTable().GetVkFenceInfo(fence);
 
-    VkResult replay_result = OverrideQueueSubmit2(GetDeviceTable(in_queue->handle)->QueueSubmit2KHR, returnValue, in_queue, submitCount, pSubmits, in_fence);
+    VkResult replay_result = OverrideQueueSubmit2(GetDeviceTable(in_queue->handle)->QueueSubmit2KHR, call_info.index, returnValue, in_queue, submitCount, pSubmits, in_fence);
     CheckResult("vkQueueSubmit2KHR", returnValue, replay_result, call_info);
 }
 

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -194,7 +194,7 @@ class VulkanReplayConsumerBodyGenerator(
         """Method override."""
         # Override functions receive the decoded return value in addition to parameters.
         call_expr = ''
-        if name not in ['vkQueueSubmit', 'vkBeginCommandBuffer']:
+        if name not in ['vkQueueSubmit', 'vkQueueSubmit2', 'vkQueueSubmit2KHR', 'vkBeginCommandBuffer']:
             call_expr = '{}({}, returnValue, {})'.format(
                 self.REPLAY_OVERRIDES[name], dispatch_func, arg_list
             )


### PR DESCRIPTION
vkQueueSubmit2[KHR] calls were not being handled when dumping resources and as a result no resources were dumped at all from these queue submissions