### PR TITLE
[Frame Looping] Fix handling of descriptor pools and fence creation

### DIFF
--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -70,18 +70,12 @@ void VulkanReplayFrameLoopConsumer::StartLooping()
 void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(const ApiCallInfo&       call_info,
                                                                 args::CreateCommandPool& args)
 {
-    if (frame_loop_info_.IsRepetition())
-    {
-        // Don't repeatedly recreate the command pool during the looping frame
-        return;
-    }
-
     // Set VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT in order to prevent validation
     // error regarding implicitly resetting the command buffer
     VkCommandPoolCreateInfo* create_info = args.pCreateInfo.GetPointer();
     create_info->flags |= VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 
-    VulkanReplayConsumer::Process_vkCreateCommandPool(call_info, args);
+    VulkanReplayFrameLoopConsumerBase::Process_vkCreateCommandPool(call_info, args);
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(const ApiCallInfo&           call_info,

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -84,61 +84,42 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateCommandPool(const ApiCallInf
     VulkanReplayConsumer::Process_vkCreateCommandPool(call_info, args);
 }
 
-void VulkanReplayFrameLoopConsumer::Process_vkCreateDescriptorPool(const ApiCallInfo&          call_info,
-                                                                   args::CreateDescriptorPool& args)
-{
-    format::HandleId pool_id = *args.pDescriptorPool.GetPointer();
-    GFXRECON_ASSERT(args.pDescriptorPool.GetPointer() != nullptr);
-
-    if (frame_loop_info_.IsRepetition())
-    {
-        // Skip allocation of descriptor pools with a dangling creation
-        if (dangling_create_descriptor_pools_.contains(pool_id))
-        {
-            return;
-        }
-    }
-
-    VulkanReplayConsumer::Process_vkCreateDescriptorPool(call_info, args);
-
-    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
-    {
-        // Gather descriptor pools that are created during the loop range
-        // We will delete any pools from this set that are destroyed during the loop range
-        dangling_create_descriptor_pools_.insert(pool_id);
-    }
-}
-
 void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(const ApiCallInfo&           call_info,
                                                                     args::DestroyDescriptorPool& args)
 {
-    if (frame_loop_info_.IsRepetition() && !frame_loop_info_.IsFinalIteration())
-    {
-        // Skip destruction of descriptor pools with a dangling destruction
-        if (dangling_destroy_descriptor_pools_.contains(args.descriptorPool))
-        {
-            return;
-        }
-    }
+    // Skip for loop iterations 1-(n-1).
+    // Skip if looping and if not final iteration
+    // Execute if args.descriptorPool is in allocatedLoopResources
 
-    if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())
+    // Call Process_vkDestroyDescriptorPool if:
+    //    We are not looping
+    //    We are looping and args.descriptorPool is in allocatedLoopResources
+    //    We are looping and this is the last iteration
+    if (!getFrameLoopInfo().IsLooping())
     {
-        if (!dangling_create_descriptor_pools_.contains(args.descriptorPool))
-        {
-            // If this pool was not created during the loop range, ignore destroying it.
-            dangling_destroy_descriptor_pools_.insert(args.descriptorPool);
-            return;
-        }
-        else
-        {
-            // Created and destroyed during the loop range, not dangling
-            dangling_create_descriptor_pools_.erase(args.descriptorPool);
-
-            // Check if this was the pool for any heretofore dangling descriptors
-            RemovePoolDanglingCreateDescriptors(args.descriptorPool);
-        }
+        GFXRECON_ASSERT(!allocatedLoopResources.contains(args.descriptorPool))
+        VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, args);
     }
-    VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, args);
+    else if (allocatedLoopResources.contains(args.descriptorPool))
+    {
+        // Looping special case:
+        // This resource has been allocated WITHIN the loop range.
+
+        // Check if this was the pool for any heretofore dangling descriptors
+        RemovePoolDanglingCreateDescriptors(args.descriptorPool);
+        VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, args);
+        allocatedLoopResources.erase(args.descriptorPool);
+    }
+    else if (getFrameLoopInfo().IsFinalIteration())
+    {
+        // Looping special case:
+        // This resource has been allocated BEFORE the loop range.
+        // Since it might still be in use during the loop range, ONLY free it in the last iteration.
+
+        // Check if this was the pool for any heretofore dangling descriptors
+        RemovePoolDanglingCreateDescriptors(args.descriptorPool);
+        VulkanReplayConsumer::Process_vkDestroyDescriptorPool(call_info, args);
+    }
 }
 
 void VulkanReplayFrameLoopConsumer::RemovePoolDanglingCreateDescriptors(format::HandleId descriptorPool)
@@ -254,12 +235,6 @@ void VulkanReplayFrameLoopConsumer::Process_vkFreeDescriptorSets(const ApiCallIn
 
 void VulkanReplayFrameLoopConsumer::Process_vkCreateFence(const ApiCallInfo& call_info, args::CreateFence& args)
 {
-    if (frame_loop_info_.IsRepetition())
-    {
-        // Skip creating the fence on loop repetitions
-        return;
-    }
-
     VulkanReplayFrameLoopConsumerBase::Process_vkCreateFence(call_info, args);
 
     if (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition())

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -47,8 +47,6 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
 
     void Process_vkCreateCommandPool(const ApiCallInfo& call_info, args::CreateCommandPool& args) override;
 
-    void Process_vkCreateDescriptorPool(const ApiCallInfo& call_info, args::CreateDescriptorPool& args) override;
-
     void Process_vkDestroyDescriptorPool(const ApiCallInfo& call_info, args::DestroyDescriptorPool& args) override;
 
     void Process_vkResetDescriptorPool(const ApiCallInfo& call_info, args::ResetDescriptorPool& args) override;
@@ -90,9 +88,7 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
     /// A "dangling" resource is one that was either
     /// - created during the loop range but destroyed after it
     /// - or created before the loop range but destroyed during it
-    std::unordered_set<format::HandleId> dangling_create_descriptor_pools_;
     std::unordered_set<format::HandleId> dangling_create_descriptor_sets_;
-    std::unordered_set<format::HandleId> dangling_destroy_descriptor_pools_;
     std::unordered_set<format::HandleId> dangling_destroy_descriptor_sets_;
 
     std::unordered_map<format::HandleId, FenceTracking> per_device_fence_tracking_;

--- a/framework/generated/generated_vulkan_replay_frame_loop_consumer_base.cpp
+++ b/framework/generated/generated_vulkan_replay_frame_loop_consumer_base.cpp
@@ -1120,6 +1120,30 @@ void VulkanReplayFrameLoopConsumerBase::Process_vkDestroyDescriptorSetLayout(
     }
 }
 
+void VulkanReplayFrameLoopConsumerBase::Process_vkCreateDescriptorPool(
+    const ApiCallInfo&                          call_info,
+    args::CreateDescriptorPool&                 args)
+{
+    // Check for null cases
+    if (args.pDescriptorPool.IsNull())
+    {
+        return;
+    }
+    format::HandleId handle = *args.pDescriptorPool.GetPointer();
+
+    // Pass the call along if we are not looping or
+    // if we are looping and the handle is not in allocatedLoopResources
+    if (!getFrameLoopInfo().IsLooping() || !allocatedLoopResources.contains(handle))
+    {
+        VulkanReplayConsumer::Process_vkCreateDescriptorPool(call_info, args);
+        // If we are looping, save the handle in allocatedLoopResources
+        if (getFrameLoopInfo().IsLooping())
+        {
+            allocatedLoopResources.insert(handle);
+        }
+    }
+}
+
 void VulkanReplayFrameLoopConsumerBase::Process_vkCreateGraphicsPipelines(
     const ApiCallInfo&                          call_info,
     args::CreateGraphicsPipelines&              args)

--- a/framework/generated/generated_vulkan_replay_frame_loop_consumer_base.h
+++ b/framework/generated/generated_vulkan_replay_frame_loop_consumer_base.h
@@ -218,6 +218,10 @@ class VulkanReplayFrameLoopConsumerBase : public VulkanReplayConsumer
         const ApiCallInfo&                          call_info,
         args::DestroyDescriptorSetLayout&           args) override;
 
+    void Process_vkCreateDescriptorPool(
+        const ApiCallInfo&                          call_info,
+        args::CreateDescriptorPool&                 args) override;
+
     void Process_vkCreateGraphicsPipelines(
         const ApiCallInfo&                          call_info,
         args::CreateGraphicsPipelines&              args) override;

--- a/framework/generated/khronos_generators/vulkan_generators/replay_frame_loop_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/replay_frame_loop_overrides.json
@@ -14,6 +14,7 @@
     "vkCreateDebugReportCallbackEXT",
     "vkCreateDebugUtilsMessengerEXT",
     "vkCreateDeferredOperationKHR",
+    "vkCreateDescriptorPool",
     "vkCreateDescriptorSetLayout",
     "vkCreateDescriptorUpdateTemplate",
     "vkCreateDescriptorUpdateTemplateKHR",


### PR DESCRIPTION
`vkCreateDescriptorPool` can be generated, so it now is. `vkDestroyDescriptorPool` still calls `RemovePoolDanglingCreateDescriptors` as before.

The checks in `Process_vkCreateFence` and `Process_vkCreateCommandPool` were wrong and unnecessary, as we call the base class's implementations which handle the resources correctly.