### PR TITLE
optimize: Split into feature modules

### DIFF
--- a/tools/optimize/CMakeLists.txt
+++ b/tools/optimize/CMakeLists.txt
@@ -31,8 +31,13 @@ add_executable(gfxrecon-optimize "")
 target_sources(gfxrecon-optimize
                PRIVATE
                    ${CMAKE_CURRENT_LIST_DIR}/main.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/optimize_feature.h
+                   ${CMAKE_CURRENT_LIST_DIR}/optimize_vulkan_feature.h
+                   ${CMAKE_CURRENT_LIST_DIR}/optimize_vulkan_feature.cpp
                    ${CMAKE_CURRENT_LIST_DIR}/file_optimizer.h
                    ${CMAKE_CURRENT_LIST_DIR}/file_optimizer.cpp
+                   $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/optimize_dx12_feature.h>
+                   $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/optimize_dx12_feature.cpp>
                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_file_optimizer.h>
                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_file_optimizer.cpp>
                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_optimize_util.h>
@@ -56,7 +61,7 @@ if (MSVC)
     endif()
 endif()
 
-target_include_directories(gfxrecon-optimize PUBLIC ${CMAKE_BINARY_DIR})
+target_include_directories(gfxrecon-optimize PUBLIC ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/..)
 
 target_link_libraries(gfxrecon-optimize
                           gfxrecon_application

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2020-2026 LunarG, Inc.
 ** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -22,29 +22,21 @@
 */
 
 #include PROJECT_VERSION_HEADER_FILE
-#include "file_optimizer.h"
 
-#include "../tool_settings.h"
-
-#if defined(D3D12_SUPPORT)
-#include "dx12_optimize_util.h"
-#endif
+#include "optimize_feature.h"
+#include "tool_settings.h"
 
 #include "decode/decode_api_detection.h"
-#include "decode/dx12_optimize_options.h"
 #include "decode/file_processor.h"
-#include "format/format.h"
-#include "generated/generated_vulkan_decoder.h"
-#include "generated/generated_vulkan_referenced_resource_consumer.h"
-#include "generated/generated_vulkan_referenced_block_consumer.h"
 #include "util/argument_parser.h"
-#include "util/logging.h"
 #include "util/date_time.h"
+#include "util/feature_module_registry.h"
+#include "util/logging.h"
 
-#include <cassert>
+#include <algorithm>
+#include <memory>
 #include <stdexcept>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #if defined(WIN32)
@@ -58,14 +50,9 @@ extern "C"
 }
 #endif
 
-constexpr char kOptions[] =
-    "-h|--help,--version,--no-debug-popup,--d3d12-pso-removal,--d3d12-resource-removal,--dxr,--dxr-experimental";
-constexpr char kArguments[] = "--gpu";
-
-constexpr char kD3d12PsoRemoval[]             = "--d3d12-pso-removal";
-constexpr char kD3d12ResourceRemoval[]        = "--d3d12-resource-removal";
-constexpr char kDx12OptimizeDxr[]             = "--dxr";
-constexpr char kDx12OptimizeDxrExperimental[] = "--dxr-experimental";
+// Module-level features vector so PrintUsage() can access it.
+// tool_settings.h forward-declares PrintUsage(const char*); the signature is fixed.
+static std::vector<std::unique_ptr<gfxrecon::optimize::OptimizeFeature>> g_optimize_features;
 
 static void PrintUsage(const char* exe_name)
 {
@@ -75,17 +62,27 @@ static void PrintUsage(const char* exe_name)
     {
         app_name.replace(0, dir_location + 1, "");
     }
-    GFXRECON_WRITE_CONSOLE("\n%s - Produce new captures with enhanced performance characteristics", app_name.c_str());
 
+    // Build synopsis from feature fragments so it stays in sync automatically.
+    std::string synopsis = app_name + " [-h | --help] [--version]";
+    for (const auto& feature : g_optimize_features)
+    {
+        const std::string fragment = feature->GetSynopsisFragment();
+        if (!fragment.empty())
+        {
+            synopsis += " " + fragment;
+        }
+    }
+    synopsis += " <input-file> <output-file>";
+
+    GFXRECON_WRITE_CONSOLE("\n%s - Produce new captures with enhanced performance characteristics", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("\t\t\tFor Vulkan, the optimizer will remove unused buffer and image initialization data "
                            "(for trimmed captures)");
     GFXRECON_WRITE_CONSOLE(
         "\t\t\tFor D3D12, the optimizer will improve DXR replay performance and remove unused PSOs (for all captures)");
     GFXRECON_WRITE_CONSOLE("");
     GFXRECON_WRITE_CONSOLE("Usage:");
-    GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] [--d3d12-pso-removal] [--d3d12-resource-removal] [--dxr] "
-                           "[--gpu <index>] <input-file> <output-file>",
-                           app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("  %s", synopsis.c_str());
     GFXRECON_WRITE_CONSOLE("");
     GFXRECON_WRITE_CONSOLE("Required arguments:");
     GFXRECON_WRITE_CONSOLE("  <input-file>\t\tThe path to input GFXReconstruct capture file to be processed.");
@@ -94,179 +91,82 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("Optional arguments:");
     GFXRECON_WRITE_CONSOLE("  -h\t\t\t\tPrint usage information and exit (same as --help).");
     GFXRECON_WRITE_CONSOLE("  --version\t\t\tPrint version information and exit.");
-#if defined(WIN32)
-#if defined(_DEBUG)
+
+#if defined(WIN32) && defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("  --no-debug-popup\t\tDisable the 'Abort, Retry, Ignore' message box");
     GFXRECON_WRITE_CONSOLE("        \t\t\tdisplayed when abort() is called (Windows debug only).");
 #endif
-    GFXRECON_WRITE_CONSOLE("  --d3d12-pso-removal\t\tD3D12-only: Remove creation of unreferenced PSOs.");
-    GFXRECON_WRITE_CONSOLE("  --d3d12-resource-removal\tD3D12-only: Remove initialization of unreferenced resources "
-                           "(experimental, off by default).");
-    GFXRECON_WRITE_CONSOLE("  --dxr\t\t\t\tD3D12-only: Optimize for DXR and ExecuteIndirect replay.");
-    GFXRECON_WRITE_CONSOLE("  --gpu <index>\t\t\tUse the specified device for the optimizer replay, where index");
-    GFXRECON_WRITE_CONSOLE("          \t\t\tis the zero-based index to the array of physical devices");
-    GFXRECON_WRITE_CONSOLE("          \t\t\treturned by vkEnumeratePhysicalDevices or IDXGIFactory1::EnumAdapters1.");
-    GFXRECON_WRITE_CONSOLE(
-        "          \t\t\tThe optimizer replay may fail if the specified device is not compatible with the");
-    GFXRECON_WRITE_CONSOLE("          \t\t\toriginal capture devices.");
+
+    for (const auto& feature : g_optimize_features)
+    {
+        feature->PrintUsage();
+    }
     GFXRECON_WRITE_CONSOLE("");
-    GFXRECON_WRITE_CONSOLE("Note: running without optional arguments will instruct the optimizer to detect API and run "
-                           "all available optimizations.");
-#endif
+    GFXRECON_WRITE_CONSOLE("Note: running without optional arguments will instruct the optimizer to detect the API "
+                           "and run all available optimizations.");
 }
 
-void GetUnreferencedResources(const std::string&                              input_filename,
-                              std::unordered_set<gfxrecon::format::HandleId>* unreferenced_ids)
+int32_t main(int32_t argc, const char** argv)
 {
-    GFXRECON_ASSERT(unreferenced_ids != nullptr);
-
-    gfxrecon::decode::FileProcessor file_processor;
-    if (file_processor.Initialize(input_filename))
-    {
-        gfxrecon::decode::VulkanDecoder                    decoder;
-        gfxrecon::decode::VulkanReferencedResourceConsumer resref_consumer;
-
-        decoder.AddConsumer(&resref_consumer);
-
-        file_processor.AddDecoder(&decoder);
-        file_processor.ProcessAllFrames();
-
-        if (file_processor.GetCurrentFrameNumber() > 0 &&
-            file_processor.GetErrorState() == gfxrecon::decode::BlockIOError::kErrorNone)
-        {
-            // Get the list of resources that were included in a command buffer submission during replay.
-            resref_consumer.GetReferencedHandleIds(nullptr, unreferenced_ids);
-        }
-        else if (file_processor.GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
-        {
-            GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
-            gfxrecon::util::Log::Release();
-            exit(-1);
-        }
-        else
-        {
-            GFXRECON_WRITE_CONSOLE("File did not contain any frames");
-            gfxrecon::util::Log::Release();
-            exit(0);
-        }
-    }
-}
-
-// GetUnreferencedBlocksResult defines a simple aggregate return-type
-struct GetUnreferencedBlocksResult
-{
-    uint64_t                     num_blocks = 0;
-    std::unordered_set<uint64_t> unreferenced_blocks;
-};
-
-GetUnreferencedBlocksResult
-GetUnreferencedBlocks(const std::string&                                    input_filename,
-                      const std::unordered_set<gfxrecon::format::HandleId>& unreferenced_ids)
-{
-    gfxrecon::decode::FileProcessor file_processor;
-
-    if (file_processor.Initialize(input_filename))
-    {
-        gfxrecon::decode::VulkanDecoder                 decoder;
-        gfxrecon::decode::VulkanReferencedBlockConsumer block_ref_consumer(unreferenced_ids);
-
-        decoder.AddConsumer(&block_ref_consumer);
-
-        file_processor.AddDecoder(&decoder);
-        file_processor.ProcessAllFrames();
-
-        if (file_processor.GetCurrentFrameNumber() > 0 &&
-            file_processor.GetErrorState() == gfxrecon::decode::BlockIOError::kErrorNone)
-        {
-            // return the set of unused block-indices
-            return { .num_blocks          = file_processor.GetCurrentBlockIndex(),
-                     .unreferenced_blocks = block_ref_consumer.GetUnreferencedBlocks() };
-        }
-
-        GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
-    }
-    return {};
-}
-
-void FilterUnreferencedResources(const std::string&                                    input_filename,
-                                 const std::string&                                    output_filename,
-                                 const std::unordered_set<gfxrecon::format::HandleId>& unreferenced_ids)
-{
-    auto                    result = GetUnreferencedBlocks(input_filename, unreferenced_ids);
-    gfxrecon::FileOptimizer file_optimizer(unreferenced_ids, result.unreferenced_blocks);
-
-    if (file_optimizer.Initialize(input_filename, output_filename))
-    {
-        file_optimizer.Process();
-
-        if (file_optimizer.GetErrorState() != gfxrecon::decode::BlockIOError::kErrorNone)
-        {
-            GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
-            gfxrecon::util::Log::Release();
-            exit(-1);
-        }
-
-        GFXRECON_WRITE_CONSOLE("Resource filtering complete - Removed %zu / %" PRIu64 " blocks",
-                               result.unreferenced_blocks.size(),
-                               result.num_blocks);
-        GFXRECON_WRITE_CONSOLE("\tOriginal file size: %" PRIu64 " bytes", file_optimizer.GetNumBytesRead());
-        GFXRECON_WRITE_CONSOLE("\tOptimized file size: %" PRIu64 " bytes", file_optimizer.GetNumBytesWritten());
-    }
-}
-
-void VkRemoveRedundantResources(const std::string& input_filename, const std::string& output_filename)
-{
-    GFXRECON_WRITE_CONSOLE("Scanning Vulkan file %s for unreferenced resources.", input_filename.c_str());
-    std::unordered_set<gfxrecon::format::HandleId> unreferenced_ids;
-    GetUnreferencedResources(input_filename, &unreferenced_ids);
-
-    if (!unreferenced_ids.empty())
-    {
-        // Filter unreferenced ids.
-        GFXRECON_WRITE_CONSOLE("Writing optimized file, removing initialization data for %" PRIu64 " unused resources.",
-                               unreferenced_ids.size());
-        FilterUnreferencedResources(input_filename, output_filename, unreferenced_ids);
-    }
-    else
-    {
-        GFXRECON_WRITE_CONSOLE("No unused resources detected.  A new file will not be created.",
-                               input_filename.c_str());
-    }
-}
-
-void RunDx12Optimizations(const std::string&                        input_filename,
-                          const std::string&                        output_filename,
-                          gfxrecon::decode::Dx12OptimizationOptions dx12_options)
-{
-#if defined(D3D12_SUPPORT)
-    bool result = gfxrecon::Dx12OptimizeFile(input_filename, output_filename, dx12_options);
-    if (!result)
-    {
-        gfxrecon::util::Log::Release();
-        exit(-1);
-    }
-#endif
-}
-
-int main(int argc, const char** argv)
-{
+    bool    success    = false;
     int64_t start_time = gfxrecon::util::datetime::GetTimestamp();
+    int64_t end_time{ 0 };
+    int32_t time_in_seconds{ 0 };
+    struct LogGuard
+    {
+        LogGuard()
+        {
+            gfxrecon::util::Log::Init();
+            gfxrecon::util::Log::SetFatalCallback([](const char* message) { throw std::runtime_error(message); });
+        }
+        ~LogGuard() { gfxrecon::util::Log::Release(); }
+    } log_guard;
 
-    gfxrecon::util::Log::Init();
-    gfxrecon::util::Log::SetFatalCallback([](const char* message) { throw std::runtime_error(message); });
+    // Build features first; they must exist before we construct the ArgumentParser
+    // (to contribute their options/arguments) and before PrintUsage() is called.
+    for (const auto& creator :
+         gfxrecon::util::FeatureModuleRegistry<gfxrecon::optimize::OptimizeFeature>::GetSingleton()
+             .GetRegisteredFeatureCreators())
+    {
+        g_optimize_features.push_back(creator());
+    }
 
-    gfxrecon::util::ArgumentParser arg_parser(argc, argv, kOptions, kArguments);
+    // Aggregate option flags and argument keys from all features plus common flags.
+    std::string options   = "-h|--help,--version";
+    std::string arguments = "";
+
+#if defined(WIN32) && defined(_DEBUG)
+    options += ",--no-debug-popup";
+#endif
+
+    for (const auto& feature : g_optimize_features)
+    {
+        const std::string feature_opts = feature->GetOptions();
+        if (!feature_opts.empty())
+        {
+            options += "," + feature_opts;
+        }
+        const std::string feature_args = feature->GetArguments();
+        if (!feature_args.empty())
+        {
+            if (!arguments.empty())
+            {
+                arguments += ",";
+            }
+            arguments += feature_args;
+        }
+    }
+
+    gfxrecon::util::ArgumentParser arg_parser(argc, argv, options, arguments);
 
     if (CheckOptionPrintUsage(argv[0], arg_parser) || CheckOptionPrintVersion(argv[0], arg_parser))
     {
-        gfxrecon::util::Log::Release();
-        exit(0);
+        return EXIT_SUCCESS;
     }
     else if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 2))
     {
         PrintUsage(argv[0]);
-        gfxrecon::util::Log::Release();
-        exit(-1);
+        return EXIT_FAILURE;
     }
     else
     {
@@ -280,93 +180,73 @@ int main(int argc, const char** argv)
 
     try
     {
-        std::string                     input_filename;
-        std::string                     output_filename;
         const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();
-        input_filename                                       = positional_arguments[0];
-        output_filename                                      = positional_arguments[1];
+        const std::string&              input_filename       = positional_arguments[0];
+        const std::string&              output_filename      = positional_arguments[1];
 
-        // Parameter checking and API detection
-        gfxrecon::decode::Dx12OptimizationOptions dx12_options;
-        dx12_options.optimize_resource_values              = arg_parser.IsOptionSet(kDx12OptimizeDxr);
-        dx12_options.optimize_resource_values_experimental = arg_parser.IsOptionSet(kDx12OptimizeDxrExperimental);
-        dx12_options.remove_redundant_psos                 = arg_parser.IsOptionSet(kD3d12PsoRemoval);
-        dx12_options.remove_redundant_resources            = arg_parser.IsOptionSet(kD3d12ResourceRemoval);
-        const auto& override_gpu                           = arg_parser.GetArgumentValue(kOverrideGpuArgument);
-        if (!override_gpu.empty())
+        // Two-phase detection: quick limited scan first, full scan only if needed.
+        // This mirrors the original DetectAPIs behavior and avoids reading the whole
+        // file when the API headers appear in the first kDefaultDetectionBlockLimit blocks.
+        auto run_detection_pass = [&](uint64_t block_limit) {
+            gfxrecon::decode::FileProcessor detection_processor;
+            if (detection_processor.Initialize(input_filename))
+            {
+                for (auto& feature : g_optimize_features)
+                {
+                    feature->RegisterDetectionDecoder(detection_processor, block_limit);
+                }
+                detection_processor.ProcessAllFrames();
+            }
+        };
+
+        using Feature = gfxrecon::optimize::OptimizeFeature;
+        run_detection_pass(Feature::kDefaultDetectionBlockLimit);
+
+        bool did_any_run = std::any_of(g_optimize_features.begin(), g_optimize_features.end(), [&](const auto& f) {
+            return f->ShouldRun(arg_parser);
+        });
+        if (!did_any_run)
         {
-            dx12_options.override_gpu_index = std::stoi(override_gpu);
+            run_detection_pass(Feature::kNoDetectionBlockLimit);
         }
 
-        if (dx12_options.optimize_resource_values_experimental)
+        // Run every feature that should execute given the current arguments and detection results.
+        bool any_ran = false;
+        for (auto& feature : g_optimize_features)
         {
-            GFXRECON_WRITE_CONSOLE("Running experimental DXR optimization. This mode is experimental, and should only "
-                                   "be used if --dxr did not produce a valid capture file.");
-            dx12_options.optimize_resource_values = true;
+            if (feature->ShouldRun(arg_parser))
+            {
+                if (feature->Optimize(input_filename, output_filename, arg_parser))
+                {
+                    any_ran = true;
+                }
+            }
         }
 
-        // Automatic mode. User specified no options.
-        if (!(dx12_options.optimize_resource_values || dx12_options.remove_redundant_psos ||
-              dx12_options.remove_redundant_resources))
+        if (!any_ran)
         {
-            bool detected_d3d12  = false;
-            bool detected_vulkan = false;
-            bool detected_openxr = false;
-            gfxrecon::decode::DetectAPIs(input_filename, detected_d3d12, detected_vulkan, detected_openxr);
-
-            if ((!detected_d3d12) && (!detected_vulkan))
-            {
-                // Detect with no block limit
-                gfxrecon::decode::DetectAPIs(input_filename, detected_d3d12, detected_vulkan, detected_openxr, true);
-            }
-
-            if (detected_d3d12)
-            {
-                dx12_options.optimize_resource_values = true;
-                dx12_options.remove_redundant_psos    = true;
-                // Redundant resource removal is experimental and disabled by default.
-                dx12_options.remove_redundant_resources = false;
-                RunDx12Optimizations(input_filename, output_filename, dx12_options);
-            }
-            else if (detected_vulkan)
-            {
-                VkRemoveRedundantResources(input_filename, output_filename);
-            }
-#if ENABLE_OPENXR_SUPPORT
-            else if (detected_openxr)
-            {
-                GFXRECON_LOG_INFO("No optimizations defined for OpenXR capture files");
-            }
-#endif
-            else
-            {
-                GFXRECON_LOG_ERROR("Could not detect graphics API. Aborting optimization.")
-            }
+            GFXRECON_LOG_ERROR("Could not detect graphics API. Aborting optimization.");
         }
-        // Manual mode. Follow user instructions.
         else
         {
-            RunDx12Optimizations(input_filename, output_filename, dx12_options);
+            success = true;
         }
     }
     catch (const std::runtime_error& error)
     {
         GFXRECON_WRITE_CONSOLE("File processing has encountered a fatal error and cannot continue: %s", error.what());
-        gfxrecon::util::Log::Release();
-        return -1;
+        return EXIT_FAILURE;
     }
     catch (...)
     {
         GFXRECON_WRITE_CONSOLE("File processing failed due to an unhandled exception");
-        gfxrecon::util::Log::Release();
-        return -1;
+        return EXIT_FAILURE;
     }
 
-    int64_t end_time        = gfxrecon::util::datetime::GetTimestamp();
-    int     time_in_seconds = static_cast<int>(gfxrecon::util::datetime::ConvertTimestampToSeconds(
+    end_time        = gfxrecon::util::datetime::GetTimestamp();
+    time_in_seconds = static_cast<int32_t>(gfxrecon::util::datetime::ConvertTimestampToSeconds(
         gfxrecon::util::datetime::DiffTimestamps(start_time, end_time)));
     GFXRECON_WRITE_CONSOLE("File processing time: %d seconds", time_in_seconds);
 
-    gfxrecon::util::Log::Release();
-    return 0;
+    return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tools/optimize/optimize_dx12_feature.cpp
+++ b/tools/optimize/optimize_dx12_feature.cpp
@@ -1,0 +1,146 @@
+/*
+** Copyright (c) 2020-2026 LunarG, Inc.
+** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#if defined(D3D12_SUPPORT)
+
+#include "optimize_dx12_feature.h"
+
+// Disable the usage static prototype
+#define GFXR_TOOL_SETTINGS_NO_USAGE
+#include "tool_settings.h"
+
+#include "dx12_optimize_util.h"
+#include "util/feature_module_registry.h"
+#include "util/logging.h"
+
+#include <memory>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(optimize)
+
+GFXR_UTIL_REGISTER_FEATURE_CREATOR(OptimizeFeature, OptimizeDx12Feature)
+
+// D3D12-specific CLI flag names, private to this translation unit.
+constexpr char kD3d12PsoRemoval[]             = "--d3d12-pso-removal";
+constexpr char kD3d12ResourceRemoval[]        = "--d3d12-resource-removal";
+constexpr char kDx12OptimizeDxr[]             = "--dxr";
+constexpr char kDx12OptimizeDxrExperimental[] = "--dxr-experimental";
+
+void OptimizeDx12Feature::RegisterDetectionDecoder(decode::FileProcessor& file_processor, uint64_t block_limit)
+{
+    // Destroy decoder before consumer: decoder holds a raw pointer to consumer.
+    detection_decoder_.reset();
+    detection_consumer_ = std::make_unique<decode::Dx12DetectionConsumer>(block_limit);
+    detection_decoder_  = std::make_unique<decode::Dx12Decoder>();
+    detection_decoder_->AddConsumer(detection_consumer_.get());
+    file_processor.AddDecoder(detection_decoder_.get());
+}
+
+bool OptimizeDx12Feature::WasDetected() const
+{
+    return detection_consumer_ != nullptr && detection_consumer_->WasD3D12APIDetected();
+}
+
+bool OptimizeDx12Feature::ShouldRun(const util::ArgumentParser& args) const
+{
+    bool manual_mode = args.IsOptionSet(kDx12OptimizeDxr) || args.IsOptionSet(kDx12OptimizeDxrExperimental) ||
+                       args.IsOptionSet(kD3d12PsoRemoval) || args.IsOptionSet(kD3d12ResourceRemoval);
+    return manual_mode || WasDetected();
+}
+
+std::string OptimizeDx12Feature::GetOptions() const
+{
+    return "--d3d12-pso-removal,--d3d12-resource-removal,--dxr,--dxr-experimental";
+}
+
+std::string OptimizeDx12Feature::GetArguments() const
+{
+    return kOverrideGpuArgument;
+}
+
+std::string OptimizeDx12Feature::GetSynopsisFragment() const
+{
+    return "[--d3d12-pso-removal] [--d3d12-resource-removal] [--dxr] [--gpu <index>]";
+}
+
+void OptimizeDx12Feature::PrintUsage() const
+{
+    GFXRECON_WRITE_CONSOLE("");
+    GFXRECON_WRITE_CONSOLE(" // D3D12-only options:");
+    GFXRECON_WRITE_CONSOLE(" // -------------------");
+    GFXRECON_WRITE_CONSOLE("  --d3d12-pso-removal\t\tRemove creation of unreferenced PSOs.");
+    GFXRECON_WRITE_CONSOLE("  --d3d12-resource-removal\tRemove initialization of unreferenced resources "
+                           "(experimental, off by default).");
+    GFXRECON_WRITE_CONSOLE("  --dxr\t\t\t\tOptimize for DXR and ExecuteIndirect replay.");
+    GFXRECON_WRITE_CONSOLE("  --gpu <index>\t\t\tUse the specified device for the optimizer replay,");
+    GFXRECON_WRITE_CONSOLE("          \t\t\twhere index is the zero-based index to the array of adapters");
+    GFXRECON_WRITE_CONSOLE("          \t\t\treturned by IDXGIFactory1::EnumAdapters1.");
+    GFXRECON_WRITE_CONSOLE(
+        "          \t\t\tThe optimizer replay may fail if the specified device is not compatible with the");
+    GFXRECON_WRITE_CONSOLE("          \t\t\toriginal capture devices.");
+}
+
+decode::Dx12OptimizationOptions OptimizeDx12Feature::BuildOptions(const util::ArgumentParser& args) const
+{
+    decode::Dx12OptimizationOptions options{};
+    options.optimize_resource_values              = args.IsOptionSet(kDx12OptimizeDxr);
+    options.optimize_resource_values_experimental = args.IsOptionSet(kDx12OptimizeDxrExperimental);
+    options.remove_redundant_psos                 = args.IsOptionSet(kD3d12PsoRemoval);
+    options.remove_redundant_resources            = args.IsOptionSet(kD3d12ResourceRemoval);
+
+    if (options.optimize_resource_values_experimental)
+    {
+        GFXRECON_WRITE_CONSOLE("Running experimental DXR optimization. This mode is experimental, and should only "
+                               "be used if --dxr did not produce a valid capture file.");
+        options.optimize_resource_values = true;
+    }
+
+    const auto& gpu_override = args.GetArgumentValue(kOverrideGpuArgument);
+    if (!gpu_override.empty())
+    {
+        options.override_gpu_index = std::stoi(gpu_override);
+    }
+
+    // Automatic mode: no flags explicitly set, enable all stable defaults.
+    if (!options.optimize_resource_values && !options.remove_redundant_psos && !options.remove_redundant_resources)
+    {
+        options.optimize_resource_values = true;
+        options.remove_redundant_psos    = true;
+        // remove_redundant_resources is experimental and intentionally left false.
+    }
+
+    return options;
+}
+
+bool OptimizeDx12Feature::Optimize(const std::string&          input_filename,
+                                   const std::string&          output_filename,
+                                   const util::ArgumentParser& args)
+{
+    decode::Dx12OptimizationOptions options = BuildOptions(args);
+    return Dx12OptimizeFile(input_filename, output_filename, options);
+}
+
+GFXRECON_END_NAMESPACE(optimize)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // D3D12_SUPPORT

--- a/tools/optimize/optimize_dx12_feature.h
+++ b/tools/optimize/optimize_dx12_feature.h
@@ -1,0 +1,74 @@
+/*
+** Copyright (c) 2020-2026 LunarG, Inc.
+** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_OPTIMIZE_DX12_FEATURE_H
+#define GFXRECON_OPTIMIZE_DX12_FEATURE_H
+
+#if defined(D3D12_SUPPORT)
+
+#include "optimize_feature.h"
+
+#include "decode/dx12_detection_consumer.h"
+#include "decode/dx12_optimize_options.h"
+#include "generated/generated_dx12_decoder.h"
+
+#include <memory>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(optimize)
+
+class OptimizeDx12Feature : public OptimizeFeature
+{
+  public:
+    OptimizeDx12Feature()           = default;
+    ~OptimizeDx12Feature() override = default;
+
+    std::string Label() const override { return "D3D12"; }
+
+    void RegisterDetectionDecoder(decode::FileProcessor& file_processor, uint64_t block_limit) override;
+    bool WasDetected() const override;
+    bool ShouldRun(const util::ArgumentParser& args) const override;
+    bool Optimize(const std::string&          input_filename,
+                  const std::string&          output_filename,
+                  const util::ArgumentParser& args) override;
+
+    // Command-line options and arguments
+    // -------------------------------------
+    std::string GetOptions() const override;
+    std::string GetArguments() const override;
+    std::string GetSynopsisFragment() const override;
+    void        PrintUsage() const override;
+
+  private:
+    decode::Dx12OptimizationOptions BuildOptions(const util::ArgumentParser& args) const;
+
+    std::unique_ptr<decode::Dx12DetectionConsumer> detection_consumer_;
+    std::unique_ptr<decode::Dx12Decoder>           detection_decoder_;
+};
+
+GFXRECON_END_NAMESPACE(optimize)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // D3D12_SUPPORT
+
+#endif // GFXRECON_OPTIMIZE_DX12_FEATURE_H

--- a/tools/optimize/optimize_feature.h
+++ b/tools/optimize/optimize_feature.h
@@ -1,0 +1,85 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_OPTIMIZE_FEATURE_H
+#define GFXRECON_OPTIMIZE_FEATURE_H
+
+#include "decode/file_processor.h"
+#include "util/argument_parser.h"
+#include "util/defines.h"
+
+#include <string>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(optimize)
+
+class OptimizeFeature
+{
+  public:
+    virtual ~OptimizeFeature() = default;
+
+    virtual std::string Label() const = 0;
+
+    // Block-limit sentinels for the two-phase detection pass. Values match the
+    // kDefaultBlockLimit / kNoBlockLimit constants on both VulkanDetectionConsumer and
+    // Dx12DetectionConsumer, so main.cpp doesn't need to include those headers.
+    static constexpr uint64_t kDefaultDetectionBlockLimit = 1000;
+    static constexpr uint64_t kNoDetectionBlockLimit      = 0;
+
+    // Registers this feature's detection decoder with the given FileProcessor.
+    // Pass kDefaultDetectionBlockLimit for the initial quick scan; if nothing is
+    // detected, call again with kNoDetectionBlockLimit for a full-file scan.
+    virtual void RegisterDetectionDecoder(decode::FileProcessor& file_processor, uint64_t block_limit) = 0;
+
+    // Returns true if this feature's API was present in the capture.
+    virtual bool WasDetected() const = 0;
+
+    // Returns true if this feature should run given the parsed CLI args.
+    // Automatic mode: delegates to WasDetected().
+    // Manual mode: returns true if the feature's own flags are explicitly set.
+    virtual bool ShouldRun(const util::ArgumentParser& args) const = 0;
+
+    // Runs the optimization, managing all internal passes. Returns true on success.
+    virtual bool Optimize(const std::string&          input_filename,
+                          const std::string&          output_filename,
+                          const util::ArgumentParser& args) = 0;
+
+    // Command-line options and arguments
+    // -------------------------------------
+    // Returns feature-specific option flags for the ArgumentParser (comma-separated, | for aliases).
+    virtual std::string GetOptions() const { return ""; }
+
+    // Returns feature-specific argument keys for the ArgumentParser (comma-separated).
+    virtual std::string GetArguments() const { return ""; }
+
+    // Returns a synopsis fragment for the usage line, e.g. "[--my-flag] [--my-arg <val>]".
+    virtual std::string GetSynopsisFragment() const { return ""; }
+
+    // Prints feature-specific optional-argument help lines to the console.
+    // Called from main's PrintUsage(), which tool_settings.h invokes for --help.
+    virtual void PrintUsage() const {}
+};
+
+GFXRECON_END_NAMESPACE(optimize)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_OPTIMIZE_FEATURE_H

--- a/tools/optimize/optimize_vulkan_feature.cpp
+++ b/tools/optimize/optimize_vulkan_feature.cpp
@@ -1,0 +1,163 @@
+/*
+** Copyright (c) 2020-2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "optimize_vulkan_feature.h"
+
+#include "file_optimizer.h"
+#include "decode/file_processor.h"
+#include "generated/generated_vulkan_referenced_block_consumer.h"
+#include "generated/generated_vulkan_referenced_resource_consumer.h"
+#include "util/feature_module_registry.h"
+#include "util/logging.h"
+
+#include <cinttypes>
+#include <memory>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(optimize)
+
+GFXR_UTIL_REGISTER_FEATURE_CREATOR(OptimizeFeature, OptimizeVulkanFeature)
+
+void OptimizeVulkanFeature::RegisterDetectionDecoder(decode::FileProcessor& file_processor, uint64_t block_limit)
+{
+    // Destroy decoder before consumer: decoder holds a raw pointer to consumer.
+    detection_decoder_.reset();
+    detection_consumer_ = std::make_unique<decode::VulkanDetectionConsumer>(block_limit);
+    detection_decoder_  = std::make_unique<decode::VulkanDecoder>();
+    detection_decoder_->AddConsumer(detection_consumer_.get());
+    file_processor.AddDecoder(detection_decoder_.get());
+}
+
+bool OptimizeVulkanFeature::WasDetected() const
+{
+    return detection_consumer_ != nullptr && detection_consumer_->WasVulkanAPIDetected();
+}
+
+bool OptimizeVulkanFeature::ShouldRun(const util::ArgumentParser& args) const
+{
+    return WasDetected();
+}
+
+bool OptimizeVulkanFeature::GetUnreferencedResources(const std::string&                    input_filename,
+                                                     std::unordered_set<format::HandleId>& unreferenced_ids)
+{
+    decode::FileProcessor file_processor;
+    if (!file_processor.Initialize(input_filename))
+    {
+        return false;
+    }
+
+    decode::VulkanDecoder                    decoder;
+    decode::VulkanReferencedResourceConsumer resref_consumer;
+    decoder.AddConsumer(&resref_consumer);
+    file_processor.AddDecoder(&decoder);
+    file_processor.ProcessAllFrames();
+
+    if (file_processor.GetCurrentFrameNumber() == 0)
+    {
+        GFXRECON_WRITE_CONSOLE("File did not contain any frames");
+        return false;
+    }
+
+    if (file_processor.GetErrorState() != decode::BlockIOError::kErrorNone)
+    {
+        GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
+        return false;
+    }
+
+    resref_consumer.GetReferencedHandleIds(nullptr, &unreferenced_ids);
+    return true;
+}
+
+bool OptimizeVulkanFeature::FilterUnreferencedResources(const std::string&                          input_filename,
+                                                        const std::string&                          output_filename,
+                                                        const std::unordered_set<format::HandleId>& unreferenced_ids)
+{
+    // Collect the block indices that correspond to unreferenced resources.
+    decode::FileProcessor file_processor;
+    if (!file_processor.Initialize(input_filename))
+    {
+        return false;
+    }
+
+    decode::VulkanDecoder                 decoder;
+    decode::VulkanReferencedBlockConsumer block_ref_consumer(unreferenced_ids);
+    decoder.AddConsumer(&block_ref_consumer);
+    file_processor.AddDecoder(&decoder);
+    file_processor.ProcessAllFrames();
+
+    if (file_processor.GetErrorState() != decode::BlockIOError::kErrorNone)
+    {
+        GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
+        return false;
+    }
+
+    uint64_t                     num_blocks          = file_processor.GetCurrentBlockIndex();
+    std::unordered_set<uint64_t> unreferenced_blocks = block_ref_consumer.GetUnreferencedBlocks();
+
+    // Stream the input to the output, dropping unreferenced blocks.
+    FileOptimizer file_optimizer(unreferenced_ids, unreferenced_blocks);
+    if (!file_optimizer.Initialize(input_filename, output_filename))
+    {
+        return false;
+    }
+
+    file_optimizer.Process();
+
+    if (file_optimizer.GetErrorState() != decode::BlockIOError::kErrorNone)
+    {
+        GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
+        return false;
+    }
+
+    GFXRECON_WRITE_CONSOLE(
+        "Resource filtering complete - Removed %zu / %" PRIu64 " blocks", unreferenced_blocks.size(), num_blocks);
+    GFXRECON_WRITE_CONSOLE("\tOriginal file size: %" PRIu64 " bytes", file_optimizer.GetNumBytesRead());
+    GFXRECON_WRITE_CONSOLE("\tOptimized file size: %" PRIu64 " bytes", file_optimizer.GetNumBytesWritten());
+    return true;
+}
+
+bool OptimizeVulkanFeature::Optimize(const std::string&          input_filename,
+                                     const std::string&          output_filename,
+                                     const util::ArgumentParser& args)
+{
+    GFXRECON_WRITE_CONSOLE("Scanning Vulkan file %s for unreferenced resources.", input_filename.c_str());
+
+    std::unordered_set<format::HandleId> unreferenced_ids;
+    if (!GetUnreferencedResources(input_filename, unreferenced_ids))
+    {
+        return false;
+    }
+
+    if (unreferenced_ids.empty())
+    {
+        GFXRECON_WRITE_CONSOLE("No unused resources detected. A new file will not be created.");
+        return true;
+    }
+
+    GFXRECON_WRITE_CONSOLE("Writing optimized file, removing initialization data for %" PRIu64 " unused resources.",
+                           unreferenced_ids.size());
+    return FilterUnreferencedResources(input_filename, output_filename, unreferenced_ids);
+}
+
+GFXRECON_END_NAMESPACE(optimize)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/tools/optimize/optimize_vulkan_feature.h
+++ b/tools/optimize/optimize_vulkan_feature.h
@@ -1,0 +1,71 @@
+/*
+** Copyright (c) 2020-2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_OPTIMIZE_VULKAN_FEATURE_H
+#define GFXRECON_OPTIMIZE_VULKAN_FEATURE_H
+
+#include "optimize_feature.h"
+
+#include "decode/vulkan_detection_consumer.h"
+#include "format/format.h"
+#include "generated/generated_vulkan_decoder.h"
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(optimize)
+
+class OptimizeVulkanFeature : public OptimizeFeature
+{
+  public:
+    OptimizeVulkanFeature()           = default;
+    ~OptimizeVulkanFeature() override = default;
+
+    std::string Label() const override { return "Vulkan"; }
+
+    void RegisterDetectionDecoder(decode::FileProcessor& file_processor, uint64_t block_limit) override;
+    bool WasDetected() const override;
+    bool ShouldRun(const util::ArgumentParser& args) const override;
+    bool Optimize(const std::string&          input_filename,
+                  const std::string&          output_filename,
+                  const util::ArgumentParser& args) override;
+
+  private:
+    // Pass 1: collect handles that were never referenced in a command buffer submission.
+    bool GetUnreferencedResources(const std::string&                    input_filename,
+                                  std::unordered_set<format::HandleId>& unreferenced_ids);
+
+    // Passes 2-3: determine unreferenced block indices, then write the filtered output file.
+    bool FilterUnreferencedResources(const std::string&                          input_filename,
+                                     const std::string&                          output_filename,
+                                     const std::unordered_set<format::HandleId>& unreferenced_ids);
+
+    std::unique_ptr<decode::VulkanDetectionConsumer> detection_consumer_;
+    std::unique_ptr<decode::VulkanDecoder>           detection_decoder_;
+};
+
+GFXRECON_END_NAMESPACE(optimize)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_OPTIMIZE_VULKAN_FEATURE_H


### PR DESCRIPTION
Perform the same work done to `gfxrecon-info`, `gfxrecon-convert`, `gfxrecon-replay` and `gfxrecon-extract`  in separating out the various APIs supported by our tools into seperate features for maintainability and future modification.