### PR TITLE
Fix Vulkan-disabled build

### DIFF
--- a/framework/encode/struct_pointer_encoder.h
+++ b/framework/encode/struct_pointer_encoder.h
@@ -45,6 +45,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
+#if defined(GFXRECON_ENABLE_VULKAN)
 inline void EncodeStructPtr(ParameterEncoder*         encoder,
                             const VkBaseOutStructure* value,
                             bool                      omit_data = false,
@@ -63,6 +64,7 @@ inline void EncodeStructPtr(ParameterEncoder*         encoder,
         encoder->EncodeStructPtrPreamble(nullptr);
     }
 }
+#endif
 
 template <typename T>
 void EncodeStructPtr(ParameterEncoder* encoder, const T* value, bool omit_data = false, bool omit_addr = false)


### PR DESCRIPTION
The recent changes for ARM Tensors introduced a breakage in the Vulkan-disabled build of GFXR.  This resolves  it.