### PR TITLE
Make platform-specific features more explicit

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -328,9 +328,8 @@ bool CommonCaptureManager::ProcessMatchesCaptureName(const std::string& desired_
 
         // Now get the string before the first space
         application_name = cmd_line_string.substr(0, cmd_line_string.find(' '));
-
 #else
-        GFXRECON_ERROR_FATAL_ONCE("Unable to determine process name for this platform");
+        GFXRECON_LOG_WARNING_ONCE("Unable to determine process name for this platform");
 
         // Force to true so we capture everything
         matches = true;

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -256,6 +256,21 @@ if (OPENXR_SUPPORT_ENABLED)
     target_compile_definitions(gfxrecon_util PUBLIC ENABLE_OPENXR_SUPPORT=1)
 endif()
 
+option(GFXRECON_ENABLE_USERFAULTFD "If the target platform supports it, build userfaultfd memory tracking functionality" ON)
+if (((NOT WIN32) AND (NOT APPLE) AND GFXRECON_ENABLE_USERFAULTFD))
+    target_compile_definitions(gfxrecon_util PUBLIC GFXRECON_ENABLE_USERFAULTFD=1)
+endif()
+
+option(GFXRECON_PLATFORM_SUPPORTS_GETTID "Indicate whether or not the platform supports SYS_gettid" ON)
+if ((NOT APPLE) AND GFXRECON_PLATFORM_SUPPORTS_GETTID)
+    target_compile_definitions(gfxrecon_util PUBLIC GFXRECON_PLATFORM_SUPPORTS_GETTID=1)
+endif()
+
+option(GFXRECON_PLATFORM_SUPPORTS_TGKILL "Indicate whether or not the platform supports SYS_tgkill" ON)
+if ((NOT APPLE) AND GFXRECON_PLATFORM_SUPPORTS_TGKILL)
+    target_compile_definitions(gfxrecon_util PUBLIC GFXRECON_PLATFORM_SUPPORTS_TGKILL=1)
+endif()
+
 common_build_directives(gfxrecon_util)
 
 if (${RUN_TESTS})

--- a/framework/util/image_writer.cpp
+++ b/framework/util/image_writer.cpp
@@ -576,7 +576,10 @@ bool WritePngImageSeparateAlpha(const std::string& filename,
                                 uint32_t           data_pitch,
                                 DataFormats        format)
 {
-    bool success = WritePngImage(filename, width, height, data, data_pitch, format, false);
+    bool success = true;
+
+#ifdef GFXRECON_ENABLE_PNG_SCREENSHOT
+    success = WritePngImage(filename, width, height, data, data_pitch, format, false);
     if (success && DataFormatHasAlpha(format))
     {
         const std::string alpha_filename = util::filepath::InsertFilenamePostfix(filename, "_alpha");
@@ -594,6 +597,7 @@ bool WritePngImageSeparateAlpha(const std::string& filename,
             GFXRECON_LOG_ERROR("%s() Failed writing file %s", __func__, alpha_filename.c_str());
         }
     }
+#endif
 
     return success;
 }

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -43,16 +43,13 @@
 #include <pthread.h>
 #endif
 
-#if defined(WIN32) || defined(__APPLE__)
-#define USERFAULTFD_SUPPORTED 0
-#else
-#include <linux/userfaultfd.h>
+#if defined(GFXRECON_ENABLE_USERFAULTFD) && defined(UFFD_USER_MODE_ONLY) && defined(UFFDIO_WRITEPROTECT) && \
+    defined(UFFDIO_WRITEPROTECT_MODE_WP)
 // Older kernels might not support all features we need from userfaultfd. Check what is available.
-#if defined(UFFD_USER_MODE_ONLY) && defined(UFFDIO_WRITEPROTECT) && defined(UFFDIO_WRITEPROTECT_MODE_WP)
+#include <linux/userfaultfd.h>
 #define USERFAULTFD_SUPPORTED 1
 #else
 #define USERFAULTFD_SUPPORTED 0
-#endif
 #endif
 
 #if defined(__ANDROID__)

--- a/framework/util/platform.h
+++ b/framework/util/platform.h
@@ -391,12 +391,14 @@ inline uint64_t GetCurrentThreadId()
     uint64_t thread_id;
     pthread_threadid_np(pthread_self(), &thread_id);
     return thread_id;
-#else
+#elif defined(GFXRECON_PLATFORM_SUPPORTS_GETTID)
     return static_cast<uint64_t>(syscall(SYS_gettid));
+#else
+    return static_cast<uint64_t>(pthread_self());
 #endif
 }
 
-#if !defined(__APPLE__)
+#if defined(GFXRECON_PLATFORM_SUPPORTS_TGKILL)
 inline int SendSignalToThread(uint64_t tid, int signal)
 {
     return static_cast<int>(syscall(SYS_tgkill, getpid(), tid, signal));


### PR DESCRIPTION
Add the following cmake options for more control over which platform-specific features are built:

- GFXRECON_ENABLE_USERFAULTFD
- GFXRECON_PLATFORM_SUPPORTS_GETTID
- GFXRECON_PLATFORM_SUPPORTS_TGKILL

This change also fixes builds without zlib.