### PR TITLE
Check device properties validity before setting

### DIFF
--- a/framework/decode/vulkan_stats_consumer.h
+++ b/framework/decode/vulkan_stats_consumer.h
@@ -288,8 +288,11 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         GFXRECON_UNREFERENCED_PARAMETER(call_info);
         if ((pProperties != nullptr) && !pProperties->IsNull())
         {
-            auto properties2                            = pProperties->GetPointer();
-            physical_device_properties_[physicalDevice] = properties2->properties;
+            auto properties2 = pProperties->GetPointer();
+            if (PhysicalDevicePropertiesValid(properties2->properties))
+            {
+                physical_device_properties_[physicalDevice] = properties2->properties;
+            }
         }
     }
 
@@ -302,8 +305,11 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         GFXRECON_UNREFERENCED_PARAMETER(call_info);
         if ((pProperties != nullptr) && !pProperties->IsNull())
         {
-            auto properties2                            = pProperties->GetPointer();
-            physical_device_properties_[physicalDevice] = properties2->properties;
+            auto properties2 = pProperties->GetPointer();
+            if (PhysicalDevicePropertiesValid(properties2->properties))
+            {
+                physical_device_properties_[physicalDevice] = properties2->properties;
+            }
         }
     }
 
@@ -782,6 +788,12 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     }
 
   private:
+    static bool PhysicalDevicePropertiesValid(const VkPhysicalDeviceProperties& properties)
+    {
+        return (properties.apiVersion != 0) || (properties.driverVersion != 0) || (properties.vendorID != 0) ||
+               (properties.deviceID != 0) || (properties.deviceName[0] != '\0');
+    }
+
     uint32_t trimmed_frame_{ 0 };
 
     // Physical device info.


### PR DESCRIPTION
Motivated by https://github.com/LunarG/gfxreconstruct/issues/2695

Using `gfxrecon-info` on some captures had device properties seemingly set to all default zero values. This mainly occurs on captures with certain extensions seen in `VulkanStateWriter::WritePhysicalDeviceExtensionPropertiesState`, as it writes a `vkGetPhysicalDeviceProperties2` command with empty `pProperties` as the intent was to write the `pNext` extension struct. However, the stats consumer assumes this is a valid command, and records empty properties for gfxrecon-info.

Add checks that these values aren't the default zero value before setting.

Fixes https://github.com/LunarG/gfxreconstruct/issues/2695