### PR TITLE
Add a CI workflow job that runs clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: '-*,bugprone-virtual-near-miss,clang-analyzer-optin.cplusplus.VirtualCall'

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -43,6 +43,24 @@ jobs:
           exit 1
         fi
 
+  clang-tidy:
+    name: "Check code quality with clang-tidy"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-tidy-18 libx11-xcb-dev libxcb-keysyms1-dev libwayland-dev libxrandr-dev liblz4-dev libzstd-dev
+    - name: Configure
+      run: cmake -S . -B tidy-build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - name: Run clang-tidy
+      run: |
+        run-clang-tidy-18 -p tidy-build -quiet \
+          -warnings-as-errors='*' \
+          'framework/|tools/|layer/'
 
   linux:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         run-clang-tidy-18 -p tidy-build -quiet \
           -warnings-as-errors='*' \
-          'framework/|tools/|layer/'
+          '(framework/(?!generated/)|tools/|layer/)'
 
   linux:
     name: ${{ matrix.config.name }}

--- a/framework/decode/async_processor.h
+++ b/framework/decode/async_processor.h
@@ -72,7 +72,7 @@ class AsyncProcessor
         explicit AsyncBatchIterator(AsyncProcessor& async_processor, AsyncBatchQueue& queue) :
             async_processor_(&async_processor), queue_(&queue)
         {
-            Advance();
+            AsyncBatchIterator::Advance();
         }
         void Advance() override;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -314,7 +314,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     }
 
     // Idle all devices before destroying other resources.
-    WaitDevicesIdle();
+    VulkanReplayConsumerBase::WaitDevicesIdle();
 
     // free replacer internal vulkan-resources
     device_address_replacers_.clear();

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -319,7 +319,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     }
 
     // Idle all devices before destroying other resources.
-    WaitDevicesIdle();
+    VulkanReplayConsumerBase::WaitDevicesIdle();
 
     // free replacer internal vulkan-resources
     device_address_replacers_.clear();

--- a/tools/replay/replay_feature.h
+++ b/tools/replay/replay_feature.h
@@ -47,7 +47,7 @@ GFXRECON_BEGIN_NAMESPACE(replay)
 class ReplayFeatureBase : public util::FeatureBase
 {
   public:
-    virtual ~ReplayFeatureBase() { Destroy(); }
+    virtual ~ReplayFeatureBase() = default;
 
     // Options queries
     virtual void QueryOptions(util::ArgumentParser& arg_parser, const std::string& capture_filename) {}


### PR DESCRIPTION
Add a job that runs clang-tidy on C++ code _except generated code_.  The job currently runs at 30 minutes without generated code, nearly an hour with generated.  Another possibility is to run `clang-tidy-cache` which would generally reduce runtime somewhat.