### PR TITLE
Fix crash in `VulkanReplayConsumerBase::OverrideCmdBindDescriptorSets2`

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5457,7 +5457,8 @@ void VulkanReplayConsumerBase::OverrideCmdBindDescriptorSets2(
     VkCommandBuffer           command_buffer            = in_commandBuffer->handle;
     VkBindDescriptorSetsInfo* bind_descriptor_sets_info = pBindDescriptorSetsInfo->GetPointer();
 
-    if (bind_descriptor_sets_info != nullptr && UseAddressReplacement(device_info))
+    if (bind_descriptor_sets_info != nullptr && UseAddressReplacement(device_info) &&
+        !in_commandBuffer->bound_pipelines.empty())
     {
         auto*               bind_descriptor_sets_info_meta = pBindDescriptorSetsInfo->GetMetaStructPointer();
         VkPipelineBindPoint pipelineBindPoint              = in_commandBuffer->bound_pipelines.begin()->first;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5457,18 +5457,25 @@ void VulkanReplayConsumerBase::OverrideCmdBindDescriptorSets2(
     VkCommandBuffer           command_buffer            = in_commandBuffer->handle;
     VkBindDescriptorSetsInfo* bind_descriptor_sets_info = pBindDescriptorSetsInfo->GetPointer();
 
-    if (bind_descriptor_sets_info != nullptr && UseAddressReplacement(device_info) &&
-        !in_commandBuffer->bound_pipelines.empty())
+    if (bind_descriptor_sets_info != nullptr && UseAddressReplacement(device_info))
     {
-        auto*               bind_descriptor_sets_info_meta = pBindDescriptorSetsInfo->GetMetaStructPointer();
-        VkPipelineBindPoint pipelineBindPoint              = in_commandBuffer->bound_pipelines.begin()->first;
-        auto&               address_replacer               = GetDeviceAddressReplacer(device_info);
-        address_replacer.ProcessCmdBindDescriptorSets(in_commandBuffer,
-                                                      pipelineBindPoint,
-                                                      bind_descriptor_sets_info->firstSet,
-                                                      bind_descriptor_sets_info->descriptorSetCount,
-                                                      &bind_descriptor_sets_info_meta->pDescriptorSets,
-                                                      GetDeviceAddressTracker(device_info));
+        auto* bind_descriptor_sets_info_meta = pBindDescriptorSetsInfo->GetMetaStructPointer();
+        auto& address_replacer               = GetDeviceAddressReplacer(device_info);
+
+        // derive bind-points from stage-flags. process for all bound pipelines.
+        for (VkPipelineBindPoint bind_point :
+             graphics::ShaderStageFlagsToPipelineBindPoints(bind_descriptor_sets_info->stageFlags))
+        {
+            if (in_commandBuffer->bound_pipelines.contains(bind_point))
+            {
+                address_replacer.ProcessCmdBindDescriptorSets(in_commandBuffer,
+                                                              bind_point,
+                                                              bind_descriptor_sets_info->firstSet,
+                                                              bind_descriptor_sets_info->descriptorSetCount,
+                                                              &bind_descriptor_sets_info_meta->pDescriptorSets,
+                                                              GetDeviceAddressTracker(device_info));
+            }
+        }
     }
     func(command_buffer, bind_descriptor_sets_info);
 }

--- a/framework/decode/vulkan_replay_dump_resources.cpp
+++ b/framework/decode/vulkan_replay_dump_resources.cpp
@@ -1212,7 +1212,7 @@ void VulkanReplayDumpResourcesBase::OverrideCmdBindDescriptorSets2(
     const auto bind_meta = pBindDescriptorSetsInfo->GetMetaStructPointer();
 
     std::vector<VkPipelineBindPoint> bind_points =
-        ShaderStageFlagsToPipelineBindPoints(bind_meta->decoded_value->stageFlags);
+        graphics::ShaderStageFlagsToPipelineBindPoints(bind_meta->decoded_value->stageFlags);
 
     const auto layout_info = object_info_table_->GetVkPipelineLayoutInfo(bind_meta->layout);
 

--- a/framework/decode/vulkan_replay_dump_resources_common.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_common.cpp
@@ -996,35 +996,6 @@ void ShaderStageFlagsToStageNames(VkShaderStageFlags flags, std::vector<std::str
     }
 }
 
-std::vector<VkPipelineBindPoint> ShaderStageFlagsToPipelineBindPoints(VkShaderStageFlags flags)
-{
-    std::vector<VkPipelineBindPoint> bind_points;
-
-    constexpr VkShaderStageFlags gr_flags =
-        VK_SHADER_STAGE_ALL_GRAPHICS | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
-    constexpr VkShaderStageFlags com_flags = VK_SHADER_STAGE_COMPUTE_BIT;
-    constexpr VkShaderStageFlags rt_flags  = VK_SHADER_STAGE_RAYGEN_BIT_KHR | VK_SHADER_STAGE_ANY_HIT_BIT_KHR |
-                                            VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR | VK_SHADER_STAGE_MISS_BIT_KHR |
-                                            VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR;
-
-    if (flags & gr_flags)
-    {
-        bind_points.push_back(VK_PIPELINE_BIND_POINT_GRAPHICS);
-    }
-
-    if (flags & com_flags)
-    {
-        bind_points.push_back(VK_PIPELINE_BIND_POINT_COMPUTE);
-    }
-
-    if (flags & rt_flags)
-    {
-        bind_points.push_back(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
-    }
-
-    return bind_points;
-}
-
 bool ValidateImageSubresourceRange(const ImageSubresourceRanges& requested_subresource_range,
                                    ImageSubresourceRanges&       modified_subresource_range,
                                    const VulkanImageInfo*        image_info)

--- a/framework/decode/vulkan_replay_dump_resources_common.h
+++ b/framework/decode/vulkan_replay_dump_resources_common.h
@@ -158,8 +158,6 @@ std::string ShaderStageFlagsToString(VkShaderStageFlags flags);
 
 void ShaderStageFlagsToStageNames(VkShaderStageFlags flags, std::vector<std::string>& stage_names);
 
-std::vector<VkPipelineBindPoint> ShaderStageFlagsToPipelineBindPoints(VkShaderStageFlags flags);
-
 // Submit a single VkSubmitInfo2 to the queue using vkQueueSubmit2 when it is available. On devices that do not support
 // synchronization2, the submit info is converted into a VkSubmitInfo and submitted via vkQueueSubmit. The
 // dump-resources submissions are serialized with host fence waits, so the wait-stage masks lost during down-conversion

--- a/framework/graphics/vulkan_util.cpp
+++ b/framework/graphics/vulkan_util.cpp
@@ -165,5 +165,33 @@ uint32_t FindComputeQueueFamilyIndex(const VulkanQueueFamilyFlags& families)
     return VK_QUEUE_FAMILY_IGNORED;
 }
 
+std::vector<VkPipelineBindPoint> ShaderStageFlagsToPipelineBindPoints(VkShaderStageFlags flags)
+{
+    std::vector<VkPipelineBindPoint> bind_points;
+
+    constexpr VkShaderStageFlags graphics_flags =
+        VK_SHADER_STAGE_ALL_GRAPHICS | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
+    constexpr VkShaderStageFlags compute_flags = VK_SHADER_STAGE_COMPUTE_BIT;
+    constexpr VkShaderStageFlags rt_flags      = VK_SHADER_STAGE_RAYGEN_BIT_KHR | VK_SHADER_STAGE_ANY_HIT_BIT_KHR |
+                                            VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR | VK_SHADER_STAGE_MISS_BIT_KHR |
+                                            VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR;
+
+    if (flags & graphics_flags)
+    {
+        bind_points.push_back(VK_PIPELINE_BIND_POINT_GRAPHICS);
+    }
+
+    if (flags & compute_flags)
+    {
+        bind_points.push_back(VK_PIPELINE_BIND_POINT_COMPUTE);
+    }
+
+    if (flags & rt_flags)
+    {
+        bind_points.push_back(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
+    }
+    return bind_points;
+}
+
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -157,6 +157,14 @@ uint32_t FindTransferQueueFamilyIndex(const VulkanQueueFamilyFlags& families);
  */
 uint32_t FindComputeQueueFamilyIndex(const VulkanQueueFamilyFlags& families);
 
+/**
+ * @brief   Map shader-stage flags to corresponding pipeline bind points.
+ *
+ * @param[in]   flags   The shader-stage flags
+ * @return  The pipeline bind points implied by the given stage flags
+ */
+std::vector<VkPipelineBindPoint> ShaderStageFlagsToPipelineBindPoints(VkShaderStageFlags flags);
+
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)
 


### PR DESCRIPTION
The function wrongly assumes that it can be called only after a call to `vkCmdBindPipeline`
