### PR TITLE
fix junk fpsinfo output; use sized integer print macros

### DIFF
--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -180,9 +180,10 @@ void FpsInfo::LogMeasurements()
     uint64_t measured_frames = measurement_end_frame_ - measurement_start_frame_;
     double   measured_fps    = (measured_time > 0.0) ? static_cast<double>(measured_frames) / measured_time : 0.0;
 
-    GFXRECON_WRITE_CONSOLE("Load time:  %f seconds (frame %lu)", load_time, replay_start_frame_);
+    GFXRECON_WRITE_CONSOLE("Load time:  %f seconds (frame %" PRIu64 ")", load_time, replay_start_frame_);
     GFXRECON_WRITE_CONSOLE("Total time: %f seconds", total_time);
-    GFXRECON_WRITE_CONSOLE("Measured FPS: %f fps, %f seconds, %lu frame%s, 1 loop, framerange [%lu-%lu)",
+    GFXRECON_WRITE_CONSOLE("Measured FPS: %f fps, %f seconds, %" PRIu64 " frame%s, 1 loop, framerange [%" PRIu64
+                           "-%" PRIu64 ")",
                            measured_fps,
                            measured_time,
                            measured_frames,


### PR DESCRIPTION
integer types in Varargs didn't match the printf-style format types, so different sizes were consumed, causing subsequent specifiers to consume the wrong values.  Fix the printf types to match the passed parameters on 64-bit and 32-bit.