### PR TITLE
Fix -m rebind regression from spurious uvec2 BDA candidates

### DIFF
--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -542,6 +542,39 @@ VulkanAddressReplacer::ResolveBufferAddresses(std::vector<VulkanCommandBufferInf
         }
     }
 
+    // drop heuristic false-positives: keep only host-visible candidates whose stored value resolves to a tracked
+    // capture-address (device-local candidates are hashmap-filtered by the dispatch).
+    std::unordered_map<const VulkanBufferInfo*, void*> mapped_buffers;
+    std::erase_if(addresses_to_replace, [&](VkDeviceAddress location) {
+        const auto* buffer_info = address_tracker.GetBufferByReplayDeviceAddress(location);
+        if (buffer_info == nullptr || !(buffer_info->memory_property_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT))
+        {
+            // cannot cheaply inspect -> keep
+            return false;
+        }
+
+        // map each candidate-buffer at most once
+        auto [it, inserted] = mapped_buffers.try_emplace(buffer_info, nullptr);
+        if (inserted)
+        {
+            resource_allocator_->MapResourceMemoryDirect(VK_WHOLE_SIZE, 0, &it->second, buffer_info->allocator_data);
+        }
+        if (it->second == nullptr)
+        {
+            return false;
+        }
+        const VkDeviceAddress stored = *reinterpret_cast<VkDeviceAddress*>(static_cast<uint8_t*>(it->second) +
+                                                                           (location - buffer_info->replay_address));
+        return address_tracker.GetBufferByCaptureDeviceAddress(stored) == nullptr;
+    });
+    for (const auto& [buffer_info, ptr] : mapped_buffers)
+    {
+        if (ptr != nullptr)
+        {
+            resource_allocator_->UnmapResourceMemoryDirect(buffer_info->allocator_data);
+        }
+    }
+
     return { addresses_to_replace, cmd_buf_info };
 }
 
@@ -1727,7 +1760,11 @@ void VulkanAddressReplacer::ProcessVulkanAccelerationStructuresWritePropertiesMe
     VkAccelerationStructureKHR                acceleration_structure,
     const decode::VulkanDeviceAddressTracker& address_tracker)
 {
-    if (init_queue_assets())
+    if (!init_queue_assets() || !init_as_compact_query_pool())
+    {
+        return;
+    }
+
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
@@ -1893,6 +1930,20 @@ bool VulkanAddressReplacer::init_queue_assets()
         return false;
     }
 
+    device_table_->GetDeviceQueue(device_, 0, 0, &queue_);
+    GFXRECON_ASSERT(queue_ != VK_NULL_HANDLE);
+
+    bool submit_asset_created = create_submit_asset(submit_asset_);
+    return queue_ != VK_NULL_HANDLE && submit_asset_created;
+}
+
+bool VulkanAddressReplacer::init_as_compact_query_pool()
+{
+    if (query_pool_ != VK_NULL_HANDLE)
+    {
+        return true;
+    }
+
     VkQueryPoolCreateInfo pool_info;
     pool_info.sType              = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
     pool_info.pNext              = nullptr;
@@ -1900,18 +1951,12 @@ bool VulkanAddressReplacer::init_queue_assets()
     pool_info.queryType          = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR;
     pool_info.queryCount         = 1;
     pool_info.pipelineStatistics = 0;
-    result                       = device_table_->CreateQueryPool(device_, &pool_info, nullptr, &query_pool_);
-    if (result != VK_SUCCESS)
+    if (device_table_->CreateQueryPool(device_, &pool_info, nullptr, &query_pool_) != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal query-pool creation failed");
         return false;
     }
-
-    device_table_->GetDeviceQueue(device_, 0, 0, &queue_);
-    GFXRECON_ASSERT(queue_ != VK_NULL_HANDLE);
-
-    bool submit_asset_created = create_submit_asset(submit_asset_);
-    return queue_ != VK_NULL_HANDLE && submit_asset_created;
+    return true;
 }
 
 bool VulkanAddressReplacer::create_buffer(VulkanAddressReplacer::buffer_context_t& buffer_context,

--- a/framework/decode/vulkan_address_replacer.h
+++ b/framework/decode/vulkan_address_replacer.h
@@ -469,6 +469,9 @@ class VulkanAddressReplacer
 
     [[nodiscard]] bool init_queue_assets();
 
+    //! lazily create the acceleration-structure compacted-size query-pool (only used by AS-compaction).
+    [[nodiscard]] bool init_as_compact_query_pool();
+
     void update_global_hashmap(VkCommandBuffer command_buffer);
 
     void run_compute_replace(const VulkanCommandBufferInfo*    command_buffer_info,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3543,6 +3543,50 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
                                                      modified_create_info.pNext,
                                                      modified_create_info.pEnabledFeatures,
                                                      options_.remove_unsupported_features);
+
+    // the address-replacer's injected compute-shaders use Device-scope atomics, which require
+    // vulkanMemoryModelDeviceScope when the memory-model is enabled (VUID-RuntimeSpirv-vulkanMemoryModel-06265).
+    auto* memory_model_features =
+        graphics::vulkan_struct_get_pnext<VkPhysicalDeviceVulkanMemoryModelFeatures>(&modified_create_info);
+    auto* vulkan_1_2_features =
+        graphics::vulkan_struct_get_pnext<VkPhysicalDeviceVulkan12Features>(&modified_create_info);
+    const bool memory_model_enabled = (memory_model_features != nullptr && memory_model_features->vulkanMemoryModel) ||
+                                      (vulkan_1_2_features != nullptr && vulkan_1_2_features->vulkanMemoryModel);
+
+    if (memory_model_enabled)
+    {
+        // Mirror UseAddressReplacement(): address-replacement is active when the allocator uses non-opaque addresses.
+        std::unique_ptr<VulkanResourceAllocator> probe_allocator(options_.create_resource_allocator());
+        const bool use_address_replacement = probe_allocator && !probe_allocator->SupportsOpaqueDeviceAddresses();
+
+        if (use_address_replacement)
+        {
+            VkPhysicalDeviceVulkanMemoryModelFeatures supported_memory_model{
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES
+            };
+            VkPhysicalDeviceFeatures2 supported_features{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
+                                                          &supported_memory_model };
+            instance_table->GetPhysicalDeviceFeatures2(physical_device, &supported_features);
+
+            if (supported_memory_model.vulkanMemoryModelDeviceScope)
+            {
+                if (memory_model_features != nullptr)
+                {
+                    memory_model_features->vulkanMemoryModelDeviceScope = VK_TRUE;
+                }
+                if (vulkan_1_2_features != nullptr)
+                {
+                    vulkan_1_2_features->vulkanMemoryModelDeviceScope = VK_TRUE;
+                }
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING(
+                    "Replay device does not support vulkanMemoryModelDeviceScope; the address-replacer "
+                    "compute-shaders may fail to create with -m rebind.");
+            }
+        }
+    }
 }
 
 VkResult VulkanReplayConsumerBase::PostCreateDeviceUpdateState(VulkanPhysicalDeviceInfo* physical_device_info,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3555,11 +3555,8 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
 
     if (memory_model_enabled)
     {
-        // Mirror UseAddressReplacement(): address-replacement is active when the allocator uses non-opaque addresses.
-        std::unique_ptr<VulkanResourceAllocator> probe_allocator(options_.create_resource_allocator());
-        const bool use_address_replacement = probe_allocator && !probe_allocator->SupportsOpaqueDeviceAddresses();
-
-        if (use_address_replacement)
+        // no device exists yet -> UseAddressReplacement(nullptr) probes a throwaway allocator.
+        if (UseAddressReplacement(nullptr))
         {
             VkPhysicalDeviceVulkanMemoryModelFeatures supported_memory_model{
                 VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES
@@ -11831,6 +11828,12 @@ bool VulkanReplayConsumerBase::UseExtraDescriptorInfo(const VulkanDeviceInfo* de
 
 bool VulkanReplayConsumerBase::UseAddressReplacement(const VulkanDeviceInfo* device_info) const
 {
+    // Before the device exists (e.g. during device-creation) probe a throwaway allocator instead.
+    if (device_info == nullptr)
+    {
+        std::unique_ptr<VulkanResourceAllocator> probe_allocator(options_.create_resource_allocator());
+        return probe_allocator && !probe_allocator->SupportsOpaqueDeviceAddresses();
+    }
     return !device_info->allocator->SupportsOpaqueDeviceAddresses();
 }
 

--- a/framework/util/spirv_parsing_util.cpp
+++ b/framework/util/spirv_parsing_util.cpp
@@ -124,18 +124,19 @@ LayoutInfo compute_type_layout(const SpvReflectTypeDescription* type_description
     return { alignment, num_bytes };
 }
 
-static bool check_type_potential_ref(const SpvReflectTypeDescription* td)
+static bool check_type_potential_ref(const SpvReflectTypeDescription* td, bool allow_uvec2)
 {
-    return td->storage_class == spv::StorageClassPhysicalStorageBuffer ||
-           // uint64_t
-           (td->op == SpvOpTypeInt && td->traits.numeric.scalar.width == 64 && !td->traits.numeric.scalar.signedness) ||
-           // uvec2
-           (td->op == SpvOpTypeVector && td->traits.numeric.vector.component_count == 2 &&
-            td->traits.numeric.scalar.width == 32 && !td->traits.numeric.scalar.signedness) ||
-           // uvec2 array
-           ((td->op == SpvOpTypeRuntimeArray || td->op == SpvOpTypeArray) &&
-            td->traits.numeric.vector.component_count == 2 && td->traits.numeric.scalar.width == 32 &&
-            !td->traits.numeric.scalar.signedness);
+    if (td->storage_class == spv::StorageClassPhysicalStorageBuffer ||
+        // uint64_t
+        (td->op == SpvOpTypeInt && td->traits.numeric.scalar.width == 64 && !td->traits.numeric.scalar.signedness))
+    {
+        return true;
+    }
+
+    const bool is_uvec2 = td->traits.numeric.vector.component_count == 2 && td->traits.numeric.scalar.width == 32 &&
+                          !td->traits.numeric.scalar.signedness;
+    return allow_uvec2 && is_uvec2 &&
+           (td->op == SpvOpTypeVector || td->op == SpvOpTypeRuntimeArray || td->op == SpvOpTypeArray);
 }
 
 // Instruction represents a single Spv::Op instruction.
@@ -338,16 +339,68 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
         spvReflectCreateShaderModule(spirv_num_bytes, spirv_code, &spv_shader_module.value());
     }
 
+    // only consider uvec2 as potential BDAs when the module actually casts uvec2 into a buffer-pointers
+    bool allow_uvec2_ref = false;
+    {
+        std::unordered_map<uint32_t, const Instruction*> defs;
+        for (const Instruction& insn : instructions)
+        {
+            if (insn.resultId() != 0)
+            {
+                defs[insn.resultId()] = &insn;
+            }
+        }
+        auto find = [&defs](uint32_t id) -> const Instruction* {
+            auto it = defs.find(id);
+            return it != defs.end() ? it->second : nullptr;
+        };
+        auto is_uvec2_value = [&find](uint32_t id) {
+            const Instruction* value = find(id);
+            const Instruction* vec   = value != nullptr ? find(value->typeId()) : nullptr;
+            if (vec == nullptr || vec->opcode() != spv::OpTypeVector || vec->operand(1) != 2)
+            {
+                return false;
+            }
+            const Instruction* comp = find(vec->operand(0));
+            return comp != nullptr && comp->opcode() == spv::OpTypeInt && comp->operand(0) == 32;
+        };
+        auto is_physical_storage_pointer = [&find](uint32_t type_id) {
+            const Instruction* type = find(type_id);
+            return type != nullptr && type->opcode() == spv::OpTypePointer &&
+                   type->operand(0) == spv::StorageClassPhysicalStorageBuffer;
+        };
+        for (const Instruction& insn : instructions)
+        {
+            // direct uvec2 -> physical-storage-buffer pointer bitcast
+            if (insn.opcode() == spv::OpBitcast && is_physical_storage_pointer(insn.typeId()) &&
+                is_uvec2_value(insn.operand(0)))
+            {
+                allow_uvec2_ref = true;
+                break;
+            }
+            // uvec2 -> uint64 (bitcast) -> pointer (OpConvertUToPtr)
+            if (insn.opcode() == spv::OpConvertUToPtr)
+            {
+                const Instruction* src = find(insn.operand(0));
+                if (src != nullptr && src->opcode() == spv::OpBitcast && is_uvec2_value(src->operand(0)))
+                {
+                    allow_uvec2_ref = true;
+                    break;
+                }
+            }
+        }
+    }
+
     // forward spirv-reflect-pass
     constexpr bool use_forward_spirv_reflect_pass = true;
 
     if constexpr (use_forward_spirv_reflect_pass)
     {
         // define a function to walk blocks breadth-first and check for buffer-references
-        auto check_buffer_references = [this](const SpvReflectTypeDescription* type,
-                                              BufferReferenceLocation          source,
-                                              uint32_t                         set,
-                                              uint32_t                         binding) {
+        auto check_buffer_references = [this, allow_uvec2_ref](const SpvReflectTypeDescription* type,
+                                                               BufferReferenceLocation          source,
+                                                               uint32_t                         set,
+                                                               uint32_t                         binding) {
             struct queue_item_t
             {
                 const SpvReflectTypeDescription* type_description = nullptr;
@@ -372,7 +425,7 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
                     member_names.emplace_back(td->struct_member_name ? td->struct_member_name : "unknown");
 
                     // we pick up potential buffer-references here and confirm later.
-                    bool is_potential_ref = check_type_potential_ref(td);
+                    bool is_potential_ref = check_type_potential_ref(td, allow_uvec2_ref);
 
                     if (td->op == SpvOpTypeArray || td->op == SpvOpTypeRuntimeArray)
                     {

--- a/framework/util/spirv_parsing_util.cpp
+++ b/framework/util/spirv_parsing_util.cpp
@@ -332,6 +332,15 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
     }
     instructions.shrink_to_fit();
 
+    // build the result-id -> instruction lookup once
+    for (const Instruction& insn : instructions)
+    {
+        if (insn.resultId() != 0)
+        {
+            definitions_[insn.resultId()] = &insn;
+        }
+    }
+
     if (spv_shader_module == std::nullopt)
     {
         // spirv-reflect parsing only on-demand
@@ -342,30 +351,18 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
     // only consider uvec2 as potential BDAs when the module actually casts uvec2 into a buffer-pointers
     bool allow_uvec2_ref = false;
     {
-        std::unordered_map<uint32_t, const Instruction*> defs;
-        for (const Instruction& insn : instructions)
-        {
-            if (insn.resultId() != 0)
-            {
-                defs[insn.resultId()] = &insn;
-            }
-        }
-        auto find = [&defs](uint32_t id) -> const Instruction* {
-            auto it = defs.find(id);
-            return it != defs.end() ? it->second : nullptr;
-        };
-        auto is_uvec2_value = [&find](uint32_t id) {
-            const Instruction* value = find(id);
-            const Instruction* vec   = value != nullptr ? find(value->typeId()) : nullptr;
+        auto is_uvec2_value = [this](uint32_t id) {
+            const Instruction* value = FindDef(id);
+            const Instruction* vec   = value != nullptr ? FindDef(value->typeId()) : nullptr;
             if (vec == nullptr || vec->opcode() != spv::OpTypeVector || vec->operand(1) != 2)
             {
                 return false;
             }
-            const Instruction* comp = find(vec->operand(0));
+            const Instruction* comp = FindDef(vec->operand(0));
             return comp != nullptr && comp->opcode() == spv::OpTypeInt && comp->operand(0) == 32;
         };
-        auto is_physical_storage_pointer = [&find](uint32_t type_id) {
-            const Instruction* type = find(type_id);
+        auto is_physical_storage_pointer = [this](uint32_t type_id) {
+            const Instruction* type = FindDef(type_id);
             return type != nullptr && type->opcode() == spv::OpTypePointer &&
                    type->operand(0) == spv::StorageClassPhysicalStorageBuffer;
         };
@@ -381,7 +378,7 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
             // uvec2 -> uint64 (bitcast) -> pointer (OpConvertUToPtr)
             if (insn.opcode() == spv::OpConvertUToPtr)
             {
-                const Instruction* src = find(insn.operand(0));
+                const Instruction* src = FindDef(insn.operand(0));
                 if (src != nullptr && src->opcode() == spv::OpBitcast && is_uvec2_value(src->operand(0)))
                 {
                     allow_uvec2_ref = true;
@@ -680,17 +677,10 @@ bool SpirVParsingUtil::ParseBufferReferences(const uint32_t* const spirv_code, s
         }
     };
 
-    // now we walk the SPIR-V one more time to find remaining occurances of buffer-references.
+    // now we walk the SPIR-V one more time to find remaining occurrences of buffer-references.
     // that's e.g. cases when a uint64_t is casted. we can only tell by following back the dereferencing spv::OpLoad
     for (const Instruction& insn : instructions)
     {
-        // because it is SSA, we can build this up as we are looping in this pass
-        const uint32_t result_id = insn.resultId();
-        if (result_id != 0)
-        {
-            definitions_[result_id] = &insn;
-        }
-
         const uint32_t opcode = insn.opcode();
 
         if (opcode == spv::OpStore)


### PR DESCRIPTION
- Address-replacer: in ResolveBufferAddresses, only keep a candidate whose stored value maps to a tracked capture-address. The uvec2 BDA-heuristic (#3019) flags additional potential BDA candidates; Filtering them avoids entering the dispatch path for non-addresses
- Enable vulkanMemoryModelDeviceScope at replay device creation when the memory-model is enabled and address-replacement is active (injected hashmap shaders use Device-scope atomics; VUID-RuntimeSpirv-vulkanMemoryModel-06265)
- Create the AS-compacted-size query-pool lazily (only on the AS-compaction path) instead of unconditionally in init_queue_assets; BDA-only captures no longer require VK_KHR_acceleration_structure
- SpirVParsingUtil: check_type_potential_ref: only treat uvec2 (and uvec2 arrays) as a potential
  buffer-device-address when module actually converts any uvec2 to pointer (uvec2 -> OpBitcast -> OpConvertUToPtr).