### PR TITLE
remove spurious extra option; fix --verbose

### DIFF
--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -758,11 +758,6 @@ int main(int argc, const char** argv)
     std::string arguments = kArguments;
     std::string options   = kOptions;
 
-#if defined(D3D12_SUPPORT)
-    options += " ";
-    options += kEnumGpuIndices;
-#endif
-
     gfxrecon::util::ArgumentParser arg_parser(argc, argv, options, arguments);
 
     if (CheckOptionPrintUsage(app_name.c_str(), arg_parser))


### PR DESCRIPTION
The deleted lines of code made the options list end with `--verbose --emun-gpu-indices`.  Since the option list is comma-separated, this broke `--verbose`.