### PR TITLE
Parse local root signatures & associations from DXIL library subobjects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,10 @@ if (MSVC)
 
         find_package(DXC)
         if (DXC_FOUND)
-            set(D3D12_INCLUDE_DIRECTORIES ${D3D12_INCLUDE_DIRECTORIES} ${DXC_INCLUDE_DIR})
+            # The DXC redist doesn't have an RDAT reader. Add the external, header-only reader (external/dxc-rdat) so
+            # the in-DXIL local root signature parsing can include "dxc/DxilContainer/DxilRuntimeReflection.inl".
+            set(D3D12_INCLUDE_DIRECTORIES ${D3D12_INCLUDE_DIRECTORIES} ${DXC_INCLUDE_DIR}
+                                          "${PROJECT_SOURCE_DIR}/external/dxc-rdat")
             add_definitions(-DGFXRECON_DXC_SUPPORT)
         endif ()
 

--- a/cmake/FindDXC.cmake
+++ b/cmake/FindDXC.cmake
@@ -43,8 +43,12 @@ if (${D3D12_SUPPORT})
 
     if(DXC_ARCH)
         message(STATUS "Selected DXC_ARCH: ${DXC_ARCH}")
+        # DXC_VERSION is the release version of the DXC redist binaries and the vendored RDAT reader
+        # (external/dxc-rdat). When changing DXC_VERSION, update the redist archive URL below and re-vendor
+        # external/dxc-rdat from the matching DXC source tag.
+        set(DXC_VERSION "v1.8.2407")
         set(DXC_SDK_DIR "${CMAKE_BINARY_DIR}/external/DXC")
-        set(DXC_SDK_URL "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2407/dxc_2024_07_31.zip")
+        set(DXC_SDK_URL "https://github.com/microsoft/DirectXShaderCompiler/releases/download/${DXC_VERSION}/dxc_2024_07_31.zip")
         
         # Suppress warning on newer versions of CMake related to FetchContent file timestamp behavior.
         if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")

--- a/external/dxc-rdat/LICENSE.TXT
+++ b/external/dxc-rdat/LICENSE.TXT
@@ -1,0 +1,601 @@
+==============================================================================
+LLVM Release License
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2003-2015 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+
+==============================================================================
+Copyrights and Licenses for Third Party Software Distributed with LLVM:
+==============================================================================
+The LLVM software contains code written by third parties.  Such software will
+have its own individual LICENSE.TXT file in the directory in which it appears.
+This file will describe the copyrights, license, and restrictions which apply
+to that code.
+
+The disclaimer of warranty in the University of Illinois Open Source License
+applies to all code in the LLVM Distribution, and nothing in any of the
+other licenses gives permission to use the names of the LLVM Team or the
+University of Illinois to endorse or promote products derived from this
+Software.
+
+------------------
+
+Files: lib/Miniz/* include/miniz/*
+
+Copyright 2013-2014 RAD Game Tools and Valve Software
+Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
+
+All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------
+
+Files: lib/Miniz/miniz.c
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>
+
+------------------
+
+Files: lib/Support/* docs/SystemLibrary.rst
+
+Written by Henry Spencer.  Not derived from licensed software.
+
+Permission is granted to anyone to use this software for any
+purpose on any computer system, and to redistribute it freely,
+subject to the following restrictions:
+
+1. The author is not responsible for the consequences of use of
+        this software, no matter how awful, even if they arise
+        from defects in it.
+
+2. The origin of this software must not be misrepresented, either
+        by explicit claim or by omission.
+
+3. Altered versions must be plainly marked as such, and must not
+        be misrepresented as being the original software.
+
+------------------
+
+Files: include/llvm/Support/ConvertUTF.h
+
+Copyright 2001-2004 Unicode, Inc.
+
+Disclaimer
+
+This source code is provided as is by Unicode, Inc. No claims are
+made as to fitness for any particular purpose. No warranties of any
+kind are expressed or implied. The recipient agrees to determine
+applicability of information provided. If this file has been
+purchased on magnetic or optical media from Unicode, Inc., the
+sole remedy for any claim will be exchange of defective media
+within 90 days of receipt.
+
+Limitations on Rights to Redistribute This Code
+
+Unicode, Inc. hereby grants the right to freely use the information
+supplied in this file in the creation of products supporting the
+Unicode Standard, and to make copies of this file in any form
+for internal or external distribution as long as this notice
+remains attached.
+
+------------------
+
+Files: include/llvm/Support/MD5.h
+
+This software was written by Alexander Peslyak in 2001.  No copyright is
+claimed, and the software is hereby placed in the public domain.
+In case this attempt to disclaim copyright and place the software in the
+public domain is deemed null and void, then the software is
+Copyright (c) 2001 Alexander Peslyak and it is hereby released to the
+general public under the following terms:
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted.
+
+There's ABSOLUTELY NO WARRANTY, express or implied.
+
+------------------
+
+Files: lib/Support/regstrlcpy.c
+
+Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+
+
+------------------
+------------------
+
+THE FOLLOWING LICENSES ARE FOR BUILD AND TEST DEPENDENCIES ONLY.
+
+------------------
+------------------
+
+Files: utils/unittest/googletest/*
+
+Copyright 2008, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------
+
+Files: utils/unittest/googlemock/*
+
+Copyright 2008, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------
+
+Files: test/YamlParser/*
+
+Copyright (c) 2006 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------
+
+Files: autoconf/config.guess
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+Autoconf Exception
+
+As a special exception, the Free Software Foundation gives unlimited
+permission to copy, distribute and modify the configure scripts that are the
+output of Autoconf. You need not follow the terms of the GNU General Public
+License when using or distributing such scripts, even though portions of the
+text of Autoconf appear in them. The GNU General Public License (GPL) does
+govern all other use of the material that constitutes the Autoconf program.
+
+Certain portions of the Autoconf source text are designed to be copied (in
+certain cases, depending on the input) into the output of Autoconf. We call
+these the "data" portions. The rest of the Autoconf source text consists of
+comments plus executable code that decides which of the data portions to
+output in any given case. We call these comments and executable code the "non-
+data" portions. Autoconf never copies any of the non-data portions into its
+output.
+
+This special exception to the GPL applies to versions of Autoconf released by
+the Free Software Foundation. When you make and distribute a modified version
+of Autoconf, you may extend this special exception to the GPL to apply to your
+modified version as well, *unless* your modified version has the potential to
+copy into its output some of the text that was the non-data portion of the
+version that you started with. (In other words, unless your change moves or
+copies text from the non-data portions to the data portions.) If your
+modification has such potential, you must delete any notice of this special
+exception to the GPL from your modified version.
+
+                     END OF TERMS AND CONDITIONS

--- a/external/dxc-rdat/README.md
+++ b/external/dxc-rdat/README.md
@@ -1,0 +1,27 @@
+# DXC RDAT reader
+
+This directory holds a copy of DirectX Shader Compiler's header-only reader for a DXIL container's
+`RDAT` part. GFXR uses it during D3D12/DXR replay to parse subobjects compiled into a DXIL library.
+
+These files are in sync with the version of the DXC redistributable that `cmake/FindDXC.cmake` fetches.
+The redistributable ships the public headers (`dxcapi.h`, `d3d12shader.h`, ...) but the RDAT reader
+exists only in the DXC source tree, so the relevant files are vendored here.
+
+## Provenance
+
+- Upstream: https://github.com/microsoft/DirectXShaderCompiler
+- Tag: `v1.8.2407` (commit `416fab6b5c4ba956a320d9131102304da995edfc`)
+
+## License
+
+University of Illinois/NCSA Open Source License (the LLVM Release License). The per-file
+headers retain the upstream notice; the full text is in `LICENSE.TXT` here and is also
+recorded in the repository-root `LICENSE_ThirdParty.txt` under
+"DirectX Shader Compiler - all other files".
+
+## Updating
+
+Do not edit these files; they are vendored verbatim. Keep their version in sync with the DXC
+redistributalbe--see `DXC_VERSION` in `cmake/FindDXC.cmake`. If a new DXC version adds a sibling
+`RDAT_*Types.inl` to the master list in `RDAT_Macros.inl`, vendor it too (follow the `#include`s
+in `RDAT_Macros.inl`).

--- a/external/dxc-rdat/dxc/DXIL/DxilConstants.h
+++ b/external/dxc-rdat/dxc/DXIL/DxilConstants.h
@@ -1,0 +1,2057 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// DxilConstants.h                                                           //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Essential DXIL constants.                                                 //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <stdint.h>
+
+namespace hlsl {
+
+/* <py>
+import hctdb_instrhelp
+</py> */
+
+// TODO:
+//   2. get rid of DXIL namespace.
+//   3. use class enum for shader flags.
+//   4. use class enum for address spaces.
+
+namespace DXIL {
+// DXIL version.
+const unsigned kDxilMajor = 1;
+/* <py::lines('VALRULE-TEXT')>hctdb_instrhelp.get_dxil_version_minor()</py>*/
+// VALRULE-TEXT:BEGIN
+const unsigned kDxilMinor = 8;
+// VALRULE-TEXT:END
+
+inline unsigned MakeDxilVersion(unsigned DxilMajor, unsigned DxilMinor) {
+  return 0 | (DxilMajor << 8) | (DxilMinor);
+}
+inline unsigned GetCurrentDxilVersion() {
+  return MakeDxilVersion(kDxilMajor, kDxilMinor);
+}
+inline unsigned GetDxilVersionMajor(unsigned DxilVersion) {
+  return (DxilVersion >> 8) & 0xFF;
+}
+inline unsigned GetDxilVersionMinor(unsigned DxilVersion) {
+  return DxilVersion & 0xFF;
+}
+// Return positive if v1 > v2, negative if v1 < v2, zero if equal
+inline int CompareVersions(unsigned Major1, unsigned Minor1, unsigned Major2,
+                           unsigned Minor2) {
+  if (Major1 != Major2) {
+    // Special case for Major == 0 (latest/unbound)
+    if (Major1 == 0 || Major2 == 0)
+      return Major1 > 0 ? -1 : 1;
+    return Major1 < Major2 ? -1 : 1;
+  }
+  if (Minor1 < Minor2)
+    return -1;
+  if (Minor1 > Minor2)
+    return 1;
+  return 0;
+}
+
+// Utility for updating major,minor to max of current and new.
+inline bool UpdateToMaxOfVersions(unsigned &major, unsigned &minor,
+                                  unsigned newMajor, unsigned newMinor) {
+  if (newMajor > major) {
+    major = newMajor;
+    minor = newMinor;
+    return true;
+  } else if (newMajor == major) {
+    if (newMinor > minor) {
+      minor = newMinor;
+      return true;
+    }
+  }
+  return false;
+}
+
+// Shader flags.
+const unsigned kDisableOptimizations =
+    0x00000001; // D3D11_1_SB_GLOBAL_FLAG_SKIP_OPTIMIZATION
+const unsigned kDisableMathRefactoring =
+    0x00000002; //~D3D10_SB_GLOBAL_FLAG_REFACTORING_ALLOWED
+const unsigned kEnableDoublePrecision =
+    0x00000004; // D3D11_SB_GLOBAL_FLAG_ENABLE_DOUBLE_PRECISION_FLOAT_OPS
+const unsigned kForceEarlyDepthStencil =
+    0x00000008; // D3D11_SB_GLOBAL_FLAG_FORCE_EARLY_DEPTH_STENCIL
+const unsigned kEnableRawAndStructuredBuffers =
+    0x00000010; // D3D11_SB_GLOBAL_FLAG_ENABLE_RAW_AND_STRUCTURED_BUFFERS
+const unsigned kEnableMinPrecision =
+    0x00000020; // D3D11_1_SB_GLOBAL_FLAG_ENABLE_MINIMUM_PRECISION
+const unsigned kEnableDoubleExtensions =
+    0x00000040; // D3D11_1_SB_GLOBAL_FLAG_ENABLE_DOUBLE_EXTENSIONS
+const unsigned kEnableMSAD =
+    0x00000080; // D3D11_1_SB_GLOBAL_FLAG_ENABLE_SHADER_EXTENSIONS
+const unsigned kAllResourcesBound =
+    0x00000100; // D3D12_SB_GLOBAL_FLAG_ALL_RESOURCES_BOUND
+
+const unsigned kNumOutputStreams = 4;
+const unsigned kNumClipPlanes = 6;
+
+// TODO: move these to appropriate places (ShaderModel.cpp?)
+const unsigned kMaxTempRegCount = 4096; // DXBC only
+const unsigned kMaxCBufferSize = 4096;
+const unsigned kMaxStructBufferStride = 2048;
+const unsigned kMaxHSOutputControlPointsTotalScalars = 3968;
+const unsigned kMaxHSOutputPatchConstantTotalScalars = 32 * 4;
+const unsigned kMaxSignatureTotalVectors = 32;
+const unsigned kMaxOutputTotalScalars = kMaxSignatureTotalVectors * 4;
+const unsigned kMaxInputTotalScalars = kMaxSignatureTotalVectors * 4;
+const unsigned kMaxClipOrCullDistanceElementCount = 2;
+const unsigned kMaxClipOrCullDistanceCount = 2 * 4;
+const unsigned kMaxGSOutputVertexCount = 1024;
+const unsigned kMaxGSInstanceCount = 32;
+const unsigned kMinIAPatchControlPointCount = 1;
+const unsigned kMaxIAPatchControlPointCount = 32;
+const float kHSMaxTessFactorLowerBound = 1.0f;
+const float kHSMaxTessFactorUpperBound = 64.0f;
+const unsigned kHSDefaultInputControlPointCount = 1;
+const unsigned kMaxCSThreadsPerGroup = 1024;
+const unsigned kMaxCSThreadGroupX = 1024;
+const unsigned kMaxCSThreadGroupY = 1024;
+const unsigned kMaxCSThreadGroupZ = 64;
+const unsigned kMinCSThreadGroupX = 1;
+const unsigned kMinCSThreadGroupY = 1;
+const unsigned kMinCSThreadGroupZ = 1;
+const unsigned kMaxCS4XThreadsPerGroup = 768;
+const unsigned kMaxCS4XThreadGroupX = 768;
+const unsigned kMaxCS4XThreadGroupY = 768;
+const unsigned kMaxTGSMSize = 8192 * 4;
+const unsigned kMaxGSOutputTotalScalars = 1024;
+const unsigned kMaxMSASThreadsPerGroup = 128;
+const unsigned kMaxMSASThreadGroupX = 128;
+const unsigned kMaxMSASThreadGroupY = 128;
+const unsigned kMaxMSASThreadGroupZ = 128;
+const unsigned kMinMSASThreadGroupX = 1;
+const unsigned kMinMSASThreadGroupY = 1;
+const unsigned kMinMSASThreadGroupZ = 1;
+const unsigned kMaxMSASPayloadBytes = 1024 * 16;
+const unsigned kMaxMSOutputPrimitiveCount = 256;
+const unsigned kMaxMSOutputVertexCount = 256;
+const unsigned kMaxMSOutputTotalBytes = 1024 * 32;
+const unsigned kMaxMSInputOutputTotalBytes = 1024 * 47;
+const unsigned kMaxMSVSigRows = 32;
+const unsigned kMaxMSPSigRows = 32;
+const unsigned kMaxMSTotalSigRows = 32;
+const unsigned kMaxMSSMSize = 1024 * 28;
+const unsigned kMinWaveSize = 4;
+const unsigned kMaxWaveSize = 128;
+
+const float kMaxMipLodBias = 15.99f;
+const float kMinMipLodBias = -16.0f;
+
+const unsigned kResRetStatusIndex = 4;
+
+enum class ComponentType : uint32_t {
+  Invalid = 0,
+  I1,
+  I16,
+  U16,
+  I32,
+  U32,
+  I64,
+  U64,
+  F16,
+  F32,
+  F64,
+  SNormF16,
+  UNormF16,
+  SNormF32,
+  UNormF32,
+  SNormF64,
+  UNormF64,
+  PackedS8x32,
+  PackedU8x32,
+  LastEntry
+};
+
+// Must match D3D_INTERPOLATION_MODE
+enum class InterpolationMode : uint8_t {
+  Undefined = 0,
+  Constant = 1,
+  Linear = 2,
+  LinearCentroid = 3,
+  LinearNoperspective = 4,
+  LinearNoperspectiveCentroid = 5,
+  LinearSample = 6,
+  LinearNoperspectiveSample = 7,
+  Invalid = 8
+};
+
+// size of each scalar type in signature element in bits
+enum class SignatureDataWidth : uint8_t {
+  Undefined = 0,
+  Bits16 = 16,
+  Bits32 = 32,
+};
+
+enum class SignatureKind {
+  Invalid = 0,
+  Input,
+  Output,
+  PatchConstOrPrim,
+};
+
+// Must match D3D11_SHADER_VERSION_TYPE
+enum class ShaderKind {
+  Pixel = 0,
+  Vertex,
+  Geometry,
+  Hull,
+  Domain,
+  Compute,
+  Library,
+  RayGeneration,
+  Intersection,
+  AnyHit,
+  ClosestHit,
+  Miss,
+  Callable,
+  Mesh,
+  Amplification,
+  Node,
+  Invalid,
+
+  // Last* values identify the last shader kind recognized by the highest
+  // validator version before additional kinds were added.
+  Last_1_2 = Compute,
+  Last_1_4 = Callable,
+  Last_1_7 = Amplification,
+  Last_1_8 = Node,
+  LastValid = Last_1_8,
+};
+static_assert((unsigned)DXIL::ShaderKind::LastValid + 1 ==
+                  (unsigned)DXIL::ShaderKind::Invalid,
+              "otherwise, enum needs updating.");
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('SemanticKind-ENUM')>hctdb_instrhelp.get_enum_decl("SemanticKind", hide_val=True, sort_val=False)</py>*/
+// clang-format on
+// SemanticKind-ENUM:BEGIN
+// Semantic kind; Arbitrary or specific system value.
+enum class SemanticKind : unsigned {
+  Arbitrary,
+  VertexID,
+  InstanceID,
+  Position,
+  RenderTargetArrayIndex,
+  ViewPortArrayIndex,
+  ClipDistance,
+  CullDistance,
+  OutputControlPointID,
+  DomainLocation,
+  PrimitiveID,
+  GSInstanceID,
+  SampleIndex,
+  IsFrontFace,
+  Coverage,
+  InnerCoverage,
+  Target,
+  Depth,
+  DepthLessEqual,
+  DepthGreaterEqual,
+  StencilRef,
+  DispatchThreadID,
+  GroupID,
+  GroupIndex,
+  GroupThreadID,
+  TessFactor,
+  InsideTessFactor,
+  ViewID,
+  Barycentrics,
+  ShadingRate,
+  CullPrimitive,
+  StartVertexLocation,
+  StartInstanceLocation,
+  Invalid,
+};
+// SemanticKind-ENUM:END
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('SigPointKind-ENUM')>hctdb_instrhelp.get_enum_decl("SigPointKind", hide_val=True, sort_val=False)</py>*/
+// clang-format on
+// SigPointKind-ENUM:BEGIN
+// Signature Point is more specific than shader stage or signature as it is
+// unique in both stage and item dimensionality or frequency.
+enum class SigPointKind : unsigned {
+  VSIn,    // Ordinary Vertex Shader input from Input Assembler
+  VSOut,   // Ordinary Vertex Shader output that may feed Rasterizer
+  PCIn,    // Patch Constant function non-patch inputs
+  HSIn,    // Hull Shader function non-patch inputs
+  HSCPIn,  // Hull Shader patch inputs - Control Points
+  HSCPOut, // Hull Shader function output - Control Point
+  PCOut,   // Patch Constant function output - Patch Constant data passed to
+           // Domain Shader
+  DSIn, // Domain Shader regular input - Patch Constant data plus system values
+  DSCPIn, // Domain Shader patch input - Control Points
+  DSOut,  // Domain Shader output - vertex data that may feed Rasterizer
+  GSVIn,  // Geometry Shader vertex input - qualified with primitive type
+  GSIn,   // Geometry Shader non-vertex inputs (system values)
+  GSOut,  // Geometry Shader output - vertex data that may feed Rasterizer
+  PSIn,   // Pixel Shader input
+  PSOut,  // Pixel Shader output
+  CSIn,   // Compute Shader input
+  MSIn,   // Mesh Shader input
+  MSOut,  // Mesh Shader vertices output
+  MSPOut, // Mesh Shader primitives output
+  ASIn,   // Amplification Shader input
+  Invalid,
+};
+// SigPointKind-ENUM:END
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('SemanticInterpretationKind-ENUM')>hctdb_instrhelp.get_enum_decl("SemanticInterpretationKind", hide_val=True, sort_val=False)</py>*/
+// clang-format on
+// SemanticInterpretationKind-ENUM:BEGIN
+// Defines how a semantic is interpreted at a particular SignaturePoint
+enum class SemanticInterpretationKind : unsigned {
+  NA,         // Not Available
+  SV,         // Normal System Value
+  SGV,        // System Generated Value (sorted last)
+  Arb,        // Treated as Arbitrary
+  NotInSig,   // Not included in signature (intrinsic access)
+  NotPacked,  // Included in signature, but does not contribute to packing
+  Target,     // Special handling for SV_Target
+  TessFactor, // Special handling for tessellation factors
+  Shadow,     // Shadow element must be added to a signature for compatibility
+  ClipCull,   // Special packing rules for SV_ClipDistance or SV_CullDistance
+  Invalid,
+};
+// SemanticInterpretationKind-ENUM:END
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('PackingKind-ENUM')>hctdb_instrhelp.get_enum_decl("PackingKind", hide_val=True, sort_val=False)</py>*/
+// clang-format on
+// PackingKind-ENUM:BEGIN
+// Kind of signature point
+enum class PackingKind : unsigned {
+  None,           // No packing should be performed
+  InputAssembler, // Vertex Shader input from Input Assembler
+  Vertex,         // Vertex that may feed the Rasterizer
+  PatchConstant,  // Patch constant signature
+  Target,         // Render Target (Pixel Shader Output)
+  Invalid,
+};
+// PackingKind-ENUM:END
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('FPDenormMode-ENUM')>hctdb_instrhelp.get_enum_decl("Float32DenormMode", hide_val=False, sort_val=False)</py>*/
+// clang-format on
+// FPDenormMode-ENUM:BEGIN
+// float32 denorm behavior
+enum class Float32DenormMode : unsigned {
+  Any = 0,      // Undefined behavior for denormal numbers
+  Preserve = 1, // Preserve both input and output
+  FTZ = 2,      // Preserve denormal inputs. Flush denorm outputs
+  Reserve3 = 3, // Reserved Value. Not used for now
+  Reserve4 = 4, // Reserved Value. Not used for now
+  Reserve5 = 5, // Reserved Value. Not used for now
+  Reserve6 = 6, // Reserved Value. Not used for now
+  Reserve7 = 7, // Reserved Value. Not used for now
+};
+// FPDenormMode-ENUM:END
+
+enum class PackingStrategy : unsigned {
+  Default = 0,  // Choose default packing algorithm based on target (currently
+                // PrefixStable)
+  PrefixStable, // Maintain assumption that all elements are packed in order and
+                // stable as new elements are added.
+  Optimized, // Optimize packing of all elements together (all elements must be
+             // present, in the same order, for identical placement of any
+             // individual element)
+  Invalid,
+};
+
+enum class DefaultLinkage : unsigned {
+  Default = 0,
+  Internal = 1,
+  External = 2,
+};
+
+enum class SamplerKind : unsigned {
+  Default = 0,
+  Comparison,
+  Mono,
+  Invalid,
+};
+
+enum class ResourceClass { SRV = 0, UAV, CBuffer, Sampler, Invalid };
+
+enum class ResourceKind : unsigned {
+  Invalid = 0,
+  Texture1D,
+  Texture2D,
+  Texture2DMS,
+  Texture3D,
+  TextureCube,
+  Texture1DArray,
+  Texture2DArray,
+  Texture2DMSArray,
+  TextureCubeArray,
+  TypedBuffer,
+  RawBuffer,
+  StructuredBuffer,
+  CBuffer,
+  Sampler,
+  TBuffer,
+  RTAccelerationStructure,
+  FeedbackTexture2D,
+  FeedbackTexture2DArray,
+  NumEntries,
+};
+
+/// Whether the resource kind is a texture. This does not include
+/// FeedbackTextures.
+inline bool IsAnyTexture(DXIL::ResourceKind ResourceKind) {
+  return DXIL::ResourceKind::Texture1D <= ResourceKind &&
+         ResourceKind <= DXIL::ResourceKind::TextureCubeArray;
+}
+
+/// Whether the resource kind is an array of textures. This does not include
+/// FeedbackTextures.
+inline bool IsAnyArrayTexture(DXIL::ResourceKind ResourceKind) {
+  return DXIL::ResourceKind::Texture1DArray <= ResourceKind &&
+         ResourceKind <= DXIL::ResourceKind::TextureCubeArray;
+}
+
+/// Whether the resource kind is a Texture or FeedbackTexture with array
+/// dimension.
+inline bool IsArrayKind(DXIL::ResourceKind ResourceKind) {
+  return IsAnyArrayTexture(ResourceKind) ||
+         ResourceKind == DXIL::ResourceKind::FeedbackTexture2DArray;
+}
+
+/// Whether the resource kind is a TextureCube or TextureCubeArray.
+inline bool IsAnyTextureCube(DXIL::ResourceKind ResourceKind) {
+  return DXIL::ResourceKind::TextureCube == ResourceKind ||
+         DXIL::ResourceKind::TextureCubeArray == ResourceKind;
+}
+
+inline bool IsStructuredBuffer(DXIL::ResourceKind ResourceKind) {
+  return ResourceKind == DXIL::ResourceKind::StructuredBuffer;
+}
+
+inline bool IsTypedBuffer(DXIL::ResourceKind ResourceKind) {
+  return ResourceKind == DXIL::ResourceKind::TypedBuffer;
+}
+
+inline bool IsTyped(DXIL::ResourceKind ResourceKind) {
+  return IsTypedBuffer(ResourceKind) || IsAnyTexture(ResourceKind);
+}
+
+inline bool IsRawBuffer(DXIL::ResourceKind ResourceKind) {
+  return ResourceKind == DXIL::ResourceKind::RawBuffer;
+}
+
+inline bool IsTBuffer(DXIL::ResourceKind ResourceKind) {
+  return ResourceKind == DXIL::ResourceKind::TBuffer;
+}
+
+/// Whether the resource kind is a FeedbackTexture.
+inline bool IsFeedbackTexture(DXIL::ResourceKind ResourceKind) {
+  return ResourceKind == DXIL::ResourceKind::FeedbackTexture2D ||
+         ResourceKind == DXIL::ResourceKind::FeedbackTexture2DArray;
+}
+
+// TODO: change opcodes.
+/* <py::lines('OPCODE-ENUM')>hctdb_instrhelp.get_enum_decl("OpCode")</py>*/
+// OPCODE-ENUM:BEGIN
+// Enumeration for operations specified by DXIL
+enum class OpCode : unsigned {
+  // Amplification shader instructions
+  DispatchMesh = 173, // Amplification shader intrinsic DispatchMesh
+
+  // AnyHit Terminals
+  AcceptHitAndEndSearch =
+      156, // Used in an any hit shader to abort the ray query and the
+           // intersection shader (if any). The current hit is committed and
+           // execution passes to the closest hit shader with the closest hit
+           // recorded so far
+  IgnoreHit = 155, // Used in an any hit shader to reject an intersection and
+                   // terminate the shader
+
+  // Binary float
+  FMax = 35, // returns a if a >= b, else b
+  FMin = 36, // returns a if a < b, else b
+
+  // Binary int with two outputs
+  IMul = 41, // multiply of 32-bit operands to produce the correct full 64-bit
+             // result.
+
+  // Binary int
+  IMax = 37, // IMax(a,b) returns a if a > b, else b
+  IMin = 38, // IMin(a,b) returns a if a < b, else b
+
+  // Binary uint with carry or borrow
+  UAddc = 44, // unsigned add of 32-bit operand with the carry
+  USubb = 45, // unsigned subtract of 32-bit operands with the borrow
+
+  // Binary uint with two outputs
+  UDiv = 43, // unsigned divide of the 32-bit operand src0 by the 32-bit operand
+             // src1.
+  UMul = 42, // multiply of 32-bit operands to produce the correct full 64-bit
+             // result.
+
+  // Binary uint
+  UMax = 39, // unsigned integer maximum. UMax(a,b) = a > b ? a : b
+  UMin = 40, // unsigned integer minimum. UMin(a,b) = a < b ? a : b
+
+  // Bitcasts with different sizes
+  BitcastF16toI16 = 125, // bitcast between different sizes
+  BitcastF32toI32 = 127, // bitcast between different sizes
+  BitcastF64toI64 = 129, // bitcast between different sizes
+  BitcastI16toF16 = 124, // bitcast between different sizes
+  BitcastI32toF32 = 126, // bitcast between different sizes
+  BitcastI64toF64 = 128, // bitcast between different sizes
+
+  // Comparison Samples
+  SampleCmpBias = 255, // samples a texture after applying the input bias to the
+                       // mipmap level and compares a single component against
+                       // the specified comparison value
+  SampleCmpGrad =
+      254, // samples a texture using a gradient and compares a single component
+           // against the specified comparison value
+
+  // Compute/Mesh/Amplification/Node shader
+  FlattenedThreadIdInGroup = 96, // provides a flattened index for a given
+                                 // thread within a given group (SV_GroupIndex)
+  GroupId = 94,                  // reads the group ID (SV_GroupID)
+  ThreadId = 93,                 // reads the thread ID
+  ThreadIdInGroup =
+      95, // reads the thread ID within the group (SV_GroupThreadID)
+
+  // Create/Annotate Node Handles
+  AllocateNodeOutputRecords = 238, // returns a handle for the output records
+  AnnotateNodeHandle = 249,        // annotate handle with node properties
+  AnnotateNodeRecordHandle = 251, // annotate handle with node record properties
+  CreateNodeInputRecordHandle = 250, // create a handle for an InputRecord
+  CreateNodeOutputHandle = 247,      // Creates a handle to a NodeOutput
+  IndexNodeHandle = 248, // returns the handle for the location in the output
+                         // node array at the indicated index
+
+  // Derivatives
+  CalculateLOD = 81, // calculates the level of detail
+  DerivCoarseX = 83, // computes the rate of change per stamp in x direction.
+  DerivCoarseY = 84, // computes the rate of change per stamp in y direction.
+  DerivFineX = 85,   // computes the rate of change per pixel in x direction.
+  DerivFineY = 86,   // computes the rate of change per pixel in y direction.
+
+  // Domain and hull shader
+  LoadOutputControlPoint = 103, // LoadOutputControlPoint
+  LoadPatchConstant = 104,      // LoadPatchConstant
+
+  // Domain shader
+  DomainLocation = 105, // DomainLocation
+
+  // Dot product with accumulate
+  Dot2AddHalf = 162,     // 2D half dot product with accumulate to float
+  Dot4AddI8Packed = 163, // signed dot product of 4 x i8 vectors packed into
+                         // i32, with accumulate to i32
+  Dot4AddU8Packed = 164, // unsigned dot product of 4 x u8 vectors packed into
+                         // i32, with accumulate to i32
+
+  // Dot
+  Dot2 = 54, // Two-dimensional vector dot-product
+  Dot3 = 55, // Three-dimensional vector dot-product
+  Dot4 = 56, // Four-dimensional vector dot-product
+
+  // Double precision
+  LegacyDoubleToFloat = 132,  // legacy fuction to convert double to float
+  LegacyDoubleToSInt32 = 133, // legacy fuction to convert double to int32
+  LegacyDoubleToUInt32 = 134, // legacy fuction to convert double to uint32
+  MakeDouble = 101,           // creates a double value
+  SplitDouble = 102,          // splits a double into low and high parts
+
+  // Extended Command Information
+  StartInstanceLocation =
+      257, // returns the StartInstanceLocation from Draw*Instanced
+  StartVertexLocation =
+      256, // returns the BaseVertexLocation from DrawIndexedInstanced or
+           // StartVertexLocation from DrawInstanced
+
+  // Geometry shader
+  CutStream =
+      98, // completes the current primitive topology at the specified stream
+  EmitStream = 97,        // emits a vertex to a given stream
+  EmitThenCutStream = 99, // equivalent to an EmitStream followed by a CutStream
+  GSInstanceID = 100,     // GSInstanceID
+
+  // Get Pointer to Node Record in Address Space 6
+  GetNodeRecordPtr =
+      239, // retrieve node input/output record pointer in address space 6
+
+  // Get handle from heap
+  AnnotateHandle = 216,          // annotate handle with resource properties
+  CreateHandleFromBinding = 217, // create resource handle from binding
+  CreateHandleFromHeap = 218,    // create resource handle from heap
+
+  // Graphics shader
+  ViewID = 138, // returns the view index
+
+  // Helper Lanes
+  IsHelperLane = 221, // returns true on helper lanes in pixel shaders
+
+  // Hull shader
+  OutputControlPointID = 107, // OutputControlPointID
+  StorePatchConstant = 106,   // StorePatchConstant
+
+  // Hull, Domain and Geometry shaders
+  PrimitiveID = 108, // PrimitiveID
+
+  // Indirect Shader Invocation
+  CallShader = 159, // Call a shader in the callable shader table supplied
+                    // through the DispatchRays() API
+  ReportHit = 158,  // returns true if hit was accepted
+  TraceRay = 157,   // initiates raytrace
+
+  // Inline Ray Query
+  AllocateRayQuery = 178, // allocates space for RayQuery and return handle
+  RayQuery_Abort = 181,   // aborts a ray query
+  RayQuery_CandidateGeometryIndex = 203, // returns candidate hit geometry index
+  RayQuery_CandidateInstanceContributionToHitGroupIndex =
+      214, // returns candidate hit InstanceContributionToHitGroupIndex
+  RayQuery_CandidateInstanceID = 202,    // returns candidate hit instance ID
+  RayQuery_CandidateInstanceIndex = 201, // returns candidate hit instance index
+  RayQuery_CandidateObjectRayDirection =
+      206, // returns candidate object ray direction
+  RayQuery_CandidateObjectRayOrigin =
+      205, // returns candidate hit object ray origin
+  RayQuery_CandidateObjectToWorld3x4 =
+      186, // returns matrix for transforming from object-space to world-space
+           // for a candidate hit.
+  RayQuery_CandidatePrimitiveIndex =
+      204, // returns candidate hit geometry index
+  RayQuery_CandidateProceduralPrimitiveNonOpaque =
+      190, // returns if current candidate procedural primitive is non opaque
+  RayQuery_CandidateTriangleBarycentrics =
+      193, // returns candidate triangle hit barycentrics
+  RayQuery_CandidateTriangleFrontFace =
+      191, // returns if current candidate triangle is front facing
+  RayQuery_CandidateTriangleRayT =
+      199, // returns float representing the parametric point on the ray for the
+           // current candidate triangle hit.
+  RayQuery_CandidateType =
+      185, // returns uint candidate type (CANDIDATE_TYPE) of the current hit
+           // candidate in a ray query, after Proceed() has returned true
+  RayQuery_CandidateWorldToObject3x4 =
+      187, // returns matrix for transforming from world-space to object-space
+           // for a candidate hit.
+  RayQuery_CommitNonOpaqueTriangleHit =
+      182, // commits a non opaque triangle hit
+  RayQuery_CommitProceduralPrimitiveHit =
+      183,                               // commits a procedural primitive hit
+  RayQuery_CommittedGeometryIndex = 209, // returns committed hit geometry index
+  RayQuery_CommittedInstanceContributionToHitGroupIndex =
+      215, // returns committed hit InstanceContributionToHitGroupIndex
+  RayQuery_CommittedInstanceID = 208,    // returns committed hit instance ID
+  RayQuery_CommittedInstanceIndex = 207, // returns committed hit instance index
+  RayQuery_CommittedObjectRayDirection =
+      212, // returns committed object ray direction
+  RayQuery_CommittedObjectRayOrigin =
+      211, // returns committed hit object ray origin
+  RayQuery_CommittedObjectToWorld3x4 =
+      188, // returns matrix for transforming from object-space to world-space
+           // for a Committed hit.
+  RayQuery_CommittedPrimitiveIndex =
+      210, // returns committed hit geometry index
+  RayQuery_CommittedRayT =
+      200, // returns float representing the parametric point on the ray for the
+           // current committed hit.
+  RayQuery_CommittedStatus = 184, // returns uint status (COMMITTED_STATUS) of
+                                  // the committed hit in a ray query
+  RayQuery_CommittedTriangleBarycentrics =
+      194, // returns committed triangle hit barycentrics
+  RayQuery_CommittedTriangleFrontFace =
+      192, // returns if current committed triangle is front facing
+  RayQuery_CommittedWorldToObject3x4 =
+      189, // returns matrix for transforming from world-space to object-space
+           // for a Committed hit.
+  RayQuery_Proceed = 180,  // advances a ray query
+  RayQuery_RayFlags = 195, // returns ray flags
+  RayQuery_RayTMin = 198,  // returns float representing the parametric starting
+                           // point for the ray.
+  RayQuery_TraceRayInline = 179,    // initializes RayQuery for raytrace
+  RayQuery_WorldRayDirection = 197, // returns world ray direction
+  RayQuery_WorldRayOrigin = 196,    // returns world ray origin
+
+  // Legacy floating-point
+  LegacyF16ToF32 = 131, // legacy fuction to convert half (f16) to float (f32)
+                        // (this is not related to min-precision)
+  LegacyF32ToF16 = 130, // legacy fuction to convert float (f32) to half (f16)
+                        // (this is not related to min-precision)
+
+  // Library create handle from resource struct (like HL intrinsic)
+  CreateHandleForLib =
+      160, // create resource handle from resource struct for library
+
+  // Mesh shader instructions
+  EmitIndices = 169, // emit a primitive's vertex indices in a mesh shader
+  GetMeshPayload =
+      170, // get the mesh payload which is from amplification shader
+  SetMeshOutputCounts = 168, // Mesh shader intrinsic SetMeshOutputCounts
+  StorePrimitiveOutput =
+      172,                 // stores the value to mesh shader primitive output
+  StoreVertexOutput = 171, // stores the value to mesh shader vertex output
+
+  // Other
+  CycleCounterLegacy = 109, // CycleCounterLegacy
+
+  // Packing intrinsics
+  Pack4x8 = 220, // packs vector of 4 signed or unsigned values into a packed
+                 // datatype, drops or clamps unused bits
+
+  // Pixel shader
+  AttributeAtVertex =
+      137,              // returns the values of the attributes at the vertex.
+  Coverage = 91,        // returns the coverage mask input in a pixel shader
+  Discard = 82,         // discard the current pixel
+  EvalCentroid = 89,    // evaluates an input attribute at pixel center
+  EvalSampleIndex = 88, // evaluates an input attribute at a sample location
+  EvalSnapped =
+      87, // evaluates an input attribute at pixel center with an offset
+  InnerCoverage = 92, // returns underestimated coverage input from conservative
+                      // rasterization in a pixel shader
+  SampleIndex =
+      90, // returns the sample index in a sample-frequency pixel shader
+
+  // Quad Wave Ops
+  QuadOp = 123,         // returns the result of a quad-level operation
+  QuadReadLaneAt = 122, // reads from a lane in the quad
+  QuadVote = 222,       // compares boolean accross a quad
+
+  // Quaternary
+  Bfi = 53, // Given a bit range from the LSB of a number, places that number of
+            // bits in another number at any offset
+
+  // Ray Dispatch Arguments
+  DispatchRaysDimensions =
+      146, // The Width and Height values from the D3D12_DISPATCH_RAYS_DESC
+           // structure provided to the originating DispatchRays() call.
+  DispatchRaysIndex =
+      145, // The current x and y location within the Width and Height
+
+  // Ray Transforms
+  ObjectToWorld =
+      151, // Matrix for transforming from object-space to world-space.
+  WorldToObject =
+      152, // Matrix for transforming from world-space to object-space.
+
+  // Ray Vectors
+  WorldRayDirection = 148, // The world-space direction for the current ray.
+  WorldRayOrigin = 147,    // The world-space origin for the current ray.
+
+  // Ray object space Vectors
+  ObjectRayDirection = 150, // Object-space direction for the current ray.
+  ObjectRayOrigin = 149,    // Object-space origin for the current ray.
+
+  // RayT
+  RayTCurrent =
+      154, // float representing the current parametric ending point for the ray
+  RayTMin =
+      153, // float representing the parametric starting point for the ray.
+
+  // Raytracing hit uint System Values
+  HitKind = 143, // Returns the value passed as HitKind in ReportIntersection().
+                 // If intersection was reported by fixed-function triangle
+                 // intersection, HitKind will be one of
+                 // HIT_KIND_TRIANGLE_FRONT_FACE or HIT_KIND_TRIANGLE_BACK_FACE.
+
+  // Raytracing object space uint System Values, raytracing tier 1.1
+  GeometryIndex = 213, // The autogenerated index of the current geometry in the
+                       // bottom-level structure
+
+  // Raytracing object space uint System Values
+  InstanceID =
+      141, // The user-provided InstanceID on the bottom-level acceleration
+           // structure instance within the top-level structure
+  InstanceIndex = 142, // The autogenerated index of the current instance in the
+                       // top-level structure
+  PrimitiveIndex = 161, // PrimitiveIndex for raytracing shaders
+
+  // Raytracing uint System Values
+  RayFlags = 144, // uint containing the current ray flags.
+
+  // Resources - gather
+  TextureGather = 73,     // gathers the four texels that would be used in a
+                          // bi-linear filtering operation
+  TextureGatherCmp = 74,  // same as TextureGather, except this instrution
+                          // performs comparison on texels, similar to SampleCmp
+  TextureGatherRaw = 223, // Gather raw elements from 4 texels with no type
+                          // conversions (SRV type is constrained)
+
+  // Resources - sample
+  RenderTargetGetSampleCount =
+      77, // gets the number of samples for a render target
+  RenderTargetGetSamplePosition =
+      76,      // gets the position of the specified sample
+  Sample = 60, // samples a texture
+  SampleBias =
+      61, // samples a texture after applying the input bias to the mipmap level
+  SampleCmp = 64, // samples a texture and compares a single component against
+                  // the specified comparison value
+  SampleCmpLevel = 224,    // samples a texture and compares a single component
+                           // against the specified comparison value
+  SampleCmpLevelZero = 65, // samples a texture and compares a single component
+                           // against the specified comparison value
+  SampleGrad = 63,  // samples a texture using a gradient to influence the way
+                    // the sample location is calculated
+  SampleLevel = 62, // samples a texture using a mipmap-level offset
+  Texture2DMSGetSamplePosition =
+      75, // gets the position of the specified sample
+
+  // Resources
+  BufferLoad = 68,          // reads from a TypedBuffer
+  BufferStore = 69,         // writes to a RWTypedBuffer
+  BufferUpdateCounter = 70, // atomically increments/decrements the hidden
+                            // 32-bit counter stored with a Count or Append UAV
+  CBufferLoad = 58,         // loads a value from a constant buffer resource
+  CBufferLoadLegacy = 59,   // loads a value from a constant buffer resource
+  CheckAccessFullyMapped =
+      71, // determines whether all values from a Sample, Gather, or Load
+          // operation accessed mapped tiles in a tiled resource
+  CreateHandle = 57,    // creates the handle to a resource
+  GetDimensions = 72,   // gets texture size information
+  RawBufferLoad = 139,  // reads from a raw buffer and structured buffer
+  RawBufferStore = 140, // writes to a RWByteAddressBuffer or RWStructuredBuffer
+  TextureLoad = 66,     // reads texel data without any filtering or sampling
+  TextureStore = 67,    // reads texel data without any filtering or sampling
+  TextureStoreSample = 225, // stores texel data at specified sample index
+
+  // Sampler Feedback
+  WriteSamplerFeedback =
+      174, // updates a feedback texture for a sampling operation
+  WriteSamplerFeedbackBias = 175,  // updates a feedback texture for a sampling
+                                   // operation with a bias on the mipmap level
+  WriteSamplerFeedbackGrad = 177,  // updates a feedback texture for a sampling
+                                   // operation with explicit gradients
+  WriteSamplerFeedbackLevel = 176, // updates a feedback texture for a sampling
+                                   // operation with a mipmap-level offset
+
+  // Synchronization
+  AtomicBinOp = 78,           // performs an atomic operation on two operands
+  AtomicCompareExchange = 79, // atomic compare and exchange to memory
+  Barrier = 80,               // inserts a memory barrier in the shader
+  BarrierByMemoryHandle =
+      245, // Request a barrier for just the memory used by the specified object
+  BarrierByMemoryType = 244, // Request a barrier for a set of memory types
+                             // and/or thread group execution sync
+  BarrierByNodeRecordHandle =
+      246, // Request a barrier for just the memory used by the node record
+
+  // Temporary, indexable, input, output registers
+  LoadInput = 4,        // Loads the value from shader input
+  MinPrecXRegLoad = 2,  // Helper load operation for minprecision
+  MinPrecXRegStore = 3, // Helper store operation for minprecision
+  StoreOutput = 5,      // Stores the value to shader output
+  TempRegLoad = 0,      // Helper load operation
+  TempRegStore = 1,     // Helper store operation
+
+  // Tertiary float
+  FMad = 46, // floating point multiply & add
+  Fma = 47,  // fused multiply-add
+
+  // Tertiary int
+  IMad = 48, // Signed integer multiply & add
+  Ibfe = 51, // Integer bitfield extract
+  Msad = 50, // masked Sum of Absolute Differences.
+
+  // Tertiary uint
+  UMad = 49, // Unsigned integer multiply & add
+  Ubfe = 52, // Unsigned integer bitfield extract
+
+  // Unary float - rounding
+  Round_ne = 26, // floating-point round to integral float.
+  Round_ni = 27, // floating-point round to integral float.
+  Round_pi = 28, // floating-point round to integral float.
+  Round_z = 29,  // floating-point round to integral float.
+
+  // Unary float
+  Acos = 15, // Returns the arccosine of the specified value. Input should be a
+             // floating-point value within the range of -1 to 1.
+  Asin = 16, // Returns the arccosine of the specified value. Input should be a
+             // floating-point value within the range of -1 to 1
+  Atan = 17, // Returns the arctangent of the specified value. The return value
+             // is within the range of -PI/2 to PI/2.
+  Cos = 12,  // returns cosine(theta) for theta in radians.
+  Exp = 21,  // returns 2^exponent
+  FAbs = 6,  // returns the absolute value of the input value.
+  Frc = 22,  // extract fracitonal component.
+  Hcos = 18, // returns the hyperbolic cosine of the specified value.
+  Hsin = 19, // returns the hyperbolic sine of the specified value.
+  Htan = 20, // returns the hyperbolic tangent of the specified value.
+  IsFinite = 10, // Returns true if x is finite, false otherwise.
+  IsInf = 9,     // Returns true if x is +INF or -INF, false otherwise.
+  IsNaN = 8,     // Returns true if x is NAN or QNAN, false otherwise.
+  IsNormal = 11, // returns IsNormal
+  Log = 23,      // returns log base 2.
+  Rsqrt = 25,    // returns reciprocal square root (1 / sqrt(src)
+  Saturate = 7,  // clamps the result of a single or double precision floating
+                 // point value to [0.0f...1.0f]
+  Sin = 13,      // returns sine(theta) for theta in radians.
+  Sqrt = 24,     // returns square root
+  Tan = 14,      // returns tan(theta) for theta in radians.
+
+  // Unary int
+  Bfrev = 30,       // Reverses the order of the bits.
+  Countbits = 31,   // Counts the number of bits in the input integer.
+  FirstbitLo = 32,  // Returns the location of the first set bit starting from
+                    // the lowest order bit and working upward.
+  FirstbitSHi = 34, // Returns the location of the first set bit from the
+                    // highest order bit based on the sign.
+
+  // Unary uint
+  FirstbitHi = 33, // Returns the location of the first set bit starting from
+                   // the highest order bit and working downward.
+
+  // Unpacking intrinsics
+  Unpack4x8 = 219, // unpacks 4 8-bit signed or unsigned values into int32 or
+                   // int16 vector
+
+  // Wave
+  WaveActiveAllEqual = 115, // returns 1 if all the lanes have the same value
+  WaveActiveBallot = 116, // returns a struct with a bit set for each lane where
+                          // the condition is true
+  WaveActiveBit = 120,   // returns the result of the operation across all lanes
+  WaveActiveOp = 119,    // returns the result the operation across waves
+  WaveAllBitCount = 135, // returns the count of bits set to 1 across the wave
+  WaveAllTrue = 114, // returns 1 if all the lanes evaluate the value to true
+  WaveAnyTrue = 113, // returns 1 if any of the lane evaluates the value to true
+  WaveGetLaneCount = 112, // returns the number of lanes in the wave
+  WaveGetLaneIndex = 111, // returns the index of the current lane in the wave
+  WaveIsFirstLane = 110,  // returns 1 for the first lane in the wave
+  WaveMatch =
+      165, // returns the bitmask of active lanes that have the same value
+  WaveMultiPrefixBitCount = 167, // returns the count of bits set to 1 on groups
+                                 // of lanes identified by a bitmask
+  WaveMultiPrefixOp = 166,  // returns the result of the operation on groups of
+                            // lanes identified by a bitmask
+  WavePrefixBitCount = 136, // returns the count of bits set to 1 on prior lanes
+  WavePrefixOp = 121,      // returns the result of the operation on prior lanes
+  WaveReadLaneAt = 117,    // returns the value from the specified lane
+  WaveReadLaneFirst = 118, // returns the value from the first lane
+
+  // WaveMatrix
+  WaveMatrix_Add = 237, // Element-wise accumulate, or broadcast add of fragment
+                        // into accumulator
+  WaveMatrix_Annotate =
+      226, // Annotate a wave matrix pointer with the type information
+  WaveMatrix_Depth =
+      227,               // Returns depth (K) value for matrix of specified type
+  WaveMatrix_Fill = 228, // Fill wave matrix with scalar value
+  WaveMatrix_LoadGroupShared = 230, // Load wave matrix from group shared array
+  WaveMatrix_LoadRawBuf = 229,      // Load wave matrix from raw buffer
+  WaveMatrix_Multiply =
+      233, // Mutiply left and right wave matrix and store in accumulator
+  WaveMatrix_MultiplyAccumulate =
+      234, // Mutiply left and right wave matrix and accumulate into accumulator
+  WaveMatrix_ScalarOp =
+      235, // Perform scalar operation on each element of wave matrix
+  WaveMatrix_StoreGroupShared = 232, // Store wave matrix to group shared array
+  WaveMatrix_StoreRawBuf = 231,      // Store wave matrix to raw buffer
+  WaveMatrix_SumAccumulate = 236, // Sum rows or columns of an input matrix into
+                                  // an existing accumulator fragment matrix
+
+  // Work Graph intrinsics
+  FinishedCrossGroupSharing = 243, // returns true if the current thread group
+                                   // is the last to access the input
+  GetInputRecordCount = 242, // returns the number of records that have been
+                             // coalesced into the current thread group
+  GetRemainingRecursionLevels =
+      253, // returns how many levels of recursion remain
+  IncrementOutputCount =
+      240, // Select the next logical output count for an EmptyNodeOutput for
+           // the whole group or per thread.
+  NodeOutputIsValid = 252, // returns true if the specified output node is
+                           // present in the work graph
+  OutputComplete =
+      241, // indicates all outputs for a given records are complete
+
+  NumOpCodes_Dxil_1_0 = 137,
+  NumOpCodes_Dxil_1_1 = 139,
+  NumOpCodes_Dxil_1_2 = 141,
+  NumOpCodes_Dxil_1_3 = 162,
+  NumOpCodes_Dxil_1_4 = 165,
+  NumOpCodes_Dxil_1_5 = 216,
+  NumOpCodes_Dxil_1_6 = 222,
+  NumOpCodes_Dxil_1_7 = 226,
+  NumOpCodes_Dxil_1_8 = 258,
+
+  NumOpCodes = 258 // exclusive last value of enumeration
+};
+// OPCODE-ENUM:END
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('OPCODECLASS-ENUM')>hctdb_instrhelp.get_enum_decl("OpCodeClass")</py>*/
+// clang-format on
+// OPCODECLASS-ENUM:BEGIN
+// Groups for DXIL operations with equivalent function templates
+enum class OpCodeClass : unsigned {
+  // Amplification shader instructions
+  DispatchMesh,
+
+  // AnyHit Terminals
+  AcceptHitAndEndSearch,
+  IgnoreHit,
+
+  // Binary uint with carry or borrow
+  BinaryWithCarryOrBorrow,
+
+  // Binary uint with two outputs
+  BinaryWithTwoOuts,
+
+  // Binary uint
+  Binary,
+
+  // Bitcasts with different sizes
+  BitcastF16toI16,
+  BitcastF32toI32,
+  BitcastF64toI64,
+  BitcastI16toF16,
+  BitcastI32toF32,
+  BitcastI64toF64,
+
+  // Comparison Samples
+  SampleCmpBias,
+  SampleCmpGrad,
+
+  // Compute/Mesh/Amplification/Node shader
+  FlattenedThreadIdInGroup,
+  GroupId,
+  ThreadId,
+  ThreadIdInGroup,
+
+  // Create/Annotate Node Handles
+  AllocateNodeOutputRecords,
+  AnnotateNodeHandle,
+  AnnotateNodeRecordHandle,
+  CreateNodeInputRecordHandle,
+  IndexNodeHandle,
+  createNodeOutputHandle,
+
+  // Derivatives
+  CalculateLOD,
+  Unary,
+
+  // Domain and hull shader
+  LoadOutputControlPoint,
+  LoadPatchConstant,
+
+  // Domain shader
+  DomainLocation,
+
+  // Dot product with accumulate
+  Dot2AddHalf,
+  Dot4AddPacked,
+
+  // Dot
+  Dot2,
+  Dot3,
+  Dot4,
+
+  // Double precision
+  LegacyDoubleToFloat,
+  LegacyDoubleToSInt32,
+  LegacyDoubleToUInt32,
+  MakeDouble,
+  SplitDouble,
+
+  // Extended Command Information
+  StartInstanceLocation,
+  StartVertexLocation,
+
+  // Geometry shader
+  CutStream,
+  EmitStream,
+  EmitThenCutStream,
+  GSInstanceID,
+
+  // Get Pointer to Node Record in Address Space 6
+  GetNodeRecordPtr,
+
+  // Get handle from heap
+  AnnotateHandle,
+  CreateHandleFromBinding,
+  CreateHandleFromHeap,
+
+  // Graphics shader
+  ViewID,
+
+  // Helper Lanes
+  IsHelperLane,
+
+  // Hull shader
+  OutputControlPointID,
+  StorePatchConstant,
+
+  // Hull, Domain and Geometry shaders
+  PrimitiveID,
+
+  // Indirect Shader Invocation
+  CallShader,
+  ReportHit,
+  TraceRay,
+
+  // Inline Ray Query
+  AllocateRayQuery,
+  RayQuery_Abort,
+  RayQuery_CommitNonOpaqueTriangleHit,
+  RayQuery_CommitProceduralPrimitiveHit,
+  RayQuery_Proceed,
+  RayQuery_StateMatrix,
+  RayQuery_StateScalar,
+  RayQuery_StateVector,
+  RayQuery_TraceRayInline,
+
+  // LLVM Instructions
+  LlvmInst,
+
+  // Legacy floating-point
+  LegacyF16ToF32,
+  LegacyF32ToF16,
+
+  // Library create handle from resource struct (like HL intrinsic)
+  CreateHandleForLib,
+
+  // Mesh shader instructions
+  EmitIndices,
+  GetMeshPayload,
+  SetMeshOutputCounts,
+  StorePrimitiveOutput,
+  StoreVertexOutput,
+
+  // Other
+  CycleCounterLegacy,
+
+  // Packing intrinsics
+  Pack4x8,
+
+  // Pixel shader
+  AttributeAtVertex,
+  Coverage,
+  Discard,
+  EvalCentroid,
+  EvalSampleIndex,
+  EvalSnapped,
+  InnerCoverage,
+  SampleIndex,
+
+  // Quad Wave Ops
+  QuadOp,
+  QuadReadLaneAt,
+  QuadVote,
+
+  // Quaternary
+  Quaternary,
+
+  // Ray Dispatch Arguments
+  DispatchRaysDimensions,
+  DispatchRaysIndex,
+
+  // Ray Transforms
+  ObjectToWorld,
+  WorldToObject,
+
+  // Ray Vectors
+  WorldRayDirection,
+  WorldRayOrigin,
+
+  // Ray object space Vectors
+  ObjectRayDirection,
+  ObjectRayOrigin,
+
+  // RayT
+  RayTCurrent,
+  RayTMin,
+
+  // Raytracing hit uint System Values
+  HitKind,
+
+  // Raytracing object space uint System Values, raytracing tier 1.1
+  GeometryIndex,
+
+  // Raytracing object space uint System Values
+  InstanceID,
+  InstanceIndex,
+  PrimitiveIndex,
+
+  // Raytracing uint System Values
+  RayFlags,
+
+  // Resources - gather
+  TextureGather,
+  TextureGatherCmp,
+  TextureGatherRaw,
+
+  // Resources - sample
+  RenderTargetGetSampleCount,
+  RenderTargetGetSamplePosition,
+  Sample,
+  SampleBias,
+  SampleCmp,
+  SampleCmpLevel,
+  SampleCmpLevelZero,
+  SampleGrad,
+  SampleLevel,
+  Texture2DMSGetSamplePosition,
+
+  // Resources
+  BufferLoad,
+  BufferStore,
+  BufferUpdateCounter,
+  CBufferLoad,
+  CBufferLoadLegacy,
+  CheckAccessFullyMapped,
+  CreateHandle,
+  GetDimensions,
+  RawBufferLoad,
+  RawBufferStore,
+  TextureLoad,
+  TextureStore,
+  TextureStoreSample,
+
+  // Sampler Feedback
+  WriteSamplerFeedback,
+  WriteSamplerFeedbackBias,
+  WriteSamplerFeedbackGrad,
+  WriteSamplerFeedbackLevel,
+
+  // Synchronization
+  AtomicBinOp,
+  AtomicCompareExchange,
+  Barrier,
+  BarrierByMemoryHandle,
+  BarrierByMemoryType,
+  BarrierByNodeRecordHandle,
+
+  // Temporary, indexable, input, output registers
+  LoadInput,
+  MinPrecXRegLoad,
+  MinPrecXRegStore,
+  StoreOutput,
+  TempRegLoad,
+  TempRegStore,
+
+  // Tertiary uint
+  Tertiary,
+
+  // Unary float
+  IsSpecialFloat,
+
+  // Unary int
+  UnaryBits,
+
+  // Unpacking intrinsics
+  Unpack4x8,
+
+  // Wave
+  WaveActiveAllEqual,
+  WaveActiveBallot,
+  WaveActiveBit,
+  WaveActiveOp,
+  WaveAllOp,
+  WaveAllTrue,
+  WaveAnyTrue,
+  WaveGetLaneCount,
+  WaveGetLaneIndex,
+  WaveIsFirstLane,
+  WaveMatch,
+  WaveMultiPrefixBitCount,
+  WaveMultiPrefixOp,
+  WavePrefixOp,
+  WaveReadLaneAt,
+  WaveReadLaneFirst,
+
+  // WaveMatrix
+  WaveMatrix_Accumulate,
+  WaveMatrix_Annotate,
+  WaveMatrix_Depth,
+  WaveMatrix_Fill,
+  WaveMatrix_LoadGroupShared,
+  WaveMatrix_LoadRawBuf,
+  WaveMatrix_Multiply,
+  WaveMatrix_ScalarOp,
+  WaveMatrix_StoreGroupShared,
+  WaveMatrix_StoreRawBuf,
+
+  // Work Graph intrinsics
+  FinishedCrossGroupSharing,
+  GetInputRecordCount,
+  GetRemainingRecursionLevels,
+  IncrementOutputCount,
+  NodeOutputIsValid,
+  OutputComplete,
+
+  NumOpClasses_Dxil_1_0 = 93,
+  NumOpClasses_Dxil_1_1 = 95,
+  NumOpClasses_Dxil_1_2 = 97,
+  NumOpClasses_Dxil_1_3 = 118,
+  NumOpClasses_Dxil_1_4 = 120,
+  NumOpClasses_Dxil_1_5 = 143,
+  NumOpClasses_Dxil_1_6 = 149,
+  NumOpClasses_Dxil_1_7 = 153,
+  NumOpClasses_Dxil_1_8 = 183,
+
+  NumOpClasses = 183 // exclusive last value of enumeration
+};
+// OPCODECLASS-ENUM:END
+
+// Operand Index for every OpCodeClass.
+namespace OperandIndex {
+// Opcode is always operand 0.
+const unsigned kOpcodeIdx = 0;
+
+// Unary operators.
+const unsigned kUnarySrc0OpIdx = 1;
+
+// Binary operators.
+const unsigned kBinarySrc0OpIdx = 1;
+const unsigned kBinarySrc1OpIdx = 2;
+
+// Trinary operators.
+const unsigned kTrinarySrc0OpIdx = 1;
+const unsigned kTrinarySrc1OpIdx = 2;
+const unsigned kTrinarySrc2OpIdx = 3;
+
+// LoadInput.
+const unsigned kLoadInputIDOpIdx = 1;
+const unsigned kLoadInputRowOpIdx = 2;
+const unsigned kLoadInputColOpIdx = 3;
+const unsigned kLoadInputVertexIDOpIdx = 4;
+
+// StoreOutput, StoreVertexOutput, StorePrimitiveOutput
+const unsigned kStoreOutputIDOpIdx = 1;
+const unsigned kStoreOutputRowOpIdx = 2;
+const unsigned kStoreOutputColOpIdx = 3;
+const unsigned kStoreOutputValOpIdx = 4;
+const unsigned kStoreOutputVPIDOpIdx = 5;
+
+// DomainLocation.
+const unsigned kDomainLocationColOpIdx = 1;
+
+// BufferLoad.
+const unsigned kBufferLoadHandleOpIdx = 1;
+const unsigned kBufferLoadCoord0OpIdx = 2;
+const unsigned kBufferLoadCoord1OpIdx = 3;
+
+// BufferStore.
+const unsigned kBufferStoreHandleOpIdx = 1;
+const unsigned kBufferStoreCoord0OpIdx = 2;
+const unsigned kBufferStoreCoord1OpIdx = 3;
+const unsigned kBufferStoreVal0OpIdx = 4;
+const unsigned kBufferStoreVal1OpIdx = 5;
+const unsigned kBufferStoreVal2OpIdx = 6;
+const unsigned kBufferStoreVal3OpIdx = 7;
+const unsigned kBufferStoreMaskOpIdx = 8;
+
+// RawBufferLoad.
+const unsigned kRawBufferLoadHandleOpIdx = 1;
+const unsigned kRawBufferLoadIndexOpIdx = 2;
+const unsigned kRawBufferLoadElementOffsetOpIdx = 3;
+const unsigned kRawBufferLoadMaskOpIdx = 4;
+const unsigned kRawBufferLoadAlignmentOpIdx = 5;
+
+// RawBufferStore
+const unsigned kRawBufferStoreHandleOpIdx = 1;
+const unsigned kRawBufferStoreIndexOpIdx = 2;
+const unsigned kRawBufferStoreElementOffsetOpIdx = 3;
+const unsigned kRawBufferStoreVal0OpIdx = 4;
+const unsigned kRawBufferStoreVal1OpIdx = 5;
+const unsigned kRawBufferStoreVal2OpIdx = 6;
+const unsigned kRawBufferStoreVal3OpIdx = 7;
+const unsigned kRawBufferStoreMaskOpIdx = 8;
+const unsigned kRawBufferStoreAlignmentOpIdx = 8;
+
+// TextureStore.
+const unsigned kTextureStoreHandleOpIdx = 1;
+const unsigned kTextureStoreCoord0OpIdx = 2;
+const unsigned kTextureStoreCoord1OpIdx = 3;
+const unsigned kTextureStoreCoord2OpIdx = 4;
+const unsigned kTextureStoreVal0OpIdx = 5;
+const unsigned kTextureStoreVal1OpIdx = 6;
+const unsigned kTextureStoreVal2OpIdx = 7;
+const unsigned kTextureStoreVal3OpIdx = 8;
+const unsigned kTextureStoreMaskOpIdx = 9;
+
+// TextureGather.
+const unsigned kTextureGatherTexHandleOpIdx = 1;
+const unsigned kTextureGatherSamplerHandleOpIdx = 2;
+const unsigned kTextureGatherCoord0OpIdx = 3;
+const unsigned kTextureGatherCoord1OpIdx = 4;
+const unsigned kTextureGatherCoord2OpIdx = 5;
+const unsigned kTextureGatherCoord3OpIdx = 6;
+const unsigned kTextureGatherOffset0OpIdx = 7;
+const unsigned kTextureGatherOffset1OpIdx = 8;
+const unsigned kTextureGatherChannelOpIdx = 9;
+// TextureGatherCmp.
+const unsigned kTextureGatherCmpCmpValOpIdx = 11;
+
+// TextureSample.
+const unsigned kTextureSampleTexHandleOpIdx = 1;
+const unsigned kTextureSampleSamplerHandleOpIdx = 2;
+const unsigned kTextureSampleCoord0OpIdx = 3;
+const unsigned kTextureSampleCoord1OpIdx = 4;
+const unsigned kTextureSampleCoord2OpIdx = 5;
+const unsigned kTextureSampleCoord3OpIdx = 6;
+const unsigned kTextureSampleOffset0OpIdx = 7;
+const unsigned kTextureSampleOffset1OpIdx = 8;
+const unsigned kTextureSampleOffset2OpIdx = 9;
+const unsigned kTextureSampleClampOpIdx = 10;
+
+// TextureLoad.
+const unsigned kTextureLoadOffset0OpIdx = 6;
+const unsigned kTextureLoadOffset1OpIdx = 8;
+const unsigned kTextureLoadOffset2OpIdx = 9;
+
+// AtomicBinOp.
+const unsigned kAtomicBinOpHandleOpIdx = 1;
+const unsigned kAtomicBinOpCoord0OpIdx = 3;
+const unsigned kAtomicBinOpCoord1OpIdx = 4;
+const unsigned kAtomicBinOpCoord2OpIdx = 5;
+
+// AtomicCmpExchange.
+const unsigned kAtomicCmpExchangeCoord0OpIdx = 2;
+const unsigned kAtomicCmpExchangeCoord1OpIdx = 3;
+const unsigned kAtomicCmpExchangeCoord2OpIdx = 4;
+
+// CreateHandle
+const unsigned kCreateHandleResClassOpIdx = 1;
+const unsigned kCreateHandleResIDOpIdx = 2;
+const unsigned kCreateHandleResIndexOpIdx = 3;
+const unsigned kCreateHandleIsUniformOpIdx = 4;
+
+// CreateHandleFromResource
+const unsigned kCreateHandleForLibResOpIdx = 1;
+
+// CreateHandleFromHeap
+const unsigned kCreateHandleFromHeapHeapIndexOpIdx = 1;
+const unsigned kCreateHandleFromHeapSamplerHeapOpIdx = 2;
+const unsigned kCreateHandleFromHeapNonUniformIndexOpIdx = 3;
+
+// CreateHandleFromBinding
+const unsigned kCreateHandleFromBindingResIndexOpIdx = 2;
+
+// TraceRay
+const unsigned kTraceRayRayDescOpIdx = 7;
+const unsigned kTraceRayPayloadOpIdx = 15;
+const unsigned kTraceRayNumOp = 16;
+
+// TraceRayInline
+const unsigned kTraceRayInlineRayDescOpIdx = 5;
+const unsigned kTraceRayInlineNumOp = 13;
+
+// Emit/Cut
+const unsigned kStreamEmitCutIDOpIdx = 1;
+
+// StoreVectorOutput/StorePrimitiveOutput.
+const unsigned kMSStoreOutputIDOpIdx = 1;
+const unsigned kMSStoreOutputRowOpIdx = 2;
+const unsigned kMSStoreOutputColOpIdx = 3;
+const unsigned kMSStoreOutputVIdxOpIdx = 4;
+const unsigned kMSStoreOutputValOpIdx = 5;
+
+// TODO: add operand index for all the OpCodeClass.
+} // namespace OperandIndex
+
+// Atomic binary operation kind.
+enum class AtomicBinOpCode : unsigned {
+  Add,
+  And,
+  Or,
+  Xor,
+  IMin,
+  IMax,
+  UMin,
+  UMax,
+  Exchange,
+  Invalid // Must be last.
+};
+
+// Barrier/fence modes.
+enum class BarrierMode : unsigned {
+  Invalid = 0,
+  SyncThreadGroup = 0x00000001,
+  UAVFenceGlobal = 0x00000002,
+  UAVFenceThreadGroup = 0x00000004,
+  TGSMFence = 0x00000008,
+};
+
+// Address space.
+const unsigned kDefaultAddrSpace = 0;
+const unsigned kDeviceMemoryAddrSpace = 1;
+const unsigned kCBufferAddrSpace = 2;
+const unsigned kTGSMAddrSpace = 3;
+const unsigned kGenericPointerAddrSpace = 4;
+const unsigned kImmediateCBufferAddrSpace = 5;
+const unsigned kNodeRecordAddrSpace = 6;
+
+// Input primitive, must match D3D_PRIMITIVE
+enum class InputPrimitive : unsigned {
+  Undefined = 0,
+  Point = 1,
+  Line = 2,
+  Triangle = 3,
+  Reserved4 = 4,
+  Reserved5 = 5,
+  LineWithAdjacency = 6,
+  TriangleWithAdjacency = 7,
+  ControlPointPatch1 = 8,
+  ControlPointPatch2 = 9,
+  ControlPointPatch3 = 10,
+  ControlPointPatch4 = 11,
+  ControlPointPatch5 = 12,
+  ControlPointPatch6 = 13,
+  ControlPointPatch7 = 14,
+  ControlPointPatch8 = 15,
+  ControlPointPatch9 = 16,
+  ControlPointPatch10 = 17,
+  ControlPointPatch11 = 18,
+  ControlPointPatch12 = 19,
+  ControlPointPatch13 = 20,
+  ControlPointPatch14 = 21,
+  ControlPointPatch15 = 22,
+  ControlPointPatch16 = 23,
+  ControlPointPatch17 = 24,
+  ControlPointPatch18 = 25,
+  ControlPointPatch19 = 26,
+  ControlPointPatch20 = 27,
+  ControlPointPatch21 = 28,
+  ControlPointPatch22 = 29,
+  ControlPointPatch23 = 30,
+  ControlPointPatch24 = 31,
+  ControlPointPatch25 = 32,
+  ControlPointPatch26 = 33,
+  ControlPointPatch27 = 34,
+  ControlPointPatch28 = 35,
+  ControlPointPatch29 = 36,
+  ControlPointPatch30 = 37,
+  ControlPointPatch31 = 38,
+  ControlPointPatch32 = 39,
+
+  LastEntry,
+};
+
+// Primitive topology, must match D3D_PRIMITIVE_TOPOLOGY
+enum class PrimitiveTopology : unsigned {
+  Undefined = 0,
+  PointList = 1,
+  LineList = 2,
+  LineStrip = 3,
+  TriangleList = 4,
+  TriangleStrip = 5,
+
+  LastEntry,
+};
+
+// Must match D3D_TESSELLATOR_DOMAIN
+enum class TessellatorDomain {
+  Undefined = 0,
+  IsoLine = 1,
+  Tri = 2,
+  Quad = 3,
+
+  LastEntry,
+};
+
+// Must match D3D_TESSELLATOR_OUTPUT_PRIMITIVE
+enum class TessellatorOutputPrimitive {
+  Undefined = 0,
+  Point = 1,
+  Line = 2,
+  TriangleCW = 3,
+  TriangleCCW = 4,
+
+  LastEntry,
+};
+
+enum class MeshOutputTopology {
+  Undefined = 0,
+  Line = 1,
+  Triangle = 2,
+
+  LastEntry,
+};
+
+// Tessellator partitioning, must match D3D_TESSELLATOR_PARTITIONING
+enum class TessellatorPartitioning : unsigned {
+  Undefined = 0,
+  Integer,
+  Pow2,
+  FractionalOdd,
+  FractionalEven,
+
+  LastEntry,
+};
+
+enum class NodeLaunchType {
+  Invalid = 0,
+  Broadcasting,
+  Coalescing,
+  Thread,
+
+  LastEntry
+};
+
+enum class NodeIOFlags : uint32_t {
+  None = 0x0,
+  Input = 0x1,
+  Output = 0x2,
+  ReadWrite = 0x4,
+  EmptyRecord = 0x8, // EmptyNodeOutput[Array], EmptyNodeInput
+  NodeArray = 0x10,  // NodeOutputArray, EmptyNodeOutputArray
+
+  // Record granularity (enum in 2 bits)
+  ThreadRecord = 0x20,   // [RW]ThreadNodeInputRecord, ThreadNodeOutputRecords
+  GroupRecord = 0x40,    // [RW]GroupNodeInputRecord, GroupNodeOutputRecords
+  DispatchRecord = 0x60, // [RW]DispatchNodeInputRecord
+  RecordGranularityMask = 0x60,
+
+  NodeIOKindMask = 0x7F,
+
+  TrackRWInputSharing = 0x100, // TrackRWInputSharing tracked on all non-empty
+                               // input/output record/node types
+  GloballyCoherent = 0x200,    // applies to RWDispatchNodeInputRecord
+
+  // Mask for node/record properties beyond NodeIOKind
+  RecordFlagsMask = 0x300,
+  NodeFlagsMask = 0x100,
+};
+
+enum class NodeIOKind : uint32_t {
+  Invalid = 0,
+
+  EmptyInput =
+      (uint32_t)NodeIOFlags::EmptyRecord | (uint32_t)NodeIOFlags::Input,
+  NodeOutput = (uint32_t)NodeIOFlags::ReadWrite | (uint32_t)NodeIOFlags::Output,
+  NodeOutputArray = (uint32_t)NodeIOFlags::ReadWrite |
+                    (uint32_t)NodeIOFlags::Output |
+                    (uint32_t)NodeIOFlags::NodeArray,
+  EmptyOutput =
+      (uint32_t)NodeIOFlags::EmptyRecord | (uint32_t)NodeIOFlags::Output,
+  EmptyOutputArray = (uint32_t)NodeIOFlags::EmptyRecord |
+                     (uint32_t)NodeIOFlags::Output |
+                     (uint32_t)NodeIOFlags::NodeArray,
+
+  DispatchNodeInputRecord =
+      (uint32_t)NodeIOFlags::Input | (uint32_t)NodeIOFlags::DispatchRecord,
+  GroupNodeInputRecords =
+      (uint32_t)NodeIOFlags::Input | (uint32_t)NodeIOFlags::GroupRecord,
+  ThreadNodeInputRecord =
+      (uint32_t)NodeIOFlags::Input | (uint32_t)NodeIOFlags::ThreadRecord,
+
+  RWDispatchNodeInputRecord = (uint32_t)NodeIOFlags::ReadWrite |
+                              (uint32_t)NodeIOFlags::Input |
+                              (uint32_t)NodeIOFlags::DispatchRecord,
+  RWGroupNodeInputRecords = (uint32_t)NodeIOFlags::ReadWrite |
+                            (uint32_t)NodeIOFlags::Input |
+                            (uint32_t)NodeIOFlags::GroupRecord,
+  RWThreadNodeInputRecord = (uint32_t)NodeIOFlags::ReadWrite |
+                            (uint32_t)NodeIOFlags::Input |
+                            (uint32_t)NodeIOFlags::ThreadRecord,
+
+  GroupNodeOutputRecords = (uint32_t)NodeIOFlags::ReadWrite |
+                           (uint32_t)NodeIOFlags::Output |
+                           (uint32_t)NodeIOFlags::GroupRecord,
+  ThreadNodeOutputRecords = (uint32_t)NodeIOFlags::ReadWrite |
+                            (uint32_t)NodeIOFlags::Output |
+                            (uint32_t)NodeIOFlags::ThreadRecord,
+};
+
+// Kind of quad-level operation
+enum class QuadOpKind {
+  ReadAcrossX = 0, // returns the value from the other lane in the quad in the
+                   // horizontal direction
+  ReadAcrossY = 1, // returns the value from the other lane in the quad in the
+                   // vertical direction
+  ReadAcrossDiagonal = 2, // returns the value from the lane across the quad in
+                          // horizontal and vertical direction
+};
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('WAVEBITOPKIND-ENUM')>hctdb_instrhelp.get_enum_decl("WaveBitOpKind")</py>*/
+// clang-format on
+// WAVEBITOPKIND-ENUM:BEGIN
+// Kind of bitwise cross-lane operation
+enum class WaveBitOpKind : unsigned {
+  And = 0, // bitwise and of values
+  Or = 1,  // bitwise or of values
+  Xor = 2, // bitwise xor of values
+};
+// WAVEBITOPKIND-ENUM:END
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('WAVEOPKIND-ENUM')>hctdb_instrhelp.get_enum_decl("WaveOpKind")</py>*/
+// clang-format on
+// WAVEOPKIND-ENUM:BEGIN
+// Kind of cross-lane operation
+enum class WaveOpKind : unsigned {
+  Max = 3,     // maximum value
+  Min = 2,     // minimum value
+  Product = 1, // product of values
+  Sum = 0,     // sum of values
+};
+// WAVEOPKIND-ENUM:END
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('WAVEMULTIPREFIXOPKIND-ENUM')>hctdb_instrhelp.get_enum_decl("WaveMultiPrefixOpKind")</py>*/
+// clang-format on
+// WAVEMULTIPREFIXOPKIND-ENUM:BEGIN
+// Kind of cross-lane for multi-prefix operation
+enum class WaveMultiPrefixOpKind : unsigned {
+  And = 1,     // bitwise and of values
+  Or = 2,      // bitwise or of values
+  Product = 4, // product of values
+  Sum = 0,     // sum of values
+  Xor = 3,     // bitwise xor of values
+};
+// WAVEMULTIPREFIXOPKIND-ENUM:END
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('SIGNEDOPKIND-ENUM')>hctdb_instrhelp.get_enum_decl("SignedOpKind")</py>*/
+// clang-format on
+// SIGNEDOPKIND-ENUM:BEGIN
+// Sign vs. unsigned operands for operation
+enum class SignedOpKind : unsigned {
+  Signed = 0,   // signed integer or floating-point operands
+  Unsigned = 1, // unsigned integer operands
+};
+// SIGNEDOPKIND-ENUM:END
+
+// clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('QUADVOTEOPKIND-ENUM')>hctdb_instrhelp.get_enum_decl("QuadVoteOpKind")</py>*/
+// clang-format on
+// QUADVOTEOPKIND-ENUM:BEGIN
+// Kind of cross-quad vote operation
+enum class QuadVoteOpKind : unsigned {
+  All = 1, // true if all conditions are true in this quad
+  Any = 0, // true if any condition is true in this quad
+};
+// QUADVOTEOPKIND-ENUM:END
+
+// Kind of control flow hint
+enum class ControlFlowHint : unsigned {
+  Undefined = 0,
+  Branch = 1,
+  Flatten = 2,
+  FastOpt = 3,
+  AllowUavCondition = 4,
+  ForceCase = 5,
+  Call = 6,
+  // Loop and Unroll is using llvm.loop.unroll Metadata.
+
+  LastEntry,
+};
+
+// XYZW component mask.
+const uint8_t kCompMask_X = 0x1;
+const uint8_t kCompMask_Y = 0x2;
+const uint8_t kCompMask_Z = 0x4;
+const uint8_t kCompMask_W = 0x8;
+const uint8_t kCompMask_All = 0xF;
+
+enum class LowPrecisionMode {
+  Undefined = 0,
+  UseMinPrecision,
+  UseNativeLowPrecision
+};
+
+// Corresponds to RAY_FLAG_* in HLSL
+enum class RayFlag : uint32_t {
+  None = 0x00,
+  ForceOpaque = 0x01,
+  ForceNonOpaque = 0x02,
+  AcceptFirstHitAndEndSearch = 0x04,
+  SkipClosestHitShader = 0x08,
+  CullBackFacingTriangles = 0x10,
+  CullFrontFacingTriangles = 0x20,
+  CullOpaque = 0x40,
+  CullNonOpaque = 0x80,
+  SkipTriangles = 0x100,
+  SkipProceduralPrimitives = 0x200,
+};
+
+// Packing/unpacking intrinsics
+enum class UnpackMode : uint8_t {
+  Unsigned = 0, // not sign extended
+  Signed = 1,   // sign extended
+};
+
+enum class PackMode : uint8_t {
+  Trunc = 0,  // Pack low bits, drop the rest
+  UClamp = 1, // Unsigned clamp - [0, 255] for 8-bits
+  SClamp = 2, // Signed clamp - [-128, 127] for 8-bits
+};
+
+// Corresponds to HIT_KIND_* in HLSL
+enum class HitKind : uint8_t {
+  None = 0x00,
+  TriangleFrontFace = 0xFE,
+  TriangleBackFace = 0xFF,
+};
+
+enum class SamplerFeedbackType : uint8_t {
+  MinMip = 0,
+  MipRegionUsed = 1,
+  LastEntry = 2
+};
+
+enum class WaveMatrixKind : uint8_t {
+  Left = 0,
+  Right = 1,
+  LeftColAcc = 2,
+  RightRowAcc = 3,
+  Accumulator = 4,
+  NumKinds = 5,
+  MaskSide = 1,
+  MaskClass = 6, // 0 = Left/Right, 2 = Fragment, 4 = Accumulator
+};
+
+/* <py::lines('WAVEMATRIXSCALAROPCODE-ENUM')>hctdb_instrhelp.get_enum_decl("WaveMatrixScalarOpCode")</py>*/
+// WAVEMATRIXSCALAROPCODE-ENUM:BEGIN
+// Operation for WaveMatrix_ScalarOp
+enum class WaveMatrixScalarOpCode : unsigned {
+  Add = 0,
+  Divide = 3,
+  Invalid = 4,
+  Multiply = 2,
+  Subtract = 1,
+};
+// WAVEMATRIXSCALAROPCODE-ENUM:END
+
+// Corresponds to MEMORY_TYPE_FLAG enums in HLSL
+enum class MemoryTypeFlag : uint32_t {
+  UavMemory = 0x00000001,         // UAV_MEMORY
+  GroupSharedMemory = 0x00000002, // GROUP_SHARED_MEMORY
+  NodeInputMemory = 0x00000004,   // NODE_INPUT_MEMORY
+  NodeOutputMemory = 0x00000008,  // NODE_OUTPUT_MEMORY
+  AllMemory = 0x0000000F,         // ALL_MEMORY
+  ValidMask = 0x0000000F,
+  NodeFlags = NodeInputMemory | NodeOutputMemory,
+  LegacyFlags = UavMemory | GroupSharedMemory,
+  GroupFlags = GroupSharedMemory,
+};
+
+// Corresponds to SEMANTIC_FLAG enums in HLSL
+enum class BarrierSemanticFlag : uint32_t {
+  GroupSync = 0x00000001,   // GROUP_SYNC
+  GroupScope = 0x00000002,  // GROUP_SCOPE
+  DeviceScope = 0x00000004, // DEVICE_SCOPE
+  ValidMask = 0x00000007,
+  GroupFlags = GroupSync | GroupScope,
+};
+
+// Constant for Container.
+const uint8_t DxilProgramSigMaskX = 1;
+const uint8_t DxilProgramSigMaskY = 2;
+const uint8_t DxilProgramSigMaskZ = 4;
+const uint8_t DxilProgramSigMaskW = 8;
+
+// DFCC_FeatureInfo is a uint64_t value with these flags.
+const uint64_t ShaderFeatureInfo_Doubles = 0x0001;
+const uint64_t
+    ShaderFeatureInfo_ComputeShadersPlusRawAndStructuredBuffersViaShader4X =
+        0x0002;
+const uint64_t ShaderFeatureInfo_UAVsAtEveryStage = 0x0004;
+const uint64_t ShaderFeatureInfo_64UAVs = 0x0008;
+const uint64_t ShaderFeatureInfo_MinimumPrecision = 0x0010;
+const uint64_t ShaderFeatureInfo_11_1_DoubleExtensions = 0x0020;
+const uint64_t ShaderFeatureInfo_11_1_ShaderExtensions = 0x0040;
+const uint64_t ShaderFeatureInfo_LEVEL9ComparisonFiltering = 0x0080;
+const uint64_t ShaderFeatureInfo_TiledResources = 0x0100;
+const uint64_t ShaderFeatureInfo_StencilRef = 0x0200;
+const uint64_t ShaderFeatureInfo_InnerCoverage = 0x0400;
+const uint64_t ShaderFeatureInfo_TypedUAVLoadAdditionalFormats = 0x0800;
+const uint64_t ShaderFeatureInfo_ROVs = 0x1000;
+const uint64_t
+    ShaderFeatureInfo_ViewportAndRTArrayIndexFromAnyShaderFeedingRasterizer =
+        0x2000;
+const uint64_t ShaderFeatureInfo_WaveOps = 0x4000;
+const uint64_t ShaderFeatureInfo_Int64Ops = 0x8000;
+
+// SM 6.1+
+const uint64_t ShaderFeatureInfo_ViewID = 0x10000;
+const uint64_t ShaderFeatureInfo_Barycentrics = 0x20000;
+
+// SM 6.2+
+const uint64_t ShaderFeatureInfo_NativeLowPrecision = 0x40000;
+
+// SM 6.4+
+const uint64_t ShaderFeatureInfo_ShadingRate = 0x80000;
+
+// SM 6.5+
+const uint64_t ShaderFeatureInfo_Raytracing_Tier_1_1 = 0x100000;
+const uint64_t ShaderFeatureInfo_SamplerFeedback = 0x200000;
+
+// SM 6.6+
+const uint64_t ShaderFeatureInfo_AtomicInt64OnTypedResource = 0x400000;
+const uint64_t ShaderFeatureInfo_AtomicInt64OnGroupShared = 0x800000;
+const uint64_t ShaderFeatureInfo_DerivativesInMeshAndAmpShaders = 0x1000000;
+const uint64_t ShaderFeatureInfo_ResourceDescriptorHeapIndexing = 0x2000000;
+const uint64_t ShaderFeatureInfo_SamplerDescriptorHeapIndexing = 0x4000000;
+
+const uint64_t ShaderFeatureInfo_AtomicInt64OnHeapResource = 0x10000000;
+
+// SM 6.7+
+const uint64_t ShaderFeatureInfo_AdvancedTextureOps = 0x20000000;
+const uint64_t ShaderFeatureInfo_WriteableMSAATextures = 0x40000000;
+
+// SM 6.8+
+const uint64_t ShaderFeatureInfo_SampleCmpGradientOrBias = 0x80000000;
+const uint64_t ShaderFeatureInfo_ExtendedCommandInfo = 0x100000000;
+
+// Experimental SM 6.9+ - Reserved, not yet supported.
+// WaveMMA slots in between two SM 6.6 feature bits.
+const uint64_t ShaderFeatureInfo_WaveMMA = 0x8000000;
+
+// Maximum count without rolling over into another 64-bit field is 40,
+// so the last flag we can use for a feature requirement is: 0x8000000000
+// This is because of the following set of flags, considered optional
+// and ignored by the runtime if not recognized:
+// D3D11_OPTIONAL_FEATURE_FLAGS 0x7FFFFF0000000000
+const unsigned ShaderFeatureInfoCount = 33;
+static_assert(ShaderFeatureInfoCount <= 40,
+              "ShaderFeatureInfo flags must fit within the first 40 bits; "
+              "after that we need to expand the FeatureInfo blob part and "
+              "start defining a new set of flags for ShaderFeatureInfo2.");
+
+// OptFeatureInfo flags in higher bits of DFCC_FeatureInfo uint64_t value.
+// This section is for flags that do not necessarily indicate a required
+// feature, but are used to indicate something about the shader.
+// Some of these flags may not actually show up in DFCC_FeatureInfo, instead
+// only being used in intermediate feature info and in RDAT's FeatureInfo.
+
+// Create flag here for any derivative use.  This allows call-graph validation
+// in the runtime to detect misuse of derivatives for an entry point that cannot
+// support it, or to determine when the flag
+// ShaderFeatureInfo_DerivativesInMeshAndAmpShaders is required.
+const uint64_t OptFeatureInfo_UsesDerivatives = 0x0000010000000000ULL;
+// OptFeatureInfo_RequiresGroup tracks whether a function requires a visible
+// group that supports things like groupshared memory and group sync.
+const uint64_t OptFeatureInfo_RequiresGroup = 0x0000020000000000ULL;
+
+const uint64_t OptFeatureInfoShift = 40;
+const unsigned OptFeatureInfoCount = 2;
+static_assert(OptFeatureInfoCount <= 23,
+              "OptFeatureInfo flags must fit in 23 bits; after that we need to "
+              "expand the FeatureInfo blob part and start defining a new set "
+              "of flags for OptFeatureInfo2.");
+
+// DxilSubobjectType must match D3D12_STATE_SUBOBJECT_TYPE, with
+// certain values reserved, since they cannot be used from Dxil.
+enum class SubobjectKind : uint32_t {
+  StateObjectConfig = 0,
+  GlobalRootSignature = 1,
+  LocalRootSignature = 2,
+  // 3-7 are reserved (not supported in Dxil)
+  SubobjectToExportsAssociation = 8,
+  RaytracingShaderConfig = 9,
+  RaytracingPipelineConfig = 10,
+  HitGroup = 11,
+  RaytracingPipelineConfig1 = 12,
+  NumKinds // aka D3D12_STATE_SUBOBJECT_TYPE_MAX_VALID
+};
+
+inline bool IsValidSubobjectKind(SubobjectKind kind) {
+  return (kind < SubobjectKind::NumKinds &&
+          (kind <= SubobjectKind::LocalRootSignature ||
+           kind >= SubobjectKind::SubobjectToExportsAssociation));
+}
+
+enum class StateObjectFlags : uint32_t {
+  AllowLocalDependenciesOnExternalDefinitions = 0x1,
+  AllowExternalDependenciesOnLocalDefinitions = 0x2,
+  AllowStateObjectAdditions = 0x4,
+  ValidMask_1_4 = 0x3,
+  ValidMask = 0x7,
+};
+
+enum class HitGroupType : uint32_t {
+  Triangle = 0x0,
+  ProceduralPrimitive = 0x1,
+  LastEntry,
+};
+
+enum class RaytracingPipelineFlags : uint32_t {
+  None = 0x0,
+  SkipTriangles = 0x100,
+  SkipProceduralPrimitives = 0x200,
+  ValidMask = 0x300,
+};
+
+enum class CommittedStatus : uint32_t {
+  CommittedNothing = 0,
+  CommittedTriangleHit = 1,
+  CommittedProceduralPrimitiveHit = 2,
+};
+
+enum class CandidateType : uint32_t {
+  CandidateNonOpaqueTriangle = 0,
+  CandidateProceduralPrimitive = 1,
+};
+
+enum class PayloadAccessQualifier : uint32_t {
+  NoAccess = 0,
+  Read = 1,
+  Write = 2,
+  ReadWrite = 3
+};
+
+enum class PayloadAccessShaderStage : uint32_t {
+  Caller = 0,
+  Closesthit = 1,
+  Miss = 2,
+  Anyhit = 3,
+  Invalid = 0xffffffffu
+};
+
+// Allocate 4 bits per shader stage:
+//     bits 0-1 for payload access qualifiers
+//     bits 2-3 reserved for future use
+const uint32_t PayloadAccessQualifierBitsPerStage = 4;
+const uint32_t PayloadAccessQualifierValidMaskPerStage = 3;
+const uint32_t PayloadAccessQualifierValidMask = 0x00003333;
+
+inline bool IsValidHitGroupType(HitGroupType type) {
+  return (type >= HitGroupType::Triangle && type < HitGroupType::LastEntry);
+}
+
+extern const char *kLegacyLayoutString;
+extern const char *kNewLayoutString;
+extern const char *kFP32DenormKindString;
+extern const char *kFP32DenormValueAnyString;
+extern const char *kFP32DenormValuePreserveString;
+extern const char *kFP32DenormValueFtzString;
+
+extern const char *kDxBreakFuncName;
+extern const char *kDxBreakCondName;
+extern const char *kDxBreakMDName;
+extern const char *kDxIsHelperGlobalName;
+
+extern const char *kHostLayoutTypePrefix;
+
+extern const char *kWaveOpsIncludeHelperLanesString;
+
+} // namespace DXIL
+
+} // namespace hlsl

--- a/external/dxc-rdat/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/external/dxc-rdat/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -1,0 +1,688 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// DxilLibraryReflection.h                                                   //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Defines shader reflection for runtime usage.                              //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "dxc/DXIL/DxilConstants.h"
+
+#include <cstddef>
+
+#define RDAT_NULL_REF ((uint32_t)0xFFFFFFFF)
+
+namespace hlsl {
+namespace RDAT {
+
+// Data Layout:
+// -start:
+//  RuntimeDataHeader header;
+//  uint32_t offsets[header.PartCount];
+//  - for each i in header.PartCount:
+//    - at &header + offsets[i]:
+//      RuntimeDataPartHeader part;
+//    - if part.Type is a Table (Function or Resource):
+//      RuntimeDataTableHeader table;
+//      byte TableData[table.RecordCount][table.RecordStride];
+//    - else if part.Type is String:
+//      byte UTF8Data[part.Size];
+//    - else if part.Type is Index:
+//      uint32_t IndexData[part.Size / 4];
+
+enum RuntimeDataVersion {
+  // Cannot be mistaken for part count from prerelease version
+  RDAT_Version_10 = 0x10,
+};
+
+enum class RuntimeDataGroup : uint32_t {
+  Core = 0,
+  PdbInfo = 1,
+};
+
+constexpr uint32_t RDAT_PART_ID_WITH_GROUP(RuntimeDataGroup group,
+                                           uint32_t id) {
+  return (((uint32_t)(group) << 16) | ((id)&0xFFFF));
+}
+
+enum class RuntimeDataPartType : uint32_t {
+  Invalid = 0,
+  StringBuffer = 1,
+  IndexArrays = 2,
+  ResourceTable = 3,
+  FunctionTable = 4,
+  Last_1_3 = FunctionTable,
+  RawBytes = 5,
+  SubobjectTable = 6,
+  Last_1_4 = SubobjectTable,
+
+  NodeIDTable = 7,
+  NodeShaderIOAttribTable = 8,
+  NodeShaderFuncAttribTable = 9,
+  IONodeTable = 10,
+  NodeShaderInfoTable = 11,
+  Last_1_8 = NodeShaderInfoTable,
+
+  // Insert experimental here.
+  SignatureElementTable,
+  VSInfoTable,
+  PSInfoTable,
+  HSInfoTable,
+  DSInfoTable,
+  GSInfoTable,
+  CSInfoTable,
+  MSInfoTable,
+  ASInfoTable,
+
+  LastPlus1,
+  LastExperimental = LastPlus1 - 1,
+
+  DxilPdbInfoTable = RDAT_PART_ID_WITH_GROUP(RuntimeDataGroup::PdbInfo, 1),
+  DxilPdbInfoSourceTable =
+      RDAT_PART_ID_WITH_GROUP(RuntimeDataGroup::PdbInfo, 2),
+  DxilPdbInfoLibraryTable =
+      RDAT_PART_ID_WITH_GROUP(RuntimeDataGroup::PdbInfo, 3),
+};
+
+inline RuntimeDataPartType MaxPartTypeForValVer(unsigned Major,
+                                                unsigned Minor) {
+  return DXIL::CompareVersions(Major, Minor, 1, 3) < 0
+             ? RuntimeDataPartType::Invalid // No RDAT before 1.3
+         : DXIL::CompareVersions(Major, Minor, 1, 4) < 0
+             ? RuntimeDataPartType::Last_1_3
+         : DXIL::CompareVersions(Major, Minor, 1, 8) < 0
+             ? RuntimeDataPartType::Last_1_4
+         : DXIL::CompareVersions(Major, Minor, 1, 8) == 0
+             ? RuntimeDataPartType::Last_1_8
+             : RuntimeDataPartType::LastExperimental;
+}
+
+enum class RecordTableIndex : unsigned {
+  ResourceTable,
+  FunctionTable,
+  SubobjectTable,
+
+  NodeIDTable,
+  NodeShaderIOAttribTable,
+  NodeShaderFuncAttribTable,
+  IONodeTable,
+  NodeShaderInfoTable,
+
+  DxilPdbInfoTable,
+  DxilPdbInfoSourceTable,
+  DxilPdbInfoLibraryTable,
+
+  SignatureElementTable,
+  VSInfoTable,
+  PSInfoTable,
+  HSInfoTable,
+  DSInfoTable,
+  GSInfoTable,
+  CSInfoTable,
+  MSInfoTable,
+  ASInfoTable,
+
+  RecordTableCount
+};
+
+///////////////////////////////////////
+// Header Structures
+
+struct RuntimeDataHeader {
+  uint32_t Version;
+  uint32_t PartCount;
+  // Followed by uint32_t array of offsets to parts
+  // offsets are relative to the beginning of this header
+  // offsets must be 4-byte aligned
+  //  uint32_t offsets[];
+};
+struct RuntimeDataPartHeader {
+  RuntimeDataPartType Type;
+  uint32_t Size; // Not including this header.  Must be 4-byte aligned.
+  // Followed by part data
+  //  byte Data[ALIGN4(Size)];
+};
+
+// For tables of records, such as Function and Resource tables
+// Stride allows for extending records, with forward and backward compatibility
+struct RuntimeDataTableHeader {
+  uint32_t RecordCount;
+  uint32_t RecordStride; // Must be 4-byte aligned.
+  // Followed by recordCount records of recordStride size
+  // byte TableData[RecordCount * RecordStride];
+};
+
+///////////////////////////////////////
+// Raw Reader Classes
+
+// General purpose strided table reader with casting Row() operation that
+// returns nullptr if stride is smaller than type, for record expansion.
+class TableReader {
+  const char *m_table;
+  uint32_t m_count;
+  uint32_t m_stride;
+
+public:
+  TableReader() : TableReader(nullptr, 0, 0) {}
+  TableReader(const char *table, uint32_t count, uint32_t stride)
+      : m_table(table), m_count(count), m_stride(stride) {}
+  void Init(const char *table, uint32_t count, uint32_t stride) {
+    m_table = table;
+    m_count = count;
+    m_stride = stride;
+  }
+  const char *Data() const { return m_table; }
+  uint32_t Count() const { return m_count; }
+  uint32_t Stride() const { return m_stride; }
+
+  template <typename T> const T *Row(uint32_t index) const {
+    if (Valid() && index < m_count && sizeof(T) <= m_stride)
+      return reinterpret_cast<const T *>(m_table + (m_stride * index));
+    return nullptr;
+  }
+  bool Valid() const { return m_table && m_count && m_stride; }
+  operator bool() { return Valid(); }
+};
+
+// Index table is a sequence of rows, where each row has a count as a first
+// element followed by the count number of elements pre computing values
+class IndexTableReader {
+private:
+  const uint32_t *m_table;
+  uint32_t m_size;
+
+public:
+  class IndexRow {
+  private:
+    const uint32_t *m_values;
+    const uint32_t m_count;
+
+  public:
+    IndexRow() : m_values(nullptr), m_count(0) {}
+    IndexRow(const uint32_t *values, uint32_t count)
+        : m_values(values), m_count(count) {}
+    uint32_t Count() const { return m_count; }
+    uint32_t At(uint32_t i) const {
+      return (m_values && i < m_count) ? m_values[i] : 0;
+    }
+    const uint32_t &operator[](uint32_t i) const {
+      if (m_values && i < m_count)
+        return m_values[i];
+      return m_values[0]; // If null, we should AV if value is read
+    }
+    bool empty() const { return !(m_values && m_count > 0); }
+    operator bool() const { return !empty(); }
+  };
+
+  IndexTableReader() : IndexTableReader(nullptr, 0) {}
+  IndexTableReader(const uint32_t *table, uint32_t size)
+      : m_table(table), m_size(size) {}
+  void Init(const uint32_t *table, uint32_t size) {
+    m_table = table;
+    m_size = size;
+  }
+  IndexRow getRow(uint32_t i) const {
+    if (Valid() && i < m_size - 1 && m_table[i] + i < m_size) {
+      return IndexRow(&m_table[i] + 1, m_table[i]);
+    }
+    return {};
+  }
+  const uint32_t *Data() const { return m_table; }
+  uint32_t Count() const { return Valid() ? m_size : 0; }
+  bool Valid() const { return m_table && m_size > 0; }
+  operator bool() const { return Valid(); }
+};
+
+class StringTableReader {
+  const char *m_table = nullptr;
+  uint32_t m_size = 0;
+
+public:
+  void Init(const char *table, uint32_t size) {
+    m_table = table;
+    m_size = size;
+  }
+  const char *Get(uint32_t offset) const {
+    (void)m_size; // avoid unused private warning if use above is ignored.
+    return m_table + offset;
+  }
+  uint32_t Size() const { return m_size; }
+  const char *Data() const { return m_table; }
+};
+
+class RawBytesReader {
+  const void *m_table;
+  uint32_t m_size;
+
+public:
+  RawBytesReader(const void *table, uint32_t size)
+      : m_table(table), m_size(size) {}
+  RawBytesReader() : RawBytesReader(nullptr, 0) {}
+  void Init(const void *table, uint32_t size) {
+    m_table = table;
+    m_size = size;
+  }
+  uint32_t Size() const { return m_size; }
+  const void *Get(uint32_t offset) const {
+    return (const void *)(((const char *)m_table) + offset);
+  }
+};
+
+///////////////////////////////////////
+// Record Traits
+
+template <typename _T> class RecordTraits {
+public:
+  static constexpr const char *TypeName();
+
+  static constexpr RuntimeDataPartType PartType();
+
+  // If the following static assert is hit, it means a structure defined with
+  // RDAT_STRUCT is being used in ref type, which requires the struct to have
+  // a table and be defined with RDAT_STRUCT_TABLE instead.
+  static constexpr RecordTableIndex TableIndex();
+
+  // RecordSize() is defined in order to allow for use of forward decl type in
+  // RecordRef
+  static constexpr size_t RecordSize() { return sizeof(_T); }
+  static constexpr size_t MaxRecordSize() {
+    return RecordTraits<_T>::DerivedRecordSize();
+  }
+  static constexpr size_t DerivedRecordSize() { return sizeof(_T); }
+};
+
+///////////////////////////////////////
+// RDATContext
+
+struct RDATContext {
+  StringTableReader StringBuffer;
+  IndexTableReader IndexTable;
+  RawBytesReader RawBytes;
+  TableReader Tables[(unsigned)RecordTableIndex::RecordTableCount];
+  const TableReader &Table(RecordTableIndex idx) const {
+    if (idx < RecordTableIndex::RecordTableCount)
+      return Tables[(unsigned)idx];
+    return Tables[0]; // TODO: assert
+  }
+  TableReader &Table(RecordTableIndex idx) {
+    return const_cast<TableReader &>(((const RDATContext *)this)->Table(idx));
+  }
+  template <typename RecordType> const TableReader &Table() const {
+    static_assert(RecordTraits<RecordType>::TableIndex() <
+                      RecordTableIndex::RecordTableCount,
+                  "");
+    return Table(RecordTraits<RecordType>::TableIndex());
+  }
+  template <typename RecordType> TableReader &Table() {
+    return const_cast<TableReader &>(
+        ((const RDATContext *)this)
+            ->Table(RecordTraits<RecordType>::TableIndex()));
+  }
+};
+
+///////////////////////////////////////
+// Generic Reader Classes
+
+class BaseRecordReader {
+protected:
+  const RDATContext *m_pContext = nullptr;
+  const void *m_pRecord = nullptr;
+  uint32_t m_Size = 0;
+
+  template <typename _ReaderTy> const _ReaderTy asReader() const {
+    if (*this &&
+        m_Size >= RecordTraits<typename _ReaderTy::RecordType>::RecordSize())
+      return _ReaderTy(*this);
+    return {};
+  }
+
+  template <typename _T> const _T *asRecord() const {
+    return static_cast<const _T *>(
+        (*this && m_Size >= RecordTraits<_T>::RecordSize()) ? m_pRecord
+                                                            : nullptr);
+  }
+
+  void InvalidateReader() {
+    m_pContext = nullptr;
+    m_pRecord = nullptr;
+    m_Size = 0;
+  }
+
+public:
+  BaseRecordReader(const RDATContext *ctx, const void *record, uint32_t size)
+      : m_pContext(ctx), m_pRecord(record), m_Size(size) {}
+  BaseRecordReader() : BaseRecordReader(nullptr, nullptr, 0) {}
+
+  // Is this a valid reader
+  operator bool() const {
+    return m_pContext != nullptr && m_pRecord != nullptr && m_Size != 0;
+  }
+  const RDATContext *GetContext() const { return m_pContext; }
+};
+
+template <typename _ReaderTy> class RecordArrayReader {
+  const RDATContext *m_pContext;
+  const uint32_t m_IndexOffset;
+
+public:
+  RecordArrayReader(const RDATContext *ctx, uint32_t indexOffset)
+      : m_pContext(ctx), m_IndexOffset(indexOffset) {
+    typedef typename _ReaderTy::RecordType RecordType;
+    const TableReader &Table = m_pContext->Table<RecordType>();
+    // RecordArrays must be declared with the base record type,
+    // with element reader upcast as necessary.
+    if (Table.Stride() < RecordTraits<RecordType>::RecordSize())
+      InvalidateReader();
+  }
+  RecordArrayReader() : RecordArrayReader(nullptr, 0) {}
+  uint32_t Count() const {
+    return *this ? m_pContext->IndexTable.getRow(m_IndexOffset).Count() : 0;
+  }
+  const _ReaderTy operator[](uint32_t idx) const {
+    typedef typename _ReaderTy::RecordType RecordType;
+    if (*this) {
+      const TableReader &Table = m_pContext->Table<RecordType>();
+      return _ReaderTy(BaseRecordReader(
+          m_pContext,
+          (const void *)Table.Row<RecordType>(
+              m_pContext->IndexTable.getRow(m_IndexOffset).At(idx)),
+          Table.Stride()));
+    }
+    return {};
+  }
+  // Is this a valid reader
+  operator bool() const {
+    return m_pContext != nullptr && m_IndexOffset < RDAT_NULL_REF;
+  }
+  void InvalidateReader() { m_pContext = nullptr; }
+  const RDATContext *GetContext() const { return m_pContext; }
+};
+
+class StringArrayReader {
+  const RDATContext *m_pContext;
+  const uint32_t m_IndexOffset;
+
+public:
+  StringArrayReader(const RDATContext *pContext, uint32_t indexOffset)
+      : m_pContext(pContext), m_IndexOffset(indexOffset) {}
+  uint32_t Count() const {
+    return *this ? m_pContext->IndexTable.getRow(m_IndexOffset).Count() : 0;
+  }
+  const char *operator[](uint32_t idx) const {
+    return *this ? m_pContext->StringBuffer.Get(
+                       m_pContext->IndexTable.getRow(m_IndexOffset).At(idx))
+                 : 0;
+  }
+  // Is this a valid reader
+  operator bool() const {
+    return m_pContext != nullptr && m_IndexOffset < RDAT_NULL_REF;
+  }
+  void InvalidateReader() { m_pContext = nullptr; }
+  const RDATContext *GetContext() const { return m_pContext; }
+};
+
+///////////////////////////////////////
+// Field Helpers
+
+template <typename _T> struct RecordRef {
+  uint32_t Index;
+
+  template <typename RecordType = _T>
+  const _T *Get(const RDATContext &ctx) const {
+    return ctx.Table<_T>().template Row<RecordType>(Index);
+  }
+  RecordRef &operator=(uint32_t index) {
+    Index = index;
+    return *this;
+  }
+  operator uint32_t &() { return Index; }
+  operator const uint32_t &() const { return Index; }
+  uint32_t *operator&() { return &Index; }
+};
+
+template <typename _T> struct RecordArrayRef {
+  uint32_t Index;
+
+  RecordArrayReader<_T> Get(const RDATContext &ctx) const {
+    return RecordArrayReader<_T>(ctx.IndexTable, ctx.Table<_T>(), Index);
+  }
+  RecordArrayRef &operator=(uint32_t index) {
+    Index = index;
+    return *this;
+  }
+  operator uint32_t &() { return Index; }
+  operator const uint32_t &() const { return Index; }
+  uint32_t *operator&() { return &Index; }
+};
+
+struct RDATString {
+  uint32_t Offset;
+
+  const char *Get(const RDATContext &ctx) const {
+    return ctx.StringBuffer.Get(Offset);
+  }
+  RDATString &operator=(uint32_t offset) {
+    Offset = offset;
+    return *this;
+  }
+  operator uint32_t &() { return Offset; }
+  operator const uint32_t &() const { return Offset; }
+  uint32_t *operator&() { return &Offset; }
+};
+
+struct RDATStringArray {
+  uint32_t Index;
+
+  StringArrayReader Get(const RDATContext &ctx) const {
+    return StringArrayReader(&ctx, Index);
+  }
+  operator bool() const { return Index == 0 ? false : true; }
+  RDATStringArray &operator=(uint32_t index) {
+    Index = index;
+    return *this;
+  }
+  operator uint32_t &() { return Index; }
+  operator const uint32_t &() const { return Index; }
+  uint32_t *operator&() { return &Index; }
+};
+
+struct IndexArrayRef {
+  uint32_t Index;
+
+  IndexTableReader::IndexRow Get(const RDATContext &ctx) const {
+    return ctx.IndexTable.getRow(Index);
+  }
+  IndexArrayRef &operator=(uint32_t index) {
+    Index = index;
+    return *this;
+  }
+  operator uint32_t &() { return Index; }
+  operator const uint32_t &() const { return Index; }
+  uint32_t *operator&() { return &Index; }
+};
+
+struct BytesRef {
+  uint32_t Offset;
+  uint32_t Size;
+
+  const void *GetBytes(const RDATContext &ctx) const {
+    return ctx.RawBytes.Get(Offset);
+  }
+  template <typename _T> const _T *GetAs(const RDATContext &ctx) const {
+    return (sizeof(_T) > Size)
+               ? nullptr
+               : reinterpret_cast<const _T *>(ctx.RawBytes.Get(Offset));
+  }
+  uint32_t *operator&() { return &Offset; }
+};
+
+struct BytesPtr {
+  const void *Ptr = nullptr;
+  uint32_t Size = 0;
+
+  BytesPtr(const void *ptr, uint32_t size) : Ptr(ptr), Size(size) {}
+  BytesPtr() : BytesPtr(nullptr, 0) {}
+  template <typename _T> const _T *GetAs() const {
+    return (sizeof(_T) > Size) ? nullptr : reinterpret_cast<const _T *>(Ptr);
+  }
+};
+
+///////////////////////////////////////
+// Record Helpers
+
+template <typename _RecordReader> class RecordReader : public BaseRecordReader {
+public:
+  typedef _RecordReader ThisReaderType;
+  RecordReader(const BaseRecordReader &base) : BaseRecordReader(base) {
+    typedef typename _RecordReader::RecordType RecordType;
+    if ((m_pContext || m_pRecord) &&
+        m_Size < RecordTraits<RecordType>::RecordSize())
+      InvalidateReader();
+  }
+  RecordReader() : BaseRecordReader() {}
+  template <typename _ReaderType> _ReaderType as() { _ReaderType(*this); }
+
+protected:
+  template <typename _FieldRecordReader>
+  _FieldRecordReader GetField_RecordValue(const void *pField) const {
+    if (*this) {
+      return _FieldRecordReader(BaseRecordReader(
+          m_pContext, pField,
+          (uint32_t)RecordTraits<
+              typename _FieldRecordReader::RecordType>::RecordSize()));
+    }
+    return {};
+  }
+  template <typename _FieldRecordReader>
+  _FieldRecordReader GetField_RecordRef(const void *pIndex) const {
+    typedef typename _FieldRecordReader::RecordType RecordType;
+    if (*this) {
+      const TableReader &Table = m_pContext->Table<RecordType>();
+      return _FieldRecordReader(BaseRecordReader(
+          m_pContext,
+          (const void *)Table.Row<RecordType>(*(const uint32_t *)pIndex),
+          Table.Stride()));
+    }
+    return {};
+  }
+  template <typename _FieldRecordReader>
+  RecordArrayReader<_FieldRecordReader>
+  GetField_RecordArrayRef(const void *pIndex) const {
+    if (*this) {
+      return RecordArrayReader<_FieldRecordReader>(m_pContext,
+                                                   *(const uint32_t *)pIndex);
+    }
+    return {};
+  }
+  template <typename _T, typename _StorageTy>
+  _T GetField_Value(const _StorageTy *value) const {
+    _T result = {};
+    if (*this)
+      result = (_T)*value;
+    return result;
+  }
+  IndexTableReader::IndexRow GetField_IndexArray(const void *pIndex) const {
+    if (*this) {
+      return m_pContext->IndexTable.getRow(*(const uint32_t *)pIndex);
+    }
+    return {};
+  }
+  // Would use std::array, but don't want this header dependent on that.
+  // Array reference syntax is almost enough reason to abandon C++!!!
+  template <typename _T, size_t _ArraySize>
+  decltype(auto) GetField_ValueArray(_T const (&value)[_ArraySize]) const {
+    typedef _T ArrayType[_ArraySize];
+    if (*this)
+      return value;
+    return *(const ArrayType *)nullptr;
+  }
+  const char *GetField_String(const void *pIndex) const {
+    return *this ? m_pContext->StringBuffer.Get(*(const uint32_t *)pIndex)
+                 : nullptr;
+  }
+  StringArrayReader GetField_StringArray(const void *pIndex) const {
+    return *this ? StringArrayReader(m_pContext, *(const uint32_t *)pIndex)
+                 : StringArrayReader(nullptr, 0);
+  }
+  const void *GetField_Bytes(const void *pIndex) const {
+    return *this ? m_pContext->RawBytes.Get(*(const uint32_t *)pIndex)
+                 : nullptr;
+  }
+  uint32_t GetField_BytesSize(const void *pIndex) const {
+    return *this ? *(((const uint32_t *)pIndex) + 1) : 0;
+  }
+};
+
+template <typename _RecordReader> class RecordTableReader {
+  const RDATContext *m_pContext;
+
+public:
+  RecordTableReader(const RDATContext *pContext) : m_pContext(pContext) {}
+  template <typename RecordReaderType = _RecordReader>
+  RecordReaderType Row(uint32_t index) const {
+    typedef typename _RecordReader::RecordType RecordType;
+    const TableReader &Table = m_pContext->Table<RecordType>();
+    return RecordReaderType(BaseRecordReader(
+        m_pContext, Table.Row<RecordType>(index), Table.Stride()));
+  }
+  uint32_t Count() const {
+    return m_pContext->Table<typename _RecordReader::RecordType>().Count();
+  }
+  uint32_t size() const { return Count(); }
+  const _RecordReader operator[](uint32_t index) const { return Row(index); }
+  operator bool() { return m_pContext && Count(); }
+};
+
+/////////////////////////////
+// All RDAT enums and types
+
+#define DEF_RDAT_ENUMS DEF_RDAT_ENUM_CLASS
+#define DEF_RDAT_TYPES DEF_RDAT_TYPES_FORWARD_DECL
+#include "dxc/DxilContainer/RDAT_Macros.inl"
+
+#define DEF_RDAT_TYPES DEF_RDAT_TYPES_USE_HELPERS
+#include "dxc/DxilContainer/RDAT_Macros.inl"
+
+#define DEF_RDAT_TYPES DEF_RDAT_TRAITS
+#include "dxc/DxilContainer/RDAT_Macros.inl"
+
+#define DEF_RDAT_TYPES DEF_RDAT_READER_DECL
+#include "dxc/DxilContainer/RDAT_Macros.inl"
+
+/////////////////////////////
+/////////////////////////////
+
+class DxilRuntimeData {
+private:
+  RDATContext m_Context;
+  size_t m_DataSize = 0;
+
+public:
+  DxilRuntimeData();
+  DxilRuntimeData(const void *ptr, size_t size);
+  // initializing reader from RDAT. return true if no error has occured.
+  bool InitFromRDAT(const void *pRDAT, size_t size);
+
+  // Make sure data is well formed.
+  bool Validate();
+
+  size_t GetDataSize() const { return m_DataSize; }
+
+  RDATContext &GetContext() { return m_Context; }
+  const RDATContext &GetContext() const { return m_Context; }
+
+#define RDAT_STRUCT_TABLE(type, table)                                         \
+  RecordTableReader<type##_Reader> Get##table() const {                        \
+    return RecordTableReader<type##_Reader>(&m_Context);                       \
+  }
+#define DEF_RDAT_TYPES DEF_RDAT_DEFAULTS
+#include "dxc/DxilContainer/RDAT_Macros.inl"
+};
+
+} // namespace RDAT
+} // namespace hlsl

--- a/external/dxc-rdat/dxc/DxilContainer/DxilRuntimeReflection.inl
+++ b/external/dxc-rdat/dxc/DxilContainer/DxilRuntimeReflection.inl
@@ -1,0 +1,302 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// DxilRuntimeReflection.inl                                                 //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Defines shader reflection for runtime usage.                              //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#include "dxc/DxilContainer/DxilRuntimeReflection.h"
+#include <cwchar>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace hlsl {
+namespace RDAT {
+
+#define DEF_RDAT_TYPES DEF_RDAT_READER_IMPL
+#include "dxc/DxilContainer/RDAT_Macros.inl"
+
+struct ResourceKey {
+  uint32_t Class, ID;
+  ResourceKey(uint32_t Class, uint32_t ID) : Class(Class), ID(ID) {}
+  bool operator==(const ResourceKey &other) const {
+    return other.Class == Class && other.ID == ID;
+  }
+};
+
+// Size-checked reader
+//  on overrun: throw buffer_overrun{};
+//  on overlap: throw buffer_overlap{};
+class CheckedReader {
+  const char *Ptr;
+  size_t Size;
+  size_t Offset;
+
+public:
+  class exception : public std::exception {};
+  class buffer_overrun : public exception {
+  public:
+    buffer_overrun() noexcept {}
+    virtual const char *what() const noexcept override {
+      return ("buffer_overrun");
+    }
+  };
+  class buffer_overlap : public exception {
+  public:
+    buffer_overlap() noexcept {}
+    virtual const char *what() const noexcept override {
+      return ("buffer_overlap");
+    }
+  };
+
+  CheckedReader(const void *ptr, size_t size)
+      : Ptr(reinterpret_cast<const char *>(ptr)), Size(size), Offset(0) {}
+  void Reset(size_t offset = 0) {
+    if (offset >= Size)
+      throw buffer_overrun{};
+    Offset = offset;
+  }
+  // offset is absolute, ensure offset is >= current offset
+  void Advance(size_t offset = 0) {
+    if (offset < Offset)
+      throw buffer_overlap{};
+    if (offset >= Size)
+      throw buffer_overrun{};
+    Offset = offset;
+  }
+  void CheckBounds(size_t size) const {
+    assert(Offset <= Size && "otherwise, offset larger than size");
+    if (size > Size - Offset)
+      throw buffer_overrun{};
+  }
+  template <typename T> const T *Cast(size_t size = 0) {
+    if (0 == size)
+      size = sizeof(T);
+    CheckBounds(size);
+    return reinterpret_cast<const T *>(Ptr + Offset);
+  }
+  template <typename T> const T &Read() {
+    const size_t size = sizeof(T);
+    const T *p = Cast<T>(size);
+    Offset += size;
+    return *p;
+  }
+  template <typename T> const T *ReadArray(size_t count = 1) {
+    const size_t size = sizeof(T) * count;
+    const T *p = Cast<T>(size);
+    Offset += size;
+    return p;
+  }
+};
+
+DxilRuntimeData::DxilRuntimeData() : DxilRuntimeData(nullptr, 0) {}
+
+DxilRuntimeData::DxilRuntimeData(const void *ptr, size_t size) {
+  InitFromRDAT(ptr, size);
+}
+
+static void InitTable(RDATContext &ctx, CheckedReader &PR,
+                      RecordTableIndex tableIndex) {
+  RuntimeDataTableHeader table = PR.Read<RuntimeDataTableHeader>();
+  size_t tableSize = table.RecordCount * table.RecordStride;
+  ctx.Table(tableIndex)
+      .Init(PR.ReadArray<char>(tableSize), table.RecordCount,
+            table.RecordStride);
+}
+
+// initializing reader from RDAT. return true if no error has occured.
+bool DxilRuntimeData::InitFromRDAT(const void *pRDAT, size_t size) {
+  if (pRDAT) {
+    m_DataSize = size;
+    try {
+      CheckedReader Reader(pRDAT, size);
+      RuntimeDataHeader RDATHeader = Reader.Read<RuntimeDataHeader>();
+      if (RDATHeader.Version < RDAT_Version_10) {
+        return false;
+      }
+      const uint32_t *offsets =
+          Reader.ReadArray<uint32_t>(RDATHeader.PartCount);
+      for (uint32_t i = 0; i < RDATHeader.PartCount; ++i) {
+        Reader.Advance(offsets[i]);
+        RuntimeDataPartHeader part = Reader.Read<RuntimeDataPartHeader>();
+        CheckedReader PR(Reader.ReadArray<char>(part.Size), part.Size);
+        switch (part.Type) {
+        case RuntimeDataPartType::StringBuffer: {
+          m_Context.StringBuffer.Init(PR.ReadArray<char>(part.Size), part.Size);
+          break;
+        }
+        case RuntimeDataPartType::IndexArrays: {
+          uint32_t count = part.Size / sizeof(uint32_t);
+          m_Context.IndexTable.Init(PR.ReadArray<uint32_t>(count), count);
+          break;
+        }
+        case RuntimeDataPartType::RawBytes: {
+          m_Context.RawBytes.Init(PR.ReadArray<char>(part.Size), part.Size);
+          break;
+        }
+
+// Once per table.
+#define RDAT_STRUCT_TABLE(type, table)                                         \
+  case RuntimeDataPartType::table:                                             \
+    InitTable(m_Context, PR, RecordTableIndex::table);                         \
+    break;
+#define DEF_RDAT_TYPES DEF_RDAT_DEFAULTS
+#include "dxc/DxilContainer/RDAT_Macros.inl"
+
+        default:
+          continue; // Skip unrecognized parts
+        }
+      }
+#ifndef NDEBUG
+      return Validate();
+#else  // NDEBUG
+      return true;
+#endif // NDEBUG
+    } catch (CheckedReader::exception e) {
+      // TODO: error handling
+      // throw hlsl::Exception(DXC_E_MALFORMED_CONTAINER, e.what());
+      return false;
+    }
+  }
+  m_DataSize = 0;
+  return false;
+}
+
+// TODO: Incorporate field names and report errors in error stream
+
+// TODO: Low-pri: Check other things like that all the index, string,
+// and binary buffer space is actually used.
+
+template <typename _RecordType>
+static bool ValidateRecordRef(const RDATContext &ctx, uint32_t id) {
+  if (id == RDAT_NULL_REF)
+    return true;
+  // id should be a valid index into the appropriate table
+  auto &table = ctx.Table(RecordTraits<_RecordType>::TableIndex());
+  if (id >= table.Count())
+    return false;
+  return true;
+}
+
+static bool ValidateIndexArrayRef(const RDATContext &ctx, uint32_t id) {
+  if (id == RDAT_NULL_REF)
+    return true;
+  uint32_t size = ctx.IndexTable.Count();
+  // check that id < size of index array
+  if (id >= size)
+    return false;
+  // check that array size fits in remaining index space
+  if (id + ctx.IndexTable.Data()[id] >= size)
+    return false;
+  return true;
+}
+
+template <typename _RecordType>
+static bool ValidateRecordArrayRef(const RDATContext &ctx, uint32_t id) {
+  // Make sure index array is well-formed
+  if (!ValidateIndexArrayRef(ctx, id))
+    return false;
+  // Make sure each record id is a valid record ref in the table
+  auto ids = ctx.IndexTable.getRow(id);
+  for (unsigned i = 0; i < ids.Count(); i++) {
+    if (!ValidateRecordRef<_RecordType>(ctx, ids.At(i)))
+      return false;
+  }
+  return true;
+}
+static bool ValidateStringRef(const RDATContext &ctx, uint32_t id) {
+  if (id == RDAT_NULL_REF)
+    return true;
+  uint32_t size = ctx.StringBuffer.Size();
+  if (id >= size)
+    return false;
+  return true;
+}
+static bool ValidateStringArrayRef(const RDATContext &ctx, uint32_t id) {
+  if (id == RDAT_NULL_REF)
+    return true;
+  // Make sure index array is well-formed
+  if (!ValidateIndexArrayRef(ctx, id))
+    return false;
+  // Make sure each index is valid in string buffer
+  auto ids = ctx.IndexTable.getRow(id);
+  for (unsigned i = 0; i < ids.Count(); i++) {
+    if (!ValidateStringRef(ctx, ids.At(i)))
+      return false;
+  }
+  return true;
+}
+
+// Specialized for each record type
+template <typename _RecordType>
+bool ValidateRecord(const RDATContext &ctx, const _RecordType *pRecord) {
+  return false;
+}
+
+#define DEF_RDAT_TYPES DEF_RDAT_STRUCT_VALIDATION
+#include "dxc/DxilContainer/RDAT_Macros.inl"
+
+// This class ensures that all versions of record to latest one supported by
+// table stride are validated
+class RecursiveRecordValidator {
+  const hlsl::RDAT::RDATContext &m_Context;
+  uint32_t m_RecordStride;
+
+public:
+  RecursiveRecordValidator(const hlsl::RDAT::RDATContext &ctx,
+                           uint32_t recordStride)
+      : m_Context(ctx), m_RecordStride(recordStride) {}
+  template <typename _RecordType>
+  bool Validate(const _RecordType *pRecord) const {
+    if (pRecord && sizeof(_RecordType) <= m_RecordStride) {
+      if (!ValidateRecord(m_Context, pRecord))
+        return false;
+      return ValidateDerived<_RecordType>(pRecord);
+    }
+    return true;
+  }
+  // Specialized for base type to recurse into derived
+  template <typename _RecordType>
+  bool ValidateDerived(const _RecordType *) const {
+    return true;
+  }
+};
+
+template <typename _RecordType>
+static bool ValidateRecordTable(RDATContext &ctx, RecordTableIndex tableIndex) {
+  // iterate through records, bounds-checking all refs and index arrays
+  auto &table = ctx.Table(tableIndex);
+  for (unsigned i = 0; i < table.Count(); i++) {
+    RecursiveRecordValidator(ctx, table.Stride())
+        .Validate<_RecordType>(table.Row<_RecordType>(i));
+  }
+  return true;
+}
+
+bool DxilRuntimeData::Validate() {
+  if (m_Context.StringBuffer.Size()) {
+    if (m_Context.StringBuffer.Data()[m_Context.StringBuffer.Size() - 1] != 0)
+      return false;
+  }
+
+  // Once per table.
+#define RDAT_STRUCT_TABLE(type, table)                                         \
+  ValidateRecordTable<type>(m_Context, RecordTableIndex::table);
+  // As an assumption of the way record types are versioned, derived record
+  // types must always be larger than base record types.
+#define RDAT_STRUCT_DERIVED(type, base)                                        \
+  static_assert(sizeof(type) > sizeof(base),                                   \
+                "otherwise, derived record type " #type                        \
+                " is not larger than base record type " #base ".");
+#define DEF_RDAT_TYPES DEF_RDAT_DEFAULTS
+#include "dxc/DxilContainer/RDAT_Macros.inl"
+  return true;
+}
+
+} // namespace RDAT
+} // namespace hlsl

--- a/external/dxc-rdat/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/external/dxc-rdat/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -1,0 +1,732 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// RDAT_LibraryTypes.inl                                                     //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Defines types used in Dxil Library Runtime Data (RDAT).                   //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+// clang-format off
+// Macro indentation makes this file easier to read, but clang-format flattens
+// everything.  Turn off clang-format for this file.
+
+#ifdef DEF_RDAT_ENUMS
+
+RDAT_ENUM_START(DxilResourceFlag, uint32_t)
+  RDAT_ENUM_VALUE(None,                     0)
+  RDAT_ENUM_VALUE(UAVGloballyCoherent,      1 << 0)
+  RDAT_ENUM_VALUE(UAVCounter,               1 << 1)
+  RDAT_ENUM_VALUE(UAVRasterizerOrderedView, 1 << 2)
+  RDAT_ENUM_VALUE(DynamicIndexing,          1 << 3)
+  RDAT_ENUM_VALUE(Atomics64Use,             1 << 4)
+RDAT_ENUM_END()
+
+RDAT_ENUM_START(DxilShaderStageFlags, uint32_t)
+  RDAT_ENUM_VALUE(Pixel, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Pixel))
+  RDAT_ENUM_VALUE(Vertex, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Vertex))
+  RDAT_ENUM_VALUE(Geometry, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Geometry))
+  RDAT_ENUM_VALUE(Hull, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Hull))
+  RDAT_ENUM_VALUE(Domain, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Domain))
+  RDAT_ENUM_VALUE(Compute, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Compute))
+  RDAT_ENUM_VALUE(Library, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Library))
+  RDAT_ENUM_VALUE(RayGeneration, (1 << (uint32_t)hlsl::DXIL::ShaderKind::RayGeneration))
+  RDAT_ENUM_VALUE(Intersection, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Intersection))
+  RDAT_ENUM_VALUE(AnyHit, (1 << (uint32_t)hlsl::DXIL::ShaderKind::AnyHit))
+  RDAT_ENUM_VALUE(ClosestHit, (1 << (uint32_t)hlsl::DXIL::ShaderKind::ClosestHit))
+  RDAT_ENUM_VALUE(Miss, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Miss))
+  RDAT_ENUM_VALUE(Callable, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Callable))
+  RDAT_ENUM_VALUE(Mesh, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Mesh))
+  RDAT_ENUM_VALUE(Amplification, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Amplification))
+  RDAT_ENUM_VALUE(Node, (1 << (uint32_t)hlsl::DXIL::ShaderKind::Node))
+RDAT_ENUM_END()
+
+// Low 32-bits of ShaderFeatureInfo from DFCC_FeatureInfo
+RDAT_ENUM_START(DxilFeatureInfo1, uint32_t)
+  RDAT_ENUM_VALUE(Doubles, 0x0001)
+  RDAT_ENUM_VALUE(ComputeShadersPlusRawAndStructuredBuffersViaShader4X, 0x0002)
+  RDAT_ENUM_VALUE(UAVsAtEveryStage, 0x0004)
+  RDAT_ENUM_VALUE(_64UAVs, 0x0008)
+  RDAT_ENUM_VALUE(MinimumPrecision, 0x0010)
+  RDAT_ENUM_VALUE(_11_1_DoubleExtensions, 0x0020)
+  RDAT_ENUM_VALUE(_11_1_ShaderExtensions, 0x0040)
+  RDAT_ENUM_VALUE(LEVEL9ComparisonFiltering, 0x0080)
+  RDAT_ENUM_VALUE(TiledResources, 0x0100)
+  RDAT_ENUM_VALUE(StencilRef, 0x0200)
+  RDAT_ENUM_VALUE(InnerCoverage, 0x0400)
+  RDAT_ENUM_VALUE(TypedUAVLoadAdditionalFormats, 0x0800)
+  RDAT_ENUM_VALUE(ROVs, 0x1000)
+  RDAT_ENUM_VALUE(ViewportAndRTArrayIndexFromAnyShaderFeedingRasterizer, 0x2000)
+  RDAT_ENUM_VALUE(WaveOps, 0x4000)
+  RDAT_ENUM_VALUE(Int64Ops, 0x8000)
+  RDAT_ENUM_VALUE(ViewID, 0x10000)
+  RDAT_ENUM_VALUE(Barycentrics, 0x20000)
+  RDAT_ENUM_VALUE(NativeLowPrecision, 0x40000)
+  RDAT_ENUM_VALUE(ShadingRate, 0x80000)
+  RDAT_ENUM_VALUE(Raytracing_Tier_1_1, 0x100000)
+  RDAT_ENUM_VALUE(SamplerFeedback, 0x200000)
+  RDAT_ENUM_VALUE(AtomicInt64OnTypedResource, 0x400000)
+  RDAT_ENUM_VALUE(AtomicInt64OnGroupShared, 0x800000)
+  RDAT_ENUM_VALUE(DerivativesInMeshAndAmpShaders, 0x1000000)
+  RDAT_ENUM_VALUE(ResourceDescriptorHeapIndexing, 0x2000000)
+  RDAT_ENUM_VALUE(SamplerDescriptorHeapIndexing, 0x4000000)
+  RDAT_ENUM_VALUE(WaveMMA, 0x8000000)
+  RDAT_ENUM_VALUE(AtomicInt64OnHeapResource, 0x10000000)
+  RDAT_ENUM_VALUE(AdvancedTextureOps, 0x20000000)
+  RDAT_ENUM_VALUE(WriteableMSAATextures, 0x40000000)
+  RDAT_ENUM_VALUE(SampleCmpGradientOrBias, 0x80000000)
+RDAT_ENUM_END()
+
+// High 32-bits of ShaderFeatureInfo from DFCC_FeatureInfo
+RDAT_ENUM_START(DxilFeatureInfo2, uint32_t)
+  RDAT_ENUM_VALUE(ExtendedCommandInfo, 0x1)
+  // OptFeatureInfo flags
+  RDAT_ENUM_VALUE(Opt_UsesDerivatives, 0x100)
+  RDAT_ENUM_VALUE(Opt_RequiresGroup, 0x200)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert(DXIL::ShaderFeatureInfoCount == 33,
+                "otherwise, RDAT_ENUM definition needs updating");
+  static_assert(DXIL::OptFeatureInfoCount == 2,
+                "otherwise, RDAT_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+#endif // DEF_RDAT_ENUMS
+
+#ifdef DEF_DXIL_ENUMS
+
+// Enums using RDAT_DXIL_ENUM_START use existing definitions of enums, rather
+// than redefining the enum locally.  The definition here is mainly to
+// implement the ToString function.
+// A static_assert under DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL is used to
+// check one enum value that would change if the enum were to be updated,
+// making sure this definition is updated as well.
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::ResourceClass, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(SRV)
+  RDAT_ENUM_VALUE_NODEF(UAV)
+  RDAT_ENUM_VALUE_NODEF(CBuffer)
+  RDAT_ENUM_VALUE_NODEF(Sampler)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::ResourceClass::Invalid == 4,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::ResourceKind, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Texture1D)
+  RDAT_ENUM_VALUE_NODEF(Texture2D)
+  RDAT_ENUM_VALUE_NODEF(Texture2DMS)
+  RDAT_ENUM_VALUE_NODEF(Texture3D)
+  RDAT_ENUM_VALUE_NODEF(TextureCube)
+  RDAT_ENUM_VALUE_NODEF(Texture1DArray)
+  RDAT_ENUM_VALUE_NODEF(Texture2DArray)
+  RDAT_ENUM_VALUE_NODEF(Texture2DMSArray)
+  RDAT_ENUM_VALUE_NODEF(TextureCubeArray)
+  RDAT_ENUM_VALUE_NODEF(TypedBuffer)
+  RDAT_ENUM_VALUE_NODEF(RawBuffer)
+  RDAT_ENUM_VALUE_NODEF(StructuredBuffer)
+  RDAT_ENUM_VALUE_NODEF(CBuffer)
+  RDAT_ENUM_VALUE_NODEF(Sampler)
+  RDAT_ENUM_VALUE_NODEF(TBuffer)
+  RDAT_ENUM_VALUE_NODEF(RTAccelerationStructure)
+  RDAT_ENUM_VALUE_NODEF(FeedbackTexture2D)
+  RDAT_ENUM_VALUE_NODEF(FeedbackTexture2DArray)
+  RDAT_ENUM_VALUE_NODEF(NumEntries)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::ResourceKind::NumEntries == 19,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::ShaderKind, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Pixel)
+  RDAT_ENUM_VALUE_NODEF(Vertex)
+  RDAT_ENUM_VALUE_NODEF(Geometry)
+  RDAT_ENUM_VALUE_NODEF(Hull)
+  RDAT_ENUM_VALUE_NODEF(Domain)
+  RDAT_ENUM_VALUE_NODEF(Compute)
+  RDAT_ENUM_VALUE_NODEF(Library)
+  RDAT_ENUM_VALUE_NODEF(RayGeneration)
+  RDAT_ENUM_VALUE_NODEF(Intersection)
+  RDAT_ENUM_VALUE_NODEF(AnyHit)
+  RDAT_ENUM_VALUE_NODEF(ClosestHit)
+  RDAT_ENUM_VALUE_NODEF(Miss)
+  RDAT_ENUM_VALUE_NODEF(Callable)
+  RDAT_ENUM_VALUE_NODEF(Mesh)
+  RDAT_ENUM_VALUE_NODEF(Amplification)
+  RDAT_ENUM_VALUE_NODEF(Node)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::ShaderKind::Invalid == 16,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+#endif // DEF_DXIL_ENUMS
+
+#ifdef DEF_RDAT_TYPES
+
+#define RECORD_TYPE RuntimeDataResourceInfo
+RDAT_STRUCT_TABLE(RuntimeDataResourceInfo, ResourceTable)
+  RDAT_ENUM(uint32_t, hlsl::DXIL::ResourceClass, Class)
+  RDAT_ENUM(uint32_t, hlsl::DXIL::ResourceKind, Kind)
+  RDAT_VALUE(uint32_t, ID)
+  RDAT_VALUE(uint32_t, Space)
+  RDAT_VALUE(uint32_t, LowerBound)
+  RDAT_VALUE(uint32_t, UpperBound)
+  RDAT_STRING(Name)
+  RDAT_FLAGS(uint32_t, DxilResourceFlag, Flags)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+// ------------ RuntimeDataFunctionInfo ------------
+
+#define RECORD_TYPE RuntimeDataFunctionInfo
+RDAT_STRUCT_TABLE(RuntimeDataFunctionInfo, FunctionTable)
+  // full function name
+  RDAT_STRING(Name)
+  // unmangled function name
+  RDAT_STRING(UnmangledName)
+  // list of global resources used by this function
+  RDAT_RECORD_ARRAY_REF(RuntimeDataResourceInfo, Resources)
+  // list of external function names this function calls
+  RDAT_STRING_ARRAY_REF(FunctionDependencies)
+  // Shader type, or library function
+  RDAT_ENUM(uint32_t, hlsl::DXIL::ShaderKind, ShaderKind)
+  // Payload Size:
+  // 1) any/closest hit or miss shader: payload size
+  // 2) call shader: parameter size
+  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
+  // attribute size for closest hit and any hit
+  RDAT_VALUE(uint32_t, AttributeSizeInBytes)
+  // first 32 bits of feature flag
+  RDAT_FLAGS(uint32_t, hlsl::RDAT::DxilFeatureInfo1, FeatureInfo1)
+  // second 32 bits of feature flag
+  RDAT_FLAGS(uint32_t, hlsl::RDAT::DxilFeatureInfo2, FeatureInfo2)
+  // valid shader stage flag.
+  RDAT_FLAGS(uint32_t, hlsl::RDAT::DxilShaderStageFlags, ShaderStageFlag)
+  // minimum shader target.
+  RDAT_VALUE_HEX(uint32_t, MinShaderTarget)
+
+#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
+  // void SetFeatureFlags(uint64_t flags) convenience method
+  void SetFeatureFlags(uint64_t flags) {
+    FeatureInfo1 = flags & 0xffffffff;
+    FeatureInfo2 = (flags >> 32) & 0xffffffff;
+  }
+#endif
+
+#if DEF_RDAT_TYPES == DEF_RDAT_READER_DECL
+  // uint64_t GetFeatureFlags() convenience method
+  uint64_t GetFeatureFlags() const;
+#elif DEF_RDAT_TYPES == DEF_RDAT_READER_IMPL
+  // uint64_t GetFeatureFlags() convenience method
+  uint64_t RuntimeDataFunctionInfo_Reader::GetFeatureFlags() const {
+    return asRecord() ? (((uint64_t)asRecord()->FeatureInfo2 << 32) |
+                         (uint64_t)asRecord()->FeatureInfo1)
+                      : 0;
+  }
+#endif
+
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#endif // DEF_RDAT_TYPES
+
+
+//////////////////////////////////////////////////////////////////////
+// The following require validator version 1.8 and above.
+
+// ------------ RuntimeDataFunctionInfo2 dependencies ------------
+
+#ifdef DEF_RDAT_ENUMS
+
+RDAT_ENUM_START(DxilShaderFlags, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 0)
+  // End of values supported by validator version 1.8
+  RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 1)
+  RDAT_ENUM_VALUE(DepthOutput, 1 << 2)
+  RDAT_ENUM_VALUE(SampleFrequency, 1 << 3)
+  RDAT_ENUM_VALUE(UsesViewID, 1 << 4)
+RDAT_ENUM_END()
+
+RDAT_ENUM_START(NodeFuncAttribKind, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(ID, 1)
+  RDAT_ENUM_VALUE(NumThreads, 2)
+  RDAT_ENUM_VALUE(ShareInputOf, 3)
+  RDAT_ENUM_VALUE(DispatchGrid, 4)
+  RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
+  RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
+  RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
+  RDAT_ENUM_VALUE_NODEF(LastValue)
+RDAT_ENUM_END()
+
+RDAT_ENUM_START(NodeAttribKind, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(OutputID, 1)
+  RDAT_ENUM_VALUE(MaxRecords, 2)
+  RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
+  RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
+  RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
+  RDAT_ENUM_VALUE(OutputArraySize, 6)
+  RDAT_ENUM_VALUE(AllowSparseNodes, 7)
+  RDAT_ENUM_VALUE(RecordAlignmentInBytes, 8)
+  RDAT_ENUM_VALUE_NODEF(LastValue)
+RDAT_ENUM_END()
+
+#endif // DEF_RDAT_ENUMS
+
+#ifdef DEF_DXIL_ENUMS
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeIOKind, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(EmptyInput)
+  RDAT_ENUM_VALUE_NODEF(NodeOutput)
+  RDAT_ENUM_VALUE_NODEF(NodeOutputArray)
+  RDAT_ENUM_VALUE_NODEF(EmptyOutput)
+  RDAT_ENUM_VALUE_NODEF(EmptyOutputArray)
+  RDAT_ENUM_VALUE_NODEF(DispatchNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(RWDispatchNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(GroupNodeInputRecords)
+  RDAT_ENUM_VALUE_NODEF(RWGroupNodeInputRecords)
+  RDAT_ENUM_VALUE_NODEF(ThreadNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(RWThreadNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(GroupNodeOutputRecords)
+  RDAT_ENUM_VALUE_NODEF(ThreadNodeOutputRecords)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeLaunchType, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Broadcasting)
+  RDAT_ENUM_VALUE_NODEF(Coalescing)
+  RDAT_ENUM_VALUE_NODEF(Thread)
+  RDAT_ENUM_VALUE_NODEF(LastEntry)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+#endif // DEF_DXIL_ENUMS
+
+#ifdef DEF_RDAT_TYPES
+
+#define RECORD_TYPE RecordDispatchGrid
+RDAT_STRUCT(RecordDispatchGrid)
+  RDAT_VALUE(uint16_t, ByteOffset)
+  RDAT_VALUE(uint16_t, ComponentNumAndType) // 0:2 = NumComponents (0-3), 3:15 =
+                                          // hlsl::DXIL::ComponentType enum
+#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
+  uint8_t GetNumComponents() const { return (ComponentNumAndType & 0x3); }
+  hlsl::DXIL::ComponentType GetComponentType() const {
+    return (hlsl::DXIL::ComponentType)(ComponentNumAndType >> 2);
+  }
+  void SetNumComponents(uint8_t num) { ComponentNumAndType |= (num & 0x3); }
+  void SetComponentType(hlsl::DXIL::ComponentType type) {
+    ComponentNumAndType |= (((uint16_t)type) << 2);
+  }
+#endif
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE NodeID
+RDAT_STRUCT_TABLE(NodeID, NodeIDTable)
+  RDAT_STRING(Name)
+  RDAT_VALUE(uint32_t, Index)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE NodeShaderFuncAttrib
+RDAT_STRUCT_TABLE(NodeShaderFuncAttrib, NodeShaderFuncAttribTable)
+  RDAT_ENUM(uint32_t, hlsl::RDAT::NodeFuncAttribKind, AttribKind)
+  RDAT_UNION()
+    RDAT_UNION_IF(ID, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::ID)
+      RDAT_RECORD_REF(NodeID, ID)
+    RDAT_UNION_ELIF(NumThreads, getAttribKind() ==
+                                    hlsl::RDAT::NodeFuncAttribKind::NumThreads)
+      RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3
+                                       // elements, default value is 1
+    RDAT_UNION_ELIF(SharedInput,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::ShareInputOf)
+      RDAT_RECORD_REF(NodeID, ShareInputOf)
+    RDAT_UNION_ELIF(DispatchGrid,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::DispatchGrid)
+      RDAT_INDEX_ARRAY_REF(DispatchGrid)
+    RDAT_UNION_ELIF(MaxRecursionDepth,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::MaxRecursionDepth)
+      RDAT_VALUE(uint32_t, MaxRecursionDepth)
+    RDAT_UNION_ELIF(
+        LocalRootArgumentsTableIndex,
+        getAttribKind() ==
+            hlsl::RDAT::NodeFuncAttribKind::LocalRootArgumentsTableIndex)
+      RDAT_VALUE(uint32_t, LocalRootArgumentsTableIndex)
+    RDAT_UNION_ELIF(MaxDispatchGrid,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::MaxDispatchGrid)
+      RDAT_INDEX_ARRAY_REF(MaxDispatchGrid)
+    RDAT_UNION_ENDIF()
+  RDAT_UNION_END()
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE NodeShaderIOAttrib
+RDAT_STRUCT_TABLE(NodeShaderIOAttrib, NodeShaderIOAttribTable)
+  RDAT_ENUM(uint32_t, hlsl::RDAT::NodeAttribKind, AttribKind)
+  RDAT_UNION()
+    RDAT_UNION_IF(ID, getAttribKind() == hlsl::RDAT::NodeAttribKind::OutputID)
+      RDAT_RECORD_REF(NodeID, OutputID)
+    RDAT_UNION_ELIF(MaxRecords,
+                    getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecords)
+      RDAT_VALUE(uint32_t, MaxRecords)
+    RDAT_UNION_ELIF(MaxRecordsSharedWith,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::MaxRecordsSharedWith)
+      RDAT_VALUE(uint32_t, MaxRecordsSharedWith)
+    RDAT_UNION_ELIF(RecordSizeInBytes,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::RecordSizeInBytes)
+      RDAT_VALUE(uint32_t, RecordSizeInBytes)
+    RDAT_UNION_ELIF(RecordDispatchGrid,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::RecordDispatchGrid)
+      RDAT_RECORD_VALUE(RecordDispatchGrid, RecordDispatchGrid)
+    RDAT_UNION_ELIF(OutputArraySize,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::OutputArraySize)
+      RDAT_VALUE(uint32_t, OutputArraySize)
+    RDAT_UNION_ELIF(AllowSparseNodes,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::AllowSparseNodes)
+      RDAT_VALUE(uint32_t, AllowSparseNodes)
+    RDAT_UNION_ELIF(RecordAlignmentInBytes,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::RecordAlignmentInBytes)
+      RDAT_VALUE(uint32_t, RecordAlignmentInBytes)
+    RDAT_UNION_ENDIF()
+  RDAT_UNION_END()
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE IONode
+  RDAT_STRUCT_TABLE(IONode, IONodeTable)
+  // Required field
+  RDAT_VALUE(uint32_t, IOFlagsAndKind)
+  // Optional fields
+  RDAT_RECORD_ARRAY_REF(NodeShaderIOAttrib, Attribs)
+#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
+  uint32_t GetIOFlags() const {
+    return IOFlagsAndKind & (uint32_t)DXIL::NodeIOFlags::NodeFlagsMask;
+  }
+  hlsl::DXIL::NodeIOKind GetIOKind() const {
+    return (hlsl::DXIL::NodeIOKind)(IOFlagsAndKind &
+                                    (uint32_t)DXIL::NodeIOFlags::NodeIOKindMask);
+  }
+  void SetIOFlags(uint32_t flags) { IOFlagsAndKind |= flags; }
+  void SetIOKind(hlsl::DXIL::NodeIOKind kind) {
+    IOFlagsAndKind |= (uint32_t)kind;
+  }
+#endif
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE NodeShaderInfo
+RDAT_STRUCT_TABLE(NodeShaderInfo, NodeShaderInfoTable)
+  // Function Attributes
+  RDAT_ENUM(uint32_t, hlsl::DXIL::NodeLaunchType, LaunchType)
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+  RDAT_RECORD_ARRAY_REF(NodeShaderFuncAttrib, Attribs)
+  RDAT_RECORD_ARRAY_REF(IONode, Outputs)
+  RDAT_RECORD_ARRAY_REF(IONode, Inputs)
+
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+// ------------ RuntimeDataFunctionInfo2 ------------
+
+#define RECORD_TYPE RuntimeDataFunctionInfo2
+RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo,
+                          FunctionTable)
+
+  // 128 lanes is maximum that could be supported by HLSL
+  RDAT_VALUE(uint8_t, MinimumExpectedWaveLaneCount) // 0 = none specified
+  RDAT_VALUE(uint8_t, MaximumExpectedWaveLaneCount) // 0 = none specified
+  RDAT_FLAGS(uint16_t, hlsl::RDAT::DxilShaderFlags, ShaderFlags)
+
+  RDAT_UNION()
+    RDAT_UNION_IF(RawShaderRef,
+                    (getShaderKind() == hlsl::DXIL::ShaderKind::Invalid))
+      RDAT_VALUE(uint32_t, RawShaderRef)
+    RDAT_UNION_ELIF(Node, (getShaderKind() == hlsl::DXIL::ShaderKind::Node))
+      RDAT_RECORD_REF(NodeShaderInfo, Node)
+    // End of values supported by validator version 1.8
+    RDAT_UNION_ELIF(VS, (getShaderKind() == hlsl::DXIL::ShaderKind::Vertex))
+      RDAT_RECORD_REF(VSInfo, VS)
+    RDAT_UNION_ELIF(PS, (getShaderKind() == hlsl::DXIL::ShaderKind::Pixel))
+      RDAT_RECORD_REF(PSInfo, PS)
+    RDAT_UNION_ELIF(HS, (getShaderKind() == hlsl::DXIL::ShaderKind::Hull))
+      RDAT_RECORD_REF(HSInfo, HS)
+    RDAT_UNION_ELIF(DS, (getShaderKind() == hlsl::DXIL::ShaderKind::Domain))
+      RDAT_RECORD_REF(DSInfo, DS)
+    RDAT_UNION_ELIF(GS, (getShaderKind() == hlsl::DXIL::ShaderKind::Geometry))
+      RDAT_RECORD_REF(GSInfo, GS)
+    RDAT_UNION_ELIF(CS, (getShaderKind() == hlsl::DXIL::ShaderKind::Compute))
+      RDAT_RECORD_REF(CSInfo, CS)
+    RDAT_UNION_ELIF(MS, (getShaderKind() == hlsl::DXIL::ShaderKind::Mesh))
+      RDAT_RECORD_REF(MSInfo, MS)
+    RDAT_UNION_ELIF(AS,
+                    (getShaderKind() == hlsl::DXIL::ShaderKind::Amplification))
+      RDAT_RECORD_REF(ASInfo, AS)
+    RDAT_UNION_ENDIF()
+  RDAT_UNION_END()
+
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#endif // DEF_RDAT_TYPES
+
+
+///////////////////////////////////////////////////////////////////////////////
+// The following are experimental, and are not currently supported on any
+// validator version.
+
+#ifdef DEF_DXIL_ENUMS
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::SemanticKind, uint32_t)
+  /* <py::lines('SemanticKind-ENUM')>hctdb_instrhelp.get_rdat_enum_decl("SemanticKind", nodef=True)</py>*/
+  // SemanticKind-ENUM:BEGIN
+  RDAT_ENUM_VALUE_NODEF(Arbitrary)
+  RDAT_ENUM_VALUE_NODEF(VertexID)
+  RDAT_ENUM_VALUE_NODEF(InstanceID)
+  RDAT_ENUM_VALUE_NODEF(Position)
+  RDAT_ENUM_VALUE_NODEF(RenderTargetArrayIndex)
+  RDAT_ENUM_VALUE_NODEF(ViewPortArrayIndex)
+  RDAT_ENUM_VALUE_NODEF(ClipDistance)
+  RDAT_ENUM_VALUE_NODEF(CullDistance)
+  RDAT_ENUM_VALUE_NODEF(OutputControlPointID)
+  RDAT_ENUM_VALUE_NODEF(DomainLocation)
+  RDAT_ENUM_VALUE_NODEF(PrimitiveID)
+  RDAT_ENUM_VALUE_NODEF(GSInstanceID)
+  RDAT_ENUM_VALUE_NODEF(SampleIndex)
+  RDAT_ENUM_VALUE_NODEF(IsFrontFace)
+  RDAT_ENUM_VALUE_NODEF(Coverage)
+  RDAT_ENUM_VALUE_NODEF(InnerCoverage)
+  RDAT_ENUM_VALUE_NODEF(Target)
+  RDAT_ENUM_VALUE_NODEF(Depth)
+  RDAT_ENUM_VALUE_NODEF(DepthLessEqual)
+  RDAT_ENUM_VALUE_NODEF(DepthGreaterEqual)
+  RDAT_ENUM_VALUE_NODEF(StencilRef)
+  RDAT_ENUM_VALUE_NODEF(DispatchThreadID)
+  RDAT_ENUM_VALUE_NODEF(GroupID)
+  RDAT_ENUM_VALUE_NODEF(GroupIndex)
+  RDAT_ENUM_VALUE_NODEF(GroupThreadID)
+  RDAT_ENUM_VALUE_NODEF(TessFactor)
+  RDAT_ENUM_VALUE_NODEF(InsideTessFactor)
+  RDAT_ENUM_VALUE_NODEF(ViewID)
+  RDAT_ENUM_VALUE_NODEF(Barycentrics)
+  RDAT_ENUM_VALUE_NODEF(ShadingRate)
+  RDAT_ENUM_VALUE_NODEF(CullPrimitive)
+  RDAT_ENUM_VALUE_NODEF(StartVertexLocation)
+  RDAT_ENUM_VALUE_NODEF(StartInstanceLocation)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  // SemanticKind-ENUM:END
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::ComponentType, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(I1)
+  RDAT_ENUM_VALUE_NODEF(I16)
+  RDAT_ENUM_VALUE_NODEF(U16)
+  RDAT_ENUM_VALUE_NODEF(I32)
+  RDAT_ENUM_VALUE_NODEF(U32)
+  RDAT_ENUM_VALUE_NODEF(I64)
+  RDAT_ENUM_VALUE_NODEF(U64)
+  RDAT_ENUM_VALUE_NODEF(F16)
+  RDAT_ENUM_VALUE_NODEF(F32)
+  RDAT_ENUM_VALUE_NODEF(F64)
+  RDAT_ENUM_VALUE_NODEF(SNormF16)
+  RDAT_ENUM_VALUE_NODEF(UNormF16)
+  RDAT_ENUM_VALUE_NODEF(SNormF32)
+  RDAT_ENUM_VALUE_NODEF(UNormF32)
+  RDAT_ENUM_VALUE_NODEF(SNormF64)
+  RDAT_ENUM_VALUE_NODEF(UNormF64)
+  RDAT_ENUM_VALUE_NODEF(PackedS8x32)
+  RDAT_ENUM_VALUE_NODEF(PackedU8x32)
+  RDAT_ENUM_VALUE_NODEF(LastEntry)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::InterpolationMode, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Undefined)
+  RDAT_ENUM_VALUE_NODEF(Constant)
+  RDAT_ENUM_VALUE_NODEF(Linear)
+  RDAT_ENUM_VALUE_NODEF(LinearCentroid)
+  RDAT_ENUM_VALUE_NODEF(LinearNoperspective)
+  RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveCentroid)
+  RDAT_ENUM_VALUE_NODEF(LinearSample)
+  RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveSample)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+#endif // DEF_DXIL_ENUMS
+
+#ifdef DEF_RDAT_TYPES
+
+#define RECORD_TYPE SignatureElement
+RDAT_STRUCT_TABLE(SignatureElement, SignatureElementTable)
+  RDAT_STRING(SemanticName)
+  RDAT_INDEX_ARRAY_REF(SemanticIndices) // Rows = SemanticIndices.Count()
+  RDAT_ENUM(uint8_t, hlsl::DXIL::SemanticKind, SemanticKind)
+  RDAT_ENUM(uint8_t, hlsl::DXIL::ComponentType, ComponentType)
+  RDAT_ENUM(uint8_t, hlsl::DXIL::InterpolationMode, InterpolationMode)
+  RDAT_VALUE(
+      uint8_t,
+      StartRow) // Starting row of packed location if allocated, otherwise 0xFF
+  // TODO: use struct with bitfields or accessors for ColsAndStream and
+  // UsageAndDynIndexMasks
+  RDAT_VALUE(uint8_t, ColsAndStream) // 0:2 = (Cols-1) (0-3), 2:4 = StartCol
+                                     // (0-3), 4:6 = OutputStream (0-3)
+  RDAT_VALUE(uint8_t,
+             UsageAndDynIndexMasks) // 0:4 = UsageMask, 4:8 = DynamicIndexMask
+#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
+  uint8_t GetCols() const { return (ColsAndStream & 3) + 1; }
+  uint8_t GetStartCol() const { return (ColsAndStream >> 2) & 3; }
+  uint8_t GetOutputStream() const { return (ColsAndStream >> 4) & 3; }
+  uint8_t GetUsageMask() const { return UsageAndDynIndexMasks & 0xF; }
+  uint8_t GetDynamicIndexMask() const {
+    return (UsageAndDynIndexMasks >> 4) & 0xF;
+  }
+  void SetCols(unsigned cols) {
+    ColsAndStream &= ~3;
+    ColsAndStream |= (cols - 1) & 3;
+  }
+  void SetStartCol(unsigned col) {
+    ColsAndStream &= ~(3 << 2);
+    ColsAndStream |= (col & 3) << 2;
+  }
+  void SetOutputStream(unsigned stream) {
+    ColsAndStream &= ~(3 << 4);
+    ColsAndStream |= (stream & 3) << 4;
+  }
+  void SetUsageMask(unsigned mask) {
+    UsageAndDynIndexMasks &= ~0xF;
+    UsageAndDynIndexMasks |= mask & 0xF;
+  }
+  void SetDynamicIndexMask(unsigned mask) {
+    UsageAndDynIndexMasks &= ~(0xF << 4);
+    UsageAndDynIndexMasks |= (mask & 0xF) << 4;
+  }
+#endif
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE VSInfo
+RDAT_STRUCT_TABLE(VSInfo, VSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE PSInfo
+RDAT_STRUCT_TABLE(PSInfo, PSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE HSInfo
+RDAT_STRUCT_TABLE(HSInfo, HSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPatchConstOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(ViewIDPatchConstOutputMask)
+  RDAT_BYTES(InputToOutputMasks)
+  RDAT_BYTES(InputToPatchConstOutputMasks)
+  RDAT_VALUE(uint8_t, InputControlPointCount)
+  RDAT_VALUE(uint8_t, OutputControlPointCount)
+  RDAT_VALUE(uint8_t, TessellatorDomain)
+  RDAT_VALUE(uint8_t, TessellatorOutputPrimitive)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE DSInfo
+RDAT_STRUCT_TABLE(DSInfo, DSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPatchConstInputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(InputToOutputMasks)
+  RDAT_BYTES(PatchConstInputToOutputMasks)
+  RDAT_VALUE(uint8_t, InputControlPointCount)
+  RDAT_VALUE(uint8_t, TessellatorDomain)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE GSInfo
+RDAT_STRUCT_TABLE(GSInfo, GSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(InputToOutputMasks)
+  RDAT_VALUE(uint8_t, InputPrimitive)
+  RDAT_VALUE(uint8_t, OutputTopology)
+  RDAT_VALUE(uint8_t, MaxVertexCount)
+  RDAT_VALUE(uint8_t, OutputStreamMask)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE CSInfo
+RDAT_STRUCT_TABLE(CSInfo, CSInfoTable)
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE MSInfo
+RDAT_STRUCT_TABLE(MSInfo, MSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPrimOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(ViewIDPrimOutputMask)
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+  RDAT_VALUE(uint32_t, GroupSharedBytesDependentOnViewID)
+  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
+  RDAT_VALUE(uint16_t, MaxOutputVertices)
+  RDAT_VALUE(uint16_t, MaxOutputPrimitives)
+  RDAT_VALUE(uint8_t, MeshOutputTopology)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE ASInfo
+RDAT_STRUCT_TABLE(ASInfo, ASInfoTable)
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#endif // DEF_RDAT_TYPES
+
+// clang-format on

--- a/external/dxc-rdat/dxc/DxilContainer/RDAT_Macros.inl
+++ b/external/dxc-rdat/dxc/DxilContainer/RDAT_Macros.inl
@@ -1,0 +1,536 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// RDAT_Macros.inl                                                           //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Defines macros use to define types Dxil Library Runtime Data (RDAT).      //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+// Pay attention to alignment when organizing structures.
+// RDAT_STRING and *_REF types are always 4 bytes.
+// RDAT_BYTES is 2 * 4 bytes.
+
+// These are the modes set to DEF_RDAT_TYPES and/or DEF_RDAT_ENUMS that drive
+// macro expansion for types and enums which define the necessary declarations
+// and code.
+// While some of associated macros sets are not defined in this file, these
+// definitions allow custom paths in the type definition files in certain cases.
+
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - define empty macros for anything not
+// already defined
+#define DEF_RDAT_DEFAULTS 1
+// DEF_RDAT_TYPES - define structs with basic types, matching RDAT format
+#define DEF_RDAT_TYPES_BASIC_STRUCT 2
+// DEF_RDAT_TYPES - define structs using helpers, matching RDAT format
+#define DEF_RDAT_TYPES_USE_HELPERS 3
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write dump declarations
+#define DEF_RDAT_DUMP_DECL 4
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write dump implementation
+#define DEF_RDAT_DUMP_IMPL 5
+// DEF_RDAT_TYPES - define deserialized version using pointers instead of
+// offsets
+#define DEF_RDAT_TYPES_USE_POINTERS 6
+// DEF_RDAT_ENUMS - declare enums with enum class
+#define DEF_RDAT_ENUM_CLASS 7
+// DEF_RDAT_TYPES - define type traits
+#define DEF_RDAT_TRAITS 8
+// DEF_RDAT_TYPES - forward declare type struct/class
+#define DEF_RDAT_TYPES_FORWARD_DECL 9
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write reader classes
+#define DEF_RDAT_READER_DECL 10
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write reader classes
+#define DEF_RDAT_READER_IMPL 11
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - define structural validation
+#define DEF_RDAT_STRUCT_VALIDATION 13
+
+// clang-format off
+#define CLOSE_COMPOUND_DECL };
+// clang-format on
+
+#define GLUE2(a, b) a##b
+#define GLUE(a, b) GLUE2(a, b)
+
+#ifdef DEF_RDAT_TYPES
+
+#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_FORWARD_DECL
+
+#define RDAT_STRUCT(type)                                                      \
+  struct type;                                                                 \
+  class type##_Reader;
+#define RDAT_STRUCT_DERIVED(type, base) RDAT_STRUCT(type)
+#define RDAT_WRAP_ARRAY(type, count, type_name)                                \
+  struct type_name {                                                           \
+    type arr[count];                                                           \
+  };
+
+#elif DEF_RDAT_TYPES == DEF_RDAT_TYPES_BASIC_STRUCT
+
+#define RDAT_STRUCT(type) struct type {
+#define RDAT_STRUCT_DERIVED(type, base) struct type : public base {
+#define RDAT_STRUCT_END() CLOSE_COMPOUND_DECL
+#define RDAT_UNION() union {
+#define RDAT_UNION_END() CLOSE_COMPOUND_DECL
+#define RDAT_RECORD_REF(type, name) uint32_t name;
+#define RDAT_RECORD_ARRAY_REF(type, name) uint32_t name;
+#define RDAT_RECORD_VALUE(type, name) type name;
+#define RDAT_STRING(name) uint32_t name;
+#define RDAT_STRING_ARRAY_REF(name) uint32_t name;
+#define RDAT_VALUE(type, name) type name;
+#define RDAT_INDEX_ARRAY_REF(name) uint32_t name;
+#define RDAT_ENUM(sTy, eTy, name) sTy name;
+#define RDAT_FLAGS(sTy, eTy, name) sTy name;
+#define RDAT_BYTES(name)                                                       \
+  uint32_t name;                                                               \
+  uint32_t name##_Size;                                                        \
+  name;
+#define RDAT_ARRAY_VALUE(type, count, type_name, name) type_name name;
+
+#elif DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
+
+#define RDAT_STRUCT(type) struct type {
+#define RDAT_STRUCT_DERIVED(type, base) struct type : public base {
+#define RDAT_STRUCT_END() CLOSE_COMPOUND_DECL
+#define RDAT_UNION() union {
+#define RDAT_UNION_END() CLOSE_COMPOUND_DECL
+#define RDAT_RECORD_REF(type, name) RecordRef<type> name;
+#define RDAT_RECORD_ARRAY_REF(type, name) RecordArrayRef<type> name;
+#define RDAT_RECORD_VALUE(type, name) struct type name;
+#define RDAT_STRING(name) RDATString name;
+#define RDAT_STRING_ARRAY_REF(name) RDATStringArray name;
+#define RDAT_VALUE(type, name) type name;
+#define RDAT_INDEX_ARRAY_REF(name) IndexArrayRef name;
+#define RDAT_ENUM(sTy, eTy, name) sTy name;
+#define RDAT_FLAGS(sTy, eTy, name) sTy name;
+#define RDAT_BYTES(name) hlsl::RDAT::BytesRef name;
+#define RDAT_ARRAY_VALUE(type, count, type_name, name) type_name name;
+#define RDAT_STRUCT_TABLE_DERIVED(type, base, table)                           \
+  template <> constexpr const char *RecordTraits<type>::TypeName();            \
+  template <> constexpr RecordTableIndex RecordTraits<type>::TableIndex();     \
+  template <> constexpr RuntimeDataPartType RecordTraits<type>::PartType();    \
+  template <> constexpr size_t RecordTraits<base>::DerivedRecordSize();        \
+  RDAT_STRUCT_DERIVED(type, base)
+
+#elif DEF_RDAT_TYPES == DEF_RDAT_READER_DECL
+
+#define RDAT_STRUCT(type)                                                      \
+  class type##_Reader : public RecordReader<type##_Reader> {                   \
+  public:                                                                      \
+    typedef type RecordType;                                                   \
+    type##_Reader(const BaseRecordReader &reader);                             \
+    type##_Reader() : RecordReader<type##_Reader>() {}                         \
+    const RecordType *asRecord() const;                                        \
+    const RecordType *operator->() const { return asRecord(); }
+#define RDAT_STRUCT_DERIVED(type, base)                                        \
+  class type##_Reader : public base##_Reader {                                 \
+  public:                                                                      \
+    typedef type RecordType;                                                   \
+    type##_Reader(const BaseRecordReader &reader);                             \
+    type##_Reader();                                                           \
+    const RecordType *asRecord() const;                                        \
+    const RecordType *operator->() const { return asRecord(); }
+#define RDAT_STRUCT_END() CLOSE_COMPOUND_DECL
+#define RDAT_UNION_IF(name, expr) bool has##name() const;
+#define RDAT_UNION_ELIF(name, expr) RDAT_UNION_IF(name, expr)
+#define RDAT_RECORD_REF(type, name) type##_Reader get##name() const;
+#define RDAT_RECORD_ARRAY_REF(type, name)                                      \
+  RecordArrayReader<type##_Reader> get##name() const;
+#define RDAT_RECORD_VALUE(type, name) type##_Reader get##name() const;
+#define RDAT_STRING(name) const char *get##name() const;
+#define RDAT_STRING_ARRAY_REF(name) StringArrayReader get##name() const;
+#define RDAT_VALUE(type, name) type get##name() const;
+#define RDAT_INDEX_ARRAY_REF(name) IndexTableReader::IndexRow get##name() const;
+#define RDAT_ENUM(sTy, eTy, name) eTy get##name() const;
+#define RDAT_FLAGS(sTy, eTy, name) sTy get##name() const;
+#define RDAT_BYTES(name)                                                       \
+  const void *get##name() const;                                               \
+  uint32_t size##name() const;
+#define RDAT_ARRAY_VALUE(type, count, type_name, name)                         \
+  type_name get##name() const;
+
+#elif DEF_RDAT_TYPES == DEF_RDAT_READER_IMPL
+
+#define RDAT_STRUCT(type)                                                      \
+  type##_Reader::type##_Reader(const BaseRecordReader &reader)                 \
+      : RecordReader<type##_Reader>(reader) {}                                 \
+  const type *type##_Reader::asRecord() const {                                \
+    return BaseRecordReader::asRecord<type>();                                 \
+  }
+#define RDAT_STRUCT_DERIVED(type, base)                                        \
+  type##_Reader::type##_Reader(const BaseRecordReader &reader)                 \
+      : base##_Reader(reader) {                                                \
+    if ((m_pContext || m_pRecord) && m_Size < sizeof(type))                    \
+      InvalidateReader();                                                      \
+  }                                                                            \
+  type##_Reader::type##_Reader() : base##_Reader() {}                          \
+  const type *type##_Reader::asRecord() const {                                \
+    return BaseRecordReader::asRecord<type>();                                 \
+  }
+#define RDAT_STRUCT_TABLE(type, table) RDAT_STRUCT(type)
+#define RDAT_STRUCT_TABLE_DERIVED(type, base, table)                           \
+  RDAT_STRUCT_DERIVED(type, base)
+#define RDAT_UNION_IF(name, expr)                                              \
+  bool GLUE(RECORD_TYPE, _Reader)::has##name() const {                         \
+    if (auto *pRecord = asRecord())                                            \
+      return !!(expr);                                                         \
+    return false;                                                              \
+  }
+#define RDAT_UNION_ELIF(name, expr) RDAT_UNION_IF(name, expr)
+#define RDAT_RECORD_REF(type, name)                                            \
+  type##_Reader GLUE(RECORD_TYPE, _Reader)::get##name() const {                \
+    return GetField_RecordRef<type##_Reader>(&(asRecord()->name));             \
+  }
+#define RDAT_RECORD_ARRAY_REF(type, name)                                      \
+  RecordArrayReader<type##_Reader> GLUE(RECORD_TYPE, _Reader)::get##name()     \
+      const {                                                                  \
+    return GetField_RecordArrayRef<type##_Reader>(&(asRecord()->name));        \
+  }
+#define RDAT_RECORD_VALUE(type, name)                                          \
+  type##_Reader GLUE(RECORD_TYPE, _Reader)::get##name() const {                \
+    return GetField_RecordValue<type##_Reader>(&(asRecord()->name));           \
+  }
+#define RDAT_STRING(name)                                                      \
+  const char *GLUE(RECORD_TYPE, _Reader)::get##name() const {                  \
+    return GetField_String(&(asRecord()->name));                               \
+  }
+#define RDAT_STRING_ARRAY_REF(name)                                            \
+  StringArrayReader GLUE(RECORD_TYPE, _Reader)::get##name() const {            \
+    return GetField_StringArray(&(asRecord()->name));                          \
+  }
+#define RDAT_VALUE(type, name)                                                 \
+  type GLUE(RECORD_TYPE, _Reader)::get##name() const {                         \
+    return GetField_Value<type, type>(&(asRecord()->name));                    \
+  }
+#define RDAT_INDEX_ARRAY_REF(name)                                             \
+  IndexTableReader::IndexRow GLUE(RECORD_TYPE, _Reader)::get##name() const {   \
+    return GetField_IndexArray(&(asRecord()->name));                           \
+  }
+#define RDAT_ENUM(sTy, eTy, name)                                              \
+  eTy GLUE(RECORD_TYPE, _Reader)::get##name() const {                          \
+    return GetField_Value<eTy, sTy>(&(asRecord()->name));                      \
+  }
+#define RDAT_FLAGS(sTy, eTy, name)                                             \
+  sTy GLUE(RECORD_TYPE, _Reader)::get##name() const {                          \
+    return GetField_Value<sTy, sTy>(&(asRecord()->name));                      \
+  }
+#define RDAT_BYTES(name)                                                       \
+  const void *GLUE(RECORD_TYPE, _Reader)::get##name() const {                  \
+    return GetField_Bytes(&(asRecord()->name));                                \
+  }                                                                            \
+  uint32_t GLUE(RECORD_TYPE, _Reader)::size##name() const {                    \
+    return GetField_BytesSize(&(asRecord()->name));                            \
+  }
+#define RDAT_ARRAY_VALUE(type, count, type_name, name)                         \
+  type_name GLUE(RECORD_TYPE, _Reader)::get##name() const {                    \
+    return GetField_Value<type_name, type_name>(&(asRecord()->name));          \
+  }
+
+#elif DEF_RDAT_TYPES == DEF_RDAT_STRUCT_VALIDATION
+
+#define RDAT_STRUCT(type)                                                      \
+  template <>                                                                  \
+  bool ValidateRecord<type>(const RDATContext &ctx, const type *pRecord) {     \
+    type##_Reader reader(BaseRecordReader(                                     \
+        &ctx, (void *)pRecord, (uint32_t)RecordTraits<type>::RecordSize()));
+#define RDAT_STRUCT_DERIVED(type, base) RDAT_STRUCT(type)
+#define RDAT_STRUCT_END()                                                      \
+  return true;                                                                 \
+  }
+#define RDAT_UNION_IF(name, expr) if (reader.has##name()) {
+#define RDAT_UNION_ELIF(name, expr)                                            \
+  }                                                                            \
+  else if (reader.has##name()) {
+#define RDAT_UNION_ENDIF() }
+#define RDAT_RECORD_REF(type, name)                                            \
+  if (!ValidateRecordRef<type>(ctx, pRecord->name))                            \
+    return false;
+#define RDAT_RECORD_ARRAY_REF(type, name)                                      \
+  if (!ValidateRecordArrayRef<type>(ctx, pRecord->name))                       \
+    return false;
+#define RDAT_RECORD_VALUE(type, name)                                          \
+  if (!ValidateRecord<type>(ctx, &pRecord->name))                              \
+    return false;
+#define RDAT_STRING(name)                                                      \
+  if (!ValidateStringRef(ctx, pRecord->name))                                  \
+    return false;
+#define RDAT_STRING_ARRAY_REF(name)                                            \
+  if (!ValidateStringArrayRef(ctx, pRecord->name))                             \
+    return false;
+#define RDAT_INDEX_ARRAY_REF(name)                                             \
+  if (!ValidateIndexArrayRef(ctx, pRecord->name))                              \
+    return false;
+
+#elif DEF_RDAT_TYPES == DEF_RDAT_DUMP_IMPL
+
+#define RDAT_STRUCT(type)                                                      \
+  template <>                                                                  \
+  void RecordDumper<hlsl::RDAT::type>::Dump(                                   \
+      const hlsl::RDAT::RDATContext &ctx, DumpContext &d) const {              \
+    d.Indent();                                                                \
+    const hlsl::RDAT::type *pRecord = this;                                    \
+    type##_Reader reader(BaseRecordReader(                                     \
+        &ctx, (void *)pRecord, (uint32_t)RecordTraits<type>::RecordSize()));
+#define RDAT_STRUCT_DERIVED(type, base)                                        \
+  template <>                                                                  \
+  const char *RecordRefDumper<hlsl::RDAT::base>::TypeNameDerived(              \
+      const hlsl::RDAT::RDATContext &ctx) const {                              \
+    return TypeName<hlsl::RDAT::type>(ctx);                                    \
+  }                                                                            \
+  template <>                                                                  \
+  void RecordRefDumper<hlsl::RDAT::base>::DumpDerived(                         \
+      const hlsl::RDAT::RDATContext &ctx, DumpContext &d) const {              \
+    Dump<hlsl::RDAT::type>(ctx, d);                                            \
+  }                                                                            \
+  template <>                                                                  \
+  void RecordDumper<hlsl::RDAT::type>::Dump(                                   \
+      const hlsl::RDAT::RDATContext &ctx, DumpContext &d) const;               \
+  template <>                                                                  \
+  void DumpWithBase<hlsl::RDAT::type>(const hlsl::RDAT::RDATContext &ctx,      \
+                                      DumpContext &d,                          \
+                                      const hlsl::RDAT::type *pRecord) {       \
+    DumpWithBase<hlsl::RDAT::base>(ctx, d, pRecord);                           \
+    static_cast<const RecordDumper<hlsl::RDAT::type> *>(pRecord)->Dump(ctx,    \
+                                                                       d);     \
+  }                                                                            \
+  RDAT_STRUCT(type)
+#define RDAT_STRUCT_END()                                                      \
+  d.Dedent();                                                                  \
+  }
+#define RDAT_UNION_IF(name, expr) if (reader.has##name()) {
+#define RDAT_UNION_ELIF(name, expr)                                            \
+  }                                                                            \
+  else if (reader.has##name()) {
+#define RDAT_UNION_ENDIF() }
+#define RDAT_RECORD_REF(type, name) DumpRecordRef(ctx, d, #type, #name, name);
+#define RDAT_RECORD_ARRAY_REF(type, name)                                      \
+  DumpRecordArrayRef(ctx, d, #type, #name, name);
+#define RDAT_RECORD_VALUE(type, name)                                          \
+  DumpRecordValue(ctx, d, #type, #name, &name);
+#define RDAT_STRING(name)                                                      \
+  d.WriteLn(#name ": ", QuotedStringValue(name.Get(ctx)));
+#define RDAT_STRING_ARRAY_REF(name) DumpStringArray(ctx, d, #name, name);
+#define RDAT_VALUE(type, name) d.WriteLn(#name ": ", name);
+#define RDAT_VALUE_HEX(type, name)                                             \
+  d.WriteLn(#name ": ", std::hex, std::showbase, name);
+#define RDAT_INDEX_ARRAY_REF(name) DumpIndexArray(ctx, d, #name, name);
+#define RDAT_ENUM(sTy, eTy, name) d.DumpEnum<eTy>(#name, (eTy)name);
+#define RDAT_FLAGS(sTy, eTy, name) d.DumpFlags<eTy, sTy>(#name, name);
+#define RDAT_BYTES(name) DumpBytesRef(ctx, d, #name, name);
+#define RDAT_ARRAY_VALUE(type, count, type_name, name)                         \
+  DumpValueArray<type>(d, #name, #type, &name, count);
+
+#elif DEF_RDAT_TYPES == DEF_RDAT_TRAITS
+
+#define RDAT_STRUCT(type)                                                      \
+  template <> constexpr const char *RecordTraits<type>::TypeName() {           \
+    return #type;                                                              \
+  }
+#define RDAT_STRUCT_DERIVED(type, base) RDAT_STRUCT(type)
+#define RDAT_STRUCT_TABLE(type, table)                                         \
+  RDAT_STRUCT(type)                                                            \
+  template <> constexpr RecordTableIndex RecordTraits<type>::TableIndex() {    \
+    return RecordTableIndex::table;                                            \
+  }                                                                            \
+  template <> constexpr RuntimeDataPartType RecordTraits<type>::PartType() {   \
+    return RuntimeDataPartType::table;                                         \
+  }
+#define RDAT_STRUCT_TABLE_DERIVED(type, base, table)                           \
+  RDAT_STRUCT_DERIVED(type, base)                                              \
+  template <> constexpr RecordTableIndex RecordTraits<type>::TableIndex() {    \
+    return RecordTableIndex::table;                                            \
+  }                                                                            \
+  template <> constexpr RuntimeDataPartType RecordTraits<type>::PartType() {   \
+    return RuntimeDataPartType::table;                                         \
+  }                                                                            \
+  template <> constexpr size_t RecordTraits<base>::DerivedRecordSize() {       \
+    return RecordTraits<type>::MaxRecordSize();                                \
+  }
+#endif // DEF_RDAT_TYPES cases
+
+// Define any undefined macros to defaults
+#ifndef RDAT_STRUCT
+#define RDAT_STRUCT(type)
+#endif
+#ifndef RDAT_STRUCT_DERIVED
+#define RDAT_STRUCT_DERIVED(type, base)
+#endif
+#ifndef RDAT_STRUCT_TABLE
+#define RDAT_STRUCT_TABLE(type, table) RDAT_STRUCT(type)
+#endif
+#ifndef RDAT_STRUCT_TABLE_DERIVED
+#define RDAT_STRUCT_TABLE_DERIVED(type, base, table)                           \
+  RDAT_STRUCT_DERIVED(type, base)
+#endif
+#ifndef RDAT_STRUCT_END
+#define RDAT_STRUCT_END()
+#endif
+#ifndef RDAT_UNION
+#define RDAT_UNION()
+#endif
+#ifndef RDAT_UNION_IF
+#define RDAT_UNION_IF(                                                         \
+    name, expr) // In expr: 'this' is reader; pRecord is record struct
+#endif
+#ifndef RDAT_UNION_ELIF
+#define RDAT_UNION_ELIF(                                                       \
+    name, expr) // In expr: 'this' is reader; pRecord is record struct
+#endif
+#ifndef RDAT_UNION_ENDIF
+#define RDAT_UNION_ENDIF()
+#endif
+#ifndef RDAT_UNION_END
+#define RDAT_UNION_END()
+#endif
+#ifndef RDAT_RECORD_REF
+#define RDAT_RECORD_REF(                                                       \
+    type, name) // always use base record type in RDAT_RECORD_REF
+#endif
+#ifndef RDAT_RECORD_ARRAY_REF
+#define RDAT_RECORD_ARRAY_REF(                                                 \
+    type, name) // always use base record type in RDAT_RECORD_ARRAY_REF
+#endif
+#ifndef RDAT_RECORD_VALUE
+#define RDAT_RECORD_VALUE(type, name)
+#endif
+#ifndef RDAT_STRING
+#define RDAT_STRING(name)
+#endif
+#ifndef RDAT_STRING_ARRAY_REF
+#define RDAT_STRING_ARRAY_REF(name)
+#endif
+#ifndef RDAT_VALUE
+#define RDAT_VALUE(type, name)
+#endif
+#ifndef RDAT_VALUE_HEX
+#define RDAT_VALUE_HEX(type, name) RDAT_VALUE(type, name)
+#endif
+#ifndef RDAT_INDEX_ARRAY_REF
+#define RDAT_INDEX_ARRAY_REF(name) // ref to array of uint32_t values
+#endif
+#ifndef RDAT_ENUM
+#define RDAT_ENUM(sTy, eTy, name)
+#endif
+#ifndef RDAT_FLAGS
+#define RDAT_FLAGS(sTy, eTy, name)
+#endif
+#ifndef RDAT_BYTES
+#define RDAT_BYTES(name)
+#endif
+#ifndef RDAT_WRAP_ARRAY
+#define RDAT_WRAP_ARRAY(type, count,                                           \
+                        type_name) // define struct-wrapped array type here
+#endif
+#ifndef RDAT_ARRAY_VALUE
+#define RDAT_ARRAY_VALUE(type, count, type_name,                               \
+                         name) // define struct-wrapped array member
+#endif
+
+#endif // DEF_RDAT_TYPES defined
+
+#if defined(DEF_RDAT_ENUMS) || defined(DEF_DXIL_ENUMS)
+
+#if DEF_RDAT_ENUMS == DEF_RDAT_ENUM_CLASS
+
+#define RDAT_ENUM_START(eTy, sTy) enum class eTy : sTy {
+// No RDAT_DXIL_ENUM_START, DXIL enums are defined elsewhere
+#define RDAT_ENUM_VALUE(name, value) name = value,
+#define RDAT_ENUM_VALUE_ALIAS(name, value) name = value,
+#define RDAT_ENUM_VALUE_NODEF(name) name,
+#define RDAT_ENUM_END() CLOSE_COMPOUND_DECL
+
+#elif DEF_RDAT_ENUMS == DEF_RDAT_DUMP_DECL
+
+#define RDAT_ENUM_START(eTy, sTy) const char *ToString(eTy e);
+#define RDAT_DXIL_ENUM_START(eTy, sTy) const char *ToString(eTy e);
+
+#elif DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+
+//#define RDAT_ENUM_START(eTy, sTy) \
+  //  const char *ToString(eTy e) { \
+  //    switch((sTy)e) {
+//#define RDAT_ENUM_VALUE(name, value) case value: return #name;
+#define RDAT_ENUM_START(eTy, sTy)                                              \
+  const char *ToString(eTy e) {                                                \
+    typedef eTy thisEnumTy;                                                    \
+    switch (e) {
+#define RDAT_DXIL_ENUM_START(eTy, sTy)                                         \
+  const char *ToString(eTy e) {                                                \
+    typedef eTy thisEnumTy;                                                    \
+    switch (e) {
+#define RDAT_ENUM_VALUE_NODEF(name)                                            \
+  case thisEnumTy::name:                                                       \
+    return #name;
+#define RDAT_ENUM_VALUE(name, value) RDAT_ENUM_VALUE_NODEF(name)
+#define RDAT_ENUM_END()                                                        \
+  default:                                                                     \
+    return nullptr;                                                            \
+    }                                                                          \
+    }
+
+#endif // DEF_RDAT_ENUMS cases
+
+// Define any undefined macros to defaults
+#ifndef RDAT_ENUM_START
+#define RDAT_ENUM_START(eTy, sTy)
+#endif
+#ifndef RDAT_DXIL_ENUM_START
+#define RDAT_DXIL_ENUM_START(eTy, sTy)
+#endif
+#ifndef RDAT_ENUM_VALUE
+#define RDAT_ENUM_VALUE(name, value) // value only used during declaration
+#endif
+#ifndef RDAT_ENUM_VALUE_ALIAS
+#define RDAT_ENUM_VALUE_ALIAS(name,                                            \
+                              value) // secondary enum names that alias to the
+                                     // same value as another name in the enum
+#endif
+#ifndef RDAT_ENUM_VALUE_NODEF
+#define RDAT_ENUM_VALUE_NODEF(name) // enum names that have no explicitly
+                                    // defined value, or are defined elsewhere
+#endif
+#ifndef RDAT_ENUM_END
+#define RDAT_ENUM_END()
+#endif
+
+#endif // DEF_RDAT_ENUMS or DEF_DXIL_ENUMS defined
+
+#include "RDAT_LibraryTypes.inl"
+#include "RDAT_PdbInfoTypes.inl"
+#include "RDAT_SubobjectTypes.inl"
+
+#undef DEF_RDAT_TYPES
+#undef DEF_RDAT_ENUMS
+#undef DEF_DXIL_ENUMS
+
+#undef RDAT_STRUCT
+#undef RDAT_STRUCT_DERIVED
+#undef RDAT_STRUCT_TABLE
+#undef RDAT_STRUCT_TABLE_DERIVED
+#undef RDAT_STRUCT_END
+#undef RDAT_UNION
+#undef RDAT_UNION_IF
+#undef RDAT_UNION_ELIF
+#undef RDAT_UNION_ENDIF
+#undef RDAT_UNION_END
+#undef RDAT_RECORD_REF
+#undef RDAT_RECORD_ARRAY_REF
+#undef RDAT_RECORD_VALUE
+#undef RDAT_STRING
+#undef RDAT_STRING_ARRAY_REF
+#undef RDAT_VALUE
+#undef RDAT_VALUE_HEX
+#undef RDAT_INDEX_ARRAY_REF
+#undef RDAT_ENUM
+#undef RDAT_FLAGS
+#undef RDAT_BYTES
+#undef RDAT_WRAP_ARRAY
+#undef RDAT_ARRAY_VALUE
+
+#undef RDAT_ENUM_START
+#undef RDAT_DXIL_ENUM_START
+#undef RDAT_ENUM_VALUE
+#undef RDAT_ENUM_VALUE_ALIAS
+#undef RDAT_ENUM_VALUE_NODEF
+#undef RDAT_ENUM_END

--- a/external/dxc-rdat/dxc/DxilContainer/RDAT_PdbInfoTypes.inl
+++ b/external/dxc-rdat/dxc/DxilContainer/RDAT_PdbInfoTypes.inl
@@ -1,0 +1,41 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// RDAT_PdbInfoTypes.inl                                                     //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Defines macros use to define types Dxil PDBInfo data.                     //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef DEF_RDAT_TYPES
+
+#define RECORD_TYPE DxilPdbInfoLibrary
+RDAT_STRUCT_TABLE(DxilPdbInfoLibrary, DxilPdbInfoLibraryTable)
+RDAT_STRING(Name)
+RDAT_BYTES(Data)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE DxilPdbInfoSource
+RDAT_STRUCT_TABLE(DxilPdbInfoSource, DxilPdbInfoSourceTable)
+RDAT_STRING(Name)
+RDAT_STRING(Content)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE DxilPdbInfo
+RDAT_STRUCT_TABLE(DxilPdbInfo, DxilPdbInfoTable)
+RDAT_RECORD_ARRAY_REF(DxilPdbInfoSource, Sources)
+RDAT_RECORD_ARRAY_REF(DxilPdbInfoLibrary, Libraries)
+RDAT_STRING_ARRAY_REF(ArgPairs)
+RDAT_BYTES(Hash)
+RDAT_STRING(PdbName)
+RDAT_VALUE(uint32_t, CustomToolchainId)
+RDAT_BYTES(CustomToolchainData)
+RDAT_BYTES(WholeDxil)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#endif // DEF_RDAT_TYPES

--- a/external/dxc-rdat/dxc/DxilContainer/RDAT_SubobjectTypes.inl
+++ b/external/dxc-rdat/dxc/DxilContainer/RDAT_SubobjectTypes.inl
@@ -1,0 +1,185 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// RDAT_SubobjectTypes.inl                                                   //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Defines types used in Dxil Library Runtime Data (RDAT).                   //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+// clang-format off
+// Macro indentation makes this file easier to read, but clang-format flattens
+// everything.  Turn off clang-format for this file.
+
+//////////////////////////////////////////////////////////////////////
+// The following require validator version 1.4 and above.
+
+#ifdef DEF_RDAT_ENUMS
+
+// Nothing yet
+
+#endif // DEF_RDAT_ENUMS
+
+#ifdef DEF_DXIL_ENUMS
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::SubobjectKind, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(StateObjectConfig)
+  RDAT_ENUM_VALUE_NODEF(GlobalRootSignature)
+  RDAT_ENUM_VALUE_NODEF(LocalRootSignature)
+  RDAT_ENUM_VALUE_NODEF(SubobjectToExportsAssociation)
+  RDAT_ENUM_VALUE_NODEF(RaytracingShaderConfig)
+  RDAT_ENUM_VALUE_NODEF(RaytracingPipelineConfig)
+  RDAT_ENUM_VALUE_NODEF(HitGroup)
+  RDAT_ENUM_VALUE_NODEF(RaytracingPipelineConfig1)
+  // No need to define this here
+  //RDAT_ENUM_VALUE_NODEF(NumKinds)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::SubobjectKind::NumKinds == 13,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::StateObjectFlags, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(AllowLocalDependenciesOnExternalDefinitions)
+  RDAT_ENUM_VALUE_NODEF(AllowExternalDependenciesOnLocalDefinitions)
+  RDAT_ENUM_VALUE_NODEF(AllowStateObjectAdditions)
+  // No need to define these masks here
+  //RDAT_ENUM_VALUE_NODEF(ValidMask_1_4)
+  //RDAT_ENUM_VALUE_NODEF(ValidMask)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::StateObjectFlags::ValidMask == 0x7,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::HitGroupType, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Triangle)
+  RDAT_ENUM_VALUE_NODEF(ProceduralPrimitive)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::HitGroupType::LastEntry == 2,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::RaytracingPipelineFlags, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(None)
+  RDAT_ENUM_VALUE_NODEF(SkipTriangles)
+  RDAT_ENUM_VALUE_NODEF(SkipProceduralPrimitives)
+  // No need to define mask here
+  // RDAT_ENUM_VALUE_NODEF(ValidMask)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::RaytracingPipelineFlags::ValidMask ==
+                    0x300,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+#endif // DEF_DXIL_ENUMS
+
+#ifdef DEF_RDAT_TYPES
+
+#define RECORD_TYPE StateObjectConfig_t
+RDAT_STRUCT(StateObjectConfig_t)
+  RDAT_FLAGS(uint32_t, hlsl::DXIL::StateObjectFlags, Flags)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE RootSignature_t
+RDAT_STRUCT(RootSignature_t)
+  RDAT_BYTES(Data)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE SubobjectToExportsAssociation_t
+RDAT_STRUCT(SubobjectToExportsAssociation_t)
+  RDAT_STRING(Subobject)
+  RDAT_STRING_ARRAY_REF(Exports)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE RaytracingShaderConfig_t
+RDAT_STRUCT(RaytracingShaderConfig_t)
+  RDAT_VALUE(uint32_t, MaxPayloadSizeInBytes)
+  RDAT_VALUE(uint32_t, MaxAttributeSizeInBytes)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE RaytracingPipelineConfig_t
+RDAT_STRUCT(RaytracingPipelineConfig_t)
+  RDAT_VALUE(uint32_t, MaxTraceRecursionDepth)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE HitGroup_t
+RDAT_STRUCT(HitGroup_t)
+  RDAT_ENUM(uint32_t, hlsl::DXIL::HitGroupType, Type)
+  RDAT_STRING(AnyHit)
+  RDAT_STRING(ClosestHit)
+  RDAT_STRING(Intersection)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE RaytracingPipelineConfig1_t
+RDAT_STRUCT(RaytracingPipelineConfig1_t)
+  RDAT_VALUE(uint32_t, MaxTraceRecursionDepth)
+  RDAT_FLAGS(uint32_t, hlsl::DXIL::RaytracingPipelineFlags, Flags)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE RuntimeDataSubobjectInfo
+RDAT_STRUCT_TABLE(RuntimeDataSubobjectInfo, SubobjectTable)
+  RDAT_ENUM(uint32_t, hlsl::DXIL::SubobjectKind, Kind)
+  RDAT_STRING(Name)
+  RDAT_UNION()
+    RDAT_UNION_IF(StateObjectConfig,
+                  ((uint32_t)pRecord->Kind ==
+                   (uint32_t)hlsl::DXIL::SubobjectKind::StateObjectConfig))
+      RDAT_RECORD_VALUE(StateObjectConfig_t, StateObjectConfig)
+    RDAT_UNION_ELIF(
+        RootSignature,
+        ((uint32_t)pRecord->Kind ==
+         (uint32_t)hlsl::DXIL::SubobjectKind::GlobalRootSignature) ||
+            ((uint32_t)pRecord->Kind ==
+             (uint32_t)hlsl::DXIL::SubobjectKind::LocalRootSignature))
+      RDAT_RECORD_VALUE(RootSignature_t, RootSignature)
+    RDAT_UNION_ELIF(
+        SubobjectToExportsAssociation,
+        ((uint32_t)pRecord->Kind ==
+         (uint32_t)hlsl::DXIL::SubobjectKind::SubobjectToExportsAssociation))
+      RDAT_RECORD_VALUE(SubobjectToExportsAssociation_t,
+                        SubobjectToExportsAssociation)
+    RDAT_UNION_ELIF(
+        RaytracingShaderConfig,
+        ((uint32_t)pRecord->Kind ==
+         (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingShaderConfig))
+      RDAT_RECORD_VALUE(RaytracingShaderConfig_t, RaytracingShaderConfig)
+    RDAT_UNION_ELIF(
+        RaytracingPipelineConfig,
+        ((uint32_t)pRecord->Kind ==
+         (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingPipelineConfig))
+      RDAT_RECORD_VALUE(RaytracingPipelineConfig_t, RaytracingPipelineConfig)
+    RDAT_UNION_ELIF(HitGroup, ((uint32_t)pRecord->Kind ==
+                               (uint32_t)hlsl::DXIL::SubobjectKind::HitGroup))
+      RDAT_RECORD_VALUE(HitGroup_t, HitGroup)
+    RDAT_UNION_ELIF(
+        RaytracingPipelineConfig1,
+        ((uint32_t)pRecord->Kind ==
+         (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingPipelineConfig1))
+      RDAT_RECORD_VALUE(RaytracingPipelineConfig1_t, RaytracingPipelineConfig1)
+    RDAT_UNION_ENDIF()
+  RDAT_UNION_END()
+
+  // Note: this is how one could inject custom code into one of the definition
+  // modes:
+#if DEF_RDAT_TYPES == DEF_RDAT_READER
+  // Add custom code here that only gets added to the reader class definition
+#endif
+
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#endif // DEF_RDAT_TYPES
+
+// clang-format on

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -481,8 +481,49 @@ if (${RUN_TESTS})
     add_executable(gfxrecon_decode_test "")
     target_sources(gfxrecon_decode_test PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
+            $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/test/dxr_lrs_tests.cpp>
             ${CMAKE_CURRENT_LIST_DIR}/../../tools/platform_debug_helper.cpp)
-    target_link_libraries(gfxrecon_decode_test PRIVATE gfxrecon_decode)
+    # The in-DXIL LRS tests pull dx12_resource_value_mapper.obj into the test exe, which references symbols from
+    # d3d12.lib and DXC that gfxrecon_decode (a static lib) leaves to the consuming executable.
+    target_link_libraries(gfxrecon_decode_test
+                            PRIVATE
+                                gfxrecon_decode
+                                $<$<BOOL:${D3D12_SUPPORT}>:d3d12.lib>
+                                $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>
+                                $<$<BOOL:${DXC_FOUND}>:${DXC_LIBRARY_PATH}>)
+    if (D3D12_SUPPORT AND DXC_FOUND)
+        # dxcompiler.dll must sit beside the test exe at load time (the RDAT reader imports DxcCreateInstance).
+        add_custom_command(TARGET gfxrecon_decode_test POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${DXC_DLL_PATH}" "$<TARGET_FILE_DIR:gfxrecon_decode_test>")
+
+        # Stage the Agility SDK runtime (a D3D12/ folder beside the test exe). The in-DXIL LRS resolver deserializes
+        # through ID3D12DeviceConfiguration1 which requires the Agility SDK runtime to be loaded.
+        include(${PROJECT_SOURCE_DIR}/cmake/AgilitySDK.cmake)
+
+        # Compile the in-DXIL LRS test shaders from HLSL to DXIL libraries with the DXC executable from the fetched
+        # DXC redist. Each .hlsl declares subobjects that land in the library's RDAT part.
+        get_filename_component(DXC_BIN_DIR "${DXC_DLL_PATH}" DIRECTORY)
+        set(DXR_LRS_FIXTURE_SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/test/dxr_lrs_fixtures)
+        set(DXR_LRS_FIXTURE_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR}/dxr_lrs_fixtures)
+        set(DXR_LRS_FIXTURES default_lrs associated_lrs two_lrs global_and_local mixed_lrs no_subobjects)
+        set(DXR_LRS_FIXTURE_OUTPUTS "")
+        foreach(fixture ${DXR_LRS_FIXTURES})
+            add_custom_command(
+                OUTPUT ${DXR_LRS_FIXTURE_BIN_DIR}/${fixture}.cso
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${DXR_LRS_FIXTURE_BIN_DIR}
+                COMMAND "${DXC_BIN_DIR}/dxc.exe" -T lib_6_3
+                        -Fo ${DXR_LRS_FIXTURE_BIN_DIR}/${fixture}.cso
+                        ${DXR_LRS_FIXTURE_SRC_DIR}/${fixture}.hlsl
+                DEPENDS ${DXR_LRS_FIXTURE_SRC_DIR}/${fixture}.hlsl
+                COMMENT "Compiling DXR LRS fixture ${fixture}.hlsl")
+            list(APPEND DXR_LRS_FIXTURE_OUTPUTS ${DXR_LRS_FIXTURE_BIN_DIR}/${fixture}.cso)
+        endforeach()
+        add_custom_target(dxr_lrs_fixtures DEPENDS ${DXR_LRS_FIXTURE_OUTPUTS})
+        add_dependencies(gfxrecon_decode_test dxr_lrs_fixtures)
+        target_compile_definitions(gfxrecon_decode_test PRIVATE
+                                   GFXRECON_TEST_DXR_LRS_FIXTURE_DIR="${DXR_LRS_FIXTURE_BIN_DIR}")
+    endif()
     if (MSVC)
         # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
         # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -179,6 +179,7 @@ target_sources(gfxrecon_decode
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_resource_value_tracker.cpp>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_experimental_resource_value_tracker.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_experimental_resource_value_tracker.cpp>
+                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_dxil_lrs_parser.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_resource_value_mapper.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_resource_value_mapper.cpp>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_json_consumer_base.h>

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -506,7 +506,8 @@ if (${RUN_TESTS})
         get_filename_component(DXC_BIN_DIR "${DXC_DLL_PATH}" DIRECTORY)
         set(DXR_LRS_FIXTURE_SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/test/dxr_lrs_fixtures)
         set(DXR_LRS_FIXTURE_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR}/dxr_lrs_fixtures)
-        set(DXR_LRS_FIXTURES default_lrs associated_lrs two_lrs global_and_local mixed_lrs no_subobjects)
+        set(DXR_LRS_FIXTURES default_lrs associated_lrs multi_association two_lrs global_and_local mixed_lrs
+            no_subobjects)
         set(DXR_LRS_FIXTURE_OUTPUTS "")
         foreach(fixture ${DXR_LRS_FIXTURES})
             add_custom_command(

--- a/framework/decode/dx12_dxil_lrs_parser.h
+++ b/framework/decode/dx12_dxil_lrs_parser.h
@@ -1,0 +1,52 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_DX12_DXIL_LRS_PARSER_H
+#define GFXRECON_DECODE_DX12_DXIL_LRS_PARSER_H
+
+#include "decode/dx12_object_info.h"
+#include "util/defines.h"
+
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+#if defined(GFXRECON_DXC_SUPPORT)
+// Parse local root signatures and their associations from inside a DXIL library. This function is defined in
+// dx12_resource_value_mapper.cpp and declared here so the decode unit tests in framework/decode/test/dxr_lrs_tests.cpp
+// can exercise it.
+void GetDxilLibraryInDxilLrsInfo(const void*                                          dxil_library_bytecode,
+                                 SIZE_T                                               bytecode_length,
+                                 format::HandleId                                     state_object_id,
+                                 ID3D12DeviceConfiguration1*                          device_config,
+                                 std::set<ResourceValueInfo>&                         default_lrs_value_infos,
+                                 std::map<std::wstring, std::set<ResourceValueInfo>>& export_lrs_value_infos);
+#endif // GFXRECON_DXC_SUPPORT
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_DX12_DXIL_LRS_PARSER_H

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -4636,7 +4636,7 @@ Dx12ReplayConsumerBase::OverrideCreateStateObject(DxObjectInfo* device5_object_i
 
         if (resource_value_mapper_ != nullptr)
         {
-            resource_value_mapper_->PostProcessCreateStateObject(state_object_decoder, desc_decoder, nullptr);
+            resource_value_mapper_->PostProcessCreateStateObject(device5, state_object_decoder, desc_decoder, nullptr);
         }
     }
 
@@ -4671,7 +4671,7 @@ Dx12ReplayConsumerBase::OverrideAddToStateObject(
             auto state_object_to_grow_from_extra_info =
                 GetExtraInfo<D3D12StateObjectInfo>(state_object_to_grow_from_object_info);
             resource_value_mapper_->PostProcessCreateStateObject(
-                new_state_object_decoder, addition_decoder, state_object_to_grow_from_extra_info);
+                device7, new_state_object_decoder, addition_decoder, state_object_to_grow_from_extra_info);
         }
     }
 

--- a/framework/decode/dx12_resource_value_mapper.cpp
+++ b/framework/decode/dx12_resource_value_mapper.cpp
@@ -24,15 +24,22 @@
 #include "decode/dx12_resource_value_mapper.h"
 
 #include "decode/custom_dx12_struct_decoders.h"
+#include "decode/dx12_dxil_lrs_parser.h"
 #include "decode/dx12_experimental_resource_value_tracker.h"
 #include "decode/dx12_object_mapping_util.h"
 
 #if defined(GFXRECON_DXC_SUPPORT)
 #include <d3d12shader.h>
 #include <dxcapi.h>
+
+// Header-only DXC reader for a DXIL container's RDAT (runtime data) part. The .inl pulls in
+// its function definitions, so it must be included in exactly one translation unit (this one).
+#include "dxc/DxilContainer/DxilRuntimeReflection.inl"
 #endif
 
 #include <codecvt>
+#include <stdexcept>
+#include <tuple>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -151,31 +158,269 @@ void CopyMappedResourceValuesFromSrcToDst(std::map<uint64_t, T>&                
     }
 }
 
-std::string DemangleDxilExportName(const std::string& mangled_name)
+std::tuple<bool, std::string> TryDemangleDxilExportName(const std::string& export_name)
 {
-    size_t demangled_name_start = mangled_name.find_first_of("?");
-    size_t demangled_name_end   = mangled_name.find_first_of("@");
+    bool        was_demangled  = false;
+    std::string demangled_name = export_name;
 
-    std::string demangled_name = "";
-    if (demangled_name_start != std::string::npos && demangled_name_end != std::string::npos)
+    size_t demangled_name_start = export_name.find_first_of("?");
+    size_t demangled_name_end   = export_name.find_first_of("@");
+    if ((demangled_name_start != std::string::npos) && (demangled_name_end != std::string::npos) &&
+        (demangled_name_end > demangled_name_start))
     {
         // The char after '?' is the first char of the unmangled name so increment start pos.
         ++demangled_name_start;
-        demangled_name = mangled_name.substr(demangled_name_start, demangled_name_end - demangled_name_start);
+        demangled_name = export_name.substr(demangled_name_start, demangled_name_end - demangled_name_start);
+        was_demangled  = true;
     }
 
-    if (!demangled_name.empty())
-    {
-        GFXRECON_LOG_DEBUG("Found demangled DXIL export name '%s'.", demangled_name.c_str());
-    }
-    else
-    {
-        GFXRECON_LOG_WARNING("Failed to demangle DXIL export name '%s'.", mangled_name.c_str());
-    }
-    return demangled_name;
+    return { was_demangled, demangled_name };
 }
 
 } // namespace
+
+#if defined(GFXRECON_DXC_SUPPORT)
+// GetDxilLibraryInDxilLrsInfo has external linkage (declared in dx12_dxil_lrs_parser.h) so the decode unit test can
+// exercise it directly.
+
+// Recover the local root signatures authored inside a DXIL library (HLSL LocalRootSignature /
+// SubobjectToExportsAssociation subobjects, which live in the container's RDAT part) and resolve their export
+// associations.
+void GetDxilLibraryInDxilLrsInfo(const void*                                          dxil_library_bytecode,
+                                 SIZE_T                                               bytecode_length,
+                                 format::HandleId                                     state_object_id,
+                                 ID3D12DeviceConfiguration1*                          device_config,
+                                 std::set<ResourceValueInfo>&                         default_lrs_value_infos,
+                                 std::map<std::wstring, std::set<ResourceValueInfo>>& export_lrs_value_infos)
+{
+    if ((dxil_library_bytecode == nullptr) || (bytecode_length == 0))
+    {
+        return;
+    }
+
+    if (device_config == nullptr)
+    {
+        // ID3D12DeviceConfiguration1 is the only way to deserialize an in-DXIL local root signature.
+        GFXRECON_LOG_WARNING_ONCE(
+            "The replay device does not support ID3D12DeviceConfiguration1, so local root signatures authored inside "
+            "DXIL libraries cannot be deserialized. Some DXR shader-binding-table arguments may be left unmapped.");
+        return;
+    }
+
+    graphics::dx12::IDxcUtilsComPtr dxc_utils;
+    if (FAILED(DxcCreateInstance(CLSID_DxcUtils, IID_PPV_ARGS(&dxc_utils))))
+    {
+        GFXRECON_LOG_WARNING_ONCE("GetDxilLibraryInDxilLrsInfo: Failed to create a DxcUtils instance. Cannot parse "
+                                  "local root signatures from DXIL libraries.");
+        return;
+    }
+
+    graphics::dx12::IDxcContainerReflectionComPtr container_reflection;
+    if (FAILED(DxcCreateInstance(CLSID_DxcContainerReflection, IID_PPV_ARGS(&container_reflection))))
+    {
+        GFXRECON_LOG_WARNING_ONCE(
+            "GetDxilLibraryInDxilLrsInfo: Failed to create a DxcContainerReflection instance. Cannot parse "
+            "local root signatures from DXIL libraries.");
+        return;
+    }
+
+    graphics::dx12::IDxcBlobEncodingComPtr container_blob;
+    if (FAILED(dxc_utils->CreateBlobFromPinned(
+            dxil_library_bytecode, static_cast<UINT32>(bytecode_length), DXC_CP_ACP, &container_blob)))
+    {
+        GFXRECON_LOG_WARNING_ONCE("GetDxilLibraryInDxilLrsInfo: Failed to create a DXC blob for a DXIL library. "
+                                  "Shader ID to LRS associations may be incorrect.");
+        return;
+    }
+    if (FAILED(container_reflection->Load(container_blob)))
+    {
+        GFXRECON_LOG_WARNING_ONCE("GetDxilLibraryInDxilLrsInfo: Failed to load a DXIL library into container "
+                                  "reflection. Shader ID to LRS associations may be incorrect.");
+        return;
+    }
+
+    // The DXC redist's dxcapi.h defines no RDAT part constant, so construct the fourcc directly.
+    constexpr UINT32 kDxcPartRuntimeData = DXC_FOURCC('R', 'D', 'A', 'T');
+    UINT32           rdat_part_index     = 0;
+    if (FAILED(container_reflection->FindFirstPartKind(kDxcPartRuntimeData, &rdat_part_index)))
+    {
+        // No RDAT part means the library carries no runtime-data subobjects.
+        return;
+    }
+
+    graphics::dx12::IDxcBlobComPtr rdat_blob;
+    if (FAILED(container_reflection->GetPartContent(rdat_part_index, &rdat_blob)))
+    {
+        GFXRECON_LOG_WARNING_ONCE(
+            "Failed to read the RDAT part of a DXIL library. Shader ID to LRS associations may be incorrect.");
+        return;
+    }
+
+    hlsl::RDAT::DxilRuntimeData rdat;
+    if (!rdat.InitFromRDAT(rdat_blob->GetBufferPointer(), rdat_blob->GetBufferSize()))
+    {
+        GFXRECON_LOG_DEBUG("Failed to parse RDAT runtime data from a DXIL library subobject.");
+        return;
+    }
+
+    // Compute resource value infos for each in-DXIL LRS (keyed by subobject name) and collect any
+    // explicit subobject-to-exports associations. A LocalRootSignature with no association is the library default.
+    std::map<std::string, std::set<ResourceValueInfo>> named_lrs_value_infos;
+    std::map<std::string, std::vector<std::string>>    associations;
+    auto                                               subobjects = rdat.GetSubobjectTable();
+    for (uint32_t i = 0; i < subobjects.Count(); ++i)
+    {
+        auto subobject = subobjects[i];
+        switch (subobject.getKind())
+        {
+            case hlsl::DXIL::SubobjectKind::LocalRootSignature:
+            {
+                // Deserialize the in-DXIL local root signature using
+                // CreateVersionedRootSignatureDeserializerFromSubobjectInLibrary, then walk the resulting desc with the
+                // same helper the API root-signature path uses.
+                std::wstring subobject_name;
+                try
+                {
+                    subobject_name =
+                        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>().from_bytes(subobject.getName());
+                }
+                catch (const std::range_error&)
+                {
+                    GFXRECON_LOG_WARNING("Failed to convert the name '%s' of an in-DXIL local root signature in state "
+                                         "object (id=%" PRIu64 ") to UTF-16. Shader ID to LRS associations may be "
+                                         "incorrect.",
+                                         subobject.getName(),
+                                         state_object_id);
+                    break;
+                }
+                graphics::dx12::ID3D12VersionedRootSignatureDeserializerComPtr deserializer;
+                HRESULT hr = device_config->CreateVersionedRootSignatureDeserializerFromSubobjectInLibrary(
+                    dxil_library_bytecode, bytecode_length, subobject_name.c_str(), IID_PPV_ARGS(&deserializer));
+                if (SUCCEEDED(hr) && (deserializer != nullptr))
+                {
+                    std::set<ResourceValueInfo>                value_infos;
+                    const D3D12_VERSIONED_ROOT_SIGNATURE_DESC* versioned =
+                        deserializer->GetUnconvertedRootSignatureDesc();
+                    switch (versioned->Version)
+                    {
+                        case D3D_ROOT_SIGNATURE_VERSION_1_0:
+                            GetRootSignatureResourceValueInfos(&versioned->Desc_1_0, value_infos);
+                            break;
+                        case D3D_ROOT_SIGNATURE_VERSION_1_1:
+                            GetRootSignatureResourceValueInfos(&versioned->Desc_1_1, value_infos);
+                            break;
+                        case D3D_ROOT_SIGNATURE_VERSION_1_2:
+                            GetRootSignatureResourceValueInfos(&versioned->Desc_1_2, value_infos);
+                            break;
+                        default:
+                            GFXRECON_LOG_WARNING("Ignoring in-DXIL local root signature '%s' with unrecognized version "
+                                                 "(%d) in state object (id=%" PRIu64 ").",
+                                                 subobject.getName(),
+                                                 versioned->Version,
+                                                 state_object_id);
+                            break;
+                    }
+                    named_lrs_value_infos[subobject.getName()] = std::move(value_infos);
+                }
+                else
+                {
+                    GFXRECON_LOG_WARNING("Failed to deserialize in-DXIL local root signature '%s' in state object "
+                                         "(id=%" PRIu64
+                                         ") (hr=0x%08lx). Shader ID to LRS associations may be incorrect.",
+                                         subobject.getName(),
+                                         state_object_id,
+                                         static_cast<unsigned long>(hr));
+                }
+                break;
+            }
+            case hlsl::DXIL::SubobjectKind::SubobjectToExportsAssociation:
+            {
+                auto                     association = subobject.getSubobjectToExportsAssociation();
+                auto                     exports     = association.getExports();
+                std::vector<std::string> export_list;
+                for (uint32_t e = 0; e < exports.Count(); ++e)
+                {
+                    export_list.push_back(exports[e]);
+                }
+                associations[association.getSubobject()] = std::move(export_list);
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    // Resolve associations that target an LRS. An association with no exports is an explicit default.
+    std::set<std::string> associated_lrs_names;
+    for (const auto& association : associations)
+    {
+        auto lrs_iter = named_lrs_value_infos.find(association.first);
+        if (lrs_iter == named_lrs_value_infos.end())
+        {
+            continue;
+        }
+        associated_lrs_names.insert(association.first);
+
+        if (association.second.empty())
+        {
+            if (!default_lrs_value_infos.empty())
+            {
+                GFXRECON_LOG_WARNING("Found multiple default in-DXIL local root signatures in state object (id=%" PRIu64
+                                     "). Shader ID to LRS associations may be incorrect.",
+                                     state_object_id);
+            }
+            default_lrs_value_infos = lrs_iter->second;
+        }
+        else
+        {
+            // Associate the local root signature with each listed export. GFXR needs the unmangled name to match the
+            // names passed to ID3D12StateObjectProperties::GetShaderIdentifier. Inspection of the test fixtures shows
+            // that their in-DXIL associations resolve to unmangled names. The demangling path below is kept to be
+            // defensive but has not been exercised.
+            for (const auto& mangled_export : association.second)
+            {
+                auto [was_demangled, demangled_export] = TryDemangleDxilExportName(mangled_export);
+                std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+                try
+                {
+                    export_lrs_value_infos[converter.from_bytes(demangled_export)] = lrs_iter->second;
+                }
+                catch (const std::range_error&)
+                {
+                    GFXRECON_LOG_WARNING("Failed to convert in-DXIL association export name '%s' to UTF-16. Shader ID "
+                                         "to LRS associations may be incorrect.",
+                                         demangled_export.c_str());
+                    continue;
+                }
+
+                if (was_demangled)
+                {
+                    GFXRECON_LOG_WARNING("Found a mangled export name '%s' in an in-DXIL explicit LRS association. "
+                                         "Demangling has not been exercised on this path, so the association may be "
+                                         "incorrect.",
+                                         mangled_export.c_str());
+                }
+            }
+        }
+    }
+
+    // Any LRS without an explicit association is the implicit default for the library's exports.
+    for (const auto& named_lrs : named_lrs_value_infos)
+    {
+        if (associated_lrs_names.count(named_lrs.first) != 0)
+        {
+            continue;
+        }
+        if (!default_lrs_value_infos.empty())
+        {
+            GFXRECON_LOG_WARNING("Found multiple default in-DXIL local root signatures in state object (id=%" PRIu64
+                                 "). Shader ID to LRS associations may be incorrect.",
+                                 state_object_id);
+        }
+        default_lrs_value_infos = named_lrs.second;
+    }
+}
+#endif // GFXRECON_DXC_SUPPORT
 
 Dx12ResourceValueMapper::Dx12ResourceValueMapper(std::function<DxObjectInfo*(format::HandleId id)> get_object_info_func,
                                                  const graphics::Dx12ShaderIdMap&                  shader_id_map,
@@ -643,6 +888,7 @@ void Dx12ResourceValueMapper::PostProcessCreateRootSignature(PointerDecoder<uint
 }
 
 void Dx12ResourceValueMapper::PostProcessCreateStateObject(
+    ID3D12Device*                                          device,
     HandlePointerDecoder<void*>*                           state_object_decoder,
     StructPointerDecoder<Decoded_D3D12_STATE_OBJECT_DESC>* desc_decoder,
     const D3D12StateObjectInfo*                            grow_from_state_object)
@@ -656,6 +902,11 @@ void Dx12ResourceValueMapper::PostProcessCreateStateObject(
     std::map<std::wstring, format::HandleId>       lrs_associations_map;
     std::map<graphics::Dx12ShaderIdentifier, std::set<ResourceValueInfo>> existing_shader_id_lrs_map;
 
+    // Local root signatures authored inside a DXIL library have no handle id, so they resolve to resource value infos
+    // directly. There can be a default LRS or per-export associations.
+    std::set<ResourceValueInfo>                         in_dxil_default_lrs_value_infos;
+    std::map<std::wstring, std::set<ResourceValueInfo>> in_dxil_export_lrs_value_infos;
+
     auto state_object_extra_info = GetExtraInfo<D3D12StateObjectInfo>(state_object_decoder);
     if (grow_from_state_object != nullptr)
     {
@@ -663,15 +914,22 @@ void Dx12ResourceValueMapper::PostProcessCreateStateObject(
                                                           grow_from_state_object->shader_id_lrs_map.end());
     }
 
+    // Query for the ID3D12DeviceConfiguration1 object that is used to deserialize in-DXIL root signatures.
+    graphics::dx12::ID3D12DeviceConfiguration1ComPtr device_config;
+    device->QueryInterface(IID_PPV_ARGS(&device_config));
+
     GetStateObjectLrsAssociationInfo(state_object_id,
                                      desc_decoder,
+                                     device_config,
                                      export_names,
                                      local_root_signature_ids,
                                      explicit_default_local_root_signature_id,
                                      explicit_local_root_signature_associations,
                                      hit_group_imports,
                                      lrs_associations_map,
-                                     existing_shader_id_lrs_map);
+                                     existing_shader_id_lrs_map,
+                                     in_dxil_default_lrs_value_infos,
+                                     in_dxil_export_lrs_value_infos);
 
     if (!export_names.empty())
     {
@@ -762,44 +1020,112 @@ void Dx12ResourceValueMapper::PostProcessCreateStateObject(
         GFXRECON_ASSERT(SUCCEEDED(hr));
         for (auto& root_sig_pair : lrs_associations_map)
         {
-            auto export_local_root_sig_id = root_sig_pair.second;
+            const auto& export_name              = root_sig_pair.first;
+            auto        export_local_root_sig_id = root_sig_pair.second;
+
+            // Only exports with shader identifiers can be referenced from DXR shader-binding tables. Skip any exports
+            // without a valid shader ID.
+            auto new_shader_identifier_ptr = static_cast<uint8_t*>(props->GetShaderIdentifier(export_name.c_str()));
+            if (new_shader_identifier_ptr == nullptr)
+            {
+                continue;
+            }
+
+            // Resolve the export's LRS resource value infos.
+            //  - Resource values from API-level LRS are looked up by HandleId.
+            //  - In-DXIL LRS have no HandleId and supply their resource value infos directly.
+            //  - Any API-level associations (explicit or default) takes precedence over any in-DXIL one.
+            const std::set<ResourceValueInfo>* resolved_value_infos = nullptr;
             if (export_local_root_sig_id != format::kNullHandleId)
             {
-                const auto& export_name        = root_sig_pair.first;
-                auto new_shader_identifier_ptr = static_cast<uint8_t*>(props->GetShaderIdentifier(export_name.c_str()));
-                if (new_shader_identifier_ptr != nullptr)
+                auto local_root_sig_object_info = get_object_info_func_(export_local_root_sig_id);
+                GFXRECON_ASSERT(local_root_sig_object_info != nullptr);
+
+                auto local_root_sig_extra_info = GetExtraInfo<D3D12RootSignatureInfo>(local_root_sig_object_info);
+                GFXRECON_ASSERT(local_root_sig_extra_info != nullptr);
+
+                resolved_value_infos = &local_root_sig_extra_info->resource_value_infos;
+
+                GFXRECON_LOG_DEBUG("CreateStateObject: associating export '%ls' in state object (id=%" PRIu64
+                                   ") to local root signature (id=%" PRIu64 ")",
+                                   export_name.c_str(),
+                                   state_object_id,
+                                   export_local_root_sig_id);
+            }
+            else
+            {
+                // A hit group's local root signature may be associated to one of its component shaders
+                // (closest-hit/any-hit/intersection) rather than to the hit group export, so promote a component's
+                // in-DXIL association to the hit group, mirroring the API-handle promotion above. The spec requires a
+                // hit group's component shaders to share one local root signature, so the loop can break after the
+                // first matching import.
+                auto in_dxil_iter = in_dxil_export_lrs_value_infos.find(export_name);
+                if (in_dxil_iter == in_dxil_export_lrs_value_infos.end())
                 {
-                    auto replay_shader_id = graphics::PackDx12ShaderIdentifier(new_shader_identifier_ptr);
-
-                    auto local_root_sig_object_info = get_object_info_func_(export_local_root_sig_id);
-                    GFXRECON_ASSERT(local_root_sig_object_info != nullptr);
-
-                    auto local_root_sig_extra_info = GetExtraInfo<D3D12RootSignatureInfo>(local_root_sig_object_info);
-                    GFXRECON_ASSERT(local_root_sig_extra_info != nullptr);
-
-                    auto lrs_map = state_object_extra_info->shader_id_lrs_map.find(replay_shader_id);
-                    if (lrs_map == state_object_extra_info->shader_id_lrs_map.end())
+                    auto hit_group_import_iter = hit_group_imports.find(export_name);
+                    if (hit_group_import_iter != hit_group_imports.end())
                     {
-                        state_object_extra_info->shader_id_lrs_map[replay_shader_id] =
-                            local_root_sig_extra_info->resource_value_infos;
-                    }
-                    else
-                    {
-                        if (!((lrs_map->second.size() == local_root_sig_extra_info->resource_value_infos.size()) &&
-                              (std::equal(lrs_map->second.begin(),
-                                          lrs_map->second.end(),
-                                          local_root_sig_extra_info->resource_value_infos.begin()))))
+                        for (const auto& hit_group_import : hit_group_import_iter->second)
                         {
-                            // Given a ShaderID to the StateObject, if it already assocated LRS but different from
-                            // defined in the current StateObject, GFXR could not determind which LRS is right to the
-                            // ShaderID.
-                            GFXRECON_LOG_ERROR_ONCE(
-                                "CreateStateObject: Duplicate shader identifier found for export '%ls' in "
-                                "state object (id=%" PRIu64 "). Shader ID to LRS associations may be incorrect.",
-                                export_name.c_str(),
-                                state_object_id);
+                            auto import_iter = in_dxil_export_lrs_value_infos.find(hit_group_import);
+                            if (import_iter != in_dxil_export_lrs_value_infos.end())
+                            {
+                                in_dxil_iter = import_iter;
+                                break;
+                            }
                         }
                     }
+                }
+
+                if (in_dxil_iter != in_dxil_export_lrs_value_infos.end())
+                {
+                    resolved_value_infos = &in_dxil_iter->second;
+
+                    GFXRECON_LOG_DEBUG("CreateStateObject: found explicit association between export '%ls' in state "
+                                       "object (id=%" PRIu64 ") and an in-DXIL local root signature.",
+                                       export_name.c_str(),
+                                       state_object_id);
+                }
+                else if (!in_dxil_default_lrs_value_infos.empty())
+                {
+                    resolved_value_infos = &in_dxil_default_lrs_value_infos;
+
+                    GFXRECON_LOG_DEBUG("CreateStateObject: found default association between export '%ls' in state "
+                                       "object (id=%" PRIu64 ") and an in-DXIL local root signature.",
+                                       export_name.c_str(),
+                                       state_object_id);
+                }
+            }
+
+            if (resolved_value_infos == nullptr)
+            {
+                GFXRECON_LOG_DEBUG("CreateStateObject: found no local root signature association for export '%ls' in "
+                                   "state object (id=%" PRIu64 ")",
+                                   export_name.c_str(),
+                                   state_object_id);
+                continue;
+            }
+
+            auto replay_shader_id = graphics::PackDx12ShaderIdentifier(new_shader_identifier_ptr);
+
+            auto lrs_map = state_object_extra_info->shader_id_lrs_map.find(replay_shader_id);
+            if (lrs_map == state_object_extra_info->shader_id_lrs_map.end())
+            {
+                state_object_extra_info->shader_id_lrs_map[replay_shader_id] = *resolved_value_infos;
+            }
+            else
+            {
+                if (!((lrs_map->second.size() == resolved_value_infos->size()) &&
+                      (std::equal(lrs_map->second.begin(), lrs_map->second.end(), resolved_value_infos->begin()))))
+                {
+                    // Given a ShaderID to the StateObject, if it already assocated LRS but different from
+                    // defined in the current StateObject, GFXR could not determind which LRS is right to the
+                    // ShaderID.
+                    GFXRECON_LOG_ERROR_ONCE("CreateStateObject: Duplicate shader identifier found for export '%ls' in "
+                                            "state object (id=%" PRIu64
+                                            "). Shader ID to LRS associations may be incorrect.",
+                                            export_name.c_str(),
+                                            state_object_id);
                 }
             }
         }
@@ -1724,13 +2050,16 @@ void Dx12ResourceValueMapper::GetExecuteIndirectResourceValues(
 void Dx12ResourceValueMapper::GetStateObjectLrsAssociationInfo(
     format::HandleId                                                       state_object_id,
     StructPointerDecoder<Decoded_D3D12_STATE_OBJECT_DESC>*                 desc_decoder,
+    ID3D12DeviceConfiguration1*                                            device_config,
     std::set<std::wstring>&                                                export_names,
     std::vector<format::HandleId>&                                         local_root_signature_ids,
     format::HandleId&                                                      explicit_default_local_root_signature_id,
     std::map<std::wstring, format::HandleId>&                              explicit_local_root_signature_associations,
     std::map<std::wstring, std::set<std::wstring>>&                        hit_group_imports,
     std::map<std::wstring, format::HandleId>&                              lrs_associations_map,
-    std::map<graphics::Dx12ShaderIdentifier, std::set<ResourceValueInfo>>& existing_shader_id_lrs_map)
+    std::map<graphics::Dx12ShaderIdentifier, std::set<ResourceValueInfo>>& existing_shader_id_lrs_map,
+    std::set<ResourceValueInfo>&                                           in_dxil_default_lrs_value_infos,
+    std::map<std::wstring, std::set<ResourceValueInfo>>&                   in_dxil_export_lrs_value_infos)
 {
     const auto* desc               = desc_decoder->GetPointer();
     const auto* subobject_decoders = desc_decoder->GetMetaStructPointer()->pSubobjects;
@@ -1785,14 +2114,27 @@ void Dx12ResourceValueMapper::GetStateObjectLrsAssociationInfo(
         }
         else if (subobject_type == D3D12_STATE_SUBOBJECT_TYPE_DXIL_LIBRARY)
         {
-            // TODO: DXIL libraries can also contain local root signature definitions as well as subobject associations.
-            // That information should be parsed here as well to ensure correct LRS handling.
-            GFXRECON_LOG_DEBUG_ONCE("A state object is being created with a DXIL library subobject. Some usages of "
-                                    "DXIL library subobjects may not be fully supported by GFXR replay.");
-
             GFXRECON_ASSERT(subobject_decoder.dxil_library_desc != nullptr);
             auto dxil_lib_desc_decoder = subobject_decoder.dxil_library_desc;
-            auto num_exports           = dxil_lib_desc_decoder->GetPointer()->NumExports;
+#if defined(GFXRECON_DXC_SUPPORT)
+            GFXRECON_LOG_DEBUG_ONCE("A state object is being created with a DXIL library subobject. GFXR parses "
+                                    "local root signatures and their associations from DXIL libraries, but other "
+                                    "in-DXIL subobject kinds (e.g. hit groups) are not parsed and may not be fully "
+                                    "supported by GFXR replay.");
+
+            // Get local root signatures and their export associations authored inside the DXIL library's RDAT part.
+            GetDxilLibraryInDxilLrsInfo(dxil_lib_desc_decoder->GetPointer()->DXILLibrary.pShaderBytecode,
+                                        dxil_lib_desc_decoder->GetPointer()->DXILLibrary.BytecodeLength,
+                                        state_object_id,
+                                        device_config,
+                                        in_dxil_default_lrs_value_infos,
+                                        in_dxil_export_lrs_value_infos);
+#else  // GFXRECON_DXC_SUPPORT
+            GFXRECON_LOG_DEBUG_ONCE("A state object is being created with a DXIL library subobject. Local root "
+                                    "signatures authored inside DXIL libraries are not parsed without DirectX Shader "
+                                    "Compiler support, so some DXR usages may not be fully supported by GFXR replay.");
+#endif // GFXRECON_DXC_SUPPORT
+            auto num_exports = dxil_lib_desc_decoder->GetPointer()->NumExports;
             if (num_exports == 0)
             {
 #if defined(GFXRECON_DXC_SUPPORT)
@@ -1848,12 +2190,26 @@ void Dx12ResourceValueMapper::GetStateObjectLrsAssociationInfo(
                                                 if (SUCCEEDED(hr))
                                                 {
                                                     // Export names are mangled so parse the unmangled name.
-                                                    auto function_name = DemangleDxilExportName(function_desc.Name);
-                                                    if (!function_name.empty())
+                                                    auto [was_demangled, function_name] =
+                                                        TryDemangleDxilExportName(function_desc.Name);
+
+                                                    if (was_demangled)
                                                     {
-                                                        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>
-                                                            converter;
-                                                        export_names.insert(converter.from_bytes(function_name));
+                                                        GFXRECON_LOG_DEBUG("Found demangled DXIL export name '%s'.",
+                                                                           function_name.c_str());
+
+                                                        if (!function_name.empty())
+                                                        {
+                                                            std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>
+                                                                converter;
+                                                            export_names.insert(converter.from_bytes(function_name));
+                                                        }
+                                                    }
+                                                    else
+                                                    {
+                                                        GFXRECON_LOG_WARNING(
+                                                            "Failed to demangle DXIL export name '%s'.",
+                                                            function_name.c_str());
                                                     }
                                                 }
                                             }

--- a/framework/decode/dx12_resource_value_mapper.cpp
+++ b/framework/decode/dx12_resource_value_mapper.cpp
@@ -335,14 +335,15 @@ void GetDxilLibraryInDxilLrsInfo(const void*                                    
             }
             case hlsl::DXIL::SubobjectKind::SubobjectToExportsAssociation:
             {
-                auto                     association = subobject.getSubobjectToExportsAssociation();
-                auto                     exports     = association.getExports();
-                std::vector<std::string> export_list;
+                // The spec allows multiple association records to reference the same subobject, so accumulate the
+                // exports across records.
+                auto  association = subobject.getSubobjectToExportsAssociation();
+                auto  exports     = association.getExports();
+                auto& export_list = associations[association.getSubobject()];
                 for (uint32_t e = 0; e < exports.Count(); ++e)
                 {
                     export_list.push_back(exports[e]);
                 }
-                associations[association.getSubobject()] = std::move(export_list);
                 break;
             }
             default:

--- a/framework/decode/dx12_resource_value_mapper.h
+++ b/framework/decode/dx12_resource_value_mapper.h
@@ -101,7 +101,8 @@ class Dx12ResourceValueMapper
                                         SIZE_T                       blob_length_in_bytes,
                                         HandlePointerDecoder<void*>* root_signature_decoder);
 
-    void PostProcessCreateStateObject(HandlePointerDecoder<void*>*                           state_object_decoder,
+    void PostProcessCreateStateObject(ID3D12Device*                                          device,
+                                      HandlePointerDecoder<void*>*                           state_object_decoder,
                                       StructPointerDecoder<Decoded_D3D12_STATE_OBJECT_DESC>* desc_decoder,
                                       const D3D12StateObjectInfo*                            grow_from_state_object);
 
@@ -212,13 +213,16 @@ class Dx12ResourceValueMapper
     void GetStateObjectLrsAssociationInfo(
         format::HandleId                                       state_object_id,
         StructPointerDecoder<Decoded_D3D12_STATE_OBJECT_DESC>* desc_decoder,
+        ID3D12DeviceConfiguration1*                            device_config,
         std::set<std::wstring>&                                export_names,
         std::vector<format::HandleId>&                         local_root_signature_ids,
         format::HandleId&                                      explicit_default_local_root_signature_id,
         std::map<std::wstring, format::HandleId>&              explicit_local_root_signature_associations,
         std::map<std::wstring, std::set<std::wstring>>&        hit_group_imports,
         std::map<std::wstring, format::HandleId>&              lrs_associations_map,
-        std::map<graphics::Dx12ShaderIdentifier, std::set<ResourceValueInfo>>& existing_shader_id_lrs_map);
+        std::map<graphics::Dx12ShaderIdentifier, std::set<ResourceValueInfo>>& existing_shader_id_lrs_map,
+        std::set<ResourceValueInfo>&                                           in_dxil_default_lrs_value_infos,
+        std::map<std::wstring, std::set<ResourceValueInfo>>&                   in_dxil_export_lrs_value_infos);
 
     QueueSyncEventInfo CreateProcessProcessResourceMappingsSyncEvent(ProcessResourceMappingsArgs args);
 

--- a/framework/decode/test/dxr_lrs_fixtures/associated_lrs.hlsl
+++ b/framework/decode/test/dxr_lrs_fixtures/associated_lrs.hlsl
@@ -1,0 +1,16 @@
+// Fixture: a local root signature associated explicitly with one export (RayGen) via SubobjectToExportsAssociation.
+// Exercises the explicit per-export association path. Two SRV root descriptors map to GPU VAs at tail offsets 0 and 8.
+//
+// Compiled to a DXIL library with: dxc -T lib_6_3 -Fo associated_lrs.cso associated_lrs.hlsl
+
+#define MyLRS_STR "SRV(t0), SRV(t1)"
+LocalRootSignature            MyLRS   = { MyLRS_STR };
+SubobjectToExportsAssociation MyAssoc = { "MyLRS", "RayGen" };
+
+struct Payload
+{
+    float4 color;
+};
+
+[shader("raygeneration")] void RayGen() {}
+[shader("miss")] void Miss(inout Payload payload) {}

--- a/framework/decode/test/dxr_lrs_fixtures/default_lrs.hlsl
+++ b/framework/decode/test/dxr_lrs_fixtures/default_lrs.hlsl
@@ -1,0 +1,15 @@
+// Fixture: a single unassociated local root signature, which is the library default. Two SRV root descriptors (GPU
+// VAs at shader-binding-table tail offsets 0 and 8) followed by four root constants.
+//
+// Compiled to a DXIL library with: dxc -T lib_6_3 -Fo default_lrs.cso default_lrs.hlsl
+
+#define DefaultLRS_STR "SRV(t0), SRV(t1), RootConstants(num32BitConstants=4, b0)"
+LocalRootSignature DefaultLRS = { DefaultLRS_STR };
+
+struct Payload
+{
+    float4 color;
+};
+
+[shader("raygeneration")] void RayGen() {}
+[shader("miss")] void Miss(inout Payload payload) {}

--- a/framework/decode/test/dxr_lrs_fixtures/global_and_local.hlsl
+++ b/framework/decode/test/dxr_lrs_fixtures/global_and_local.hlsl
@@ -1,0 +1,17 @@
+// Fixture: a global root signature alongside an unassociated local root signature. The resolver ignores the global
+// root signature; only the local one (one SRV -> one GPU VA) contributes, as the library default.
+//
+// Compiled to a DXIL library with: dxc -T lib_6_3 -Fo global_and_local.cso global_and_local.hlsl
+
+#define LocalLRS_STR "SRV(t0)"
+#define GlobalRS_STR "CBV(b0)"
+LocalRootSignature  LocalLRS = { LocalLRS_STR };
+GlobalRootSignature GlobalRS = { GlobalRS_STR };
+
+struct Payload
+{
+    float4 color;
+};
+
+[shader("raygeneration")] void RayGen() {}
+[shader("miss")] void Miss(inout Payload payload) {}

--- a/framework/decode/test/dxr_lrs_fixtures/mixed_lrs.hlsl
+++ b/framework/decode/test/dxr_lrs_fixtures/mixed_lrs.hlsl
@@ -1,0 +1,16 @@
+// Fixture: a single unassociated (default) local root signature mixing descriptor tables and root descriptors. The
+// descriptor tables map to GPU descriptor handles and the root descriptors to GPU VAs, so the SBT argument tail
+// interleaves both resource value kinds. Exercises the descriptor-table path end to end through DXC.
+//
+// Compiled to a DXIL library with: dxc -T lib_6_3 -Fo mixed_lrs.cso mixed_lrs.hlsl
+
+#define MixedLRS_STR "DescriptorTable(SRV(t0)), SRV(t1), DescriptorTable(UAV(u0)), CBV(b0)"
+LocalRootSignature MixedLRS = { MixedLRS_STR };
+
+struct Payload
+{
+    float4 color;
+};
+
+[shader("raygeneration")] void RayGen() {}
+[shader("miss")] void Miss(inout Payload payload) {}

--- a/framework/decode/test/dxr_lrs_fixtures/multi_association.hlsl
+++ b/framework/decode/test/dxr_lrs_fixtures/multi_association.hlsl
@@ -1,0 +1,20 @@
+// Fixture: one local root signature referenced by two SubobjectToExportsAssociation records, the second listing two
+// exports. The spec allows a subobject to be named by multiple association records and a record to list multiple
+// exports, so RayGen, Miss, and ClosestHit must all resolve to SharedLRS. Two SRV root descriptors map to GPU VAs at
+// tail offsets 0 and 8.
+//
+// Compiled to a DXIL library with: dxc -T lib_6_3 -Fo multi_association.cso multi_association.hlsl
+
+#define SharedLRS_STR "SRV(t0), SRV(t1)"
+LocalRootSignature            SharedLRS   = { SharedLRS_STR };
+SubobjectToExportsAssociation RayGenAssoc = { "SharedLRS", "RayGen" };
+SubobjectToExportsAssociation HitAssoc    = { "SharedLRS", "Miss;ClosestHit" };
+
+struct Payload
+{
+    float4 color;
+};
+
+[shader("raygeneration")] void RayGen() {}
+[shader("miss")] void Miss(inout Payload payload) {}
+[shader("closesthit")] void ClosestHit(inout Payload payload, in BuiltInTriangleIntersectionAttributes attribs) {}

--- a/framework/decode/test/dxr_lrs_fixtures/no_subobjects.hlsl
+++ b/framework/decode/test/dxr_lrs_fixtures/no_subobjects.hlsl
@@ -1,0 +1,13 @@
+// Fixture: a DXIL library with shader exports but no root signature subobjects. The resolver should produce neither a
+// default local root signature nor any export associations, and must not crash on a library whose RDAT has no
+// subobject table entries of interest.
+//
+// Compiled to a DXIL library with: dxc -T lib_6_3 -Fo no_subobjects.cso no_subobjects.hlsl
+
+struct Payload
+{
+    float4 color;
+};
+
+[shader("raygeneration")] void RayGen() {}
+[shader("miss")] void Miss(inout Payload payload) {}

--- a/framework/decode/test/dxr_lrs_fixtures/two_lrs.hlsl
+++ b/framework/decode/test/dxr_lrs_fixtures/two_lrs.hlsl
@@ -1,0 +1,19 @@
+// Fixture: two local root signatures. AssociatedLRS (one SRV -> one GPU VA) is bound explicitly to RayGen; DefaultLRS
+// (two SRVs -> two GPU VAs) is left unassociated and so is the library default for the other exports. Exercises the
+// explicit-association and implicit-default paths in one library.
+//
+// Compiled to a DXIL library with: dxc -T lib_6_3 -Fo two_lrs.cso two_lrs.hlsl
+
+#define AssociatedLRS_STR "SRV(t0)"
+#define DefaultLRS_STR    "SRV(t0), SRV(t1)"
+LocalRootSignature            AssociatedLRS = { AssociatedLRS_STR };
+LocalRootSignature            DefaultLRS    = { DefaultLRS_STR };
+SubobjectToExportsAssociation Assoc         = { "AssociatedLRS", "RayGen" };
+
+struct Payload
+{
+    float4 color;
+};
+
+[shader("raygeneration")] void RayGen() {}
+[shader("miss")] void Miss(inout Payload payload) {}

--- a/framework/decode/test/dxr_lrs_tests.cpp
+++ b/framework/decode/test/dxr_lrs_tests.cpp
@@ -180,6 +180,22 @@ TEST_CASE("In-DXIL LRS resolver binds an explicitly associated local root signat
                         { { 0, ResourceValueType::kGpuVirtualAddress }, { 8, ResourceValueType::kGpuVirtualAddress } });
 }
 
+TEST_CASE("In-DXIL LRS resolver accumulates association records and their export lists", "[dxr][lrs][rdat]")
+{
+    // One LRS named by two association records, the second listing two exports.
+    auto resolved = ResolveFixture("multi_association.cso");
+    CHECK(resolved.default_infos.empty());
+    // SharedLRS: two SRVs, resolved onto all three exports.
+    for (const wchar_t* export_name : { L"RayGen", L"Miss", L"ClosestHit" })
+    {
+        INFO("export: " << Narrow(export_name));
+        REQUIRE(resolved.export_infos.count(export_name) == 1);
+        CheckResourceValues(
+            resolved.export_infos.at(export_name),
+            { { 0, ResourceValueType::kGpuVirtualAddress }, { 8, ResourceValueType::kGpuVirtualAddress } });
+    }
+}
+
 TEST_CASE("In-DXIL LRS resolver handles an associated and a default local root signature together", "[dxr][lrs][rdat]")
 {
     auto resolved = ResolveFixture("two_lrs.cso");

--- a/framework/decode/test/dxr_lrs_tests.cpp
+++ b/framework/decode/test/dxr_lrs_tests.cpp
@@ -1,0 +1,208 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2026 LunarG, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/// \description Unit tests for parsing local root signatures authored inside DXIL libraries.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "decode/dx12_dxil_lrs_parser.h"
+
+#include <catch2/catch.hpp>
+
+#if defined(D3D12_SUPPORT)
+#include <windows.h>
+
+// The in-DXIL LRS tests create a WARP device and query ID3D12DeviceConfiguration1 from it. The
+// ID3D12DeviceConfiguration1 interface is only present when the Agility SDK runtime is loaded, so export these values
+// to load the version of the Agility SDK used by GFXR.
+extern "C"
+{
+    __declspec(dllexport) extern const UINT D3D12SDKVersion = 618;
+    __declspec(dllexport) extern const char* D3D12SDKPath   = reinterpret_cast<const char*>(u8".\\D3D12\\");
+}
+#endif // D3D12_SUPPORT
+
+// These tests run GetDxilLibraryInDxilLrsInfo on real DXIL library fixtures compiled from HLSL by DXC at build time.
+// The .cso files are built from framework/decode/test/dxr_lrs_fixtures/*.hlsl (see CMakeLists.txt).
+// GFXRECON_TEST_DXR_LRS_FIXTURE_DIR is the build-tree directory holding them.
+#if defined(GFXRECON_DXC_SUPPORT) && defined(GFXRECON_TEST_DXR_LRS_FIXTURE_DIR)
+
+#include "graphics/dx12_util.h"
+
+#include <d3d12.h>
+#include <dxgi1_4.h>
+
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace gfxrecon;
+using namespace gfxrecon::decode;
+
+namespace
+{
+
+// ID3D12DeviceConfiguration1 is a runtime interface provided by the Agility SDK, so a WARP device exposes it--no
+// physical GPU required. Create the device once and cache the queried interface.
+graphics::dx12::ID3D12DeviceConfiguration1ComPtr GetDeviceConfiguration()
+{
+    static graphics::dx12::ID3D12DeviceConfiguration1ComPtr device_config = [] {
+        graphics::dx12::ID3D12DeviceConfiguration1ComPtr               config;
+        _com_ptr_t<_com_IIID<IDXGIFactory4, &__uuidof(IDXGIFactory4)>> factory;
+        if (SUCCEEDED(CreateDXGIFactory2(0, IID_PPV_ARGS(&factory))))
+        {
+            graphics::dx12::IDXGIAdapterComPtr warp_adapter;
+            if (SUCCEEDED(factory->EnumWarpAdapter(IID_PPV_ARGS(&warp_adapter))))
+            {
+                graphics::dx12::ID3D12DeviceComPtr device;
+                if (SUCCEEDED(D3D12CreateDevice(warp_adapter, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device))))
+                {
+                    device->QueryInterface(IID_PPV_ARGS(&config));
+                }
+            }
+        }
+        return config;
+    }();
+    return device_config;
+}
+
+struct ResolvedLrs
+{
+    std::set<ResourceValueInfo>                         default_infos;
+    std::map<std::wstring, std::set<ResourceValueInfo>> export_infos;
+};
+
+std::vector<uint8_t> LoadFixture(const std::string& file_name)
+{
+    const std::string path =
+        std::string(GFXRECON_TEST_DXR_LRS_FIXTURE_DIR) + gfxrecon::util::filepath::kPathSepStr + file_name;
+    std::ifstream file(path, std::ios::binary);
+    INFO("fixture: " << path);
+    REQUIRE(file.is_open());
+    return std::vector<uint8_t>(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+}
+
+ResolvedLrs ResolveFixture(const std::string& file_name)
+{
+    graphics::dx12::ID3D12DeviceConfiguration1ComPtr device_config = GetDeviceConfiguration();
+    REQUIRE(device_config != nullptr);
+
+    const std::vector<uint8_t> blob = LoadFixture(file_name);
+    ResolvedLrs                resolved;
+    GetDxilLibraryInDxilLrsInfo(
+        blob.data(), blob.size(), 0, device_config, resolved.default_infos, resolved.export_infos);
+    return resolved;
+}
+
+// Narrow an ASCII export name for diagnostics on failure.
+std::string Narrow(const std::wstring& wide)
+{
+    std::string narrow;
+    for (wchar_t c : wide)
+    {
+        narrow.push_back(static_cast<char>(c));
+    }
+    return narrow;
+}
+
+// Verify an ordered set of parsed resource values matches the expected offsets and types.
+void CheckResourceValues(const std::set<ResourceValueInfo>&                         infos,
+                         const std::vector<std::pair<uint64_t, ResourceValueType>>& expected)
+{
+    REQUIRE(infos.size() == expected.size());
+    size_t i = 0;
+    for (const auto& info : infos)
+    {
+        CHECK(info.offset == expected[i].first);
+        CHECK(info.type == expected[i].second);
+        CHECK(info.size == 8);
+        ++i;
+    }
+}
+
+} // namespace
+
+TEST_CASE("In-DXIL LRS resolver treats an unassociated local root signature as the default", "[dxr][lrs][rdat]")
+{
+    auto resolved = ResolveFixture("default_lrs.cso");
+    CHECK(resolved.export_infos.empty());
+    CheckResourceValues(resolved.default_infos,
+                        { { 0, ResourceValueType::kGpuVirtualAddress }, { 8, ResourceValueType::kGpuVirtualAddress } });
+}
+
+TEST_CASE("In-DXIL LRS resolver maps a mix of descriptor tables and root descriptors", "[dxr][lrs][rdat]")
+{
+    auto resolved = ResolveFixture("mixed_lrs.cso");
+    CHECK(resolved.export_infos.empty());
+    CheckResourceValues(resolved.default_infos,
+                        { { 0, ResourceValueType::kGpuDescriptorHandle },
+                          { 8, ResourceValueType::kGpuVirtualAddress },
+                          { 16, ResourceValueType::kGpuDescriptorHandle },
+                          { 24, ResourceValueType::kGpuVirtualAddress } });
+}
+
+TEST_CASE("In-DXIL LRS resolver binds an explicitly associated local root signature to its export", "[dxr][lrs][rdat]")
+{
+    auto resolved = ResolveFixture("associated_lrs.cso");
+
+    std::string keys;
+    for (const auto& entry : resolved.export_infos)
+    {
+        keys += Narrow(entry.first) + " ";
+    }
+    INFO("export keys: " << keys);
+
+    CHECK(resolved.default_infos.empty());
+    REQUIRE(resolved.export_infos.size() == 1);
+    REQUIRE(resolved.export_infos.count(L"RayGen") == 1);
+    CheckResourceValues(resolved.export_infos.at(L"RayGen"),
+                        { { 0, ResourceValueType::kGpuVirtualAddress }, { 8, ResourceValueType::kGpuVirtualAddress } });
+}
+
+TEST_CASE("In-DXIL LRS resolver handles an associated and a default local root signature together", "[dxr][lrs][rdat]")
+{
+    auto resolved = ResolveFixture("two_lrs.cso");
+    // DefaultLRS: two SRVs.
+    CheckResourceValues(resolved.default_infos,
+                        { { 0, ResourceValueType::kGpuVirtualAddress }, { 8, ResourceValueType::kGpuVirtualAddress } });
+    REQUIRE(resolved.export_infos.count(L"RayGen") == 1);
+    // AssociatedLRS: one SRV.
+    CheckResourceValues(resolved.export_infos.at(L"RayGen"), { { 0, ResourceValueType::kGpuVirtualAddress } });
+}
+
+TEST_CASE("In-DXIL LRS resolver ignores a global root signature subobject", "[dxr][lrs][rdat]")
+{
+    auto resolved = ResolveFixture("global_and_local.cso");
+    CHECK(resolved.export_infos.empty());
+    CheckResourceValues(resolved.default_infos, { { 0, ResourceValueType::kGpuVirtualAddress } });
+}
+
+TEST_CASE("In-DXIL LRS resolver yields nothing for a library without subobjects", "[dxr][lrs][rdat]")
+{
+    auto resolved = ResolveFixture("no_subobjects.cso");
+    CHECK(resolved.default_infos.empty());
+    CHECK(resolved.export_infos.empty());
+}
+
+#endif // GFXRECON_DXC_SUPPORT && GFXRECON_TEST_DXR_LRS_FIXTURE_DIR

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -108,11 +108,14 @@ typedef _com_ptr_t<
     _com_IIID<ID3D12VersionedRootSignatureDeserializer, &__uuidof(ID3D12VersionedRootSignatureDeserializer)>>
                                                                      ID3D12VersionedRootSignatureDeserializerComPtr;
 typedef _com_ptr_t<_com_IIID<ID3D12Object, &__uuidof(ID3D12Object)>> ID3D12ObjectComPtr;
+typedef _com_ptr_t<_com_IIID<ID3D12DeviceConfiguration1, &__uuidof(ID3D12DeviceConfiguration1)>>
+    ID3D12DeviceConfiguration1ComPtr;
 
 #if defined(GFXRECON_DXC_SUPPORT)
 typedef _com_ptr_t<_com_IIID<IDxcUtils, &__uuidof(IDxcUtils)>> IDxcUtilsComPtr;
 typedef _com_ptr_t<_com_IIID<IDxcContainerReflection, &__uuidof(IDxcContainerReflection)>>
                                                                              IDxcContainerReflectionComPtr;
+typedef _com_ptr_t<_com_IIID<IDxcBlob, &__uuidof(IDxcBlob)>>                 IDxcBlobComPtr;
 typedef _com_ptr_t<_com_IIID<IDxcBlobEncoding, &__uuidof(IDxcBlobEncoding)>> IDxcBlobEncodingComPtr;
 typedef _com_ptr_t<_com_IIID<ID3D12LibraryReflection, &__uuidof(ID3D12LibraryReflection)>>
     ID3D12LibraryReflectionComPtr;


### PR DESCRIPTION
For correct DXR replay, local root signatures and their associations to shader exports must be parsed from compiled DXIL libraries specified as subobjects in `CreateStateObject`. This change uses DXC's RDAT reader and the D3D12 Agility SDK method `CreateVersionedRootSignatureDeserializerFromSubobjectInLibrary` to parse that information. It also adds tests that take compiled `.hlsl` files and parses them using the new GFXR function `GetDxilLibraryInDxilLrsInfo`.