### PR TITLE
swapchain: pick supported fallback format instead of hardcoded BGRA8

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -271,6 +271,7 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_submit_job.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_swapchain.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_swapchain.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_swapchain_format.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_tracked_object_info.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_tracked_object_info_table.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_tracked_object_info.cpp

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -42,6 +42,7 @@
 #include "graphics/vulkan_feature_util.h"
 #include "decode/vulkan_object_cleanup_util.h"
 #include "decode/vulkan_submit_job.h"
+#include "decode/vulkan_swapchain_format.h"
 #include "format/format.h"
 #include "format/format_util.h"
 #include "generated/generated_vulkan_struct_decoders.h"
@@ -7981,11 +7982,14 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
                 }
             }
 
-            // fallback to a safe surface-format
-            modified_create_info.imageFormat = fallback_color_formats[0];
-            GFXRECON_LOG_WARNING_ONCE(
-                "Replay adjusted unsupported surface imageFormat (%d) to VK_FORMAT_B8G8R8A8_UNORM",
-                replay_create_info->imageFormat);
+            // fallback to a supported surface-format
+            const VkFormat fallback_format = SelectFallbackSurfaceFormat(
+                *physical_device_info->surface_formats, vkuFormatIsSRGB(replay_create_info->imageFormat));
+
+            modified_create_info.imageFormat = fallback_format;
+            GFXRECON_LOG_WARNING_ONCE("Replay adjusted unsupported surface imageFormat (%s -> %s)",
+                                      util::ToString<VkFormat>(replay_create_info->imageFormat).c_str(),
+                                      util::ToString<VkFormat>(fallback_format).c_str());
         }
 
         if (colorspace_extension_used_unsupported)
@@ -10760,9 +10764,18 @@ VkResult VulkanReplayConsumerBase::OverrideCreateImageView(
     }
     else if (img_info->is_swapchain_image && img_info->format != modified_create_info.format)
     {
-        // for swapchain-images set image-view to a fallback format, avoid issues with distorted HDR/SRGB colors
-        modified_create_info.format =
-            vkuFormatIsSRGB(modified_create_info.format) ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8A8_UNORM;
+        // for swapchain-images set image-view to a fallback format, avoid issues with distorted HDR/SRGB colors.
+        // when the swapchain fell back to a BGRA8 format we preserve the captured view's sRGB-ness; for any other
+        // fallback format we match the swapchain image format exactly to keep the view format-compatible.
+        if (img_info->format == VK_FORMAT_B8G8R8A8_UNORM || img_info->format == VK_FORMAT_B8G8R8A8_SRGB)
+        {
+            modified_create_info.format =
+                vkuFormatIsSRGB(modified_create_info.format) ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8A8_UNORM;
+        }
+        else
+        {
+            modified_create_info.format = img_info->format;
+        }
     }
 
     if (device_info->property_feature_info.feature_descriptorBufferCaptureReplay && !UseAddressReplacement(device_info))

--- a/framework/decode/vulkan_swapchain_format.h
+++ b/framework/decode/vulkan_swapchain_format.h
@@ -1,0 +1,82 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_VULKAN_SWAPCHAIN_FORMAT_H
+#define GFXRECON_DECODE_VULKAN_SWAPCHAIN_FORMAT_H
+
+#include "util/defines.h"
+
+#include "Vulkan-Utility-Libraries/vk_format_utils.h"
+#include "vulkan/vulkan.h"
+
+#include <type_traits>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+// Selects a presentable fallback surface-format, preferring the BGRA8 variant matching want_srgb,
+// then the first supported format of matching sRGB-ness, then the first supported format
+// (or the preferred BGRA8 variant when the list is empty). Accepts a range of VkFormat or
+// VkSurfaceFormatKHR.
+template <typename FormatRange>
+VkFormat SelectFallbackSurfaceFormat(const FormatRange& supported, bool want_srgb)
+{
+    auto as_format = [](const auto& entry) -> VkFormat {
+        if constexpr (std::is_same_v<std::decay_t<decltype(entry)>, VkSurfaceFormatKHR>)
+        {
+            return entry.format;
+        }
+        else
+        {
+            return entry;
+        }
+    };
+    const VkFormat preferred        = want_srgb ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8A8_UNORM;
+    VkFormat       first_supported  = VK_FORMAT_UNDEFINED;
+    VkFormat       first_srgb_match = VK_FORMAT_UNDEFINED;
+    for (const auto& entry : supported)
+    {
+        const VkFormat format = as_format(entry);
+        if (format == preferred)
+        {
+            return preferred;
+        }
+        if (first_supported == VK_FORMAT_UNDEFINED)
+        {
+            first_supported = format;
+        }
+        if (first_srgb_match == VK_FORMAT_UNDEFINED && vkuFormatIsSRGB(format) == want_srgb)
+        {
+            first_srgb_match = format;
+        }
+    }
+    if (first_srgb_match != VK_FORMAT_UNDEFINED)
+    {
+        return first_srgb_match;
+    }
+    return first_supported == VK_FORMAT_UNDEFINED ? preferred : first_supported;
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_VULKAN_SWAPCHAIN_FORMAT_H

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -21,12 +21,13 @@
 */
 
 #include "decode/vulkan_virtual_swapchain.h"
-
 #include "Vulkan-Utility-Libraries/vk_format_utils.h"
 #include "decode/vulkan_resource_allocator.h"
 #include "decode/decoder_util.h"
 #include "util/callbacks.h"
 #include "graphics/vulkan_resources_util.h"
+#include "decode/vulkan_swapchain_format.h"
+#include "generated/generated_vulkan_enum_to_string.h"
 #include "vulkan/vulkan_core.h"
 #include <sstream>
 
@@ -1392,13 +1393,15 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
             current_window_size = swapchain.surface_info.window->GetSize();
 
             VkFormat surface_format = image_info->format;
+
             if (!swapchain.surface_formats.contains(image_info->format))
             {
-                GFXRECON_LOG_WARNING("%s: surface-format not available: %d", __func__, image_info->format);
+                GFXRECON_LOG_WARNING("%s: surface-format not available: %s",
+                                     __func__,
+                                     util::ToString<VkFormat>(image_info->format).c_str());
 
-                // fallback surface-format
                 surface_format =
-                    vkuFormatIsSRGB(image_info->format) ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8A8_UNORM;
+                    SelectFallbackSurfaceFormat(swapchain.surface_formats, vkuFormatIsSRGB(image_info->format));
             }
 
             VkSwapchainCreateInfoKHR swapchain_create_info;


### PR DESCRIPTION
- OverrideCreateSwapchainKHR: when captured imageFormat is unsupported, select fallback from supported formats instead of just VK_FORMAT_B8G8R8A8_UNORM
- OverrideCreateImageView: match the swapchain image's actual format for non-BGRA8 fallbacks to keep swapchain-image views format-compatible
- VulkanVirtualSwapchain::PresentImageAdHoc: same supported-format selection
- factor the selection into decode::SelectFallbackSurfaceFormat (vulkan_swapchain_format.h), shared by both swapchain paths
- log adjusted formats via util::ToString<VkFormat> instead of raw integers