### PR TITLE
[Frame looping] Fix nullptr crash regarding fence handling

### DIFF
--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -279,6 +279,11 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyFence(const ApiCallInfo& ca
         if (per_device_fence_tracking_.contains(args.device))
         {
             FenceTracking& t = per_device_fence_tracking_[args.device];
+
+            // Remove fence tracking struct from map if
+            // fence was destroyed during the loop range.
+            // This is a no-op in the case that the fence
+            // was created before the loop range.
             t.initial_fence_states_.erase(args.fence);
         }
     }

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -274,16 +274,14 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateFence(const ApiCallInfo& cal
 
 void VulkanReplayFrameLoopConsumer::Process_vkDestroyFence(const ApiCallInfo& call_info, args::DestroyFence& args)
 {
-    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    if (allocatedLoopResources.contains(args.fence))
     {
         if (per_device_fence_tracking_.contains(args.device))
         {
             FenceTracking& t = per_device_fence_tracking_[args.device];
 
             // Remove fence tracking struct from map if
-            // fence was destroyed during the loop range.
-            // This is a no-op in the case that the fence
-            // was created before the loop range.
+            // fence was created and destroyed during the loop range.
             t.initial_fence_states_.erase(args.fence);
         }
     }

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -274,7 +274,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateFence(const ApiCallInfo& cal
 
 void VulkanReplayFrameLoopConsumer::Process_vkDestroyFence(const ApiCallInfo& call_info, args::DestroyFence& args)
 {
-    if (frame_loop_info_.IsFinalIteration())
+    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
     {
         if (per_device_fence_tracking_.contains(args.device))
         {


### PR DESCRIPTION
This PR changes the frame loop handling of vkDestroyFence such that it deletes the fence tracking info if destroy was called during the first iteration of the loop range. Before this change, in the case of a fence being created and destroyed in the same frame, replay would crash with a nullptr dereference.