### PR TITLE
util: Replace command buffer

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -240,8 +240,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_referenced_block_consumer_base.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_remap_allocator.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_remap_allocator.cpp
-                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_command_splitter.h
-                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_command_splitter.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_command_buffer_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_command_buffer_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_replay_consumer_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_replay_consumer_base.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_replay_options.h

--- a/framework/decode/vulkan_command_buffer_util.cpp
+++ b/framework/decode/vulkan_command_buffer_util.cpp
@@ -19,7 +19,7 @@
 ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 ** DEALINGS IN THE SOFTWARE.
 */
-#include "decode/vulkan_command_splitter.h"
+#include "decode/vulkan_command_buffer_util.h"
 #include "decode/vulkan_submit_info_helper.h"
 #include "generated/generated_vulkan_enum_to_string.h"
 #include "util/callbacks.h"
@@ -28,10 +28,10 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-VulkanCommandBufferSplitInfo::VulkanCommandBufferSplitInfo(const VulkanDeviceInfo*            device_info,
-                                                           const graphics::VulkanDeviceTable* device_table,
-                                                           CommonObjectInfoTable*             object_table,
-                                                           format::HandleId                   command_buffer_id) :
+VulkanCommandBufferAssociatedInfo::VulkanCommandBufferAssociatedInfo(const VulkanDeviceInfo*            device_info,
+                                                                     const graphics::VulkanDeviceTable* device_table,
+                                                                     CommonObjectInfoTable*             object_table,
+                                                                     format::HandleId command_buffer_id) :
     device_info_(device_info),
     device_table_(device_table), object_table_(object_table), split_semaphore_(device_info, device_table)
 {
@@ -45,7 +45,7 @@ VulkanCommandBufferSplitInfo::VulkanCommandBufferSplitInfo(const VulkanDeviceInf
     original_handle_ = command_buffer_info->handle;
 }
 
-VkCommandBuffer VulkanCommandBufferSplitInfo::GetNextHandle(const VulkanCommandBufferInfo* command_buffer_info)
+void VulkanCommandBufferAssociatedInfo::ReplaceWithNewHandle(VulkanCommandBufferInfo* command_buffer_info)
 {
     VkCommandBuffer next_handle = VK_NULL_HANDLE;
 
@@ -75,15 +75,12 @@ VkCommandBuffer VulkanCommandBufferSplitInfo::GetNextHandle(const VulkanCommandB
     next_handle = associated_handles_[next_associated_index_];
     ++next_associated_index_;
 
-    // Store current handle in split vector.
-    split_handles_.push_back(command_buffer_info->handle);
-
-    return next_handle;
+    command_buffer_info->handle = next_handle;
 }
 
-VulkanCommandSplitter::VulkanCommandSplitter(const VulkanDeviceInfo*            device_info,
-                                             const graphics::VulkanDeviceTable* device_table,
-                                             CommonObjectInfoTable*             object_table) :
+VulkanCommandBufferUtil::VulkanCommandBufferUtil(const VulkanDeviceInfo*            device_info,
+                                                 const graphics::VulkanDeviceTable* device_table,
+                                                 CommonObjectInfoTable*             object_table) :
     device_info_(device_info),
     device_table_(device_table), object_table_(object_table)
 {
@@ -92,7 +89,8 @@ VulkanCommandSplitter::VulkanCommandSplitter(const VulkanDeviceInfo*            
     GFXRECON_ASSERT(object_table != nullptr);
 }
 
-VulkanCommandBufferSplitInfo& VulkanCommandSplitter::GetOrCreateSplitInfo(format::HandleId command_buffer_id)
+VulkanCommandBufferAssociatedInfo&
+VulkanCommandBufferUtil::GetOrCreateAssociatedInfo(format::HandleId command_buffer_id)
 {
     if (auto it = split_infos_.find(command_buffer_id); it != split_infos_.end())
     {
@@ -101,12 +99,12 @@ VulkanCommandBufferSplitInfo& VulkanCommandSplitter::GetOrCreateSplitInfo(format
 
     auto [new_it, success] = split_infos_.insert(
         { command_buffer_id,
-          VulkanCommandBufferSplitInfo(device_info_, device_table_, object_table_, command_buffer_id) });
+          VulkanCommandBufferAssociatedInfo(device_info_, device_table_, object_table_, command_buffer_id) });
     GFXRECON_ASSERT(success);
     return new_it->second;
 }
 
-VulkanCommandBufferSplitInfo* VulkanCommandSplitter::GetSplitInfo(format::HandleId command_buffer_id)
+VulkanCommandBufferAssociatedInfo* VulkanCommandBufferUtil::GetAssociatedInfo(format::HandleId command_buffer_id)
 {
     if (auto it = split_infos_.find(command_buffer_id); it != split_infos_.end())
     {
@@ -115,12 +113,10 @@ VulkanCommandBufferSplitInfo* VulkanCommandSplitter::GetSplitInfo(format::Handle
     return nullptr;
 }
 
-VkCommandBuffer VulkanCommandBufferSplitInfo::ResetSplitHandles()
+VkCommandBuffer VulkanCommandBufferAssociatedInfo::ResetAssociatedHandles()
 {
-    GFXRECON_ASSERT(!split_handles_.empty());
-
-    // Reset all the handles of the split.
-    for (VkCommandBuffer handle : split_handles_)
+    // Reset all the associated command buffers.
+    for (VkCommandBuffer handle : associated_handles_)
     {
         VkResult result = device_table_->ResetCommandBuffer(handle, 0);
         GFXRECON_ASSERT(result == VK_SUCCESS);
@@ -133,7 +129,7 @@ VkCommandBuffer VulkanCommandBufferSplitInfo::ResetSplitHandles()
     return original_handle_;
 }
 
-void VulkanCommandBufferSplitInfo::FreeCommandBuffers(VkCommandPool pool)
+void VulkanCommandBufferAssociatedInfo::FreeCommandBuffers(VkCommandPool pool)
 {
     GFXRECON_ASSERT(!associated_handles_.empty());
 
@@ -141,41 +137,52 @@ void VulkanCommandBufferSplitInfo::FreeCommandBuffers(VkCommandPool pool)
         device_info_->handle, pool, static_cast<uint32_t>(associated_handles_.size()), associated_handles_.data());
 }
 
-void VulkanCommandSplitter::SplitCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
+void VulkanCommandBufferUtil::ReplaceWithAssociatedCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
 {
     // Make sure current handle is mapped to the original command buffer ID.
     original_command_buffer_id_[command_buffer_info->handle] = command_buffer_info->capture_id;
 
+    // Update the command buffer info to use the new handle for subsequent calls.
+    GetOrCreateAssociatedInfo(command_buffer_info->capture_id).ReplaceWithNewHandle(command_buffer_info);
+
+    // Map the new handle to the original command buffer ID for future reference.
+    original_command_buffer_id_[command_buffer_info->handle] = command_buffer_info->capture_id;
+
+    // Reset the command buffer just in case it was recycled.
+    VkResult result = device_table_->ResetCommandBuffer(command_buffer_info->handle, 0);
+    GFXRECON_ASSERT(result == VK_SUCCESS);
+}
+
+void VulkanCommandBufferUtil::SplitCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
+{
     device_table_->EndCommandBuffer(command_buffer_info->handle);
 
-    // Update the command buffer info to use the new handle for subsequent calls.
-    command_buffer_info->handle =
-        GetOrCreateSplitInfo(command_buffer_info->capture_id).GetNextHandle(command_buffer_info);
-    original_command_buffer_id_[command_buffer_info->handle] = command_buffer_info->capture_id;
+    GetOrCreateAssociatedInfo(command_buffer_info->capture_id).PushSplitHandle(command_buffer_info->handle);
+    ReplaceWithAssociatedCommandBuffer(command_buffer_info);
 
     VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
     device_table_->BeginCommandBuffer(command_buffer_info->handle, &begin_info);
 }
 
 graphics::VulkanSemaphore
-VulkanCommandSplitter::SubmitPreviouslySplitCommandBuffers(const VulkanQueueInfo*        queue_info,
-                                                           const std::span<VkSubmitInfo> current_submits_span,
-                                                           const std::span<graphics::VulkanSemaphore> wait_semaphores)
+VulkanCommandBufferUtil::SubmitPreviouslySplitCommandBuffers(const VulkanQueueInfo*        queue_info,
+                                                             const std::span<VkSubmitInfo> current_submits_span,
+                                                             const std::span<graphics::VulkanSemaphore> wait_semaphores)
 {
     auto submits_command_buffers = GetCommandBuffersFromSubmitInfos(current_submits_span);
     return SubmitPreviouslySplitCommandBuffers(queue_info, submits_command_buffers, wait_semaphores);
 }
 
 graphics::VulkanSemaphore
-VulkanCommandSplitter::SubmitPreviouslySplitCommandBuffers(const VulkanQueueInfo*         queue_info,
-                                                           const std::span<VkSubmitInfo2> current_submits_span,
-                                                           const std::span<graphics::VulkanSemaphore> wait_semaphores)
+VulkanCommandBufferUtil::SubmitPreviouslySplitCommandBuffers(const VulkanQueueInfo*         queue_info,
+                                                             const std::span<VkSubmitInfo2> current_submits_span,
+                                                             const std::span<graphics::VulkanSemaphore> wait_semaphores)
 {
     auto submits_command_buffers = GetCommandBuffersFromSubmitInfos(current_submits_span);
     return SubmitPreviouslySplitCommandBuffers(queue_info, submits_command_buffers, wait_semaphores);
 }
 
-graphics::VulkanSemaphore VulkanCommandSplitter::SubmitPreviouslySplitCommandBuffers(
+graphics::VulkanSemaphore VulkanCommandBufferUtil::SubmitPreviouslySplitCommandBuffers(
     const VulkanQueueInfo*                        queue_info,
     const std::span<std::vector<VkCommandBuffer>> current_submits_cmdbufs,
     const std::span<graphics::VulkanSemaphore>    wait_semaphores)
@@ -199,26 +206,30 @@ graphics::VulkanSemaphore VulkanCommandSplitter::SubmitPreviouslySplitCommandBuf
             VkCommandBuffer command_buffer = command_buffers[cmdbuf_index];
             if (original_command_buffer_id_.contains(command_buffer))
             {
-                // The command buffer in this submit was split,
-                // so we need to submit the previous splits before submitting this one.
+                // The command buffer in this submit has associated command buffers.
                 auto command_buffer_id = original_command_buffer_id_[command_buffer];
 
-                // Each command buffer handle will go in its own submit.
-                const VulkanCommandBufferSplitInfo* split_info    = GetSplitInfo(command_buffer_id);
-                auto&                               split_handles = split_info->GetSplitHandles();
-                GFXRECON_ASSERT(!split_handles.empty());
+                const VulkanCommandBufferAssociatedInfo* split_info = GetAssociatedInfo(command_buffer_id);
 
-                // Make enough space for the new submits.
-                size_t submit_count = std::max(prev_submits.size(), split_handles.size());
-                prev_submits.resize(submit_count);
-                prev_submits_command_buffers.resize(submit_count);
+                // Each command buffer handle created for a split will go in its own submit.
+                auto& split_handles = split_info->GetSplitHandles();
 
-                // Store each handle in the corresponding submit.
-                for (size_t split_index = 0; split_index < split_handles.size(); ++split_index)
+                // There might cases where associated command buffers have been created, but not for a split.
+                if (!split_handles.empty())
                 {
-                    auto& prev_command_buffers = prev_submits_command_buffers[split_index];
-                    // Prev submits command buffers correspond to the previous handles in order.
-                    prev_command_buffers.push_back(split_handles[split_index]);
+                    // Make enough space for the new submits.
+                    size_t submit_count = std::max(prev_submits.size(), split_handles.size());
+                    prev_submits.resize(submit_count);
+                    prev_submits_command_buffers.resize(submit_count);
+
+                    // We need to submit the previous splits before submitting this one.
+                    // Store each handle in the corresponding submit.
+                    for (size_t split_index = 0; split_index < split_handles.size(); ++split_index)
+                    {
+                        auto& prev_command_buffers = prev_submits_command_buffers[split_index];
+                        // Prev submits command buffers correspond to the previous handles in order.
+                        prev_command_buffers.push_back(split_handles[split_index]);
+                    }
                 }
             }
         }
@@ -231,8 +242,8 @@ graphics::VulkanSemaphore VulkanCommandSplitter::SubmitPreviouslySplitCommandBuf
 
         if (!prev_command_buffers.empty())
         {
-            format::HandleId              command_buffer_id = original_command_buffer_id_[prev_command_buffers[0]];
-            VulkanCommandBufferSplitInfo* split_info        = GetSplitInfo(command_buffer_id);
+            format::HandleId                   command_buffer_id = original_command_buffer_id_[prev_command_buffers[0]];
+            VulkanCommandBufferAssociatedInfo* split_info        = GetAssociatedInfo(command_buffer_id);
 
             VkSubmitInfo           submit_info = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
             VulkanSubmitInfoHelper submit_helper(submit_info);
@@ -267,7 +278,7 @@ graphics::VulkanSemaphore VulkanCommandSplitter::SubmitPreviouslySplitCommandBuf
 }
 
 std::vector<std::vector<VkCommandBuffer>>
-VulkanCommandSplitter::GetCommandBuffersFromSubmitInfos(const std::span<VkSubmitInfo> submits_span)
+VulkanCommandBufferUtil::GetCommandBuffersFromSubmitInfos(const std::span<VkSubmitInfo> submits_span)
 {
     std::vector<std::vector<VkCommandBuffer>> submits_command_buffers(submits_span.size());
 
@@ -284,7 +295,7 @@ VulkanCommandSplitter::GetCommandBuffersFromSubmitInfos(const std::span<VkSubmit
 }
 
 std::vector<std::vector<VkCommandBuffer>>
-VulkanCommandSplitter::GetCommandBuffersFromSubmitInfos(const std::span<VkSubmitInfo2> submits_span)
+VulkanCommandBufferUtil::GetCommandBuffersFromSubmitInfos(const std::span<VkSubmitInfo2> submits_span)
 {
     std::vector<std::vector<VkCommandBuffer>> submits_command_buffers(submits_span.size());
 
@@ -303,8 +314,8 @@ VulkanCommandSplitter::GetCommandBuffersFromSubmitInfos(const std::span<VkSubmit
     return submits_command_buffers;
 }
 
-void VulkanCommandSplitter::FreeCommandBuffers(VkCommandPool                          command_pool,
-                                               const std::span<const VkCommandBuffer> command_buffers)
+void VulkanCommandBufferUtil::FreeCommandBuffers(VkCommandPool                          command_pool,
+                                                 const std::span<const VkCommandBuffer> command_buffers)
 {
     // Check whether any of the command buffers being freed are split command buffers.
     for (VkCommandBuffer command_buffer : command_buffers)
@@ -313,7 +324,7 @@ void VulkanCommandSplitter::FreeCommandBuffers(VkCommandPool                    
         {
             // This command buffer is a split command buffer, so we need to free all the splits together.
             format::HandleId command_buffer_id = original_command_buffer_id_[command_buffer];
-            auto*            split_info        = GetSplitInfo(command_buffer_id);
+            auto*            split_info        = GetAssociatedInfo(command_buffer_id);
             split_info->FreeCommandBuffers(command_pool);
 
             // Remove the associated handles from the tracking maps.
@@ -324,14 +335,14 @@ void VulkanCommandSplitter::FreeCommandBuffers(VkCommandPool                    
 
             // Update the command buffer info to use the original handle for subsequent calls.
             VulkanCommandBufferInfo* command_buffer_info = object_table_->GetVkCommandBufferInfo(command_buffer_id);
-            command_buffer_info->handle                  = split_info->ResetSplitHandles();
+            command_buffer_info->handle                  = split_info->ResetAssociatedHandles();
 
             split_infos_.erase(command_buffer_id);
         }
     }
 }
 
-void VulkanCommandSplitter::ResetCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
+void VulkanCommandBufferUtil::ResetCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
 {
     // This command buffer is expected to be already reset at this point.
     VkCommandBuffer command_buffer = command_buffer_info->handle;
@@ -340,15 +351,15 @@ void VulkanCommandSplitter::ResetCommandBuffer(VulkanCommandBufferInfo* command_
     // If so, we need to reset all the split command buffers together and restore the command buffer info handle.
     if (original_command_buffer_id_.contains(command_buffer))
     {
-        format::HandleId              command_buffer_id = original_command_buffer_id_[command_buffer];
-        VulkanCommandBufferSplitInfo* split_info        = GetSplitInfo(command_buffer_id);
+        format::HandleId                   command_buffer_id = original_command_buffer_id_[command_buffer];
+        VulkanCommandBufferAssociatedInfo* split_info        = GetAssociatedInfo(command_buffer_id);
 
         // Update the command buffer info to use the original handle for subsequent calls.
-        command_buffer_info->handle = split_info->ResetSplitHandles();
+        command_buffer_info->handle = split_info->ResetAssociatedHandles();
     }
 }
 
-void VulkanCommandSplitter::BeginCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
+void VulkanCommandBufferUtil::BeginCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
 {
     VulkanCommandPoolInfo* command_pool_info = object_table_->GetVkCommandPoolInfo(command_buffer_info->pool_id);
     GFXRECON_ASSERT(command_pool_info != nullptr);

--- a/framework/decode/vulkan_command_buffer_util.h
+++ b/framework/decode/vulkan_command_buffer_util.h
@@ -19,8 +19,8 @@
 ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 ** DEALINGS IN THE SOFTWARE.
 */
-#ifndef GFXRECON_DECODE_VULKAN_COMMAND_SPLITTER_H
-#define GFXRECON_DECODE_VULKAN_COMMAND_SPLITTER_H
+#ifndef GFXRECON_DECODE_VULKAN_COMMAND_BUFFER_UTIL_H
+#define GFXRECON_DECODE_VULKAN_COMMAND_BUFFER_UTIL_H
 
 #include "decode/common_object_info_table.h"
 #include "decode/vulkan_object_info.h"
@@ -35,7 +35,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 /// This helper class manages command buffer handles addressing cases where a single command buffer is reset and
 /// recorded multiple times. In such cases, after splitting the command buffer for the first time, a reset is expected
 /// before the next recording, and we want to avoid splitting again and instead reuse the handles of the first split.
-class VulkanCommandBufferSplitInfo
+class VulkanCommandBufferAssociatedInfo
 {
   private:
     const VulkanDeviceInfo*            device_info_  = nullptr;
@@ -63,42 +63,46 @@ class VulkanCommandBufferSplitInfo
     std::vector<VkCommandBuffer> split_handles_;
 
   public:
-    VulkanCommandBufferSplitInfo(const VulkanDeviceInfo*            device_info,
-                                 const graphics::VulkanDeviceTable* device_table,
-                                 CommonObjectInfoTable*             object_table,
-                                 format::HandleId                   command_buffer_id);
+    VulkanCommandBufferAssociatedInfo(const VulkanDeviceInfo*            device_info,
+                                      const graphics::VulkanDeviceTable* device_table,
+                                      CommonObjectInfoTable*             object_table,
+                                      format::HandleId                   command_buffer_id);
 
-    VulkanCommandBufferSplitInfo(const VulkanCommandBufferSplitInfo&)            = delete;
-    VulkanCommandBufferSplitInfo& operator=(const VulkanCommandBufferSplitInfo&) = delete;
-    VulkanCommandBufferSplitInfo(VulkanCommandBufferSplitInfo&&)                 = default;
-    VulkanCommandBufferSplitInfo& operator=(VulkanCommandBufferSplitInfo&&)      = default;
-    ~VulkanCommandBufferSplitInfo()                                              = default;
+    VulkanCommandBufferAssociatedInfo(const VulkanCommandBufferAssociatedInfo&)            = delete;
+    VulkanCommandBufferAssociatedInfo& operator=(const VulkanCommandBufferAssociatedInfo&) = delete;
+    VulkanCommandBufferAssociatedInfo(VulkanCommandBufferAssociatedInfo&&)                 = default;
+    VulkanCommandBufferAssociatedInfo& operator=(VulkanCommandBufferAssociatedInfo&&)      = default;
+    ~VulkanCommandBufferAssociatedInfo()                                                   = default;
 
-    [[nodiscard]] VkCommandBuffer GetNextHandle(const VulkanCommandBufferInfo* command_buffer_info);
-
+    void ReplaceWithNewHandle(VulkanCommandBufferInfo* command_buffer_info);
+    
     [[nodiscard]] const std::vector<VkCommandBuffer>& GetAssociatedHandles() const { return associated_handles_; }
+
+    void PushSplitHandle(VkCommandBuffer handle) { split_handles_.push_back(handle); }
     [[nodiscard]] const std::vector<VkCommandBuffer>& GetSplitHandles() const { return split_handles_; }
 
-    [[nodiscard]] VkCommandBuffer ResetSplitHandles();
+    [[nodiscard]] VkCommandBuffer ResetAssociatedHandles();
 
     [[nodiscard]] VulkanInjectedSemaphore& GetSplitSemaphore() { return split_semaphore_; }
 
     void FreeCommandBuffers(VkCommandPool pool);
 };
 
-class VulkanCommandSplitter
+class VulkanCommandBufferUtil
 {
   public:
-    VulkanCommandSplitter(const VulkanDeviceInfo*            device_info,
-                          const graphics::VulkanDeviceTable* device_table,
-                          CommonObjectInfoTable*             object_table);
+    VulkanCommandBufferUtil(const VulkanDeviceInfo*            device_info,
+                            const graphics::VulkanDeviceTable* device_table,
+                            CommonObjectInfoTable*             object_table);
 
-    ~VulkanCommandSplitter() = default;
+    ~VulkanCommandBufferUtil() = default;
 
-    VulkanCommandSplitter(const VulkanCommandSplitter&)            = delete;
-    VulkanCommandSplitter& operator=(const VulkanCommandSplitter&) = delete;
-    VulkanCommandSplitter(VulkanCommandSplitter&&)                 = default;
-    VulkanCommandSplitter& operator=(VulkanCommandSplitter&&)      = default;
+    VulkanCommandBufferUtil(const VulkanCommandBufferUtil&)            = delete;
+    VulkanCommandBufferUtil& operator=(const VulkanCommandBufferUtil&) = delete;
+    VulkanCommandBufferUtil(VulkanCommandBufferUtil&&)                 = default;
+    VulkanCommandBufferUtil& operator=(VulkanCommandBufferUtil&&)      = default;
+
+    void ReplaceWithAssociatedCommandBuffer(VulkanCommandBufferInfo* command_buffer_info);
 
     void SplitCommandBuffer(VulkanCommandBufferInfo* command_buffer_info);
 
@@ -131,23 +135,23 @@ class VulkanCommandSplitter
     std::vector<std::vector<VkCommandBuffer>>
     GetCommandBuffersFromSubmitInfos(const std::span<VkSubmitInfo2> submits_span);
 
-    VulkanCommandBufferSplitInfo& GetOrCreateSplitInfo(format::HandleId command_buffer_id);
-    VulkanCommandBufferSplitInfo* GetSplitInfo(format::HandleId command_buffer_id);
+    VulkanCommandBufferAssociatedInfo& GetOrCreateAssociatedInfo(format::HandleId command_buffer_id);
+    VulkanCommandBufferAssociatedInfo* GetAssociatedInfo(format::HandleId command_buffer_id);
 
     const VulkanDeviceInfo*            device_info_  = nullptr;
     const graphics::VulkanDeviceTable* device_table_ = nullptr;
     CommonObjectInfoTable*             object_table_ = nullptr;
 
     /// Map from the command buffer ID to the structure representing the split.
-    std::unordered_map<format::HandleId, VulkanCommandBufferSplitInfo> split_infos_;
+    std::unordered_map<format::HandleId, VulkanCommandBufferAssociatedInfo> split_infos_;
 
     /// Map from the command buffer handles to the original ID.
     std::unordered_map<VkCommandBuffer, format::HandleId> original_command_buffer_id_;
 };
 
-using VulkanPerDeviceCommandSplitters = std::unordered_map<const VulkanDeviceInfo*, VulkanCommandSplitter>;
+using VulkanPerDeviceCommandBufferUtils = std::unordered_map<const VulkanDeviceInfo*, VulkanCommandBufferUtil>;
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_DECODE_VULKAN_COMMAND_SPLITTER_H
+#endif // GFXRECON_DECODE_VULKAN_COMMAND_BUFFER_UTIL_H

--- a/framework/decode/vulkan_command_buffer_util.h
+++ b/framework/decode/vulkan_command_buffer_util.h
@@ -75,7 +75,7 @@ class VulkanCommandBufferAssociatedInfo
     ~VulkanCommandBufferAssociatedInfo()                                                   = default;
 
     void ReplaceWithNewHandle(VulkanCommandBufferInfo* command_buffer_info);
-    
+
     [[nodiscard]] const std::vector<VkCommandBuffer>& GetAssociatedHandles() const { return associated_handles_; }
 
     void PushSplitHandle(VkCommandBuffer handle) { split_handles_.push_back(handle); }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3507,6 +3507,27 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
             }
         }
 
+        if (options_.serialize_queue_submissions || options_.isolate_render_passes)
+        {
+            if (graphics::feature_util::IsSupportedExtension(available_extensions,
+                                                             VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME))
+            {
+                if (!graphics::feature_util::IsSupportedExtension(modified_extensions,
+                                                                  VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME))
+                {
+                    // Make sure to add the timeline semaphore extension name to the list of modified extensions.
+                    // This is necessary for enabling the necessary features by EnableRequiredPhysicalDeviceFeatures.
+                    modified_extensions.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
+                }
+            }
+            else
+            {
+                GFXRECON_LOG_ERROR("--serialize-queue-submissions or --isolate-render-passes was enabled, but the "
+                                   "replay device does not support timeline semaphores.");
+                std::abort();
+            }
+        }
+
         if (options_.remove_unsupported_features)
         {
             graphics::feature_util::RemoveUnsupportedExtensions(available_extensions, &modified_extensions);

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -318,7 +318,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
 
     // free replacer internal vulkan-resources
     device_address_replacers_.clear();
-    device_command_splitters_.clear();
+    device_command_buffer_utils_.clear();
 
     // free frame warm up resources
     device_frame_warmups_.clear();
@@ -3800,7 +3800,7 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
         // free replacer internal vulkan-resources for the device
         device_address_replacers_.erase(device_info);
 
-        device_command_splitters_.erase(device_info);
+        device_command_buffer_utils_.erase(device_info);
 
         // free potential swapchain-resources for the device
         GFXRECON_ASSERT(swapchain_)
@@ -4407,7 +4407,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
 
     if (options_.isolate_render_passes)
     {
-        auto& command_splitter = GetDeviceCommandSplitter(device_info);
+        auto& command_splitter = GetDeviceCommandBufferUtil(device_info);
         plan.Push(0,
                   [&command_splitter, &current_submits_span, queue_info](
                       const std::span<graphics::VulkanSemaphore> wait_semaphores) {
@@ -4671,7 +4671,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
 
     if (options_.isolate_render_passes)
     {
-        auto& command_splitter = GetDeviceCommandSplitter(device_info);
+        auto& command_splitter = GetDeviceCommandBufferUtil(device_info);
         plan.Push(0,
                   [&command_splitter, &current_submits_span, queue_info](
                       const std::span<graphics::VulkanSemaphore> wait_semaphores) {
@@ -5659,7 +5659,7 @@ void VulkanReplayConsumerBase::OverrideFreeCommandBuffers(PFN_vkFreeCommandBuffe
     if (options_.isolate_render_passes)
     {
         auto command_buffers = std::span(pCommandBuffers->GetHandlePointer(), command_buffer_count);
-        GetDeviceCommandSplitter(device_info).FreeCommandBuffers(command_pool_info->handle, command_buffers);
+        GetDeviceCommandBufferUtil(device_info).FreeCommandBuffers(command_pool_info->handle, command_buffers);
     }
 
     const VkCommandBuffer* in_pCommandBuffers = pCommandBuffers->GetHandlePointer();
@@ -10303,7 +10303,7 @@ VkResult VulkanReplayConsumerBase::OverrideBeginCommandBuffer(
     {
         auto* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
         GFXRECON_ASSERT(device_info != nullptr);
-        GetDeviceCommandSplitter(device_info).BeginCommandBuffer(command_buffer_info);
+        GetDeviceCommandBufferUtil(device_info).BeginCommandBuffer(command_buffer_info);
     }
 
     ClearCommandBufferInfo(command_buffer_info);
@@ -10359,7 +10359,7 @@ VkResult VulkanReplayConsumerBase::OverrideResetCommandBuffer(PFN_vkResetCommand
     if (options_.isolate_render_passes)
     {
         auto* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
-        GetDeviceCommandSplitter(device_info).ResetCommandBuffer(command_buffer_info);
+        GetDeviceCommandBufferUtil(device_info).ResetCommandBuffer(command_buffer_info);
     }
 
     return result;
@@ -10637,7 +10637,7 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
     if (options_.isolate_render_passes)
     {
         VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
-        GetDeviceCommandSplitter(device_info).SplitCommandBuffer(command_buffer_info);
+        GetDeviceCommandBufferUtil(device_info).SplitCommandBuffer(command_buffer_info);
     }
 
     MaybeInjectExecutionBarrier(command_buffer_info);
@@ -10673,7 +10673,7 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass2(
     if (options_.isolate_render_passes)
     {
         VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
-        GetDeviceCommandSplitter(device_info).SplitCommandBuffer(command_buffer_info);
+        GetDeviceCommandBufferUtil(device_info).SplitCommandBuffer(command_buffer_info);
     }
 
     MaybeInjectExecutionBarrier(command_buffer_info);
@@ -10751,7 +10751,7 @@ void VulkanReplayConsumerBase::OverrideCmdEndRenderPass(PFN_vkCmdEndRenderPass  
     if (options_.isolate_render_passes)
     {
         VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
-        GetDeviceCommandSplitter(device_info).SplitCommandBuffer(command_buffer_info);
+        GetDeviceCommandBufferUtil(device_info).SplitCommandBuffer(command_buffer_info);
     }
 }
 
@@ -10771,7 +10771,7 @@ void VulkanReplayConsumerBase::OverrideCmdEndRenderPass2(
     if (options_.isolate_render_passes)
     {
         VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
-        GetDeviceCommandSplitter(device_info).SplitCommandBuffer(command_buffer_info);
+        GetDeviceCommandBufferUtil(device_info).SplitCommandBuffer(command_buffer_info);
     }
 }
 
@@ -10785,7 +10785,7 @@ void VulkanReplayConsumerBase::OverrideCmdBeginRendering(
     if (options_.isolate_render_passes)
     {
         VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
-        GetDeviceCommandSplitter(device_info).SplitCommandBuffer(command_buffer_info);
+        GetDeviceCommandBufferUtil(device_info).SplitCommandBuffer(command_buffer_info);
     }
 
     MaybeInjectExecutionBarrier(command_buffer_info);
@@ -10804,7 +10804,7 @@ void VulkanReplayConsumerBase::OverrideCmdEndRendering(PFN_vkCmdEndRendering    
     if (options_.isolate_render_passes)
     {
         VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
-        GetDeviceCommandSplitter(device_info).SplitCommandBuffer(command_buffer_info);
+        GetDeviceCommandBufferUtil(device_info).SplitCommandBuffer(command_buffer_info);
     }
 }
 
@@ -11850,15 +11850,15 @@ VulkanFrameWarmUp& VulkanReplayConsumerBase::GetDeviceFrameWarmUp(const VulkanDe
     return new_it->second;
 }
 
-VulkanCommandSplitter& VulkanReplayConsumerBase::GetDeviceCommandSplitter(const VulkanDeviceInfo* device_info)
+VulkanCommandBufferUtil& VulkanReplayConsumerBase::GetDeviceCommandBufferUtil(const VulkanDeviceInfo* device_info)
 {
-    if (auto it = device_command_splitters_.find(device_info); it != device_command_splitters_.end())
+    if (auto it = device_command_buffer_utils_.find(device_info); it != device_command_buffer_utils_.end())
     {
         return it->second;
     }
 
-    auto [new_it, success] = device_command_splitters_.insert(
-        { device_info, VulkanCommandSplitter(device_info, GetDeviceTable(device_info->handle), object_info_table_) });
+    auto [new_it, success] = device_command_buffer_utils_.insert(
+        { device_info, VulkanCommandBufferUtil(device_info, GetDeviceTable(device_info->handle), object_info_table_) });
     GFXRECON_ASSERT(success);
     return new_it->second;
 }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -36,7 +36,7 @@
 #include "decode/vulkan_object_info.h"
 #include "decode/common_object_info_table.h"
 #include "decode/vulkan_replay_options.h"
-#include "decode/vulkan_command_splitter.h"
+#include "decode/vulkan_command_buffer_util.h"
 #include "decode/vulkan_resource_allocator.h"
 #include "decode/vulkan_submit_job.h"
 #include "decode/vulkan_swapchain.h"
@@ -1859,7 +1859,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     decode::VulkanDeviceAddressTracker& GetDeviceAddressTracker(const decode::VulkanDeviceInfo* device_info);
     decode::VulkanAddressReplacer&      GetDeviceAddressReplacer(const decode::VulkanDeviceInfo* device_info);
     VulkanFrameWarmUp&                  GetDeviceFrameWarmUp(const VulkanDeviceInfo* device_info);
-    VulkanCommandSplitter&              GetDeviceCommandSplitter(const VulkanDeviceInfo* device_info);
+    VulkanCommandBufferUtil&            GetDeviceCommandBufferUtil(const VulkanDeviceInfo* device_info);
     VulkanSubmitJobExecutor&            GetDeviceSubmitJobExecutor(const VulkanDeviceInfo* device_info);
 
     /**
@@ -2002,7 +2002,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VulkanPerDeviceAddressTrackers    device_address_trackers_;
     VulkanPerDeviceAddressReplacers   device_address_replacers_;
     VulkanPerDeviceFrameWarmUp        device_frame_warmups_;
-    VulkanPerDeviceCommandSplitters   device_command_splitters_;
+    VulkanPerDeviceCommandBufferUtils device_command_buffer_utils_;
     VulkanPerDeviceSubmitJobExecutors device_submit_job_executors_;
 
     util::ThreadPool main_thread_queue_;

--- a/framework/decode/vulkan_submit_job.cpp
+++ b/framework/decode/vulkan_submit_job.cpp
@@ -103,6 +103,8 @@ bool VulkanInjectedSemaphore::HasReachedTargetValue() const
         return false;
     }
 
+    GFXRECON_ASSERT(device_table_->GetSemaphoreCounterValue != nullptr);
+
     uint64_t read_value = 0;
     VkResult result = device_table_->GetSemaphoreCounterValue(device_info_->handle, semaphore_.semaphore, &read_value);
     if (result != VK_SUCCESS)

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -192,6 +192,31 @@ VkBool32 VulkanDeviceUtil::EnableDynamicRenderingFeatures(const VulkanInstanceUt
     return feature_struct->dynamicRendering;
 }
 
+template <typename T>
+VkBool32 VulkanDeviceUtil::EnableTimelineSemaphoreFeatures(const VulkanInstanceUtilInfo& instance_info,
+                                                           const VulkanInstanceTable*    instance_table,
+                                                           const VkPhysicalDevice        physical_device,
+                                                           T*                            feature_struct)
+{
+    // Type must be feature struct type that contains timelineSemaphore
+    static_assert(std::is_same<T, VkPhysicalDeviceVulkan12Features>::value ||
+                      std::is_same<T, VkPhysicalDeviceTimelineSemaphoreFeatures>::value,
+                  "Unexpected type for EnableTimelineSemaphoreFeatures");
+
+    // Enable timeline semaphore feature if it supported by the device
+    if (!feature_struct->timelineSemaphore)
+    {
+        T supported_features{ feature_struct->sType, nullptr };
+        GetPhysicalDeviceFeatures(instance_info, instance_table, physical_device, supported_features);
+        if (supported_features.timelineSemaphore)
+        {
+            feature_struct->timelineSemaphore = VK_TRUE;
+        }
+    }
+
+    return feature_struct->timelineSemaphore;
+}
+
 VulkanDevicePropertyFeatureInfo
 VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(const VulkanInstanceUtilInfo& instance_info,
                                                        const VulkanInstanceTable*    instance_table,
@@ -206,22 +231,31 @@ VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(const VulkanInstanceUtilI
     // If the pNext chain includes a VkPhysicalDeviceVulkan11Features structure, then it must not include a
     // VkPhysicalDeviceSamplerYcbcrConversionFeatures structure
     bool vulkan_1_1_features_found               = false;
+    bool vulkan_1_2_features_found               = false;
     bool vulkan_1_3_features_found               = false;
     bool sampler_ycbcr_conversion_features_found = false;
     bool maintenance10_found                     = false;
     bool dynamic_rendering_found                 = false;
+    bool timeline_semaphore_found                = false;
 
     while (current_struct->pNext != nullptr)
     {
         current_struct = current_struct->pNext;
         switch (current_struct->sType)
         {
-            // Enable bufferDeviceAddressCaptureReplay if bufferDeviceAddress feature is enabled
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES:
             {
                 auto vulkan_1_2_features = reinterpret_cast<VkPhysicalDeviceVulkan12Features*>(current_struct);
+
+                // Enable bufferDeviceAddressCaptureReplay if bufferDeviceAddress feature is enabled
                 result.feature_bufferDeviceAddressCaptureReplay = EnableRequiredBufferDeviceAddressFeatures(
                     instance_info, instance_table, physical_device, vulkan_1_2_features);
+
+                // Enable timelineSemaphore if timelineSemaphore feature is enabled
+                result.feature_timeline_semaphore = EnableTimelineSemaphoreFeatures(
+                    instance_info, instance_table, physical_device, vulkan_1_2_features);
+
+                vulkan_1_2_features_found = true;
             }
             break;
 
@@ -409,6 +443,24 @@ VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(const VulkanInstanceUtilI
             }
             break;
 
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES:
+            {
+                auto* timeline_semaphore_features =
+                    reinterpret_cast<VkPhysicalDeviceTimelineSemaphoreFeatures*>(current_struct);
+                result.feature_timeline_semaphore = timeline_semaphore_features->timelineSemaphore;
+                if (result.feature_timeline_semaphore == VK_FALSE &&
+                    graphics::feature_util::IsSupportedExtension(create_info->ppEnabledExtensionNames,
+                                                                 create_info->enabledExtensionCount,
+                                                                 VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME))
+                {
+                    result.feature_timeline_semaphore = EnableTimelineSemaphoreFeatures(
+                        instance_info, instance_table, physical_device, timeline_semaphore_features);
+                }
+
+                timeline_semaphore_found = true;
+            }
+            break;
+
             default:
                 break;
         }
@@ -465,6 +517,24 @@ VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(const VulkanInstanceUtilI
         if (dynamic_rendering_features.dynamicRendering == VK_TRUE)
         {
             current_struct->pNext = reinterpret_cast<VkBaseOutStructure*>(&dynamic_rendering_features);
+            current_struct        = current_struct->pNext;
+        }
+    }
+
+    if (!vulkan_1_2_features_found && !timeline_semaphore_found &&
+        graphics::feature_util::IsSupportedExtension(create_info->ppEnabledExtensionNames,
+                                                     create_info->enabledExtensionCount,
+                                                     VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME))
+    {
+        static VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = {
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES
+        };
+        timeline_semaphore_features.pNext = nullptr;
+        result.feature_timeline_semaphore = EnableTimelineSemaphoreFeatures(
+            instance_info, instance_table, physical_device, &timeline_semaphore_features);
+        if (timeline_semaphore_features.timelineSemaphore == VK_TRUE)
+        {
+            current_struct->pNext = reinterpret_cast<VkBaseOutStructure*>(&timeline_semaphore_features);
             current_struct        = current_struct->pNext;
         }
     }

--- a/framework/graphics/vulkan_device_util.h
+++ b/framework/graphics/vulkan_device_util.h
@@ -77,6 +77,8 @@ struct VulkanDevicePropertyFeatureInfo
     bool dynamic_rendering_depth_stencil_resolve{ false };
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties;
+
+    VkBool32 feature_timeline_semaphore{ VK_FALSE };
 };
 
 class VulkanDeviceUtil
@@ -118,6 +120,12 @@ class VulkanDeviceUtil
                                             const graphics::VulkanInstanceTable* instance_table,
                                             const VkPhysicalDevice               physical_device,
                                             T*                                   feature_struct);
+
+    template <typename T>
+    VkBool32 EnableTimelineSemaphoreFeatures(const VulkanInstanceUtilInfo&        instance_info,
+                                             const graphics::VulkanInstanceTable* instance_table,
+                                             const VkPhysicalDevice               physical_device,
+                                             T*                                   feature_struct);
 
     // VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressCaptureReplay
     VkBool32* bufferDeviceAddressCaptureReplay_ptr{ nullptr };


### PR DESCRIPTION
Generalize VulkanCommandSplitter into VulkanCommandBufferUtil.

Rename split info to associated info and extract
ReplaceWithAssociatedCommandBuffer from SplitCommandBuffer, so a command buffer handle can be swapped without ending/beginning a split. Prepares for frame-loop handling of command buffers reset during the loop frame.