### PR TITLE
cmake: Fix relative directories

### DIFF
--- a/cmake/AgilitySDK.cmake
+++ b/cmake/AgilitySDK.cmake
@@ -32,23 +32,25 @@ if (${D3D12_SUPPORT})
        set(GFXR_ARM_WINDOWS_BUILD TRUE)
    endif()
 
+    set(agility_sdk_dir_ "${CMAKE_CURRENT_LIST_DIR}/../external/AgilitySDK")
+
     # Setup src 64-bit binaries
-    set(AGILITY_SDK_CONFIG_SRC ${PROJECT_SOURCE_DIR}/external/AgilitySDK/bin/x64/d3dconfig.exe)
-    set(AGILITY_SDK_LAYERS_SRC ${PROJECT_SOURCE_DIR}/external/AgilitySDK/bin/x64/d3d12SDKLayers.dll)
-    set(AGILITY_SDK_RUNTIME_SRC ${PROJECT_SOURCE_DIR}/external/AgilitySDK/bin/x64/D3D12Core.dll)
+    set(AGILITY_SDK_CONFIG_SRC ${agility_sdk_dir_}/bin/x64/d3dconfig.exe)
+    set(AGILITY_SDK_LAYERS_SRC ${agility_sdk_dir_}/bin/x64/d3d12SDKLayers.dll)
+    set(AGILITY_SDK_RUNTIME_SRC ${agility_sdk_dir_}/bin/x64/D3D12Core.dll)
 
     # Use 32-bit binaries if needed
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-        set(AGILITY_SDK_CONFIG_SRC ${PROJECT_SOURCE_DIR}/external/AgilitySDK/bin/win32/d3dconfig.exe)
-        set(AGILITY_SDK_LAYERS_SRC ${PROJECT_SOURCE_DIR}/external/AgilitySDK/bin/win32/d3d12SDKLayers.dll)
-        set(AGILITY_SDK_RUNTIME_SRC ${PROJECT_SOURCE_DIR}/external/AgilitySDK/bin/win32/D3D12Core.dll)
+        set(AGILITY_SDK_CONFIG_SRC ${agility_sdk_dir_}/bin/win32/d3dconfig.exe)
+        set(AGILITY_SDK_LAYERS_SRC ${agility_sdk_dir_}/bin/win32/d3d12SDKLayers.dll)
+        set(AGILITY_SDK_RUNTIME_SRC ${agility_sdk_dir_}/bin/win32/D3D12Core.dll)
     endif()
 
     # Use ARM 64-bit binaries if needed
     if(GFXR_ARM_WINDOWS_BUILD)
-        set(AGILITY_SDK_CONFIG_SRC ${PROJECT_SOURCE_DIR}/external/AgilitySDK/bin/arm64/d3dconfig.exe)
-        set(AGILITY_SDK_LAYERS_SRC ${PROJECT_SOURCE_DIR}/external/AgilitySDK/bin/arm64/d3d12SDKLayers.dll)
-        set(AGILITY_SDK_RUNTIME_SRC ${PROJECT_SOURCE_DIR}/external/AgilitySDK/bin/arm64/D3D12Core.dll)
+        set(AGILITY_SDK_CONFIG_SRC ${agility_sdk_dir_}/bin/arm64/d3dconfig.exe)
+        set(AGILITY_SDK_LAYERS_SRC ${agility_sdk_dir_}/bin/arm64/d3d12SDKLayers.dll)
+        set(AGILITY_SDK_RUNTIME_SRC ${agility_sdk_dir_}/bin/arm64/D3D12Core.dll)
     endif()
 
     # Setup dst folders for each build config

--- a/cmake/CodeStyle.cmake
+++ b/cmake/CodeStyle.cmake
@@ -27,6 +27,8 @@ option(APPLY_CPP_CODE_STYLE "Apply C++ code style using clang format" OFF)
 option(CHECK_CPP_CODE_STYLE "Check C++ code style using clang format" OFF)
 option(CHECK_CPP_CODE_STYLE_BASE "Git branch/commit for C++ code style comparison" "HEAD")
 
+set(check_code_style_script_ "${CMAKE_CURRENT_LIST_DIR}/../scripts/check_code_style.py")
+
 if(${APPLY_CPP_CODE_STYLE} OR ${CHECK_CPP_CODE_STYLE})
     find_program(CLANG_FORMAT clang-format-14 DOC "Clang format executable")
 
@@ -73,7 +75,7 @@ function(target_code_style_build_directives TARGET)
         if(${CHECK_CPP_CODE_STYLE})
             # Call the script to check formatting
             add_custom_target("${TARGET}CodeStyleCheck"
-                    COMMAND "${PYTHON}" ${PROJECT_SOURCE_DIR}/scripts/check_code_style.py
+                    COMMAND "${PYTHON}" ${check_code_style_script_}
                     --sourcefile ${TARGET_SRC_FILES} --base ${CHECK_CPP_CODE_STYLE_BASE}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
                     COMMENT "Check code style for ${TARGET}")

--- a/tools/launcher/CMakeLists.txt
+++ b/tools/launcher/CMakeLists.txt
@@ -44,5 +44,5 @@ if(BUILD_LAUNCHER_AND_INTERCEPTOR)
     common_build_directives(gfxrecon-launcher)
 
     install(TARGETS gfxrecon-launcher RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-    install(FILES ${CMAKE_BINARY_DIR}/layer/gfxrecon_interceptor/$<CONFIG>/gfxrecon_interceptor.dll DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES $<TARGET_FILE:gfxrecon_interceptor> DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()


### PR DESCRIPTION
When gfxreconstruct is included as a subdirectory in another project, PROJECT_SOURCE_DIR can refer to the directory of the parent project, not gfxreconstruct. When referencing dependencies relative to gfxreconstruct, use something like CMAKE_CURRENT_LIST_DIR and not PROJECT_SOURCE_DIR.