### PR TITLE
Fix offscreen swapchain implicit synchronization

### DIFF
--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -23,9 +23,23 @@
 #include "decode/vulkan_offscreen_swapchain.h"
 #include "encode/vulkan_handle_wrapper_util.h"
 #include "decode/decoder_util.h"
+#include "generated/generated_vulkan_enum_to_string.h"
+#include "util/callbacks.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
+
+void VulkanOffscreenSwapchain::CleanDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table)
+{
+    VulkanVirtualSwapchain::CleanDeviceResources(device, device_table);
+
+    external_sync_type_.erase(device);
+}
+
+void VulkanOffscreenSwapchain::SetExternalSyncType(VkDevice device, ExternalSyncType external_sync_type)
+{
+    external_sync_type_[device] = external_sync_type;
+}
 
 VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                             original_result,
                                                  VulkanInstanceInfo*                  instance_info,
@@ -174,26 +188,9 @@ VkResult VulkanOffscreenSwapchain::AcquireNextImageKHR(VkResult                 
     *image_index = capture_image_index;
     if (semaphore != VK_NULL_HANDLE || fence != VK_NULL_HANDLE)
     {
-        uint32_t           signal_semaphore_count = 0;
-        const VkSemaphore* signal_semaphores      = nullptr;
-
-        if (semaphore != VK_NULL_HANDLE)
-        {
-            signal_semaphore_count = 1;
-            signal_semaphores      = &semaphore;
-        }
-
-        VkResult result = SignalSemaphoresFence(nullptr, 0, nullptr, signal_semaphore_count, signal_semaphores, fence);
-        if (result != VK_SUCCESS)
-        {
-            GFXRECON_LOG_ERROR("Offscreen swapchain failed to singal semaphore (Handle = %" PRIu64
-                               ") or fence (Handle = %" PRIu64 ") for swapchain (ID = %" PRIu64
-                               ") on AcquireNextImageKHR",
-                               semaphore,
-                               fence,
-                               swapchain_info->capture_id);
-            return result;
-        }
+        auto it = external_sync_type_.find(device_info->handle);
+        GFXRECON_ASSERT(it != external_sync_type_.end());
+        return SignalAcquireNextImageSemaphoreFence(device_info, semaphore, fence, it->second);
     }
     return original_result;
 }
@@ -209,27 +206,10 @@ VkResult VulkanOffscreenSwapchain::AcquireNextImage2KHR(VkResult                
     *image_index = capture_image_index;
     if (acquire_info->semaphore != VK_NULL_HANDLE || acquire_info->fence != VK_NULL_HANDLE)
     {
-        uint32_t           signal_semaphore_count = 0;
-        const VkSemaphore* signal_semaphores      = nullptr;
-
-        if (acquire_info->semaphore != VK_NULL_HANDLE)
-        {
-            signal_semaphore_count = 1;
-            signal_semaphores      = &acquire_info->semaphore;
-        }
-
-        VkResult result =
-            SignalSemaphoresFence(nullptr, 0, nullptr, signal_semaphore_count, signal_semaphores, acquire_info->fence);
-        if (result != VK_SUCCESS)
-        {
-            GFXRECON_LOG_ERROR("Offscreen swapchain failed to singal semaphore (Handle = %" PRIu64
-                               ") or fence (Handle = %" PRIu64 ") for swapchain (ID = %" PRIu64
-                               ") on AcquireNextImage2KHR",
-                               acquire_info->semaphore,
-                               acquire_info->fence,
-                               swapchain_info->capture_id);
-            return result;
-        }
+        auto it = external_sync_type_.find(device_info->handle);
+        GFXRECON_ASSERT(it != external_sync_type_.end());
+        return SignalAcquireNextImageSemaphoreFence(
+            device_info, acquire_info->semaphore, acquire_info->fence, it->second);
     }
     return original_result;
 }
@@ -241,9 +221,26 @@ VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                     
                                                    const VulkanQueueInfo*                      queue_info,
                                                    const VkPresentInfoKHR*                     present_info)
 {
+    VkResult result = original_result;
+
+    std::vector<VkPipelineStageFlags> wait_stages(present_info->waitSemaphoreCount,
+                                                  VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+
+    VkSubmitInfo submit_info;
+    submit_info.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit_info.pNext                = nullptr;
+    submit_info.waitSemaphoreCount   = present_info->waitSemaphoreCount;
+    submit_info.pWaitSemaphores      = present_info->pWaitSemaphores;
+    submit_info.pWaitDstStageMask    = wait_stages.data();
+    submit_info.commandBufferCount   = 0;
+    submit_info.pCommandBuffers      = nullptr;
+    submit_info.signalSemaphoreCount = 0;
+    submit_info.pSignalSemaphores    = nullptr;
+
+    std::vector<VkImage> images;
     if (swapchain_options_.offscreen_swapchain_frame_boundary)
     {
-        std::vector<VkImage> images(present_info->swapchainCount);
+        images.resize(present_info->swapchainCount);
         for (uint32_t i = 0; i < images.size(); ++i)
         {
             images[i] = swapchain_resources_[present_info->pSwapchains[i]]
@@ -251,40 +248,25 @@ VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                     
                             .image;
         }
         GFXRECON_NARROWING_ASSIGN(frame_boundary_.imageCount, images.size());
-        frame_boundary_.pImages    = images.data();
+        frame_boundary_.pImages = images.data();
         ++frame_boundary_.frameID;
 
-        std::vector<VkPipelineStageFlags> dstStageFlags(present_info->waitSemaphoreCount,
-                                                        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
-
-        VkSubmitInfo submitInfo;
-        submitInfo.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-        submitInfo.pNext                = &frame_boundary_;
-        submitInfo.waitSemaphoreCount   = present_info->waitSemaphoreCount;
-        submitInfo.pWaitSemaphores      = present_info->pWaitSemaphores;
-        submitInfo.pWaitDstStageMask    = dstStageFlags.data();
-        submitInfo.commandBufferCount   = 0;
-        submitInfo.pCommandBuffers      = nullptr;
-        submitInfo.signalSemaphoreCount = 0;
-        submitInfo.pSignalSemaphores    = nullptr;
-
-        device_table_->QueueSubmit(queue_info->handle, 1, &submitInfo, VK_NULL_HANDLE);
+        submit_info.pNext = &frame_boundary_;
     }
-    else if (present_info->waitSemaphoreCount > 0)
+
+    if (swapchain_options_.offscreen_swapchain_frame_boundary || present_info->waitSemaphoreCount > 0)
     {
-        VkResult result = SignalSemaphoresFence(
-            queue_info, present_info->waitSemaphoreCount, present_info->pWaitSemaphores, 0, nullptr, VK_NULL_HANDLE);
+        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+        result = device_table_->QueueSubmit(queue_info->handle, 1, &submit_info, VK_NULL_HANDLE);
+
         if (result != VK_SUCCESS)
         {
-            GFXRECON_LOG_ERROR("Offscreen swapchain failed to wait semaphore (Handle = %" PRIu64
-                               ") for queue (ID = %" PRIu64 ") on QueuePresentKHR",
-                               present_info->pWaitSemaphores[0],
+            GFXRECON_LOG_ERROR("Offscreen swapchain failed to QueueSubmit on QueuePresentKHR for queue %" PRIu64,
                                queue_info->handle);
-            return result;
         }
     }
 
-    return original_result;
+    return result;
 }
 
 void VulkanOffscreenSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*                    device_info,
@@ -308,40 +290,99 @@ void VulkanOffscreenSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*        
     GFXRECON_LOG_WARNING("%s is not implemented and should not be called", __func__);
 }
 
-// queue_info could be nullptr. It means it doesn't specify a VkQueue and use default_queue. Its purpose is to singal
-// semaphores or fence. All VkQueue should work.
-VkResult VulkanOffscreenSwapchain::SignalSemaphoresFence(const VulkanQueueInfo* queue_info,
-                                                         uint32_t               wait_semaphore_count,
-                                                         const VkSemaphore*     wait_semaphores,
-                                                         uint32_t               signal_semaphore_count,
-                                                         const VkSemaphore*     signal_semaphores,
-                                                         VkFence                fence)
+VkResult VulkanOffscreenSwapchain::SignalAcquireNextImageSemaphoreFence(const VulkanDeviceInfo* device_info,
+                                                                        VkSemaphore             semaphore,
+                                                                        VkFence                 fence,
+                                                                        ExternalSyncType        external_sync_type)
 {
-    VkPipelineStageFlags wait_stage  = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-    VkSubmitInfo         submit_info = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
+    GFXRECON_ASSERT(device_info != nullptr);
+    GFXRECON_ASSERT(semaphore != VK_NULL_HANDLE || fence != VK_NULL_HANDLE);
 
-    if (wait_semaphore_count > 0)
+    VkResult result = VK_ERROR_UNKNOWN;
+
+    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+
+    switch (external_sync_type)
     {
-        submit_info.waitSemaphoreCount = wait_semaphore_count;
-        submit_info.pWaitSemaphores    = wait_semaphores;
-        submit_info.pWaitDstStageMask  = &wait_stage;
-    }
-    if (signal_semaphore_count > 0)
-    {
-        submit_info.signalSemaphoreCount = signal_semaphore_count;
-        submit_info.pSignalSemaphores    = signal_semaphores;
+        case ExternalSyncType::QueueSubmit:
+        {
+            VkSubmitInfo submit_info;
+            submit_info.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+            submit_info.pNext                = nullptr;
+            submit_info.waitSemaphoreCount   = 0;
+            submit_info.pWaitSemaphores      = nullptr;
+            submit_info.pWaitDstStageMask    = nullptr;
+            submit_info.commandBufferCount   = 0;
+            submit_info.pCommandBuffers      = nullptr;
+            submit_info.signalSemaphoreCount = (semaphore == VK_NULL_HANDLE ? 0 : 1);
+            submit_info.pSignalSemaphores    = (semaphore == VK_NULL_HANDLE ? nullptr : &semaphore);
+
+            result = device_table_->QueueSubmit(default_queue_, 1, &submit_info, fence);
+
+            if (result != VK_SUCCESS)
+            {
+                GFXRECON_LOG_ERROR("Offscreen swapchain failed to signal semaphore and fence by submitting an empty "
+                                   "queue submission. (%s)",
+                                   util::ToString<VkResult>(result).c_str());
+            }
+
+            break;
+        }
+        case ExternalSyncType::FileDescriptor:
+        {
+            if (semaphore != VK_NULL_HANDLE)
+            {
+                VkImportSemaphoreFdInfoKHR import_info;
+                import_info.sType      = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
+                import_info.pNext      = nullptr;
+                import_info.semaphore  = semaphore;
+                import_info.flags      = VK_SEMAPHORE_IMPORT_TEMPORARY_BIT;
+                import_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
+                import_info.fd         = -1;
+
+                result = device_table_->ImportSemaphoreFdKHR(device_info->handle, &import_info);
+
+                if (result != VK_SUCCESS)
+                {
+                    GFXRECON_LOG_ERROR_ONCE("Offscreen swapchain failed to signal semaphore by importing it as a file "
+                                            "descriptor. (%s)",
+                                            util::ToString<VkResult>(result).c_str());
+                    result = SignalAcquireNextImageSemaphoreFence(
+                        device_info, semaphore, VK_NULL_HANDLE, ExternalSyncType::QueueSubmit);
+                }
+            }
+
+            if (fence != VK_NULL_HANDLE)
+            {
+                VkImportFenceFdInfoKHR import_info;
+                import_info.sType      = VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR;
+                import_info.pNext      = nullptr;
+                import_info.fence      = fence;
+                import_info.flags      = VK_FENCE_IMPORT_TEMPORARY_BIT;
+                import_info.handleType = VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT;
+                import_info.fd         = -1;
+
+                result = device_table_->ImportFenceFdKHR(device_info->handle, &import_info);
+
+                if (result != VK_SUCCESS)
+                {
+                    GFXRECON_LOG_ERROR_ONCE("Offscreen swapchain failed to signal fence by importing it as a file "
+                                            "descriptor. (%s)",
+                                            util::ToString<VkResult>(result).c_str());
+                    result = SignalAcquireNextImageSemaphoreFence(
+                        device_info, VK_NULL_HANDLE, fence, ExternalSyncType::QueueSubmit);
+                }
+            }
+
+            break;
+        }
+        default:
+        {
+            GFXRECON_LOG_FATAL("Unhandled VulkanSwapchain::ExternalSyncType. Seems like a missing implementation.");
+        }
     }
 
-    VkQueue queue = VK_NULL_HANDLE;
-    if (queue_info)
-    {
-        queue = queue_info->handle;
-    }
-    else
-    {
-        queue = default_queue_;
-    }
-    return device_table_->QueueSubmit(queue, 1, &submit_info, fence);
+    return result;
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -35,6 +35,10 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
   public:
     virtual ~VulkanOffscreenSwapchain() override {}
 
+    virtual void CleanDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table) override;
+
+    virtual void SetExternalSyncType(VkDevice device, ExternalSyncType external_sync_type) override;
+
     virtual VkResult CreateSurface(VkResult                             original_result,
                                    VulkanInstanceInfo*                  instance_info,
                                    const std::string&                   wsi_extension,
@@ -107,14 +111,14 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
     const uint32_t default_queue_family_index_{ 0 };
     VkQueue        default_queue_{ VK_NULL_HANDLE }; // default_queue_family_index_,0
 
-    VkResult SignalSemaphoresFence(const VulkanQueueInfo* queue_info,
-                                   uint32_t               wait_semaphore_count,
-                                   const VkSemaphore*     wait_semaphores,
-                                   uint32_t               signal_semaphore_count,
-                                   const VkSemaphore*     signal_semaphores,
-                                   VkFence                fence);
+    VkResult SignalAcquireNextImageSemaphoreFence(const VulkanDeviceInfo* device_info,
+                                                  VkSemaphore             semaphore,
+                                                  VkFence                 fence,
+                                                  ExternalSyncType        external_sync_type);
 
     VkFrameBoundaryEXT frame_boundary_;
+
+    std::unordered_map<VkDevice, ExternalSyncType> external_sync_type_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3477,6 +3477,36 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
         // Fake VK_GOOGLE_display_timing if requested, but not supported
         sanitize_faked_extension(VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME);
 
+        if (options_.swapchain_option == util::SwapchainOption::kOffscreen)
+        {
+            if (graphics::feature_util::IsSupportedExtension(available_extensions,
+                                                             VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME) &&
+                graphics::feature_util::IsSupportedExtension(available_extensions,
+                                                             VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME))
+            {
+                if (!graphics::feature_util::IsSupportedExtension(modified_extensions,
+                                                                  VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME))
+                {
+                    modified_extensions.push_back(VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME);
+                }
+
+                if (!graphics::feature_util::IsSupportedExtension(modified_extensions,
+                                                                  VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME))
+                {
+                    modified_extensions.push_back(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME);
+                }
+
+                create_state.external_sync_type = VulkanSwapchain::ExternalSyncType::FileDescriptor;
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING("Synchronization primitives import are not available on the replay device. "
+                                     "Offscreen swapchain may introduce additional synchronizations and slowdowns.");
+
+                create_state.external_sync_type = VulkanSwapchain::ExternalSyncType::QueueSubmit;
+            }
+        }
+
         if (options_.remove_unsupported_features)
         {
             graphics::feature_util::RemoveUnsupportedExtensions(available_extensions, &modified_extensions);
@@ -3647,6 +3677,11 @@ VkResult VulkanReplayConsumerBase::PostCreateDeviceUpdateState(VulkanPhysicalDev
 
     // Restore modified property/feature create info values to the original application values
     create_state.device_util.RestoreModifiedPhysicalDeviceFeatures();
+
+    if (options_.swapchain_option == util::SwapchainOption::kOffscreen)
+    {
+        swapchain_->SetExternalSyncType(replay_device, create_state.external_sync_type);
+    }
 
     return VK_SUCCESS;
 }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -286,6 +286,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         std::vector<VkPhysicalDevice>             replay_device_group;
         graphics::VulkanDeviceUtil                device_util;
         graphics::VulkanDevicePropertyFeatureInfo property_feature_info;
+        VulkanSwapchain::ExternalSyncType         external_sync_type{ VulkanSwapchain::ExternalSyncType::QueueSubmit };
     };
 
     // create_state passed in by reference to conserve pointers to member variable

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -56,14 +56,22 @@ struct VulkanSwapchainOptions
 class VulkanSwapchain
 {
   public:
+    enum class ExternalSyncType
+    {
+        QueueSubmit,
+        FileDescriptor
+    };
+
     virtual ~VulkanSwapchain() = default;
 
     virtual void Clean();
 
-    virtual void CleanDeviceResources(VkDevice, const graphics::VulkanDeviceTable*) {}
+    virtual void CleanDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table) {}
 
     VulkanSwapchainOptions GetOptions() { return swapchain_options_; }
-    void SetOptions(const VulkanSwapchainOptions& options) { swapchain_options_ = options; }
+    void                   SetOptions(const VulkanSwapchainOptions& options) { swapchain_options_ = options; }
+
+    virtual void SetExternalSyncType(VkDevice device, ExternalSyncType external_sync_type) {}
 
     virtual VkResult CreateSurface(VkResult                             original_result,
                                    VulkanInstanceInfo*                  instance_info,


### PR DESCRIPTION
The offscreen swapchain needs to emulate the behavior of a WSI. In particular, this implies waiting for and signaling semaphores and fences on image acquisition and queue presentation.

The behavior until now was to submit an empty workload as a queue submission waiting and signaling the correct synchronization primitives.
While this works as expected for queue presentation, this introduces additional synchronizations for image acquisition.

Indeed, image acquisition is queue independent, which means it doesn't need to wait for previous queue submissions to begin. By implementing it as an empty queue submit, we encounter cases where the implicit ordering constraints of Vulkan introduce a slowdown, making offscreen slower than onscreen.

I have currently no solution for Windows and/or Mac (assuming they don't support `VK_KHR_external_semaphore_fd` and `VK_KHR_external_fence_fd`).
However, on systems implementing these extensions (mainly Linux and Android systems), I propose to solve this using a technique inspired by Mesa's Vulkan WSI Layer:
https://gitlab.freedesktop.org/mesa/vulkan-wsi-layer

The idea is to signal semaphores and fences by importing them as temporary file descriptor system handles using a predefined "invalid" value recognized as an "already signaled primitive".

This behavior is described in the Vulkan specification for the `VkImportSemaphoreFdInfoKHR` and `VkImportFenceFdInfoKHR` structures (search for file descriptor value "-1").