### PR TITLE
Unify tool PrintUsage and PrintVersion funcs

### DIFF
--- a/android/tools/multi-win-replay/CMakeLists.txt
+++ b/android/tools/multi-win-replay/CMakeLists.txt
@@ -43,6 +43,7 @@ target_include_directories(gfxrecon-replay
                            PUBLIC
                                ${GFXRECON_SOURCE_DIR}/external/precompiled/android/include
                                ${GFXRECON_SOURCE_DIR}
+                               ${GFXRECON_SOURCE_DIR}/tools
                                ${CMAKE_BINARY_DIR})
 
 target_link_libraries(

--- a/android/tools/quest_replay/CMakeLists.txt
+++ b/android/tools/quest_replay/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(gfxrecon-quest-replay
 target_include_directories(gfxrecon-quest-replay
                            PUBLIC
                                ${GFXRECON_SOURCE_DIR}/external/precompiled/android/include
+                               ${GFXRECON_SOURCE_DIR}/tools
                                ${GFXRECON_SOURCE_DIR}
                                ${CMAKE_BINARY_DIR})
 

--- a/android/tools/replay/CMakeLists.txt
+++ b/android/tools/replay/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(gfxrecon-replay
 target_include_directories(gfxrecon-replay
                            PUBLIC
                                ${GFXRECON_SOURCE_DIR}/external/precompiled/android/include
+                               ${GFXRECON_SOURCE_DIR}/tools
                                ${GFXRECON_SOURCE_DIR}
                                ${CMAKE_BINARY_DIR})
 

--- a/project_version.h.in
+++ b/project_version.h.in
@@ -47,4 +47,11 @@ const char* GetProjectVersionString();
 #define GFXRECON_PROJECT_OPENXR_LAYER_NAME  "XR_APILAYER_LUNARG_gfxreconstruct"
 #define GFXRECON_PROJECT_DESCRIPTION        "GFXReconstruct Capture Layer"
 
+// Optional prefix applied to the display name of the command-line tools (usage banner and
+// --version output). Downstream distributions that repackage these tools under a different
+// product name can set this at configure/compile time. Empty by default.
+#ifndef GFXRECON_APP_NAME_PREFIX
+#define GFXRECON_APP_NAME_PREFIX ""
+#endif
+
 #endif // GFXRECON_PROJECT_VERSION_H

--- a/test/test_apps/launcher/test_launcher.cpp
+++ b/test/test_apps/launcher/test_launcher.cpp
@@ -54,6 +54,7 @@
 #include <util/argument_parser.h>
 
 #include <tools/tool_settings.h>
+#include <tools/tool_command_line.h>
 
 #if defined(__ANDROID__)
 #include <util/android/activity.h>

--- a/tools/compress/CMakeLists.txt
+++ b/tools/compress/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(gfxrecon-compress
                    ${CMAKE_CURRENT_LIST_DIR}/compression_converter.h
                    ${CMAKE_CURRENT_LIST_DIR}/compression_converter.cpp
                    ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/../tool_command_line.h
                    $<$<BOOL:WIN32>:${PROJECT_SOURCE_DIR}/version.rc>
                    $<$<BOOL:WIN32>:${GFXRECON_WIN_MANIFEST}>
 )
@@ -48,7 +49,10 @@ if (MSVC)
     endif()
 endif()
 
-target_include_directories(gfxrecon-compress PUBLIC ${CMAKE_BINARY_DIR})
+target_include_directories(gfxrecon-compress
+                           PUBLIC
+                              ${CMAKE_CURRENT_LIST_DIR}/..
+                              ${CMAKE_BINARY_DIR})
 
 target_link_libraries(gfxrecon-compress gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific project_version)
 

--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -22,6 +22,8 @@
 */
 
 #include PROJECT_VERSION_HEADER_FILE
+#include "tool_command_line.h"
+
 #include "compression_converter.h"
 
 #include "decode/file_processor.h"
@@ -30,15 +32,10 @@
 #include "util/compressor.h"
 #include "util/logging.h"
 
-#include "vulkan/vulkan_core.h"
-
 #include <cassert>
 #include <cstdlib>
 
-const char kHelpShortOption[] = "-h";
-const char kHelpLongOption[]  = "--help";
-const char kVersionOption[]   = "--version";
-const char kNoDebugPopup[]    = "--no-debug-popup";
+const char kNoDebugPopup[] = "--no-debug-popup";
 
 const char kOptions[] = "-h|--help,--version,--no-debug-popup";
 
@@ -50,12 +47,7 @@ const char kArgUnknown[] = "<Unknown>";
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name     = exe_name;
-    size_t      dir_location = app_name.find_last_of("/\\");
-    if (dir_location >= 0)
-    {
-        app_name.replace(0, dir_location + 1, "");
-    }
+    std::string app_name = GetApplicationName(exe_name);
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to compress/decompress GFXReconstruct capture files.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
     GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] <input_file> <output_file> <compression_format>\n",
@@ -82,42 +74,6 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
     GFXRECON_WRITE_CONSOLE("        \t\tdisplayed when abort() is called (Windows debug only).");
 #endif
-}
-
-static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
-{
-    if (arg_parser.IsOptionSet(kHelpShortOption) || arg_parser.IsOptionSet(kHelpLongOption))
-    {
-        PrintUsage(exe_name);
-        return true;
-    }
-
-    return false;
-}
-
-static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
-{
-    if (arg_parser.IsOptionSet(kVersionOption))
-    {
-        std::string app_name     = exe_name;
-        size_t      dir_location = app_name.find_last_of("/\\");
-
-        if (dir_location >= 0)
-        {
-            app_name.replace(0, dir_location + 1, "");
-        }
-
-        GFXRECON_WRITE_CONSOLE("%s version info:", app_name.c_str());
-        GFXRECON_WRITE_CONSOLE("  GFXReconstruct Version %s", GetProjectVersionString());
-        GFXRECON_WRITE_CONSOLE("  Vulkan Header Version %u.%u.%u",
-                               VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE),
-                               VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE),
-                               VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
-
-        return true;
-    }
-
-    return false;
 }
 
 static std::string GetCompressionTypeName(uint32_t type)

--- a/tools/convert/CMakeLists.txt
+++ b/tools/convert/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(gfxrecon-convert "")
 target_sources(gfxrecon-convert
                PRIVATE
                     ${CMAKE_CURRENT_LIST_DIR}/../tool_settings.h
+                   ${CMAKE_CURRENT_LIST_DIR}/../tool_command_line.h
                     ${CMAKE_CURRENT_LIST_DIR}/main.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/convert_feature.h
                     ${CMAKE_CURRENT_LIST_DIR}/convert_d3d12_feature.cpp

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2018-2026 LunarG, Inc.
 ** Copyright (c) 2020 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -25,6 +25,7 @@
 #include <string>
 #include PROJECT_VERSION_HEADER_FILE
 #include "tool_settings.h"
+#include "tool_command_line.h"
 
 #include "decode/json_writer.h" /// @todo move to util?
 #include "decode/decode_api_detection.h"
@@ -42,12 +43,7 @@ const char kArguments[] = "--output,--format,--log-level,--frame-range";
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name     = exe_name;
-    size_t      dir_location = app_name.find_last_of("/\\");
-    if (dir_location >= 0)
-    {
-        app_name.replace(0, dir_location + 1, "");
-    }
+    std::string app_name = GetApplicationName(exe_name);
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to convert the contents of GFXReconstruct capture files to JSON.\n",
                            app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");

--- a/tools/extract/CMakeLists.txt
+++ b/tools/extract/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(gfxrecon-extract
                    ${CMAKE_CURRENT_LIST_DIR}/extract_vulkan_feature.cpp
                    ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
                    ${CMAKE_CURRENT_LIST_DIR}/../tool_settings.h
+                   ${CMAKE_CURRENT_LIST_DIR}/../tool_command_line.h
                    $<$<BOOL:WIN32>:${PROJECT_SOURCE_DIR}/version.rc>
                    $<$<BOOL:WIN32>:${GFXRECON_WIN_MANIFEST}>
               )

--- a/tools/extract/main.cpp
+++ b/tools/extract/main.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2020-2026 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -22,6 +22,7 @@
 
 #include PROJECT_VERSION_HEADER_FILE
 #include "tool_settings.h"
+#include "tool_command_line.h"
 
 #include "decode/file_processor.h"
 #include "extract_feature.h"
@@ -42,12 +43,7 @@ const char kArguments[] = "--dir";
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name     = exe_name;
-    size_t      dir_location = app_name.find_last_of("/\\");
-    if (dir_location >= 0)
-    {
-        app_name.replace(0, dir_location + 1, "");
-    }
+    std::string app_name = GetApplicationName(exe_name);
     GFXRECON_WRITE_CONSOLE("\n%s - Extract shaders from a GFXReconstruct capture file.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
     GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] [--dir <dir>] <file>\n", app_name.c_str());

--- a/tools/file_version_patch/CMakeLists.txt
+++ b/tools/file_version_patch/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(gfxrecon-file-version-patch
                PRIVATE
                    ${CMAKE_CURRENT_LIST_DIR}/main.cpp
                    ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/../tool_command_line.h
                    $<$<BOOL:WIN32>:${PROJECT_SOURCE_DIR}/version.rc>
                    $<$<BOOL:WIN32>:${GFXRECON_WIN_MANIFEST}>
               )
@@ -46,7 +47,10 @@ if (MSVC)
     endif()
 endif()
 
-target_include_directories(gfxrecon-file-version-patch PUBLIC ${CMAKE_BINARY_DIR})
+target_include_directories(gfxrecon-file-version-patch
+                           PUBLIC
+                              ${CMAKE_CURRENT_LIST_DIR}/..
+                              ${CMAKE_BINARY_DIR})
 target_compile_definitions(gfxrecon_decode PUBLIC VULKAN_HPP_NO_STRUCT_SETTERS)
 
 target_link_libraries(gfxrecon-file-version-patch

--- a/tools/file_version_patch/main.cpp
+++ b/tools/file_version_patch/main.cpp
@@ -22,6 +22,7 @@
 */
 
 #include PROJECT_VERSION_HEADER_FILE
+#include "tool_command_line.h"
 
 #include "decode/file_processor.h"
 
@@ -38,10 +39,7 @@
 
 #include <nlohmann/json.hpp>
 
-const char kHelpShortOption[] = "-h";
-const char kHelpLongOption[]  = "--help";
-const char kVersionOption[]   = "--version";
-const char kNoDebugPopup[]    = "--no-debug-popup";
+const char kNoDebugPopup[] = "--no-debug-popup";
 
 const char kOptions[] = "-h|--help,--version,--no-debug-popup";
 
@@ -49,12 +47,7 @@ const char kUnrecognizedFormatString[] = "<unrecognized-format>";
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name     = exe_name;
-    size_t      dir_location = app_name.find_last_of("/\\");
-    if (dir_location >= 0)
-    {
-        app_name.replace(0, dir_location + 1, "");
-    }
+    std::string app_name = GetApplicationName(exe_name);
     GFXRECON_WRITE_CONSOLE("\n%s - Patch the file format version of a GFXReconstruct capture file.\n",
                            app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
@@ -68,42 +61,6 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
     GFXRECON_WRITE_CONSOLE("        \t\tdisplayed when abort() is called (Windows debug only).");
 #endif
-}
-
-static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
-{
-    if (arg_parser.IsOptionSet(kHelpShortOption) || arg_parser.IsOptionSet(kHelpLongOption))
-    {
-        PrintUsage(exe_name);
-        return true;
-    }
-
-    return false;
-}
-
-static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
-{
-    if (arg_parser.IsOptionSet(kVersionOption))
-    {
-        std::string app_name     = exe_name;
-        size_t      dir_location = app_name.find_last_of("/\\");
-
-        if (dir_location >= 0)
-        {
-            app_name.replace(0, dir_location + 1, "");
-        }
-
-        GFXRECON_WRITE_CONSOLE("%s version info:", app_name.c_str());
-        GFXRECON_WRITE_CONSOLE("  GFXReconstruct Version %s", GetProjectVersionString());
-        GFXRECON_WRITE_CONSOLE("  Vulkan Header Version %u.%u.%u",
-                               VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE),
-                               VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE),
-                               VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
-
-        return true;
-    }
-
-    return false;
 }
 
 static std::string GetVersionString(uint32_t api_version)

--- a/tools/info/CMakeLists.txt
+++ b/tools/info/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(gfxrecon-info "")
 target_sources(gfxrecon-info
                PRIVATE
                    ${CMAKE_CURRENT_LIST_DIR}/../tool_settings.h
+                   ${CMAKE_CURRENT_LIST_DIR}/../tool_command_line.h
                    ${CMAKE_CURRENT_LIST_DIR}/main.cpp
                    ${CMAKE_CURRENT_LIST_DIR}/info_feature.h
                    ${CMAKE_CURRENT_LIST_DIR}/info_d3d12_feature.h

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -46,6 +46,7 @@
 
 #include "info_feature.h"
 #include "tool_settings.h"
+#include "tool_command_line.h"
 
 #include <cassert>
 #include <cstdarg>
@@ -187,6 +188,7 @@ static void PrintUsage(const char* exe_name)
     {
         app_name.replace(0, dir_location + 1, "");
     }
+    app_name = GFXRECON_APP_NAME_PREFIX + app_name;
     WriteOutput("\n%s - Print statistics for a GFXReconstruct capture file.\n", app_name.c_str());
     WriteOutput("Usage:");
     WriteOutput("  %s [-h | --help] [--version] [--exe-info-only] [--verbose] [--output <file>] <capture-file>\n",
@@ -741,9 +743,6 @@ int main(int argc, const char** argv)
 {
     gfxrecon::util::Log::Init();
 
-    // Save the app name first
-    const std::string app_name = std::filesystem::path{ argv[0] }.filename().string();
-
     // Query the module registry for registered modules, and
     // call each generator here and put the unique_ptr into our
     // internal unique_ptr vector.
@@ -765,15 +764,14 @@ int main(int argc, const char** argv)
 
     gfxrecon::util::ArgumentParser arg_parser(argc, argv, options, arguments);
 
-    if (CheckOptionPrintUsage(app_name.c_str(), arg_parser))
+    if (CheckOptionPrintUsage(argv[0], arg_parser))
     {
         gfxrecon::util::Log::Release();
         exit(0);
     }
     else if (arg_parser.IsOptionSet(kVersionOption))
     {
-        GFXRECON_WRITE_CONSOLE("%s version info:", app_name.c_str());
-        GFXRECON_WRITE_CONSOLE("  GFXReconstruct Version %s", GetProjectVersionString());
+        PrintVersionHeader(argv[0]);
         for (auto& feature : g_info_features)
         {
             GFXRECON_WRITE_CONSOLE(feature->CompiledHeaderVersionString().c_str());
@@ -784,7 +782,7 @@ int main(int argc, const char** argv)
     }
     else if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 1))
     {
-        PrintUsage(app_name.c_str());
+        PrintUsage(argv[0]);
         gfxrecon::util::Log::Release();
         exit(-1);
     }

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -25,6 +25,7 @@
 
 #include "optimize_feature.h"
 #include "tool_settings.h"
+#include "tool_command_line.h"
 
 #include "decode/decode_api_detection.h"
 #include "decode/file_processor.h"
@@ -56,12 +57,7 @@ static std::vector<std::unique_ptr<gfxrecon::optimize::OptimizeFeature>> g_optim
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name     = exe_name;
-    size_t      dir_location = app_name.find_last_of("/\\");
-    if (dir_location >= 0)
-    {
-        app_name.replace(0, dir_location + 1, "");
-    }
+    std::string app_name = GetApplicationName(exe_name);
 
     // Build synopsis from feature fragments so it stays in sync automatically.
     std::string synopsis = app_name + " [-h | --help] [--version]";

--- a/tools/optimize/optimize_dx12_feature.cpp
+++ b/tools/optimize/optimize_dx12_feature.cpp
@@ -25,8 +25,6 @@
 
 #include "optimize_dx12_feature.h"
 
-// Disable the usage static prototype
-#define GFXR_TOOL_SETTINGS_NO_USAGE
 #include "tool_settings.h"
 
 #include "dx12_optimize_util.h"

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(gfxrecon-replay "")
 target_sources(gfxrecon-replay
                PRIVATE
                     ${CMAKE_CURRENT_LIST_DIR}/../tool_settings.h
+                    ${CMAKE_CURRENT_LIST_DIR}/../tool_command_line.h
                     ${CMAKE_CURRENT_LIST_DIR}/replay_settings.h
                     ${CMAKE_CURRENT_LIST_DIR}/replay_feature.h
                     ${CMAKE_CURRENT_LIST_DIR}/replay_main_common.h
@@ -51,7 +52,10 @@ target_sources(gfxrecon-replay
                     $<$<BOOL:WIN32>:${GFXRECON_WIN_MANIFEST}>
 )
 
-target_include_directories(gfxrecon-replay PUBLIC ${CMAKE_BINARY_DIR})
+target_include_directories(gfxrecon-replay
+                           PUBLIC
+                              ${CMAKE_CURRENT_LIST_DIR}/..
+                              ${CMAKE_BINARY_DIR})
 
 target_link_libraries(gfxrecon-replay
                           gfxrecon_application

--- a/tools/replay/replay_main_common.h
+++ b/tools/replay/replay_main_common.h
@@ -28,6 +28,7 @@ struct android_app;
 #endif
 
 #include "replay_feature.h"
+#include "tool_command_line.h"
 
 #include "application/application.h"
 #include "decode/file_processor.h"

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -21,7 +21,8 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include "../tool_settings.h"
+#include "tool_settings.h"
+#include "tool_command_line.h"
 
 #ifndef GFXRECON_REPLAY_SETTINGS_H
 #define GFXRECON_REPLAY_SETTINGS_H
@@ -51,13 +52,7 @@ const char kArguments[] =
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name     = exe_name;
-    size_t      dir_location = app_name.find_last_of("/\\");
-
-    if (dir_location >= 0)
-    {
-        app_name.replace(0, dir_location + 1, "");
-    }
+    std::string app_name = GetApplicationName(exe_name);
 
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to replay GFXReconstruct capture files.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");

--- a/tools/tocpp/CMakeLists.txt
+++ b/tools/tocpp/CMakeLists.txt
@@ -30,11 +30,15 @@ add_executable(gfxrecon-tocpp "")
 target_sources(gfxrecon-tocpp
                PRIVATE
                    main.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/../tool_command_line.h
                    $<$<BOOL:WIN32>:${PROJECT_SOURCE_DIR}/version.rc>
                    $<$<BOOL:WIN32>:${GFXRECON_WIN_MANIFEST}>
               )
 
-target_include_directories(gfxrecon-tocpp PUBLIC ${CMAKE_BINARY_DIR})
+target_include_directories(gfxrecon-tocpp
+                           PUBLIC
+                                ${CMAKE_CURRENT_LIST_DIR}/..
+                                ${CMAKE_BINARY_DIR})
 
 target_link_libraries(gfxrecon-tocpp gfxrecon_decode gfxrecon_format gfxrecon_util platform_specific project_version)
 

--- a/tools/tocpp/main.cpp
+++ b/tools/tocpp/main.cpp
@@ -20,6 +20,7 @@
 #include <util/date_time.h>
 
 #include PROJECT_VERSION_HEADER_FILE
+#include "tool_command_line.h"
 
 #include "decode/file_processor.h"
 #include "decode/vulkan_cpp_utilities.h"
@@ -29,8 +30,6 @@
 #include "util/argument_parser.h"
 #include "util/file_path.h"
 #include "util/logging.h"
-
-#include "vulkan/vulkan_core.h"
 
 struct CommandLineArgument
 {
@@ -121,41 +120,9 @@ const std::string path_vulkanmain = "app/src/main/jni/";
 // Directory structure where the image data will be generated in the output directory.
 const std::string path_assets = "app/src/main/assets/";
 
-static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
-{
-    // We can just check for the short option because the argument parser will assign even
-    // the long option to either one for easier detecting.
-    if (arg_parser.IsOptionSet(g_version_argument.short_option))
-    {
-        std::string app_name     = exe_name;
-        size_t      dir_location = app_name.find_last_of("/\\");
-
-        if (dir_location >= 0)
-        {
-            app_name.replace(0, dir_location + 1, "");
-        }
-
-        GFXRECON_WRITE_CONSOLE("%s version info:", app_name.c_str());
-        GFXRECON_WRITE_CONSOLE("  GFXReconstruct Version %s", GetProjectVersionString());
-        GFXRECON_WRITE_CONSOLE("  Vulkan Header Version %u.%u.%u",
-                               VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE),
-                               VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE),
-                               VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
-
-        return true;
-    }
-
-    return false;
-}
-
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name     = exe_name;
-    size_t      dir_location = app_name.find_last_of("/\\");
-    if (dir_location >= 0)
-    {
-        app_name.replace(0, dir_location + 1, "");
-    }
+    std::string app_name = GetApplicationName(exe_name);
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to convert GFXReconstruct capture files to Vulkan source.\n",
                            app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
@@ -189,19 +156,6 @@ static void PrintUsage(const char* exe_name)
                                    argument.restrictions);
         }
     }
-}
-
-static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
-{
-    // We can just check for the short option because the argument parser will assign even
-    // the long option to either one for easier detecting.
-    if (arg_parser.IsOptionSet(g_help_argument.short_option))
-    {
-        PrintUsage(exe_name);
-        return true;
-    }
-
-    return false;
 }
 
 static gfxrecon::decode::GfxToCppPlatform GetCppTargetPlatform(const gfxrecon::util::ArgumentParser& arg_parser)

--- a/tools/tool_command_line.h
+++ b/tools/tool_command_line.h
@@ -1,0 +1,110 @@
+/*
+** Copyright (c) 2019-2026 LunarG, Inc.
+** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+// Common "-h/--help" and "--version" handling shared by all of the command-line tools. Kept
+// separate from tool_settings.h (which pulls in the full replay decode/option stack) so that
+// lightweight tools can get consistent usage/version output without the heavier dependencies.
+
+#ifndef GFXRECON_TOOL_COMMAND_LINE_H
+#define GFXRECON_TOOL_COMMAND_LINE_H
+
+#include PROJECT_VERSION_HEADER_FILE
+
+#include "util/argument_parser.h"
+#include "util/logging.h"
+
+#include "vulkan/vulkan_core.h"
+
+#if ENABLE_OPENXR_SUPPORT
+#include "openxr/openxr.h"
+#endif
+
+#include <string>
+
+const char kHelpShortOption[] = "-h";
+const char kHelpLongOption[]  = "--help";
+const char kVersionOption[]   = "--version";
+
+/// @return exe_name with any leading directory components removed, and the
+/// GFXRECON_APP_NAME_PREFIX configured at build time (see project_version.h.in) applied.
+inline std::string GetApplicationName(const char* exe_name)
+{
+    std::string app_name     = exe_name;
+    size_t      dir_location = app_name.find_last_of("/\\");
+
+    if (dir_location != std::string::npos)
+    {
+        app_name.replace(0, dir_location + 1, "");
+    }
+
+    return GFXRECON_APP_NAME_PREFIX + app_name;
+}
+
+/// Prints the "<app name> version info:" / "GFXReconstruct Version x.x.x" lines common to every
+/// tool's --version output. Tools that report additional version information (e.g. per-API
+/// header versions) print it after calling this.
+inline void PrintVersionHeader(const char* exe_name)
+{
+    std::string app_name = GetApplicationName(exe_name);
+
+    GFXRECON_WRITE_CONSOLE("%s version info:", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("  " GFXRECON_APP_NAME_PREFIX "GFXReconstruct Version %s", GetProjectVersionString());
+}
+
+static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    if (arg_parser.IsOptionSet(kVersionOption))
+    {
+        PrintVersionHeader(exe_name);
+        GFXRECON_WRITE_CONSOLE("  Vulkan Header Version %u.%u.%u",
+                               VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE),
+                               VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE),
+                               VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
+
+#if ENABLE_OPENXR_SUPPORT
+        GFXRECON_WRITE_CONSOLE("  OpenXR Header Version %u.%u.%u",
+                               XR_VERSION_MAJOR(XR_CURRENT_API_VERSION),
+                               XR_VERSION_MINOR(XR_CURRENT_API_VERSION),
+                               XR_VERSION_PATCH(XR_CURRENT_API_VERSION));
+#endif
+
+        return true;
+    }
+
+    return false;
+}
+
+static void PrintUsage(const char* exe_name);
+
+static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    if (arg_parser.IsOptionSet(kHelpShortOption) || arg_parser.IsOptionSet(kHelpLongOption))
+    {
+        PrintUsage(exe_name);
+        return true;
+    }
+
+    return false;
+}
+
+#endif // GFXRECON_TOOL_COMMAND_LINE_H

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019-2025 LunarG, Inc.
+** Copyright (c) 2019-2026 LunarG, Inc.
 ** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -68,9 +68,6 @@
 const char kApplicationName[] = "GFXReconstruct Replay";
 const char kCaptureLayer[]    = "VK_LAYER_LUNARG_gfxreconstruct";
 
-const char kHelpShortOption[]                    = "-h";
-const char kHelpLongOption[]                     = "--help";
-const char kVersionOption[]                      = "--version";
 const char kLogLevelArgument[]                   = "--log-level";
 const char kLogTimestampsOption[]                = "--log-timestamps";
 const char kDebugMessageSeverityArgument[]       = "--debug-messenger-level";
@@ -1475,53 +1472,5 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
     return replay_options;
 }
 #endif
-
-// Only provide the usage functions if a define is not present
-#if !defined(GFXR_TOOL_SETTINGS_NO_USAGE)
-static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
-{
-    if (arg_parser.IsOptionSet(kVersionOption))
-    {
-        std::string app_name     = exe_name;
-        size_t      dir_location = app_name.find_last_of("/\\");
-
-        if (dir_location >= 0)
-        {
-            app_name.replace(0, dir_location + 1, "");
-        }
-
-        GFXRECON_WRITE_CONSOLE("%s version info:", app_name.c_str());
-        GFXRECON_WRITE_CONSOLE("  GFXReconstruct Version %s", GetProjectVersionString());
-        GFXRECON_WRITE_CONSOLE("  Vulkan Header Version %u.%u.%u",
-                               VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE),
-                               VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE),
-                               VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
-
-#if ENABLE_OPENXR_SUPPORT
-        GFXRECON_WRITE_CONSOLE("  OpenXR Header Version %u.%u.%u",
-                               XR_VERSION_MAJOR(XR_CURRENT_API_VERSION),
-                               XR_VERSION_MINOR(XR_CURRENT_API_VERSION),
-                               XR_VERSION_PATCH(XR_CURRENT_API_VERSION));
-#endif
-
-        return true;
-    }
-
-    return false;
-}
-
-static void PrintUsage(const char* exe_name);
-
-static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
-{
-    if (arg_parser.IsOptionSet(kHelpShortOption) || arg_parser.IsOptionSet(kHelpLongOption))
-    {
-        PrintUsage(exe_name);
-        return true;
-    }
-
-    return false;
-}
-#endif // GFXR_TOOL_SETTINGS_NO_USAGE
 
 #endif // GFXRECON_PLATFORM_SETTINGS_H


### PR DESCRIPTION
We had multiple versions of the PrintUsage and PrintVersion functions, this unifies them.
Additionally, this moves the "global" defines of these from tool_settings.h which resulted in requiring a #define to filter them out of some locations, and into a new header called tool_command_line.h