### PR TITLE
Index copy semaphores in virtual swapchain by replay image index

### DIFF
--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -365,11 +365,11 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceI
             // Create one command buffer per queue per swapchain image so that we don't reset a command buffer that
             // may be in active use.
             uint32_t command_buffer_count = static_cast<uint32_t>(copy_cmd_data.command_buffers.size());
-            if (command_buffer_count < capture_image_count)
+            if (command_buffer_count < *replay_image_count)
             {
-                copy_cmd_data.command_buffers.resize(capture_image_count);
+                copy_cmd_data.command_buffers.resize(*replay_image_count);
 
-                uint32_t                    new_count     = capture_image_count - command_buffer_count;
+                uint32_t                    new_count     = *replay_image_count - command_buffer_count;
                 VkCommandBufferAllocateInfo allocate_info = {
                     VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, // sType
                     nullptr,                                        // pNext
@@ -417,11 +417,11 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceI
                 }
             }
             uint32_t fence_count = static_cast<uint32_t>(copy_cmd_data.fences.size());
-            if (fence_count < capture_image_count)
+            if (fence_count < *replay_image_count)
             {
-                copy_cmd_data.fences.resize(capture_image_count);
+                copy_cmd_data.fences.resize(*replay_image_count);
 
-                for (uint32_t ii = fence_count; ii < capture_image_count; ++ii)
+                for (uint32_t ii = fence_count; ii < *replay_image_count; ++ii)
                 {
                     VkFenceCreateInfo fence_create_info = {
                         VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, // sType
@@ -958,12 +958,12 @@ VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                       
         const auto& virtual_image = swapchain_resources->virtual_swapchain_images[capture_image_index];
         const auto& replay_image  = swapchain_resources->replay_swapchain_images[replay_image_index];
 
-        // Use a command buffer and fence from the same queue index
-        auto& copy_cmd_data  = swapchain_resources->copy_cmd_data[queue_family_index];
-        auto  command_buffer = copy_cmd_data.command_buffers[capture_image_index];
-        auto  copy_fence     = copy_cmd_data.fences[capture_image_index];
-        // The semaphore will be waited by the present which should be coordinated by hardware image indices
+        // Use copy resources from the same queue index
+        auto& copy_cmd_data = swapchain_resources->copy_cmd_data[queue_family_index];
+        // Copy resources should be associated to the frames in flight, which is our real images
+        auto command_buffer = copy_cmd_data.command_buffers[replay_image_index];
         auto copy_semaphore = copy_cmd_data.semaphores[replay_image_index];
+        auto copy_fence     = copy_cmd_data.fences[replay_image_index];
 
         std::vector<VkSemaphore> wait_semaphores;
         std::vector<VkSemaphore> signal_semaphores;

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -390,11 +390,13 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceI
                 }
             }
             uint32_t semaphore_count = static_cast<uint32_t>(copy_cmd_data.semaphores.size());
-            if (semaphore_count < capture_image_count)
+            // Semaphores for signaling to present that copy is finished. Since our presentation of real hardware images
+            // waits on these, they should be coordinated with the replay (real) images.
+            if (semaphore_count < *replay_image_count)
             {
-                copy_cmd_data.semaphores.resize(capture_image_count);
+                copy_cmd_data.semaphores.resize(*replay_image_count);
 
-                for (uint32_t ii = semaphore_count; ii < capture_image_count; ++ii)
+                for (uint32_t ii = semaphore_count; ii < *replay_image_count; ++ii)
                 {
                     VkSemaphoreCreateInfo semaphore_create_info = {
                         VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO, // sType
@@ -956,11 +958,12 @@ VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                       
         const auto& virtual_image = swapchain_resources->virtual_swapchain_images[capture_image_index];
         const auto& replay_image  = swapchain_resources->replay_swapchain_images[replay_image_index];
 
-        // Use a command buffer and semaphore from the same queue index
+        // Use a command buffer and fence from the same queue index
         auto& copy_cmd_data  = swapchain_resources->copy_cmd_data[queue_family_index];
         auto  command_buffer = copy_cmd_data.command_buffers[capture_image_index];
-        auto  copy_semaphore = copy_cmd_data.semaphores[capture_image_index];
         auto  copy_fence     = copy_cmd_data.fences[capture_image_index];
+        // The semaphore will be waited by the present which should be coordinated by hardware image indices
+        auto copy_semaphore = copy_cmd_data.semaphores[replay_image_index];
 
         std::vector<VkSemaphore> wait_semaphores;
         std::vector<VkSemaphore> signal_semaphores;


### PR DESCRIPTION
We commonly see validation errors `VUID-vkQueueSubmit-pSignalSemaphores-00067` during replay of a wide variety of well synchronized applications, and many are likely from the queue submit associated with copying images from the virtual swapchain to the presentation swapchain. This is due to the `copy_semaphore` not being unsignaled, which should happen by the time presentation is finished. However, our logic doesn't let us know it is unsignaled, or that presentation is finished.

Example:
Frame 1: signal on semaphore associated to `capture_index = 0`, present on `replay_index = 1` 
Frame 2: signal on semaphore associated to `capture_index = 1`, present on `replay_index = 2` 
Frame 3: signal on semaphore associated to `capture_index = 0`, present on `replay_index = 0`

On frame 3, we don't know if the semaphore with `capture_index = 0` is unsignaled. The semaphore could still be signaled, hence the validation error. However, `vkQueuePresent` doesn't tell or signal us that the semaphore can be reused. 

Traditionally (there are workaround extensions), Vulkan let's us know an image's presentation is done if `AcquireNextImage` gives that index, which in the example above is a perfectly valid and released `replay_index = 0`. However, as the semaphore is not associated with the replay/real indices we have no idea if that semaphore's presentation is finished.

It shouldn't matter whether capture has more swapchain images or replay has more swapchain images, as long as the connection between the presentation image and the semaphore are not mapped together, and that there are at least two images in both swapchains, this can be an issue. All other combinations of image counts can have this subcase.

Subcase example:
Frame 1: signal on semaphore associated to `capture_index = 0`, present on `replay_index = 0` 
Frame 2: signal on semaphore associated to `capture_index = 1`, present on `replay_index = 1` 
Frame 3: signal on semaphore associated to `capture_index = 0`, present on `replay_index = 1` 
Acquire on frame 3 gives index 1 (which is perfectly valid), but still unknown if semaphore at `capture_index = 0` is unsignaled yet.

Change copy semaphores to use replay indices.

Fixes https://github.com/LunarG/gfxreconstruct/issues/2692