### PR TITLE
Remove hardcoded Android binary paths

### DIFF
--- a/android/layer/CMakeLists.txt
+++ b/android/layer/CMakeLists.txt
@@ -27,22 +27,10 @@ else()
     message(STATUS "OpenXR support disabled!")
 endif()
 
-add_subdirectory(
-    ${GFXRECON_SOURCE_DIR}/framework/util
-    ${GFXRECON_SOURCE_DIR}/build/framework/util/layer/${ANDROID_ABI}
-)
-add_subdirectory(
-    ${GFXRECON_SOURCE_DIR}/framework/graphics
-    ${GFXRECON_SOURCE_DIR}/build/framework/graphics/layer/${ANDROID_ABI}
-)
-add_subdirectory(
-    ${GFXRECON_SOURCE_DIR}/framework/format
-    ${GFXRECON_SOURCE_DIR}/build/framework/format/layer/${ANDROID_ABI}
-)
-add_subdirectory(
-    ${GFXRECON_SOURCE_DIR}/framework/encode
-    ${GFXRECON_SOURCE_DIR}/build/framework/encode/layer/${ANDROID_ABI}
-)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/util util)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/graphics graphics)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/format format)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/encode encode)
 
 add_library(VkLayer_gfxreconstruct SHARED "")
 

--- a/android/test/test_apps/common/CMakeLists.txt
+++ b/android/test/test_apps/common/CMakeLists.txt
@@ -34,13 +34,12 @@ target_include_directories(gfxrecon-testapp-base
                                ${GFXRECON_SOURCE_DIR}/test/icd)
 
 set(GFXRECON_ANDROID_TEST_APPS_DIR ${CMAKE_SOURCE_DIR}/..)
-set(FRAMEWORK_BUILD_DIR ${GFXRECON_ANDROID_DIR}/framework/build/test_apps)
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/util ${FRAMEWORK_BUILD_DIR}/util/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/plugin ${FRAMEWORK_BUILD_DIR}/plugin/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/decode ${FRAMEWORK_BUILD_DIR}/decode/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/graphics ${FRAMEWORK_BUILD_DIR}/graphics/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/format ${FRAMEWORK_BUILD_DIR}/format/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/application ${FRAMEWORK_BUILD_DIR}/application/${ANDROID_ABI})
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/util util)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/plugin plugin)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/decode decode)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/graphics graphics)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/format format)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/application application)
 
 target_link_libraries(gfxrecon-testapp-base
     PUBLIC
@@ -52,8 +51,7 @@ macro(common_build_directives TARGET)
 endmacro()
 
 macro(add_test_app TEST_NAME)
-    add_subdirectory(${GFXRECON_SOURCE_DIR}/test/test_apps/${TEST_NAME}
-                     ${GFXRECON_ANDROID_TEST_APPS_DIR}/${TEST_NAME}/build/${ANDROID_ABI})
+    add_subdirectory(${GFXRECON_SOURCE_DIR}/test/test_apps/${TEST_NAME} ${TEST_NAME})
 endmacro()
 
 add_test_app(acquired-image)

--- a/android/test/test_apps/launcher/CMakeLists.txt
+++ b/android/test/test_apps/launcher/CMakeLists.txt
@@ -35,7 +35,7 @@ project(gfxrecon-test-launcher)
 set(GFXRECON_ANDROID_TEST_APPS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 set(COMMON_DIR ${GFXRECON_ANDROID_TEST_APPS_DIR}/common)
-add_subdirectory(${COMMON_DIR} ${COMMON_DIR}/build/${ANDROID_ABI})
+add_subdirectory(${COMMON_DIR} common)
 
 
 add_library(${PROJECT_NAME}

--- a/android/tools/multi-win-replay/CMakeLists.txt
+++ b/android/tools/multi-win-replay/CMakeLists.txt
@@ -13,13 +13,13 @@ set(nlohmann_json_DIR "${GFXRECON_SOURCE_DIR}/external/nlohmann-json/share/cmake
 find_package(nlohmann_json REQUIRED CONFIG PATHS "${nlohmann_json_DIR}" NO_DEFAULT_PATH)
 
 include(../../framework/cmake-config/PlatformConfig.cmake)
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/util ${PROJECT_SOURCE_DIR}/build/framework/util/multi-win-replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/plugin ${PROJECT_SOURCE_DIR}/build/framework/plugin/multi-win-replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/graphics ${PROJECT_SOURCE_DIR}/build/framework/graphics/multi-win-replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/format ${PROJECT_SOURCE_DIR}/build/framework/format/multi-win-replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/decode ${PROJECT_SOURCE_DIR}/build/framework/decode/multi-win-replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/encode ${PROJECT_SOURCE_DIR}/build/framework/encode/multi-win-replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/android/framework/application-multi-win ${PROJECT_SOURCE_DIR}/build/framework/application-multi-win/multi-win-replay/${ANDROID_ABI})
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/util util)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/plugin plugin)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/graphics graphics)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/format format)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/decode decode)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/encode encode)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/android/framework/application-multi-win application-multi-win)
 
 add_library(gfxrecon-replay
             SHARED

--- a/android/tools/quest_replay/CMakeLists.txt
+++ b/android/tools/quest_replay/CMakeLists.txt
@@ -25,14 +25,14 @@ else()
     message(FATAL_ERROR "Failed to find OpenXR headers for support.  Continuing with it disabled!")
 endif()
 
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/util ${PROJECT_SOURCE_DIR}/build/framework/util/quest_replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/plugin ${PROJECT_SOURCE_DIR}/build/framework/plugin/quest_replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/graphics ${PROJECT_SOURCE_DIR}/build/framework/graphics/quest_replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/format ${PROJECT_SOURCE_DIR}/build/framework/format/quest_replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/decode ${PROJECT_SOURCE_DIR}/build/framework/decode/quest_replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/encode ${PROJECT_SOURCE_DIR}/build/framework/encode/quest_replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/application ${PROJECT_SOURCE_DIR}/build/framework/application/quest_replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/external/OpenXR-SDK ${PROJECT_SOURCE_DIR}/build/external/OpenXR-SDK/quest_replay/${ANDROID_ABI})
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/util util)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/plugin plugin)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/graphics graphics)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/format format)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/decode decode)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/encode encode)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/application application)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/external/OpenXR-SDK OpenXR-SDK)
 
 add_library(gfxrecon-quest-replay
             SHARED

--- a/android/tools/replay/CMakeLists.txt
+++ b/android/tools/replay/CMakeLists.txt
@@ -13,13 +13,13 @@ set(nlohmann_json_DIR "${GFXRECON_SOURCE_DIR}/external/nlohmann-json/share/cmake
 find_package(nlohmann_json REQUIRED CONFIG PATHS "${nlohmann_json_DIR}" NO_DEFAULT_PATH)
 
 include(../../framework/cmake-config/PlatformConfig.cmake)
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/util ${PROJECT_SOURCE_DIR}/build/framework/util/replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/plugin ${PROJECT_SOURCE_DIR}/build/framework/plugin/replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/graphics ${PROJECT_SOURCE_DIR}/build/framework/graphics/replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/format ${PROJECT_SOURCE_DIR}/build/framework/format/replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/decode ${PROJECT_SOURCE_DIR}/build/framework/decode/replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/encode ${PROJECT_SOURCE_DIR}/build/framework/encode/replay/${ANDROID_ABI})
-add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/application ${PROJECT_SOURCE_DIR}/build/framework/application/replay/${ANDROID_ABI})
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/util util)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/plugin plugin)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/graphics graphics)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/format format)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/decode decode)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/encode encode)
+add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/application application)
 
 add_library(gfxrecon-replay
             SHARED


### PR DESCRIPTION
Using a relative path for the add_subdirectory binary_dir keeps everything in the gradle-managed .cxx output directory, and is already disambiguated by target and ABI. Aside from being untidy, the original absolute paths were also causing build failures on Windows machines subject to the 260 character path limit.