### PR TITLE
Change Agility SDK order during state writing

### DIFF
--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -94,11 +94,13 @@ void Dx12StateWriter::WriteState(const Dx12StateTable& state_table, uint64_t fra
     WriteAgsDriverExtensionsDX12CreateDevice(ags_state_table);
 #endif // GFXRECON_AGS_SUPPORT
 
+    // Agility SDK constructs
+    StandardCreateWrite<ID3D12SDKConfiguration_Wrapper>(state_table);
+    StandardCreateWrite<ID3D12DeviceFactory_Wrapper>(state_table);
+
     // Device
     StandardCreateWrite<ID3D12Device_Wrapper>(state_table);
 
-    // Agility SDK constructs
-    StandardCreateWrite<ID3D12DeviceFactory_Wrapper>(state_table);
     StandardCreateWrite<ID3D12DeviceConfiguration_Wrapper>(state_table);
 
     // Write this out before rendering begins

--- a/framework/graphics/dx12_resource_data_util.cpp
+++ b/framework/graphics/dx12_resource_data_util.cpp
@@ -198,7 +198,8 @@ void Dx12ResourceDataUtil::GetResourceCopyInfo(ID3D12Resource*                  
         subresource_sizes.push_back(resource_desc.Width);
         subresource_offsets.push_back(0);
 
-        device->GetCopyableFootprints(&resource_desc, 0, 1, 0, layouts.data(), nullptr, nullptr, &total_size);
+        graphics::dx12::RobustGetCopyableFootprint(
+            device, resource, &resource_desc, 0, 1, 0, layouts.data(), nullptr, nullptr, &total_size);
 
         // Total resource size should be equal to buffer width and should have 0 offset.
         GFXRECON_ASSERT((total_size == resource_desc.Width) && (layouts[0].Offset == 0));


### PR DESCRIPTION
Device creation relies on the device factory. Furthermore, the device factory relies on the SDK configuration which doesn't happen unless the state writer writes it as a parent, which only happens if the app releases the configuration at state writing.

Add a write for the configuration, and create the device after the factory is created.

Also update `dx12_resource_data_util.cpp`'s `GetResourceCopyInfo` to use `RobustGetCopyableFootprint` on buffers as they might also have tight alignment.

Fixes https://github.com/LunarG/gfxreconstruct/issues/2777 's trimming issue.