### PR TITLE
rebind: Fix shadow AccelerationStructure tracking in VulkanAddressReplacer

### DIFF
--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -310,6 +310,7 @@ VulkanAddressReplacer::~VulkanAddressReplacer()
     pipeline_context_map_.clear();
     shadow_sbt_map_.clear();
     shadow_as_map_.clear();
+    shadow_scratch_map_.clear();
     submit_asset_map_.clear();
     submit_asset_ = {};
 
@@ -1350,31 +1351,29 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                     "VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR: Replay is adjusting "
                     "acceleration-structures using shadow-structures and -buffers");
 
-                // now definitely requiring address-replacement
-                force_replace = true;
+                // replacement scratch-buffer, either owned by a shadow acceleration-structure or standalone
+                buffer_context_t* replacement_scratch = nullptr;
 
-                // drop stale entries from destroyed acceleration-structures whose device-address got recycled
-                auto stale_shadow_as_it = shadow_as_map_.find(as_replay_address);
-                if (stale_shadow_as_it != shadow_as_map_.end() &&
-                    stale_shadow_as_it->second.origin_handle != build_geometry_info.dstAccelerationStructure)
+                if (!as_buffer_usable)
                 {
-                    util::MarkInjectedCommandsHelper mark_injected_commands_helper_erase;
-                    shadow_as_map_.erase(stale_shadow_as_it);
-                }
+                    // now definitely requiring address-replacement
+                    force_replace = true;
 
-                auto& replacement_as = shadow_as_map_[as_replay_address];
-
-                if (replacement_as.handle == VK_NULL_HANDLE)
-                {
-                    replacement_as.origin_handle = build_geometry_info.dstAccelerationStructure;
-
-                    if (as_buffer_usable)
+                    // drop stale entries from destroyed acceleration-structures whose device-address got recycled
+                    auto stale_shadow_as_it = shadow_as_map_.find(as_replay_address);
+                    if (stale_shadow_as_it != shadow_as_map_.end() &&
+                        stale_shadow_as_it->second.origin_handle != build_geometry_info.dstAccelerationStructure)
                     {
-                        replacement_as.handle  = build_geometry_info.dstAccelerationStructure;
-                        replacement_as.address = as_replay_address;
+                        util::MarkInjectedCommandsHelper mark_injected_commands_helper_erase;
+                        shadow_as_map_.erase(stale_shadow_as_it);
                     }
-                    else
+
+                    auto& replacement_as = shadow_as_map_[as_replay_address];
+
+                    if (replacement_as.handle == VK_NULL_HANDLE)
                     {
+                        replacement_as.origin_handle = build_geometry_info.dstAccelerationStructure;
+
                         auto ret = create_acceleration_asset(replacement_as,
                                                              build_geometry_info.type,
                                                              build_size_info.accelerationStructureSize,
@@ -1385,13 +1384,20 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                                                "acceleration-structure failed");
                         }
                     }
+
+                    // check/correct source acceleration-structure
+                    swap_acceleration_structure_handle(build_geometry_info.srcAccelerationStructure, address_tracker);
+
+                    // hot swap acceleration-structure handle
+                    build_geometry_info.dstAccelerationStructure = replacement_as.handle;
+
+                    replacement_scratch = &replacement_as.scratch;
                 }
-
-                // check/correct source acceleration-structure
-                swap_acceleration_structure_handle(build_geometry_info.srcAccelerationStructure, address_tracker);
-
-                // hot swap acceleration-structure handle
-                build_geometry_info.dstAccelerationStructure = replacement_as.handle;
+                else
+                {
+                    // only the scratch-buffer needs replacement, keep the acceleration-structure untouched
+                    replacement_scratch = &shadow_scratch_map_[build_geometry_info.dstAccelerationStructure];
+                }
 
                 // acceleration-structure properties not populated yet, check if we missed it
                 if (!replay_acceleration_structure_properties_)
@@ -1417,7 +1423,7 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                 {
                     // create a replacement scratch-buffer
                     if (!create_buffer(
-                            replacement_as.scratch,
+                            *replacement_scratch,
                             scratch_size,
                             0,
                             replay_acceleration_structure_properties_->minAccelerationStructureScratchOffsetAlignment,
@@ -1429,7 +1435,7 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                     }
 
                     // hot swap scratch-buffer
-                    build_geometry_info.scratchData.deviceAddress = replacement_as.scratch.device_address;
+                    build_geometry_info.scratchData.deviceAddress = replacement_scratch->device_address;
                 }
             }
         }
@@ -1615,8 +1621,7 @@ void VulkanAddressReplacer::ProcessUpdateDescriptorSets(uint32_t              de
                 {
                     auto acceleration_structure_it = shadow_as_map_.find(acceleration_structure_info->replay_address);
                     if (acceleration_structure_it != shadow_as_map_.end() &&
-                        acceleration_structure_it->second.origin_handle == write_as->pAccelerationStructures[j] &&
-                        acceleration_structure_it->second.storage.num_bytes > 0)
+                        acceleration_structure_it->second.origin_handle == write_as->pAccelerationStructures[j])
                     {
                         // we found an existing replacement-structure -> swap
                         auto* out_array = const_cast<VkAccelerationStructureKHR*>(write_as->pAccelerationStructures);
@@ -2133,7 +2138,8 @@ bool VulkanAddressReplacer::swap_acceleration_structure_handle(
     return false;
 }
 
-void VulkanAddressReplacer::DestroyShadowResources(const VulkanAccelerationStructureKHRInfo* acceleration_structure_info)
+void VulkanAddressReplacer::DestroyShadowResources(
+    const VulkanAccelerationStructureKHRInfo* acceleration_structure_info)
 {
     if (acceleration_structure_info != nullptr && acceleration_structure_info->handle != VK_NULL_HANDLE)
     {
@@ -2150,6 +2156,14 @@ void VulkanAddressReplacer::DestroyShadowResources(const VulkanAccelerationStruc
         {
             util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             shadow_as_map_.erase(remove_shadow_as_it);
+        }
+
+        // remove a potential replacement scratch-buffer
+        auto remove_scratch_it = shadow_scratch_map_.find(acceleration_structure_info->handle);
+        if (remove_scratch_it != shadow_scratch_map_.end())
+        {
+            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+            shadow_scratch_map_.erase(remove_scratch_it);
         }
     }
 }
@@ -2322,16 +2336,16 @@ void VulkanAddressReplacer::run_compute_replace(const VulkanCommandBufferInfo*  
     std::sort(storage_bda_binary_.begin(), storage_bda_binary_.end());
 
     std::unordered_set<VkBuffer> buffer_set;
-    for (uint32_t i = 0; i < addresses.size(); ++i)
+    for (const VkDeviceAddress address : addresses)
     {
-        auto buffer_info = address_tracker.GetBufferByReplayDeviceAddress(addresses[i]);
 
-        if (buffer_info != nullptr && buffer_info->replay_address != 0)
+        if (auto* buffer_info = address_tracker.GetBufferByReplayDeviceAddress(address);
+            buffer_info != nullptr && buffer_info->replay_address != 0)
         {
             // keep track of used handles
             buffer_set.insert(buffer_info->handle);
         }
-    };
+    }
 
     // mark injected commands
     util::MarkInjectedCommandsHelper mark_injected_commands_helper;
@@ -2597,7 +2611,7 @@ void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer
             // defer cleanup of previous control-block
             hashmap_control_block_bda_binary_prev_ = std::move(*previous_hashmap_control_block);
 
-            auto& previous_control_block =
+            const auto& previous_control_block =
                 *static_cast<gpu_array_t*>(hashmap_control_block_bda_binary_prev_.mapped_data);
 
             // create new storage- and control-blocks

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -1382,6 +1382,10 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                         {
                             GFXRECON_LOG_ERROR("ProcessCmdBuildAccelerationStructuresKHR: creation of shadow "
                                                "acceleration-structure failed");
+
+                            // do not keep a half-initialized entry around
+                            shadow_as_map_.erase(as_replay_address);
+                            return;
                         }
                     }
 

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -1353,10 +1353,21 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                 // now definitely requiring address-replacement
                 force_replace = true;
 
+                // drop stale entries from destroyed acceleration-structures whose device-address got recycled
+                auto stale_shadow_as_it = shadow_as_map_.find(as_replay_address);
+                if (stale_shadow_as_it != shadow_as_map_.end() &&
+                    stale_shadow_as_it->second.origin_handle != build_geometry_info.dstAccelerationStructure)
+                {
+                    util::MarkInjectedCommandsHelper mark_injected_commands_helper_erase;
+                    shadow_as_map_.erase(stale_shadow_as_it);
+                }
+
                 auto& replacement_as = shadow_as_map_[as_replay_address];
 
                 if (replacement_as.handle == VK_NULL_HANDLE)
                 {
+                    replacement_as.origin_handle = build_geometry_info.dstAccelerationStructure;
+
                     if (as_buffer_usable)
                     {
                         replacement_as.handle  = build_geometry_info.dstAccelerationStructure;
@@ -1553,7 +1564,8 @@ void VulkanAddressReplacer::ProcessCmdWriteAccelerationStructuresPropertiesKHR(
         if (acceleration_structure_info != nullptr)
         {
             auto shadow_as_it = shadow_as_map_.find(acceleration_structure_info->replay_address);
-            if (shadow_as_it != shadow_as_map_.end())
+            if (shadow_as_it != shadow_as_map_.end() &&
+                shadow_as_it->second.origin_handle == acceleration_structures[i])
             {
                 acceleration_structures[i] = shadow_as_it->second.handle;
             }
@@ -1603,6 +1615,7 @@ void VulkanAddressReplacer::ProcessUpdateDescriptorSets(uint32_t              de
                 {
                     auto acceleration_structure_it = shadow_as_map_.find(acceleration_structure_info->replay_address);
                     if (acceleration_structure_it != shadow_as_map_.end() &&
+                        acceleration_structure_it->second.origin_handle == write_as->pAccelerationStructures[j] &&
                         acceleration_structure_it->second.storage.num_bytes > 0)
                     {
                         // we found an existing replacement-structure -> swap
@@ -2107,7 +2120,10 @@ bool VulkanAddressReplacer::swap_acceleration_structure_handle(
         if (acceleration_structure_info != nullptr)
         {
             auto shadow_as_it = shadow_as_map_.find(acceleration_structure_info->replay_address);
-            if (shadow_as_it != shadow_as_map_.end())
+
+            // only swap if the entry was created for this acceleration-structure,
+            // otherwise it is a stale entry left behind by a destroyed structure at a recycled device-address
+            if (shadow_as_it != shadow_as_map_.end() && shadow_as_it->second.origin_handle == handle)
             {
                 handle = shadow_as_it->second.handle;
                 return true;
@@ -2117,14 +2133,23 @@ bool VulkanAddressReplacer::swap_acceleration_structure_handle(
     return false;
 }
 
-void VulkanAddressReplacer::DestroyShadowResources(VkAccelerationStructureKHR handle)
+void VulkanAddressReplacer::DestroyShadowResources(const VulkanAccelerationStructureKHRInfo* acceleration_structure_info)
 {
-    if (handle != VK_NULL_HANDLE)
+    if (acceleration_structure_info != nullptr && acceleration_structure_info->handle != VK_NULL_HANDLE)
     {
-        auto remove_as_size_it = as_compact_sizes_.find(handle);
+        auto remove_as_size_it = as_compact_sizes_.find(acceleration_structure_info->handle);
         if (remove_as_size_it != as_compact_sizes_.end())
         {
             as_compact_sizes_.erase(remove_as_size_it);
+        }
+
+        // remove a potential shadow-structure along with the tracked acceleration-structure,
+        // avoiding stale entries in case the device-address gets recycled by a future structure
+        auto remove_shadow_as_it = shadow_as_map_.find(acceleration_structure_info->replay_address);
+        if (remove_shadow_as_it != shadow_as_map_.end())
+        {
+            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+            shadow_as_map_.erase(remove_shadow_as_it);
         }
     }
 }
@@ -2140,7 +2165,8 @@ void VulkanAddressReplacer::DestroyShadowResources(const VulkanBufferInfo*      
             const auto& replay_address_it = acceleration_structure_map.find(capture_address);
             if (replay_address_it != acceleration_structure_map.end())
             {
-                auto remove_shadow_as_it = shadow_as_map_.find(replay_address_it->first);
+                // shadow_as_map_ is keyed by replay-addresses
+                auto remove_shadow_as_it = shadow_as_map_.find(replay_address_it->second);
                 if (remove_shadow_as_it != shadow_as_map_.end())
                 {
                     util::MarkInjectedCommandsHelper mark_injected_commands_helper;

--- a/framework/decode/vulkan_address_replacer.h
+++ b/framework/decode/vulkan_address_replacer.h
@@ -551,6 +551,9 @@ class VulkanAddressReplacer
     // resources related to acceleration-structures
     std::unordered_map<VkDeviceAddress, acceleration_structure_asset_t> shadow_as_map_;
 
+    // replacement scratch-buffers for builds only lacking a usable scratch-buffer
+    std::unordered_map<VkAccelerationStructureKHR, buffer_context_t> shadow_scratch_map_;
+
     // currently running compaction queries. pool -> AS -> query-pool-index
     std::unordered_map<VkQueryPool, std::unordered_map<VkAccelerationStructureKHR, uint32_t>> as_compact_queries_;
     std::unordered_map<VkAccelerationStructureKHR, VkDeviceSize>                              as_compact_sizes_;

--- a/framework/decode/vulkan_address_replacer.h
+++ b/framework/decode/vulkan_address_replacer.h
@@ -369,12 +369,12 @@ class VulkanAddressReplacer
         const decode::VulkanDeviceAddressTracker& address_tracker);
 
     /**
-     * @brief   DestroyShadowResources should be called upon destruction of provided VkAccelerationStructureKHR handle,
+     * @brief   DestroyShadowResources should be called upon destruction of a VkAccelerationStructureKHR-handle,
      *          allowing this class to free potential resources associated with it.
      *
-     * @param   handle  a provided VkAccelerationStructureKHR handle
+     * @param   acceleration_structure_info  a provided VulkanAccelerationStructureKHRInfo struct
      */
-    void DestroyShadowResources(VkAccelerationStructureKHR handle);
+    void DestroyShadowResources(const VulkanAccelerationStructureKHRInfo* acceleration_structure_info);
 
     /**
      * @brief   DestroyShadowResources should be called upon destruction of a VkBuffer-handle,
@@ -428,6 +428,9 @@ class VulkanAddressReplacer
         VkDeviceAddress            address = 0;
         buffer_context_t           storage = {};
         buffer_context_t           scratch = {};
+
+        //! the acceleration-structure this asset was created for, used to detect stale entries after address-reuse
+        VkAccelerationStructureKHR origin_handle = VK_NULL_HANDLE;
 
         VkDevice                              device     = VK_NULL_HANDLE;
         PFN_vkDestroyAccelerationStructureKHR destroy_fn = nullptr;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -9722,7 +9722,7 @@ void VulkanReplayConsumerBase::OverrideDestroyAccelerationStructureKHR(
         GetDeviceAddressTracker(device_info).RemoveAccelerationStructure(acceleration_structure_info);
 
         // free potential shadow-resources
-        GetDeviceAddressReplacer(device_info).DestroyShadowResources(acceleration_structure);
+        GetDeviceAddressReplacer(device_info).DestroyShadowResources(acceleration_structure_info);
 
         if (options_.dumping_resources)
         {


### PR DESCRIPTION
A ray-tracing capture (-m rebind) replayed fine on NVIDIA but crashed on RADV after a
`VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03800`

Two RADV specifics exposed latent bugs in the shadow-tracking logic that NVIDIA never triggered:

- `minAccelerationStructureScratchOffsetAlignment` is 256 on RADV (128 on NVIDIA). 
   ->  Rebound scratch-addresses ended up misaligned, so always using shadow/replacement path
         (was not used on NVIDIA)
- RADV recycled freed buffer device-addresses almost immediately, 
   but `shadow_as_map_` is keyed by replay device-address, and entries were not invalidated on
   destruction.
   -> A new acceleration-structure landing on a recycled address used a stale entry
        and had its valid dst handle swapped for a destroyed one.

The bug(s) are driver-independent. RADV just happened to trigger them for me.