### PR TITLE
dx12: Fix inconsistent capture and replay back buffer index

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -1104,6 +1104,10 @@ HRESULT Dx12ReplayConsumerBase::OverridePresent(DxObjectInfo* replay_object_info
 {
     auto replay_object = static_cast<IDXGISwapChain*>(replay_object_info->object);
     PrePresent(replay_object_info, flags);
+    if (FAILED(original_result))
+    {
+        flags |= DXGI_PRESENT_TEST;
+    }
     auto result = replay_object->Present(sync_interval, flags);
     PostPresent();
 


### PR DESCRIPTION
If the capture present fails, add a flag DXGI_PRESENT_TEST to fake the replay present.

Change-Id: I599a947254b082b306fdad156d8eb1724c31a9a4