### PR TITLE
Vdr fix pipeline barriers

### DIFF
--- a/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_compute_ray_tracing.cpp
@@ -548,25 +548,13 @@ void DispatchTraceRaysDumpingContext::CopyImageResource(const VulkanImageInfo* s
     assert(src_image_info != nullptr);
     assert(dst_image != VK_NULL_HANDLE);
 
-    VkImageLayout old_layout;
-    assert(original_command_buffer_info_ != nullptr);
-    const auto img_layout_entry = original_command_buffer_info_->image_layout_barriers.find(src_image_info->capture_id);
-    if (img_layout_entry != original_command_buffer_info_->image_layout_barriers.end())
-    {
-        old_layout = img_layout_entry->second;
-    }
-    else
-    {
-        old_layout = VK_IMAGE_LAYOUT_GENERAL;
-    }
-
     // Make sure any potential writes are complete and transition image to TRANSFER_SRC_OPTIMAL layout
     VkImageMemoryBarrier img_barrier;
     img_barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
     img_barrier.pNext               = nullptr;
     img_barrier.srcAccessMask       = VK_ACCESS_MEMORY_WRITE_BIT;
     img_barrier.dstAccessMask       = VK_ACCESS_TRANSFER_READ_BIT;
-    img_barrier.oldLayout           = old_layout;
+    img_barrier.oldLayout           = src_image_info->intermediate_layout;
     img_barrier.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     img_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     img_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -641,13 +629,29 @@ void DispatchTraceRaysDumpingContext::CopyImageResource(const VulkanImageInfo* s
                                 GFXRECON_NARROWING_CAST(uint32_t, copies.size()),
                                 copies.data());
 
-    // Wait for transfer and transition source image back to previous layout
+    // Wait for transfer and prepare image layout for dumping
+    img_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    img_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+    img_barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    img_barrier.newLayout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    img_barrier.image         = dst_image;
+    device_table_->CmdPipelineBarrier(DR_command_buffer_,
+                                      VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                      VkDependencyFlags(0),
+                                      0,
+                                      nullptr,
+                                      0,
+                                      nullptr,
+                                      1,
+                                      &img_barrier);
+
+    // Revert source image layout
     img_barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
     img_barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
     img_barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-    img_barrier.newLayout     = old_layout;
+    img_barrier.newLayout     = src_image_info->intermediate_layout;
     img_barrier.image         = src_image_info->handle;
-
     device_table_->CmdPipelineBarrier(DR_command_buffer_,
                                       VK_PIPELINE_STAGE_TRANSFER_BIT,
                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -1084,6 +1084,44 @@ void DrawCallsDumpingContext::FinalizeCommandBuffer(DrawCallsDumpingContext::Dra
                     cat->intermediate_layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
                 }
             }
+
+            // Transition the depth attachment as well, so that it matches the layout assumed when it is dumped and
+            // reverted. Gated on dump_resources_dump_depth to mirror DumpRenderTargetAttachments/RevertRenderTargetImageLayouts.
+            if (options_.dump_resources_dump_depth && rt.depth_att_img != nullptr &&
+                rt.depth_att_img->intermediate_layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
+            {
+                VulkanImageInfo* depth = rt.depth_att_img;
+
+                VkImageMemoryBarrier barrier;
+                barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                barrier.pNext               = nullptr;
+                barrier.srcAccessMask       = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+                barrier.dstAccessMask       = VK_ACCESS_TRANSFER_READ_BIT;
+                barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barrier.oldLayout           = depth->intermediate_layout;
+                barrier.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                barrier.image               = depth->handle;
+                barrier.subresourceRange    = { graphics::GetFormatAspects(depth->format),
+                                                0,
+                                                VK_REMAINING_MIP_LEVELS,
+                                                0,
+                                                VK_REMAINING_ARRAY_LAYERS };
+
+                device_table_->CmdPipelineBarrier(current_command_buffer,
+                                                  VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                                                      VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                                                  VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                                  0,
+                                                  0,
+                                                  nullptr,
+                                                  0,
+                                                  nullptr,
+                                                  1,
+                                                  &barrier);
+
+                depth->intermediate_layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            }
         }
     }
 
@@ -1367,7 +1405,7 @@ VkResult DrawCallsDumpingContext::RevertRenderTargetImageLayouts(VkQueue queue, 
         img_barrier.image         = image_info->handle;
         img_barriers.push_back(img_barrier);
 
-        image_info->intermediate_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        image_info->intermediate_layout = entry->second.color_attachment_layouts[i];
     }
 
     if (options_.dump_resources_dump_depth && render_targets_[rp][sp].depth_att_img != nullptr)
@@ -1381,14 +1419,18 @@ VkResult DrawCallsDumpingContext::RevertRenderTargetImageLayouts(VkQueue queue, 
         img_barrier.image         = image_info->handle;
         img_barriers.push_back(img_barrier);
 
-        image_info->intermediate_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        image_info->intermediate_layout = entry->second.depth_attachment_layout;
     }
 
     if (!img_barriers.empty())
     {
+        // The destination scope must cover both color-output (color attachments) and the depth/stencil fragment-test
+        // stages (depth attachment), since img_barriers may contain barriers of either kind.
         device_table_->CmdPipelineBarrier(aux_command_buffer_,
                                           VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                          VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                          VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                                              VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                                              VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
                                           0,
                                           0,
                                           nullptr,

--- a/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_draw_calls.cpp
@@ -1722,7 +1722,7 @@ VkResult DrawCallsDumpingContext::DumpDescriptors(uint64_t                  cmd_
                         auto& image_raw_data = std::get<VulkanDelegateImageDumpedData>(res_info.dumped_data);
 
                         VkResult res = DumpImage(new_dumped_image,
-                                                 VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                                 image_info->intermediate_layout,
                                                  options_.dump_resources_scale,
                                                  options_.dump_resources_dump_raw_images,
                                                  img_subres_range,


### PR DESCRIPTION
VDR: Fixing two pipeline barriers
DrawCallsDumpingContext::DumpDescriptors was making the assumption that
image descriptor are in VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL which is
not correct.

Similar fix in DispatchTraceRaysDumpingContext::CopyImageResource and
also add a barrier to flush the CopyImage

Fixes in layout transitions for dynamic rendering