### PR TITLE
replay: Reissue command buffer state

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -278,6 +278,7 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_swapchain.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_swapchain.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_swapchain_format.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_state_recording_decoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_temporary_objects.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_temporary_objects.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_tracked_object_info.h

--- a/framework/decode/vulkan_command_buffer_util.cpp
+++ b/framework/decode/vulkan_command_buffer_util.cpp
@@ -80,9 +80,10 @@ void VulkanCommandBufferAssociatedInfo::ReplaceWithNewHandle(VulkanCommandBuffer
 
 VulkanCommandBufferUtil::VulkanCommandBufferUtil(const VulkanDeviceInfo*            device_info,
                                                  const graphics::VulkanDeviceTable* device_table,
-                                                 CommonObjectInfoTable*             object_table) :
+                                                 CommonObjectInfoTable*             object_table,
+                                                 VulkanStateRecordingDecoder*       decoder) :
     device_info_(device_info),
-    device_table_(device_table), object_table_(object_table)
+    device_table_(device_table), object_table_(object_table), decoder_(decoder)
 {
     GFXRECON_ASSERT(device_info != nullptr);
     GFXRECON_ASSERT(device_table != nullptr);
@@ -155,6 +156,11 @@ void VulkanCommandBufferUtil::ReplaceWithAssociatedCommandBuffer(VulkanCommandBu
 
 void VulkanCommandBufferUtil::SplitCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
 {
+    if (reissuing_command_buffer_state_ == true)
+    {
+        return;
+    }
+
     device_table_->EndCommandBuffer(command_buffer_info->handle);
 
     GetOrCreateAssociatedInfo(command_buffer_info->capture_id).PushSplitHandle(command_buffer_info->handle);
@@ -162,6 +168,10 @@ void VulkanCommandBufferUtil::SplitCommandBuffer(VulkanCommandBufferInfo* comman
 
     VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
     device_table_->BeginCommandBuffer(command_buffer_info->handle, &begin_info);
+
+    reissuing_command_buffer_state_ = true;
+    decoder_->ReissueCommandBufferState(command_buffer_info->capture_id);
+    reissuing_command_buffer_state_ = false;
 }
 
 graphics::VulkanSemaphore
@@ -314,17 +324,19 @@ VulkanCommandBufferUtil::GetCommandBuffersFromSubmitInfos(const std::span<VkSubm
     return submits_command_buffers;
 }
 
-void VulkanCommandBufferUtil::FreeCommandBuffers(VkCommandPool                          command_pool,
-                                                 const std::span<const VkCommandBuffer> command_buffers)
+void VulkanCommandBufferUtil::FreeCommandBuffers(VkCommandPool                           command_pool,
+                                                 const std::span<const format::HandleId> command_buffer_ids)
 {
     // Check whether any of the command buffers being freed are split command buffers.
-    for (VkCommandBuffer command_buffer : command_buffers)
+    for (format::HandleId command_buffer_id : command_buffer_ids)
     {
-        if (original_command_buffer_id_.contains(command_buffer))
+
+        // Make sure to clear the recorded state for this command buffer.
+        decoder_->ClearRecordedState(command_buffer_id);
+
+        auto* split_info = GetAssociatedInfo(command_buffer_id);
+        if (split_info != nullptr)
         {
-            // This command buffer is a split command buffer, so we need to free all the splits together.
-            format::HandleId command_buffer_id = original_command_buffer_id_[command_buffer];
-            auto*            split_info        = GetAssociatedInfo(command_buffer_id);
             split_info->FreeCommandBuffers(command_pool);
 
             // Remove the associated handles from the tracking maps.
@@ -344,6 +356,9 @@ void VulkanCommandBufferUtil::FreeCommandBuffers(VkCommandPool                  
 
 void VulkanCommandBufferUtil::ResetCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
 {
+    // The recorded state does not survive a reset.
+    decoder_->ClearRecordedState(command_buffer_info->capture_id);
+
     // This command buffer is expected to be already reset at this point.
     VkCommandBuffer command_buffer = command_buffer_info->handle;
 
@@ -361,6 +376,9 @@ void VulkanCommandBufferUtil::ResetCommandBuffer(VulkanCommandBufferInfo* comman
 
 void VulkanCommandBufferUtil::BeginCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
 {
+    // A new recording invalidates the state commands recorded for the previous one.
+    decoder_->ClearRecordedState(command_buffer_info->capture_id);
+
     VulkanCommandPoolInfo* command_pool_info = object_table_->GetVkCommandPoolInfo(command_buffer_info->pool_id);
     GFXRECON_ASSERT(command_pool_info != nullptr);
 

--- a/framework/decode/vulkan_command_buffer_util.h
+++ b/framework/decode/vulkan_command_buffer_util.h
@@ -24,6 +24,7 @@
 
 #include "decode/common_object_info_table.h"
 #include "decode/vulkan_object_info.h"
+#include "decode/vulkan_state_recording_decoder.h"
 #include "decode/vulkan_submit_job.h"
 #include "util/defines.h"
 
@@ -93,7 +94,8 @@ class VulkanCommandBufferUtil
   public:
     VulkanCommandBufferUtil(const VulkanDeviceInfo*            device_info,
                             const graphics::VulkanDeviceTable* device_table,
-                            CommonObjectInfoTable*             object_table);
+                            CommonObjectInfoTable*             object_table,
+                            VulkanStateRecordingDecoder*       decoder);
 
     ~VulkanCommandBufferUtil() = default;
 
@@ -116,7 +118,7 @@ class VulkanCommandBufferUtil
                                         const std::span<VkSubmitInfo2>             current_submits_span,
                                         const std::span<graphics::VulkanSemaphore> wait_semaphores = {});
 
-    void FreeCommandBuffers(VkCommandPool command_pool, const std::span<const VkCommandBuffer> command_buffers);
+    void FreeCommandBuffers(VkCommandPool command_pool, const std::span<const format::HandleId> command_buffer_ids);
 
     /// @brief To be called after resetting the current command buffer.
     /// @param command_buffer_info The command buffer info structure to reset.
@@ -141,12 +143,17 @@ class VulkanCommandBufferUtil
     const VulkanDeviceInfo*            device_info_  = nullptr;
     const graphics::VulkanDeviceTable* device_table_ = nullptr;
     CommonObjectInfoTable*             object_table_ = nullptr;
+    VulkanStateRecordingDecoder*       decoder_      = nullptr;
 
     /// Map from the command buffer ID to the structure representing the split.
     std::unordered_map<format::HandleId, VulkanCommandBufferAssociatedInfo> split_infos_;
 
     /// Map from the command buffer handles to the original ID.
     std::unordered_map<VkCommandBuffer, format::HandleId> original_command_buffer_id_;
+
+    /// Flag to indicate whether the decoder is currently reissuing command buffer state. This is used to prevent
+    /// splitting command buffers while reissuing state, which could lead to infinite recursion.
+    bool reissuing_command_buffer_state_ = false;
 };
 
 using VulkanPerDeviceCommandBufferUtils = std::unordered_map<const VulkanDeviceInfo*, VulkanCommandBufferUtil>;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5736,8 +5736,8 @@ void VulkanReplayConsumerBase::OverrideFreeCommandBuffers(PFN_vkFreeCommandBuffe
 
     if (options_.isolate_render_passes)
     {
-        auto command_buffers = std::span(pCommandBuffers->GetHandlePointer(), command_buffer_count);
-        GetDeviceCommandBufferUtil(device_info).FreeCommandBuffers(command_pool_info->handle, command_buffers);
+        GetDeviceCommandBufferUtil(device_info)
+            .FreeCommandBuffers(command_pool_info->handle, pCommandBuffers->GetSpan());
     }
 
     const VkCommandBuffer* in_pCommandBuffers = pCommandBuffers->GetHandlePointer();
@@ -10470,16 +10470,24 @@ VkResult VulkanReplayConsumerBase::OverrideResetCommandPool(PFN_vkResetCommandPo
                                                             VulkanCommandPoolInfo*  pool_info,
                                                             VkCommandPoolResetFlags flags)
 {
-    assert(device_info != nullptr && pool_info != nullptr);
+    GFXRECON_ASSERT(device_info != nullptr && pool_info != nullptr);
 
-    if (options_.dumping_resources && original_result >= 0)
+    if (original_result >= 0)
     {
         for (auto& cb_id : pool_info->child_ids)
         {
             VulkanCommandBufferInfo* cb_info = object_info_table_->GetVkCommandBufferInfo(cb_id);
-            assert(cb_info != nullptr);
+            GFXRECON_ASSERT(cb_info != nullptr);
 
-            resource_dumper_->ResetCommandBuffer(cb_info->handle);
+            if (options_.dumping_resources)
+            {
+                resource_dumper_->ResetCommandBuffer(cb_info->handle);
+            }
+
+            if (options_.isolate_render_passes)
+            {
+                GetDeviceCommandBufferUtil(device_info).ResetCommandBuffer(cb_info);
+            }
         }
     }
 
@@ -10493,17 +10501,25 @@ void VulkanReplayConsumerBase::OverrideDestroyCommandPool(
     VulkanCommandPoolInfo*                               pool_info,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    assert(device_info != nullptr);
+    GFXRECON_ASSERT(device_info != nullptr);
     VkCommandPool pool_handle = pool_info ? pool_info->handle : VK_NULL_HANDLE;
 
-    if (options_.dumping_resources && pool_info != nullptr)
+    if (pool_info != nullptr)
     {
         for (auto& cb_id : pool_info->child_ids)
         {
             VulkanCommandBufferInfo* cb_info = object_info_table_->GetVkCommandBufferInfo(cb_id);
-            assert(cb_info != nullptr);
+            GFXRECON_ASSERT(cb_info != nullptr);
 
-            resource_dumper_->ResetCommandBuffer(cb_info->handle);
+            if (options_.dumping_resources)
+            {
+                resource_dumper_->ResetCommandBuffer(cb_info->handle);
+            }
+
+            if (options_.isolate_render_passes)
+            {
+                GetDeviceCommandBufferUtil(device_info).ResetCommandBuffer(cb_info);
+            }
         }
     }
 
@@ -11935,8 +11951,17 @@ VulkanCommandBufferUtil& VulkanReplayConsumerBase::GetDeviceCommandBufferUtil(co
         return it->second;
     }
 
+    auto* decoder = dynamic_cast<VulkanStateRecordingDecoder*>(GetDecoder());
+    if (decoder == nullptr)
+    {
+        GFXRECON_LOG_FATAL(
+            "VulkanReplayConsumerBase::GetDeviceCommandBufferUtil() called with non-VulkanStateRecordingDecoder");
+        std::abort();
+    }
+
     auto [new_it, success] = device_command_buffer_utils_.insert(
-        { device_info, VulkanCommandBufferUtil(device_info, GetDeviceTable(device_info->handle), object_info_table_) });
+        { device_info,
+          VulkanCommandBufferUtil(device_info, GetDeviceTable(device_info->handle), object_info_table_, decoder) });
     GFXRECON_ASSERT(success);
     return new_it->second;
 }
@@ -12035,8 +12060,8 @@ void VulkanReplayConsumerBase::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
 {
     Decoded_VkPushDescriptorSetWithTemplateInfo* in_info =
         args.pPushDescriptorSetWithTemplateInfo.GetMetaStructPointer();
-    VkPushDescriptorSetWithTemplateInfoKHR*      value   = in_info->decoded_value;
-    VulkanDescriptorUpdateTemplateInfo*          update_template_info =
+    VkPushDescriptorSetWithTemplateInfoKHR* value = in_info->decoded_value;
+    VulkanDescriptorUpdateTemplateInfo*     update_template_info =
         object_info_table_->GetVkDescriptorUpdateTemplateInfo(in_info->descriptorUpdateTemplate);
 
     VkCommandBuffer in_commandBuffer =

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -93,6 +93,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void SetFpsInfo(graphics::FpsInfo* fps_info) { fps_info_ = fps_info; }
 
+    void           SetDecoder(VulkanDecoder* decoder) { decoder_ = decoder; };
+    VulkanDecoder* GetDecoder() { return decoder_; }
+
     virtual void WaitDevicesIdle() override;
 
     virtual void ProcessStateBeginMarker(uint64_t frame_number) override;
@@ -2042,6 +2045,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unique_ptr<VulkanSwapchain>                                         swapchain_;
     std::string                                                              screenshot_file_prefix_;
     graphics::FpsInfo*                                                       fps_info_;
+    VulkanDecoder*                                                           decoder_ = nullptr;
 
     VulkanPerDeviceAddressTrackers    device_address_trackers_;
     VulkanPerDeviceAddressReplacers   device_address_replacers_;

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -85,6 +85,8 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
   private:
     graphics::FrameLoopInfo& frame_loop_info_;
 
+    VulkanDecoder* decoder_ = nullptr;
+
     /// A "dangling" resource is one that was either
     /// - created during the loop range but destroyed after it
     /// - or created before the loop range but destroyed during it

--- a/framework/decode/vulkan_state_recording_decoder.h
+++ b/framework/decode/vulkan_state_recording_decoder.h
@@ -23,25 +23,18 @@
 #ifndef GFXRECON_DECODE_VULKAN_STATE_RECORDING_DECODER_H
 #define GFXRECON_DECODE_VULKAN_STATE_RECORDING_DECODER_H
 
+#include "format/api_call_log.h"
 #include "generated/generated_vulkan_decoder.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-struct VulkanCommandEntry
-{
-    format::ApiCallId call_id;
-
-    /// Original block's info, replayed verbatim.
-    ApiCallInfo call_info;
-
-    /// Owned copy of the encoded parameter buffer.
-    std::vector<uint8_t> parameters;
-};
-
 class VulkanStateCommandRecorder
 {
   public:
+    /// Log of encoded API calls; each entry keeps the original block's ApiCallInfo, replayed verbatim.
+    using CommandBufferLog = format::ApiCallLog<ApiCallInfo>;
+
     /// Records the undecoded buffer of a Vulkan API call for reissuing later.
     void
     Record(format::ApiCallId call_id, const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
@@ -50,13 +43,10 @@ class VulkanStateCommandRecorder
         format::HandleId command_buffer_id = 0;
         ValueDecoder::DecodeHandleIdValue(parameter_buffer, buffer_size, &command_buffer_id);
 
-        const auto entry = VulkanCommandEntry{ call_id,
-                                               call_info,
-                                               std::vector<uint8_t>(parameter_buffer, parameter_buffer + buffer_size) };
-        per_cb_log_[command_buffer_id].push_back(entry);
+        per_cb_log_[command_buffer_id].Append(call_id, call_info, parameter_buffer, buffer_size);
     }
 
-    const std::vector<VulkanCommandEntry>* GetCommandBufferLog(format::HandleId command_buffer_id) const
+    const CommandBufferLog* GetCommandBufferLog(format::HandleId command_buffer_id) const
     {
         const auto it = per_cb_log_.find(command_buffer_id);
         if (it != per_cb_log_.end())
@@ -70,7 +60,7 @@ class VulkanStateCommandRecorder
     void Clear() { per_cb_log_.clear(); }
 
   private:
-    std::unordered_map<format::HandleId, std::vector<VulkanCommandEntry>> per_cb_log_;
+    std::unordered_map<format::HandleId, CommandBufferLog> per_cb_log_;
 };
 
 class VulkanStateRecordingDecoder : public VulkanDecoder
@@ -108,7 +98,7 @@ class VulkanStateRecordingDecoder : public VulkanDecoder
 
     void ReissueCommandBufferState(format::HandleId command_buffer_id)
     {
-        const std::vector<VulkanCommandEntry>* command_buffer_log =
+        const VulkanStateCommandRecorder::CommandBufferLog* command_buffer_log =
             state_recorder_.GetCommandBufferLog(command_buffer_id);
         if (command_buffer_log == nullptr)
         {
@@ -117,13 +107,14 @@ class VulkanStateRecordingDecoder : public VulkanDecoder
 
         recording_ = false;
 
-        for (const VulkanCommandEntry& entry : *command_buffer_log)
-        {
-            GFXRECON_LOG_DEBUG("Reissuing Vulkan state command %" PRIu32 " for command buffer %" PRIu64,
-                               entry.call_id,
-                               command_buffer_id);
-            DecodeFunctionCall(entry.call_id, entry.call_info, entry.parameters.data(), entry.parameters.size());
-        }
+        command_buffer_log->ForEach([this, command_buffer_id](format::ApiCallId  call_id,
+                                                              const ApiCallInfo& call_info,
+                                                              const uint8_t*     parameter_buffer,
+                                                              size_t             buffer_size) {
+            GFXRECON_LOG_DEBUG(
+                "Reissuing Vulkan state command %" PRIu32 " for command buffer %" PRIu64, call_id, command_buffer_id);
+            DecodeFunctionCall(call_id, call_info, parameter_buffer, buffer_size);
+        });
 
         recording_ = true;
     }

--- a/framework/decode/vulkan_state_recording_decoder.h
+++ b/framework/decode/vulkan_state_recording_decoder.h
@@ -1,0 +1,144 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_VULKAN_STATE_RECORDING_DECODER_H
+#define GFXRECON_DECODE_VULKAN_STATE_RECORDING_DECODER_H
+
+#include "generated/generated_vulkan_decoder.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+struct VulkanCommandEntry
+{
+    format::ApiCallId call_id;
+
+    /// Original block's info, replayed verbatim.
+    ApiCallInfo call_info;
+
+    /// Owned copy of the encoded parameter buffer.
+    std::vector<uint8_t> parameters;
+};
+
+class VulkanStateCommandRecorder
+{
+  public:
+    /// Records the undecoded buffer of a Vulkan API call for reissuing later.
+    void
+    Record(format::ApiCallId call_id, const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
+    {
+        // The call is expected to be a command buffer call, so the first parameter is the command buffer handle.
+        format::HandleId command_buffer_id = 0;
+        ValueDecoder::DecodeHandleIdValue(parameter_buffer, buffer_size, &command_buffer_id);
+
+        const auto entry = VulkanCommandEntry{ call_id,
+                                               call_info,
+                                               std::vector<uint8_t>(parameter_buffer, parameter_buffer + buffer_size) };
+        per_cb_log_[command_buffer_id].push_back(entry);
+    }
+
+    const std::vector<VulkanCommandEntry>* GetCommandBufferLog(format::HandleId command_buffer_id) const
+    {
+        const auto it = per_cb_log_.find(command_buffer_id);
+        if (it != per_cb_log_.end())
+        {
+            return &it->second;
+        }
+        return nullptr;
+    }
+
+    void ClearRecordedState(format::HandleId command_buffer_id) { per_cb_log_.erase(command_buffer_id); }
+    void Clear() { per_cb_log_.clear(); }
+
+  private:
+    std::unordered_map<format::HandleId, std::vector<VulkanCommandEntry>> per_cb_log_;
+};
+
+class VulkanStateRecordingDecoder : public VulkanDecoder
+{
+  public:
+    void DecodeFunctionCall(format::ApiCallId  call_id,
+                            const ApiCallInfo& call_info,
+                            const uint8_t*     parameter_buffer,
+                            size_t             buffer_size) override
+    {
+        if (recording_ && IsVulkanStateCommand(call_id))
+        {
+            state_recorder_.Record(call_id, call_info, parameter_buffer, buffer_size);
+        }
+        VulkanDecoder::DecodeFunctionCall(call_id, call_info, parameter_buffer, buffer_size);
+    }
+
+    bool IsVulkanStateCommand(format::ApiCallId call_id) const
+    {
+        switch (call_id)
+        {
+            case format::ApiCall_vkCmdBindDescriptorSets:
+            case format::ApiCall_vkCmdBindIndexBuffer:
+            case format::ApiCall_vkCmdBindPipeline:
+            case format::ApiCall_vkCmdBindVertexBuffers:
+            case format::ApiCall_vkCmdSetViewport:
+            case format::ApiCall_vkCmdSetScissor:
+            case format::ApiCall_vkCmdPushConstants:
+                return true;
+            default:
+                break;
+        }
+        return false;
+    }
+
+    void ReissueCommandBufferState(format::HandleId command_buffer_id)
+    {
+        const std::vector<VulkanCommandEntry>* command_buffer_log =
+            state_recorder_.GetCommandBufferLog(command_buffer_id);
+        if (command_buffer_log == nullptr)
+        {
+            return;
+        }
+
+        recording_ = false;
+
+        for (const VulkanCommandEntry& entry : *command_buffer_log)
+        {
+            GFXRECON_LOG_DEBUG("Reissuing Vulkan state command %" PRIu32 " for command buffer %" PRIu64,
+                               entry.call_id,
+                               command_buffer_id);
+            DecodeFunctionCall(entry.call_id, entry.call_info, entry.parameters.data(), entry.parameters.size());
+        }
+
+        recording_ = true;
+    }
+
+    void ClearRecordedState(format::HandleId command_buffer_id)
+    {
+        state_recorder_.ClearRecordedState(command_buffer_id);
+    }
+
+  private:
+    bool                       recording_ = true;
+    VulkanStateCommandRecorder state_recorder_;
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_VULKAN_STATE_RECORDING_DECODER_H

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -24,6 +24,7 @@
 #ifndef GFXRECON_ENCODE_DX12_OBJECT_WRAPPER_INFO_H
 #define GFXRECON_ENCODE_DX12_OBJECT_WRAPPER_INFO_H
 
+#include "format/api_call_log.h"
 #include "format/format.h"
 #include "graphics/dx12_util.h"
 #include "util/defines.h"
@@ -490,7 +491,7 @@ struct ID3D12CommandListInfo : public DxWrapperInfo
 {
     bool                             was_reset{ false };
     bool                             is_closed{ false };
-    util::MemoryOutputStream         command_data;
+    format::ApiCallLog<>             command_data;
     std::vector<DxTransitionBarrier> transition_barriers;
     D3D12_COMMAND_LIST_TYPE          command_list_type{};
 

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -172,10 +172,7 @@ void Dx12StateTracker::TrackCommandExecution(ID3D12CommandList_Wrapper*      lis
     }
 
     // Append the command data.
-    size_t size = parameter_buffer->GetDataSize();
-    list_info->command_data.Write(&size, sizeof(size));
-    list_info->command_data.Write(&call_id, sizeof(call_id));
-    list_info->command_data.Write(parameter_buffer->GetData(), size);
+    list_info->command_data.Append(call_id, parameter_buffer->GetData(), parameter_buffer->GetDataSize());
 }
 
 void Dx12StateTracker::TrackCommand(ID3D12CommandList_Wrapper*      list_wrapper,

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1266,61 +1266,52 @@ void Dx12StateWriter::WriteCommandListCommands(const ID3D12CommandList_Wrapper* 
     bool write_commands = CheckCommandListObjects(list_info.get(), state_table);
 
     // Write each of the commands that was recorded for the command buffer.
-    size_t         offset    = 0;
-    size_t         data_size = list_info->command_data.GetDataSize();
-    const uint8_t* data      = list_info->command_data.GetData();
+    bool is_first_command = true;
+    list_info->command_data.ForEach(
+        [&](format::ApiCallId call_id, const uint8_t* parameter_data, size_t parameter_size) {
+            bool write_current_command = write_commands;
 
-    while (offset < data_size)
-    {
-        const size_t*            parameter_size = reinterpret_cast<const size_t*>(&data[offset]);
-        const format::ApiCallId* call_id = reinterpret_cast<const format::ApiCallId*>(&data[offset] + sizeof(size_t));
-        const uint8_t*           parameter_data = &data[offset] + (sizeof(size_t) + sizeof(format::ApiCallId));
-
-        bool write_current_command = write_commands;
-
-        if ((*call_id) == format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Reset)
-        {
-            GFXRECON_ASSERT(list_info->was_reset);
-
-            // command_data is cleared after each reset, so only the first command can be a reset.
-            GFXRECON_ASSERT(offset == 0);
-
-            // Always write the reset command.
-            write_current_command = true;
-        }
-        else if ((*call_id) == format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Close)
-        {
-            GFXRECON_ASSERT(list_info->is_closed);
-
-            // Always write the close command.
-            write_current_command = true;
-        }
-#ifdef GFXRECON_AGS_SUPPORT
-        else if (format::GetApiCallFamily(*call_id) == format::ApiFamilyId::ApiFamily_AGS)
-        {
-            if (write_current_command)
+            if (call_id == format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Reset)
             {
-                // Ags function call, targeting command list.
-                parameter_stream_.Write(parameter_data, (*parameter_size));
-                WriteFunctionCall((*call_id), &parameter_stream_);
-                parameter_stream_.Clear();
+                GFXRECON_ASSERT(list_info->was_reset);
 
-                // The output below, in this case, should be skipped.
-                write_current_command = false;
+                // command_data is cleared after each reset, so only the first command can be a reset.
+                GFXRECON_ASSERT(is_first_command);
+
+                // Always write the reset command.
+                write_current_command = true;
             }
-        }
+            else if (call_id == format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Close)
+            {
+                GFXRECON_ASSERT(list_info->is_closed);
+
+                // Always write the close command.
+                write_current_command = true;
+            }
+#ifdef GFXRECON_AGS_SUPPORT
+            else if (format::GetApiCallFamily(call_id) == format::ApiFamilyId::ApiFamily_AGS)
+            {
+                if (write_current_command)
+                {
+                    // Ags function call, targeting command list.
+                    parameter_stream_.Write(parameter_data, parameter_size);
+                    WriteFunctionCall(call_id, &parameter_stream_);
+                    parameter_stream_.Clear();
+
+                    // The output below, in this case, should be skipped.
+                    write_current_command = false;
+                }
+            }
 #endif // GFXRECON_AGS_SUPPORT
 
-        if (write_current_command)
-        {
-            parameter_stream_.Write(parameter_data, (*parameter_size));
-            WriteMethodCall((*call_id), list_wrapper->GetCaptureId(), &parameter_stream_);
-            parameter_stream_.Clear();
-        }
-        offset += sizeof(size_t) + sizeof(format::ApiCallId) + (*parameter_size);
-    }
-
-    GFXRECON_ASSERT(offset == data_size);
+            if (write_current_command)
+            {
+                parameter_stream_.Write(parameter_data, parameter_size);
+                WriteMethodCall(call_id, list_wrapper->GetCaptureId(), &parameter_stream_);
+                parameter_stream_.Clear();
+            }
+            is_first_command = false;
+        });
 }
 
 void Dx12StateWriter::WriteCommandListCreation(const ID3D12CommandList_Wrapper* list_wrapper,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -28,6 +28,7 @@
 #include "encode/vulkan_state_info.h"
 #include "encode/handle_unwrap_memory.h"
 #include "encode/vulkan_acceleration_structure_build_state.h"
+#include "format/api_call_log.h"
 #include "format/format.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "graphics/vulkan_util.h"
@@ -445,7 +446,7 @@ struct CommandBufferWrapper : public HandleWrapper<VkCommandBuffer>
 
     // Members for trimming state tracking.
     VkCommandBufferLevel       level{ VK_COMMAND_BUFFER_LEVEL_PRIMARY };
-    util::MemoryOutputStream   command_data;
+    format::ApiCallLog<>       command_data;
     std::set<format::HandleId> command_handles[vulkan_state_info::CommandHandleType::NumHandleTypes];
 
     enum CommandBufferState

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -103,10 +103,7 @@ void VulkanStateTracker::TrackCommandExecution(vulkan_wrappers::CommandBufferWra
     if (call_id != format::ApiCallId::ApiCall_vkResetCommandBuffer)
     {
         // Append the command data.
-        size_t size = parameter_buffer->GetDataSize();
-        wrapper->command_data.Write(&size, sizeof(size));
-        wrapper->command_data.Write(&call_id, sizeof(call_id));
-        wrapper->command_data.Write(parameter_buffer->GetData(), size);
+        wrapper->command_data.Append(call_id, parameter_buffer->GetData(), parameter_buffer->GetDataSize());
     }
 }
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -4001,25 +4001,12 @@ void VulkanStateWriter::WriteCommandBufferCommands(vulkan_wrappers::CommandBuffe
     if (CheckCommandHandles(wrapper, state_table))
     {
         // Replay each of the commands that was recorded for the command buffer.
-        size_t         offset    = 0;
-        size_t         data_size = wrapper->command_data.GetDataSize();
-        const uint8_t* data      = wrapper->command_data.GetData();
-
-        while (offset < data_size)
-        {
-            const size_t*            parameter_size = reinterpret_cast<const size_t*>(&data[offset]);
-            const format::ApiCallId* call_id =
-                reinterpret_cast<const format::ApiCallId*>(&data[offset] + sizeof(size_t));
-            const uint8_t* parameter_data = &data[offset] + (sizeof(size_t) + sizeof(format::ApiCallId));
-
-            parameter_stream_.Write(parameter_data, (*parameter_size));
-            WriteFunctionCall((*call_id), &parameter_stream_);
-            parameter_stream_.Clear();
-
-            offset += sizeof(size_t) + sizeof(format::ApiCallId) + (*parameter_size);
-        }
-
-        assert(offset == data_size);
+        wrapper->command_data.ForEach(
+            [&](format::ApiCallId call_id, const uint8_t* parameter_data, size_t parameter_size) {
+                parameter_stream_.Write(parameter_data, parameter_size);
+                WriteFunctionCall(call_id, &parameter_stream_);
+                parameter_stream_.Clear();
+            });
     }
     else
     {

--- a/framework/format/CMakeLists.txt
+++ b/framework/format/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(gfxrecon_format STATIC "")
 target_sources(gfxrecon_format
                PRIVATE
                     ${CMAKE_CURRENT_LIST_DIR}/api_call_id.h
+                    ${CMAKE_CURRENT_LIST_DIR}/api_call_log.h
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_subobject_types.h>
                     ${CMAKE_CURRENT_LIST_DIR}/format.h
                     ${CMAKE_CURRENT_LIST_DIR}/format_json.h
@@ -58,6 +59,7 @@ if (${RUN_TESTS})
     add_executable(gfxrecon_format_test "")
     target_sources(gfxrecon_format_test PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/test/api_call_log_test.cpp
         ${CMAKE_CURRENT_LIST_DIR}/../../tools/platform_debug_helper.cpp)
     target_link_libraries(gfxrecon_format_test PRIVATE gfxrecon_format)
     if (MSVC)

--- a/framework/format/api_call_log.h
+++ b/framework/format/api_call_log.h
@@ -1,0 +1,130 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_FORMAT_API_CALL_LOG_H
+#define GFXRECON_FORMAT_API_CALL_LOG_H
+
+#include "format/api_call_id.h"
+#include "util/defines.h"
+#include "util/logging.h"
+
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(format)
+
+/// Default entry metadata: entries carry nothing beyond the call id and parameter buffer.
+struct ApiCallLogNoMeta
+{};
+
+/// An append-only, in-memory log of encoded API calls.
+/// Each entry holds:
+/// - a call id
+/// - a trivially-copyable metadata value (optional)
+/// - a copy of the call's encoded parameter buffer
+///
+/// Entries are packed into a single contiguous byte buffer and can only be visited in append
+/// order or cleared wholesale. The layout is process-local and never reaches a capture file.
+template <typename EntryMetaT = ApiCallLogNoMeta>
+class ApiCallLog
+{
+    static_assert(std::is_trivially_copyable_v<EntryMetaT>, "ApiCallLog entry metadata must be trivially copyable");
+
+  public:
+    void Append(ApiCallId call_id, const EntryMetaT& meta, const uint8_t* parameter_data, size_t parameter_size)
+    {
+        WriteBytes(&parameter_size, sizeof(parameter_size));
+        WriteBytes(&call_id, sizeof(call_id));
+        if constexpr (!std::is_empty_v<EntryMetaT>)
+        {
+            WriteBytes(&meta, sizeof(meta));
+        }
+        WriteBytes(parameter_data, parameter_size);
+    }
+
+    template <typename T = EntryMetaT, typename = std::enable_if_t<std::is_empty_v<T>>>
+    void Append(ApiCallId call_id, const uint8_t* parameter_data, size_t parameter_size)
+    {
+        Append(call_id, EntryMetaT{}, parameter_data, parameter_size);
+    }
+
+    /// Invoke visitor on each entry in append order. The visitor signature is
+    /// (ApiCallId, const uint8_t* parameter_data, size_t parameter_size) when EntryMetaT is empty,
+    /// (ApiCallId, const EntryMetaT&, const uint8_t* parameter_data, size_t parameter_size) otherwise.
+    template <typename Visitor>
+    void ForEach(Visitor&& visitor) const
+    {
+        size_t offset = 0;
+        while (offset < data_.size())
+        {
+            size_t    parameter_size = 0;
+            ApiCallId call_id{};
+            ReadBytes(&parameter_size, sizeof(parameter_size), offset);
+            ReadBytes(&call_id, sizeof(call_id), offset);
+
+            if constexpr (std::is_empty_v<EntryMetaT>)
+            {
+                GFXRECON_ASSERT((offset + parameter_size) <= data_.size());
+                visitor(call_id, data_.data() + offset, parameter_size);
+            }
+            else
+            {
+                EntryMetaT meta{};
+                ReadBytes(&meta, sizeof(meta), offset);
+                GFXRECON_ASSERT((offset + parameter_size) <= data_.size());
+                visitor(call_id, meta, data_.data() + offset, parameter_size);
+            }
+
+            offset += parameter_size;
+        }
+        GFXRECON_ASSERT(offset == data_.size());
+    }
+
+    void Clear() { data_.clear(); }
+
+    bool IsEmpty() const { return data_.empty(); }
+
+  private:
+    void WriteBytes(const void* data, size_t size)
+    {
+        const auto* bytes = static_cast<const uint8_t*>(data);
+        data_.insert(data_.end(), bytes, bytes + size);
+    }
+
+    // memcpy keeps header-field reads aligned regardless of their offset in the byte buffer
+    void ReadBytes(void* dst, size_t size, size_t& offset) const
+    {
+        GFXRECON_ASSERT((offset + size) <= data_.size());
+        std::memcpy(dst, data_.data() + offset, size);
+        offset += size;
+    }
+
+    std::vector<uint8_t> data_;
+};
+
+GFXRECON_END_NAMESPACE(format)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_FORMAT_API_CALL_LOG_H

--- a/framework/format/test/api_call_log_test.cpp
+++ b/framework/format/test/api_call_log_test.cpp
@@ -1,0 +1,115 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "format/api_call_log.h"
+
+#include <catch2/catch.hpp>
+
+#include <cstring>
+#include <vector>
+
+using gfxrecon::format::ApiCallId;
+using gfxrecon::format::ApiCallLog;
+
+namespace
+{
+struct RecordedEntry
+{
+    ApiCallId            call_id;
+    std::vector<uint8_t> parameters;
+};
+
+struct TestMeta
+{
+    uint64_t index{ 0 };
+    uint64_t thread_id{ 0 };
+};
+} // namespace
+
+TEST_CASE("an empty ApiCallLog visits nothing", "[api_call_log]")
+{
+    ApiCallLog<> log;
+    REQUIRE(log.IsEmpty());
+
+    size_t visit_count = 0;
+    log.ForEach([&](ApiCallId, const uint8_t*, size_t) { ++visit_count; });
+    REQUIRE(visit_count == 0);
+}
+
+TEST_CASE("ApiCallLog round-trips entries in append order", "[api_call_log]")
+{
+    const std::vector<RecordedEntry> entries = {
+        { ApiCallId::ApiCall_vkCmdBindPipeline, { 0x01, 0x02, 0x03 } },
+        { ApiCallId::ApiCall_vkCmdDraw, {} },
+        { ApiCallId::ApiCall_vkCmdDispatch, { 0xff, 0x00, 0xaa, 0xbb, 0xcc } },
+    };
+
+    ApiCallLog<> log;
+    for (const auto& entry : entries)
+    {
+        log.Append(entry.call_id, entry.parameters.data(), entry.parameters.size());
+    }
+    REQUIRE(!log.IsEmpty());
+
+    size_t index = 0;
+    log.ForEach([&](ApiCallId call_id, const uint8_t* parameter_data, size_t parameter_size) {
+        REQUIRE(index < entries.size());
+        REQUIRE(call_id == entries[index].call_id);
+        REQUIRE(parameter_size == entries[index].parameters.size());
+        REQUIRE(std::memcmp(parameter_data, entries[index].parameters.data(), parameter_size) == 0);
+        ++index;
+    });
+    REQUIRE(index == entries.size());
+
+    log.Clear();
+    REQUIRE(log.IsEmpty());
+}
+
+TEST_CASE("ApiCallLog round-trips per-entry metadata", "[api_call_log]")
+{
+    const std::vector<uint8_t> parameters = { 0x10, 0x20, 0x30, 0x40 };
+
+    ApiCallLog<TestMeta> log;
+    log.Append(ApiCallId::ApiCall_vkCmdBindDescriptorSets, TestMeta{ 42, 7 }, parameters.data(), parameters.size());
+    log.Append(ApiCallId::ApiCall_vkCmdBindIndexBuffer, TestMeta{ 43, 8 }, parameters.data(), 0);
+
+    size_t index = 0;
+    log.ForEach([&](ApiCallId call_id, const TestMeta& meta, const uint8_t* parameter_data, size_t parameter_size) {
+        if (index == 0)
+        {
+            REQUIRE(call_id == ApiCallId::ApiCall_vkCmdBindDescriptorSets);
+            REQUIRE(meta.index == 42);
+            REQUIRE(meta.thread_id == 7);
+            REQUIRE(parameter_size == parameters.size());
+            REQUIRE(std::memcmp(parameter_data, parameters.data(), parameter_size) == 0);
+        }
+        else
+        {
+            REQUIRE(call_id == ApiCallId::ApiCall_vkCmdBindIndexBuffer);
+            REQUIRE(meta.index == 43);
+            REQUIRE(meta.thread_id == 8);
+            REQUIRE(parameter_size == 0);
+        }
+        ++index;
+    });
+    REQUIRE(index == 2);
+}

--- a/tools/replay/replay_d3d12_feature.cpp
+++ b/tools/replay/replay_d3d12_feature.cpp
@@ -96,11 +96,11 @@ void ReplayD3d12Feature::RegisterDecodeComponents(graphics::FpsInfo* fps_info)
                 std::make_unique<decode::DX12TrackingConsumer>(replay_options_, &tracked_object_info_table);
             if (file_processor_tracking.Initialize(capture_filename_))
             {
-                decoder_.AddConsumer(tracking_consumer.get());
-                file_processor_tracking.AddDecoder(&decoder_);
+                decoder_->AddConsumer(tracking_consumer.get());
+                file_processor_tracking.AddDecoder(decoder_.get());
                 file_processor_tracking.ProcessAllFrames();
-                file_processor_tracking.RemoveDecoder(&decoder_);
-                decoder_.RemoveConsumer(tracking_consumer.get());
+                file_processor_tracking.RemoveDecoder(decoder_.get());
+                decoder_->RemoveConsumer(tracking_consumer.get());
             }
         }
 

--- a/tools/replay/replay_feature.h
+++ b/tools/replay/replay_feature.h
@@ -107,7 +107,8 @@ template <typename ConsumerT, typename DecoderT, typename OptionsT>
 class ReplayFeature : public ReplayFeatureBase
 {
   public:
-    void* GetConsumer() override { return reinterpret_cast<void*>(replay_consumer_.get()); }
+    void*     GetConsumer() override { return replay_consumer_.get(); }
+    DecoderT* GetDecoder() { return decoder_.get(); }
     void  Destroy() override
     {
         if (replay_consumer_)
@@ -119,7 +120,7 @@ class ReplayFeature : public ReplayFeatureBase
   protected:
     OptionsT                   replay_options_;
     std::unique_ptr<ConsumerT> replay_consumer_;
-    DecoderT                   decoder_;
+    std::unique_ptr<DecoderT>  decoder_;
 
     void InitConsumer(decode::FileProcessor* file_processor, std::shared_ptr<application::Application> application)
     {
@@ -129,11 +130,13 @@ class ReplayFeature : public ReplayFeatureBase
 
     void FinalizeConsumer() {}
 
-    void RegisterConsumerAndDecoder(graphics::FpsInfo* fps_info)
+    void RegisterConsumerAndDecoder(graphics::FpsInfo*        fps_info,
+                                    std::unique_ptr<DecoderT> decoder = std::make_unique<DecoderT>())
     {
+        decoder_ = std::move(decoder);
         replay_consumer_->SetFpsInfo(fps_info);
-        decoder_.AddConsumer(replay_consumer_.get());
-        file_processor_->AddDecoder(&decoder_);
+        decoder_->AddConsumer(replay_consumer_.get());
+        file_processor_->AddDecoder(decoder_.get());
     }
 };
 

--- a/tools/replay/replay_vulkan_feature.cpp
+++ b/tools/replay/replay_vulkan_feature.cpp
@@ -33,6 +33,7 @@
 #include "plugin/replay_event_plugin_loader.h"
 #include "util/api_version_info.h"
 #include "util/feature_module_registry.h"
+#include "decode/vulkan_state_recording_decoder.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(replay)
@@ -106,7 +107,18 @@ void ReplayVulkanFeature::RegisterDecodeComponents(graphics::FpsInfo* fps_info)
 {
     if (is_enabled_)
     {
-        RegisterConsumerAndDecoder(fps_info);
+        if (replay_options_.isolate_render_passes)
+        {
+            auto  decoder  = std::make_unique<decode::VulkanStateRecordingDecoder>();
+            auto* consumer = dynamic_cast<decode::VulkanReplayConsumerBase*>(replay_consumer_.get());
+            GFXRECON_ASSERT(consumer != nullptr);
+            consumer->SetDecoder(decoder.get());
+            RegisterConsumerAndDecoder(fps_info, std::move(decoder));
+        }
+        else
+        {
+            RegisterConsumerAndDecoder(fps_info);
+        }
 
         application_->SetPrintBlockInfoFlag(
             replay_options_.enable_print_block_info, replay_options_.block_index_from, replay_options_.block_index_to);


### PR DESCRIPTION
- Add a new VulkanStateRecordingDecoder that records the raw parameter buffers of state-setting commands per command buffer.
- When a command buffer is split, it reissues those recorded state commands into the new split buffer so draws/dispatches still have valid state (with a recursion guard and state-clearing on submit).
- Wires this up by making the feature's decoder injectable, so this custom decoder is used only when isolate_render_passes is set.