### PR TITLE
Alias memory for suballocated buffers

### DIFF
--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -640,6 +640,9 @@ VulkanRebindAllocator::AllocateMemoryForBuffer(VkBuffer                         
     allocator_->GetBufferMemoryRequirements(
         buffer, replay_req, requires_dedicated_allocation, prefers_dedicated_allocation);
 
+    // We don't know if this buffer will be sub-allocated, so we don't want a dedicated allocation
+    prefers_dedicated_allocation = false;
+
     replay_req.alignment = std::max<VkDeviceSize>(replay_req.alignment, min_buffer_alignment_);
 
     VmaAllocationCreateInfo create_info{};
@@ -661,6 +664,7 @@ VulkanRebindAllocator::AllocateMemoryForBuffer(VkBuffer                         
                           requires_dedicated_allocation,
                           prefers_dedicated_allocation,
                           create_info,
+                          true,
                           vma_mem_info))
     {
         return VK_SUCCESS;
@@ -956,6 +960,7 @@ VkResult VulkanRebindAllocator::AllocateMemoryForImage(VkImage                  
                           requires_dedicated_allocation,
                           prefers_dedicated_allocation,
                           create_info,
+                          false,
                           vma_mem_info))
     {
         return VK_SUCCESS;
@@ -2501,6 +2506,7 @@ VkResult VulkanRebindAllocator::VmaAllocateMemory(MemoryAllocInfo&            me
                           requires_dedicated_allocation,
                           prefers_dedicated_allocation,
                           create_info,
+                          dedicated_buffer != VK_NULL_HANDLE, // allow unsized capture requirements for buffers
                           vma_mem_info))
     {
         return VK_SUCCESS;
@@ -2782,6 +2788,7 @@ bool VulkanRebindAllocator::FindVmaMemoryInfo(MemoryAllocInfo&               mem
                                               bool                           requires_dedicated_allocation,
                                               bool                           prefers_dedicated_allocation,
                                               const VmaAllocationCreateInfo& alc_create_info,
+                                              bool                           allow_unsized,
                                               VmaMemoryInfo**                vma_mem_info)
 {
     if (requires_dedicated_allocation || prefers_dedicated_allocation)
@@ -2791,7 +2798,7 @@ bool VulkanRebindAllocator::FindVmaMemoryInfo(MemoryAllocInfo&               mem
 
     for (auto& mem_info : memory_alloc_info.vma_mem_infos)
     {
-        if (mem_info->is_compatible(original_offset, capture_mem_req, replay_mem_req, alc_create_info))
+        if (mem_info->is_compatible(original_offset, capture_mem_req, replay_mem_req, alc_create_info, allow_unsized))
         {
             *vma_mem_info = mem_info.get();
             return true;

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -454,19 +454,27 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         [[nodiscard]] bool is_compatible(VkDeviceSize                   offset,
                                          const VkMemoryRequirements&    capture_req,
                                          const VkMemoryRequirements&    replay_req,
-                                         const VmaAllocationCreateInfo& create_info) const
+                                         const VmaAllocationCreateInfo& create_info,
+                                         bool                           allow_unsized) const
         {
-            // If capture_req.size is 0, it means the memory requirement is not recorded in the capture file.
+            // If captured requirement sizes are 0, it means the memory requirement is not recorded in the capture file.
             // It didn't call vkGetImageMemoryRequirements or vkGetBufferMemoryRequirements before, like swapchain
             // images. We can't be sure it's compatible.
-            if (capture_req.size == 0)
+            const bool have_capture_sizes = (capture_req.size != 0) && (capture_mem_req.size != 0);
+
+            // However, we want to allow memory aliasing for buffer suballocations which might not call
+            // vkGetBufferMemoryRequirements, resulting in a capture size of 0, so we pass a flag allow_unsized for
+            // buffers.
+            if (!have_capture_sizes && !allow_unsized)
             {
                 return false;
             }
 
             // memory offset and size is in the range. mem_req and create_info are the same.
             if ((offset >= offset_from_original_device_memory) &&
-                ((offset + capture_req.size) <= (offset_from_original_device_memory + capture_mem_req.size)) &&
+                // capture-space containment: additional tightening if we have capture sizes.
+                (!have_capture_sizes ||
+                 ((offset + capture_req.size) <= (offset_from_original_device_memory + capture_mem_req.size))) &&
                 ((offset + replay_req.size) <= (offset_from_original_device_memory + replay_mem_req.size)) &&
                 (replay_req.alignment == replay_mem_req.alignment) &&
                 (replay_req.memoryTypeBits == replay_mem_req.memoryTypeBits) &&
@@ -668,6 +676,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                   bool                           requires_dedicated_allocation,
                                   bool                           prefers_dedicated_allocation,
                                   const VmaAllocationCreateInfo& alc_create_info,
+                                  bool                           allow_unsized,
                                   VmaMemoryInfo**                vma_mem_info);
 
     void RemoveVmaMemoryInfo(ResourceAllocInfo& resource_alloc_info, uint64_t object_handle);


### PR DESCRIPTION
Motivated by https://github.com/LunarG/Projects/issues/1171, where we capture WickedEngine (https://github.com/turanszkij/WickedEngine) test samples and replay with the flag `-m rebind`.

When replaying using `-m rebind`, all the models/geometries disappear.

This engine does the following:
-Allocate buffer that is binded to the shader, and the shader reads
-Suballocate buffers, and read into them from staging buffers using `cmdCopyBuffers`

This is due to GFXR's handling of reusing overlapping buffers. Although we try to resolve these with `FindVmaMemoryInfo`, and `vulkan_rebind_allocator.h`'s `is_compatible`, since these suballocated buffers do not have a corresponding `vkGetBufferMemoryRequirements` to record captured requirement sizes and defaults to 0, GFXR thinks the already allocated buffer is not compatible and creates a separate allocation, resulting in the shader seeing none of the data that was supposed to be copied.

Change 0 check of capture size to not return early by adding flag to progress specifically for buffers.

Also set `prefers_dedicated_allocation` to `false` when allocating buffers, as they could be suballocated.

Needs to be addressed that this only fixes the case where suballocations are binded after the initial allocation. If suballocations are binded before, the same missing geometries issue would still occur as the buffer binded to the shader will be a separate allocation.