### PR TITLE
refactor: replace strncpy_s with util::platform::StringCopy

### DIFF
--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -3167,7 +3167,7 @@ void D3D12CaptureManager::WriteDriverInfoCommand(const std::string& info)
     {
         format::DriverInfoBlock driver_info_header = {};
 
-        strncpy_s(driver_info_header.driver_record,
+        gfxrecon::util::platform::StringCopy(driver_info_header.driver_record,
                   util::filepath::kMaxDriverInfoSize,
                   info.c_str(),
                   util::filepath::kMaxDriverInfoSize);
@@ -3216,7 +3216,7 @@ void D3D12CaptureManager::WriteDx12RuntimeInfo()
                                                file_info.AppVersion,
                                                sizeof(runtime_info.version));
 
-                    strncpy_s(runtime_info.src,
+                    gfxrecon::util::platform::StringCopy(runtime_info.src,
                               util::filepath::kMaxFilePropertySize,
                               runtime_desc.c_str(),
                               util::filepath::kMaxFilePropertySize);

--- a/framework/util/driver_info.cpp
+++ b/framework/util/driver_info.cpp
@@ -104,7 +104,7 @@ bool AMD_GetUMDInfo(const std::string& active_driver_path, std::string& driver_i
     if (active_driver_path.empty() == false)
     {
         filepath::FileInfo file_info = {};
-        strncpy_s(file_info.AppName,
+        gfxrecon::util::platform::StringCopy(file_info.AppName,
                   sizeof(file_info.AppName),
                   active_driver_path.substr(active_driver_path.find_last_of("/\\") + 1).c_str(),
                   active_driver_path.substr(active_driver_path.find_last_of("/\\") + 1).length());

--- a/framework/util/file_path.cpp
+++ b/framework/util/file_path.cpp
@@ -312,31 +312,31 @@ void UpdateExeFileInfo(ExeInfoMember member, const std::string& value, FileInfo&
 #if defined(WIN32)
     if (member == kExeInfoCompanyName)
     {
-        strncpy_s(info.CompanyName, sizeof(info.CompanyName), value.c_str(), value.length());
+        gfxrecon::util::platform::StringCopy(info.CompanyName, sizeof(info.CompanyName), value.c_str(), value.length());
     }
     else if (member == kExeInfoFileDescription)
     {
-        strncpy_s(info.FileDescription, sizeof(info.FileDescription), value.c_str(), value.length());
+        gfxrecon::util::platform::StringCopy(info.FileDescription, sizeof(info.FileDescription), value.c_str(), value.length());
     }
     else if (member == kExeInfoFileVersion)
     {
-        strncpy_s(info.FileVersion, sizeof(info.FileVersion), value.c_str(), value.length());
+        gfxrecon::util::platform::StringCopy(info.FileVersion, sizeof(info.FileVersion), value.c_str(), value.length());
     }
     else if (member == kExeInfoInternalName)
     {
-        strncpy_s(info.InternalName, sizeof(info.InternalName), value.c_str(), value.length());
+        gfxrecon::util::platform::StringCopy(info.InternalName, sizeof(info.InternalName), value.c_str(), value.length());
     }
     else if (member == kExeInfoOriginalFilename)
     {
-        strncpy_s(info.OriginalFilename, sizeof(info.OriginalFilename), value.c_str(), value.length());
+        gfxrecon::util::platform::StringCopy(info.OriginalFilename, sizeof(info.OriginalFilename), value.c_str(), value.length());
     }
     else if (member == kExeInfoProductName)
     {
-        strncpy_s(info.ProductName, sizeof(info.ProductName), value.c_str(), value.length());
+        gfxrecon::util::platform::StringCopy(info.ProductName, sizeof(info.ProductName), value.c_str(), value.length());
     }
     else if (member == kExeInfoProductVersion)
     {
-        strncpy_s(info.ProductVersion, sizeof(info.ProductVersion), value.c_str(), value.length());
+        gfxrecon::util::platform::StringCopy(info.ProductVersion, sizeof(info.ProductVersion), value.c_str(), value.length());
     }
 #endif
 }
@@ -445,7 +445,7 @@ void GetApplicationInfo(FileInfo& file_info)
     {
         filepath = module_name;
         GetFileInfo(file_info, filepath);
-        strncpy_s(file_info.AppName,
+        gfxrecon::util::platform::StringCopy(file_info.AppName,
                   sizeof(file_info.AppName),
                   filepath.substr(filepath.find_last_of("/\\") + 1).c_str(),
                   filepath.substr(filepath.find_last_of("/\\") + 1).length());


### PR DESCRIPTION
## What does this PR do?
Replaces all direct calls to `strncpy_s` with the existing cross-platform 
wrapper `gfxrecon::util::platform::StringCopy` across 3 files.

## Why was this PR needed?
The project has a platform wrapper for string copying but it wasn't being 
used consistently. `strncpy_s` is Windows-specific and causes compatibility 
issues on Mac and Linux.

## What are the relevant issue numbers?
Closes #1358

## Does this PR meet the acceptance criteria?
- All tests passing (project builds successfully)
- Follows project style guide
- No breaking changes introduced