### PR TITLE
Add screenshot enable query to capture manager

### DIFF
--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -134,6 +134,7 @@ class ApiCaptureManager
         common_manager_->PostQueueSubmit(api_family_, current_lock);
     }
 
+    bool ScreenshotsEnabled() { return common_manager_->ScreenshotsEnabled(); }
     bool ShouldTriggerScreenshot() { return common_manager_->ShouldTriggerScreenshot(); }
 
     void CheckContinueCaptureForWriteMode(uint32_t                                               current_boundary_count,

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -244,6 +244,7 @@ class CommonCaptureManager
     void PreQueueSubmit(format::ApiFamilyId api_family, std::shared_lock<ApiCallMutexT>& current_lock);
     void PostQueueSubmit(format::ApiFamilyId api_family, std::shared_lock<ApiCallMutexT>& current_lock);
 
+    bool ScreenshotsEnabled() { return screenshots_enabled_; }
     bool ShouldTriggerScreenshot();
 
     util::ScreenshotFormat GetScreenshotFormat()

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -244,7 +244,11 @@ class CommonCaptureManager
     void PreQueueSubmit(format::ApiFamilyId api_family, std::shared_lock<ApiCallMutexT>& current_lock);
     void PostQueueSubmit(format::ApiFamilyId api_family, std::shared_lock<ApiCallMutexT>& current_lock);
 
-    bool ScreenshotsEnabled() { return screenshots_enabled_; }
+    bool ScreenshotsEnabled()
+    {
+        return screenshots_enabled_;
+    }
+
     bool ShouldTriggerScreenshot();
 
     util::ScreenshotFormat GetScreenshotFormat()


### PR DESCRIPTION
Simply adds a query to determine if the screenshot is enabled.  This allows us to restrict code that is only used if screenshotting is even enbaled.