### PR TITLE
Check memory before write

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10133,14 +10133,35 @@ VkDeviceAddress VulkanReplayConsumerBase::OverrideGetBufferDeviceAddress(
     // retrieve replay-time device-address
     VkDeviceAddress replay_device_address = func(device, address_info);
 
-    // if supported, opaque device-addresses are expected to match
-    GFXRECON_ASSERT(!device_info->allocator->SupportsOpaqueDeviceAddresses() ||
-                    original_result == replay_device_address)
-
-    // keep track of old/new addresses in any case
     format::HandleId  buffer      = pInfo->GetMetaStructPointer()->buffer;
     VulkanBufferInfo* buffer_info = GetObjectInfoTable().GetVkBufferInfo(buffer);
     GFXRECON_ASSERT(buffer_info != nullptr);
+
+    // if supported, opaque device-addresses are expected to match.
+    //
+    // According to VUID-vkGetBufferDeviceAddress-bufferDeviceAddress-03324,
+    // The buffer has to
+    // 1. be a sparse, or
+    // 2. bind a valid memory, or
+    // 3. be created with VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT.
+    //
+    // Although it's legal to GetBufferDeviceAddress,
+    // the replay address could be 0 and mismatch if the memory is invalid, so print warning, instead of ASSERT.
+    //
+    // For trimming case, the buffer could still exist, but the memory is freed when the trimming starts.
+    if (device_info->allocator->SupportsOpaqueDeviceAddresses() && original_result != replay_device_address)
+    {
+        GFXRECON_LOG_WARNING(
+            "Opaque device addresses are supported, so captured and replay buffer device addresses are "
+            "expected to match. Buffer (ID = %" PRIu64 ") was captured with address 0x%" PRIx64
+            ", but replay returned 0x%" PRIx64 ". This can happen when the buffer's memory was freed "
+            "before the trim range started.",
+            buffer_info->capture_id,
+            original_result,
+            replay_device_address);
+    }
+
+    // keep track of old/new addresses in any case
     buffer_info->capture_address = original_result;
     buffer_info->replay_address  = replay_device_address;
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -922,9 +922,10 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
 
         auto* buffer_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::BufferWrapper>(*pBuffer);
         GFXRECON_ASSERT(buffer_wrapper);
-        buffer_wrapper->device = device;
-        buffer_wrapper->size   = modified_create_info->size;
-        buffer_wrapper->usage  = pCreateInfo->usage;
+        buffer_wrapper->device         = device;
+        buffer_wrapper->size           = modified_create_info->size;
+        buffer_wrapper->usage          = pCreateInfo->usage;
+        buffer_wrapper->modified_flags = modified_create_info->flags;
 
         if (uses_address)
         {

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -215,10 +215,11 @@ struct BufferViewWrapper;
 struct BufferWrapper : public HandleWrapper<VkBuffer>, AssetWrapperBase
 {
     // State tracking info for buffers with device addresses.
-    VkDevice           device{ VK_NULL_HANDLE };
-    VkDeviceAddress    address{ 0 };
-    VkDeviceAddress    opaque_address{ 0 };
-    VkBufferUsageFlags usage{ 0 };
+    VkDevice            device{ VK_NULL_HANDLE };
+    VkDeviceAddress     address{ 0 };
+    VkDeviceAddress     opaque_address{ 0 };
+    VkBufferUsageFlags  usage{ 0 };
+    VkBufferCreateFlags modified_flags{ 0 };
 
     std::set<BufferViewWrapper*> buffer_views;
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1535,18 +1535,37 @@ void VulkanStateWriter::WriteBufferDeviceAddressState(const VulkanStateTable& st
         GFXRECON_ASSERT(wrapper != nullptr && wrapper->device != VK_NULL_HANDLE);
         if (wrapper->device != VK_NULL_HANDLE && wrapper->address != 0)
         {
-            auto physical_device_wrapper = wrapper->bind_device->physical_device;
-            auto call_id                 = physical_device_wrapper->parent_info.api_version >= VK_MAKE_VERSION(1, 2, 0)
-                                               ? format::ApiCall_vkGetBufferDeviceAddress
-                                               : format::ApiCall_vkGetBufferDeviceAddressKHR;
+            const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper =
+                state_table.GetVulkanDeviceMemoryWrapper(wrapper->bind_memory_id);
 
-            parameter_stream_.Clear();
-            encoder_.EncodeHandleIdValue(wrapper->bind_device->handle_id);
-            VkBufferDeviceAddressInfoKHR info{ VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr, wrapper->handle };
-            EncodeStructPtr(&encoder_, &info);
-            encoder_.EncodeVkDeviceAddressValue(wrapper->address);
-            WriteFunctionCall(call_id, &parameter_stream_);
-            parameter_stream_.Clear();
+            // According to VUID-vkGetBufferDeviceAddress-bufferDeviceAddress-03324,
+            // The buffer has to
+            // 1. be a sparse, or
+            // 2. bind a valid memory, or
+            // 3. be created with VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT.
+            //
+            // Since VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT is always added by gfxr,
+            // if the buffer device address is used. We don't need to check this flag.
+            //
+            // Memory could have been freed before the buffer was destroyed, so only write the buffer device address
+            // if the memory still exists.
+            if (memory_wrapper != nullptr || wrapper->is_sparse_buffer)
+            {
+                auto physical_device_wrapper = wrapper->bind_device->physical_device;
+                auto call_id = physical_device_wrapper->parent_info.api_version >= VK_MAKE_VERSION(1, 2, 0)
+                                   ? format::ApiCall_vkGetBufferDeviceAddress
+                                   : format::ApiCall_vkGetBufferDeviceAddressKHR;
+
+                parameter_stream_.Clear();
+                encoder_.EncodeHandleIdValue(wrapper->bind_device->handle_id);
+                VkBufferDeviceAddressInfoKHR info{ VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO,
+                                                   nullptr,
+                                                   wrapper->handle };
+                EncodeStructPtr(&encoder_, &info);
+                encoder_.EncodeVkDeviceAddressValue(wrapper->address);
+                WriteFunctionCall(call_id, &parameter_stream_);
+                parameter_stream_.Clear();
+            }
         }
     });
 }


### PR DESCRIPTION
Memory could have been freed before the buffer was destroyed, so only write the buffer device address if the memory still exists.