### PR TITLE
Copy pProperties when writing physical device extension properties

### DIFF
--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2187,6 +2187,12 @@ void VulkanStateWriter::WritePhysicalDeviceExtensionPropertiesState(const Vulkan
 
         if (properties2.pNext != nullptr)
         {
+            const auto entry = physical_device_properties_.find(wrapper->handle_id);
+            if (entry != physical_device_properties_.end())
+            {
+                properties2.properties = entry->second;
+            }
+
             parameter_stream_.Clear();
             encoder_.EncodeHandleIdValue(wrapper->handle_id);
             EncodeStructPtr(&encoder_, &properties2);
@@ -3544,6 +3550,8 @@ void VulkanStateWriter::WritePhysicalDevicePropertiesMetaData(
     VkPhysicalDeviceProperties properties;
 
     instance_table->GetPhysicalDeviceProperties(physical_device_handle, &properties);
+
+    physical_device_properties_[physical_device_id] = properties;
 
     WriteSetDevicePropertiesCommand(physical_device_id, properties);
     WriteSetDeviceMemoryPropertiesCommand(physical_device_id, physical_device_wrapper->memory_properties);

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -456,6 +456,8 @@ class VulkanStateWriter
     // Keeps track of buffer- and acceleration-structure device addresses
     const std::unordered_map<VkDevice, encode::VulkanDeviceAddressTracker>& device_address_trackers_;
 
+    std::unordered_map<format::HandleId, VkPhysicalDeviceProperties> physical_device_properties_;
+
     util::FileOutputStream* asset_file_stream_;
     std::string             asset_file_name_;
     AssetFileOffsetsInfo*   asset_file_offsets_;


### PR DESCRIPTION
Since `WritePhysicalDeviceExtensionPropertiesState` is just a way to write extension properties, it doesn't write the actual `pProperties` even though it appears as a `vkGetPhysicalDeviceProperties2` command and instead leaves them as default and zeroes, leading to issues when that command is expected such as in https://github.com/LunarG/gfxreconstruct/issues/2695.

Copy the properties from an earlier call that gets the physical device properties.