### PR TITLE
replay: Move screenshot option reading

### DIFF
--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -76,7 +76,6 @@ struct ReplayOptions
     uint32_t                     screenshot_interval{ 1 };
     std::string                  screenshot_dir;
     std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
-    uint32_t                     screenshot_width, screenshot_height;
     bool                         screenshot_ignore_frameBoundaryAndroid{ false };
     int32_t                      num_pipeline_creation_jobs{ 0 };
     std::string                  asset_file_path;

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -1480,6 +1480,8 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
 }
 #endif
 
+// Only provide the usage functions if a define is not present
+#if !defined(GFXR_TOOL_SETTINGS_NO_USAGE)
 static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
 {
     if (arg_parser.IsOptionSet(kVersionOption))
@@ -1524,5 +1526,6 @@ static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::Ar
 
     return false;
 }
+#endif // GFXR_TOOL_SETTINGS_NO_USAGE
 
 #endif // GFXRECON_PLATFORM_SETTINGS_H

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -1131,6 +1131,21 @@ static void GetReplayOptions(gfxrecon::decode::ReplayOptions&      options,
 
     IsForceWindowed(options, arg_parser);
     SetWindowOrigin(options, arg_parser);
+
+    // API-independent screenshot options
+    options.screenshot_ranges = GetScreenshotRanges(arg_parser);
+    if (arg_parser.IsArgumentSet(kScreenshotIntervalArgument))
+    {
+        options.screenshot_interval = std::stoi(arg_parser.GetArgumentValue(kScreenshotIntervalArgument));
+        if (options.screenshot_interval == 0)
+        {
+            GFXRECON_LOG_WARNING("A screenshot interval of 0 is invalid. Using default value of 1.");
+            options.screenshot_interval = 1;
+        }
+    }
+    options.screenshot_format      = GetScreenshotFormat(arg_parser);
+    options.screenshot_dir         = GetScreenshotDir(arg_parser);
+    options.screenshot_file_prefix = arg_parser.GetArgumentValue(kScreenshotFilePrefixArgument);
 }
 
 static gfxrecon::decode::VulkanReplayOptions
@@ -1278,19 +1293,6 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     replay_options.create_resource_allocator =
         GetCreateResourceAllocatorFunc(arg_parser, filename, replay_options, tracked_object_info_table);
 
-    replay_options.screenshot_ranges = GetScreenshotRanges(arg_parser);
-    if (arg_parser.IsArgumentSet(kScreenshotIntervalArgument))
-    {
-        replay_options.screenshot_interval = std::stoi(arg_parser.GetArgumentValue(kScreenshotIntervalArgument));
-        if (replay_options.screenshot_interval == 0)
-        {
-            GFXRECON_LOG_WARNING("A screenshot interval of 0 is invalid. Using default value of 1.");
-            replay_options.screenshot_interval = 1;
-        }
-    }
-    replay_options.screenshot_format      = GetScreenshotFormat(arg_parser);
-    replay_options.screenshot_dir         = GetScreenshotDir(arg_parser);
-    replay_options.screenshot_file_prefix = arg_parser.GetArgumentValue(kScreenshotFilePrefixArgument);
     GetScreenshotSize(arg_parser, replay_options.screenshot_width, replay_options.screenshot_height);
     replay_options.screenshot_scale = GetScreenshotScale(arg_parser);
 
@@ -1474,20 +1476,6 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
                 "The parameter to --batching-memory-usage is out of range [0, 100], will use 80 as default value.");
         }
     }
-
-    replay_options.screenshot_ranges = GetScreenshotRanges(arg_parser);
-    if (arg_parser.IsArgumentSet(kScreenshotIntervalArgument))
-    {
-        replay_options.screenshot_interval = std::stoi(arg_parser.GetArgumentValue(kScreenshotIntervalArgument));
-        if (replay_options.screenshot_interval == 0)
-        {
-            GFXRECON_LOG_WARNING("A screenshot interval of 0 is invalid. Using default value of 1.");
-            replay_options.screenshot_interval = 1;
-        }
-    }
-    replay_options.screenshot_format      = GetScreenshotFormat(arg_parser);
-    replay_options.screenshot_dir         = GetScreenshotDir(arg_parser);
-    replay_options.screenshot_file_prefix = arg_parser.GetArgumentValue(kScreenshotFilePrefixArgument);
     return replay_options;
 }
 #endif


### PR DESCRIPTION
Move the screenshot option reading code into the general replay options function GetReplayOptions() since they are API-agnostic.

(FYI, the screenshot_width/height define in the base was already mirrored in Vulkan replay options and only ever used by Vulkan, so I removed the non-Vulkan definitions).