### PR TITLE
Remove noisy warning about OpenXR/D3D12 composition

### DIFF
--- a/tools/replay/replay_openxr_feature.cpp
+++ b/tools/replay/replay_openxr_feature.cpp
@@ -90,12 +90,6 @@ void ReplayOpenXrFeature::LinkCompositionFeatures(const std::vector<std::unique_
                 replay_consumer_->SetVulkanReplayConsumer(vulkan_consumer);
             }
         }
-        else if (feature->GetConsumer() != nullptr)
-        {
-            // Warn only for other active (enabled) features we don't know how to compose with
-            GFXRECON_LOG_WARNING("GFXR does not currently support OpenXR composition with %s",
-                                 feature->Label().c_str());
-        }
     }
 }
 


### PR DESCRIPTION
The Vulkan-only graphics binding limitation is already documented here: [USAGE_desktop_OpenXR.md](https://github.com/LunarG/gfxreconstruct/blob/dev/USAGE_desktop_OpenXR.md) -> #2145

Also, the replay of OpenXR captures with non-Vulkan graphics bindings will already error out, see openxr_replay_swapchain_state.cpp

Therefore, just remove this extra nuisance warning.