### PR TITLE
Silenve MSVC warning

### DIFF
--- a/framework/util/page_status_tracker.h
+++ b/framework/util/page_status_tracker.h
@@ -51,7 +51,7 @@ class PageStatusTracker
     void SetActiveWriteBlock(size_t index, bool value) { active_writes_[index] = value ? 1 : 0; }
     void SetActiveReadBlock(size_t index, bool value) { active_reads_[index] = value ? 1 : 0; }
 
-    void SetAllBlocksActiveWrite() { std::fill(active_writes_.begin(), active_writes_.end(), 1); }
+    void SetAllBlocksActiveWrite() { std::fill(active_writes_.begin(), active_writes_.end(), static_cast<uint8_t>(1)); }
 
     const PageStatus& GetActiveWrites() const { return active_writes_; }
 


### PR DESCRIPTION
MSVC emits a warning when building gfxr-consumer-library because PageStatusTracker::SetAllBlocksActiveWrite() calls std::fill with the integer literal 1, which gets deduced as int and then narrowed to the vector's element type uint8_t.