### PR TITLE
Fix usage exe name

### DIFF
--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -47,11 +47,12 @@ const char kArgUnknown[] = "<Unknown>";
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name = GetApplicationName(exe_name);
+    std::string trimmed_exe_name = GetTrimmedExeName(exe_name);
+    std::string app_name         = GetApplicationName(exe_name);
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to compress/decompress GFXReconstruct capture files.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
     GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] <input_file> <output_file> <compression_format>\n",
-                           app_name.c_str());
+                           trimmed_exe_name.c_str());
     GFXRECON_WRITE_CONSOLE("Required arguments:");
     GFXRECON_WRITE_CONSOLE("  <input_file>\t\tPath to the input file to process.");
     GFXRECON_WRITE_CONSOLE("  <output_file>\t\tPath to the output file to generate.");

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -43,11 +43,12 @@ const char kArguments[] = "--output,--format,--log-level,--frame-range";
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name = GetApplicationName(exe_name);
+    std::string trimmed_exe_name = GetTrimmedExeName(exe_name);
+    std::string app_name         = GetApplicationName(exe_name);
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to convert the contents of GFXReconstruct capture files to JSON.\n",
                            app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
-    GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] <file>\n", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] <file>\n", trimmed_exe_name.c_str());
     GFXRECON_WRITE_CONSOLE("Required arguments:");
     GFXRECON_WRITE_CONSOLE("  <file>\t\tPath to the GFXReconstruct capture file to be converted");
     GFXRECON_WRITE_CONSOLE("        \t\tto text.");

--- a/tools/extract/main.cpp
+++ b/tools/extract/main.cpp
@@ -43,10 +43,11 @@ const char kArguments[] = "--dir";
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name = GetApplicationName(exe_name);
+    std::string trimmed_exe_name = GetTrimmedExeName(exe_name);
+    std::string app_name         = GetApplicationName(exe_name);
     GFXRECON_WRITE_CONSOLE("\n%s - Extract shaders from a GFXReconstruct capture file.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
-    GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] [--dir <dir>] <file>\n", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] [--dir <dir>] <file>\n", trimmed_exe_name.c_str());
     GFXRECON_WRITE_CONSOLE("Required arguments:");
     GFXRECON_WRITE_CONSOLE("  <file>\t\tThe GFXReconstruct capture file to be processed.");
     GFXRECON_WRITE_CONSOLE("Optional arguments:");

--- a/tools/file_version_patch/main.cpp
+++ b/tools/file_version_patch/main.cpp
@@ -47,9 +47,10 @@ const char kUnrecognizedFormatString[] = "<unrecognized-format>";
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name = GetApplicationName(exe_name);
+    std::string trimmed_exe_name = GetTrimmedExeName(exe_name);
+    std::string app_name         = GetApplicationName(exe_name);
     GFXRECON_WRITE_CONSOLE("\n%s - Patch the file format version of a GFXReconstruct capture file.\n",
-                           app_name.c_str());
+                           trimmed_exe_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
     GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version]<file>\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Required arguments:");

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -774,7 +774,11 @@ int main(int argc, const char** argv)
         PrintVersionHeader(argv[0]);
         for (auto& feature : g_info_features)
         {
-            GFXRECON_WRITE_CONSOLE(feature->CompiledHeaderVersionString().c_str());
+            std::string feature_version = feature->CompiledHeaderVersionString();
+            if (feature_version.size())
+            {
+                GFXRECON_WRITE_CONSOLE(feature_version.c_str());
+            }
         }
 
         gfxrecon::util::Log::Release();

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -57,10 +57,11 @@ static std::vector<std::unique_ptr<gfxrecon::optimize::OptimizeFeature>> g_optim
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name = GetApplicationName(exe_name);
+    std::string trimmed_exe_name = GetTrimmedExeName(exe_name);
+    std::string app_name         = GetApplicationName(exe_name);
 
     // Build synopsis from feature fragments so it stays in sync automatically.
-    std::string synopsis = app_name + " [-h | --help] [--version]";
+    std::string synopsis = trimmed_exe_name + " [-h | --help] [--version]";
     for (const auto& feature : g_optimize_features)
     {
         const std::string fragment = feature->GetSynopsisFragment();

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -52,11 +52,12 @@ const char kArguments[] =
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name = GetApplicationName(exe_name);
+    std::string trimmed_exe_name = GetTrimmedExeName(exe_name);
+    std::string app_name         = GetApplicationName(exe_name);
 
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to replay GFXReconstruct capture files.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
-    GFXRECON_WRITE_CONSOLE("  %s\t[-h | --help] [--version]", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("  %s\t[-h | --help] [--version]", trimmed_exe_name.c_str());
     GFXRECON_WRITE_CONSOLE("\t\t\t[--cpu-mask <binary-mask>] [--gpu <index>] [--gpu-group <index>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--pause-frame <N>] [--paused] [--sync] [--screenshot-all]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshots <N1(-N2),...>] [--screenshot-format <format>]");

--- a/tools/tocpp/main.cpp
+++ b/tools/tocpp/main.cpp
@@ -122,12 +122,14 @@ const std::string path_assets = "app/src/main/assets/";
 
 static void PrintUsage(const char* exe_name)
 {
-    std::string app_name = GetApplicationName(exe_name);
+    std::string trimmed_exe_name = GetTrimmedExeName(exe_name);
+    std::string app_name         = GetApplicationName(exe_name);
+
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to convert GFXReconstruct capture files to Vulkan source.\n",
                            app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
-    GFXRECON_WRITE_CONSOLE("  %s [arguments] <capture_file>\n", app_name.c_str());
-    GFXRECON_WRITE_CONSOLE("     <capture_file> must be a valid GFXReconstruct capture file\n", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("  %s [arguments] <capture_file>\n", trimmed_exe_name.c_str());
+    GFXRECON_WRITE_CONSOLE("     <capture_file> must be a valid GFXReconstruct capture file\n");
     GFXRECON_WRITE_CONSOLE("     Required Arguments:");
 
     for (auto& argument : g_argument_list)

--- a/tools/tool_command_line.h
+++ b/tools/tool_command_line.h
@@ -45,19 +45,25 @@ const char kHelpShortOption[] = "-h";
 const char kHelpLongOption[]  = "--help";
 const char kVersionOption[]   = "--version";
 
+/// @return exe_name with any leading directory components removed
+inline std::string GetTrimmedExeName(const char* exe_name)
+{
+    std::string actual_exe   = exe_name;
+    size_t      dir_location = actual_exe.find_last_of("/\\");
+
+    if (dir_location != std::string::npos)
+    {
+        actual_exe.replace(0, dir_location + 1, "");
+    }
+
+    return actual_exe;
+}
+
 /// @return exe_name with any leading directory components removed, and the
 /// GFXRECON_APP_NAME_PREFIX configured at build time (see project_version.h.in) applied.
 inline std::string GetApplicationName(const char* exe_name)
 {
-    std::string app_name     = exe_name;
-    size_t      dir_location = app_name.find_last_of("/\\");
-
-    if (dir_location != std::string::npos)
-    {
-        app_name.replace(0, dir_location + 1, "");
-    }
-
-    return GFXRECON_APP_NAME_PREFIX + app_name;
+    return GFXRECON_APP_NAME_PREFIX + GetTrimmedExeName(exe_name);
 }
 
 /// Prints the "<app name> version info:" / "GFXReconstruct Version x.x.x" lines common to every


### PR DESCRIPTION
My last commit was over-zealous and added a prefix in front of an exe name.  The usage exe name should have been the trimmed exe name, not the full app name.

This fixes that.