### PR TITLE
Cleanup decoder DispatchInitTensorCommand

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -183,7 +183,8 @@ class ApiDecoder
                                            format::HandleId device_id,
                                            format::HandleId tensor_id,
                                            uint64_t         data_size,
-                                           const uint8_t*   data) = 0;
+                                           const uint8_t*   data)
+    {}
 
     virtual void DispatchInitImageCommand(format::ThreadId             thread_id,
                                           format::HandleId             device_id,

--- a/framework/decode/custom_ags_decoder.h
+++ b/framework/decode/custom_ags_decoder.h
@@ -152,12 +152,6 @@ class AgsDecoder : public ApiDecoder
                                            uint64_t         data_size,
                                            const uint8_t*   data) override
     {}
-    void DispatchInitTensorCommand(format::ThreadId thread_id,
-                                   format::HandleId device_id,
-                                   format::HandleId tensor_id,
-                                   uint64_t         data_size,
-                                   const uint8_t*   data) override
-    {}
 
     virtual void DispatchInitImageCommand(format::ThreadId             thread_id,
                                           format::HandleId             device_id,

--- a/framework/decode/dx12_decoder_base.h
+++ b/framework/decode/dx12_decoder_base.h
@@ -190,13 +190,6 @@ class Dx12DecoderBase : public ApiDecoder
                                            uint64_t         data_size,
                                            const uint8_t*   data) override;
 
-    void DispatchInitTensorCommand(format::ThreadId thread_id,
-                                   format::HandleId device_id,
-                                   format::HandleId tensor_id,
-                                   uint64_t         data_size,
-                                   const uint8_t*   data) override
-    {}
-
     virtual void DispatchInitImageCommand(format::ThreadId             thread_id,
                                           format::HandleId             device_id,
                                           format::HandleId             image_id,

--- a/framework/decode/info_decoder.h
+++ b/framework/decode/info_decoder.h
@@ -179,12 +179,6 @@ class InfoDecoder : public ApiDecoder
                                            uint64_t         data_size,
                                            const uint8_t*   data) override
     {}
-    void DispatchInitTensorCommand(format::ThreadId thread_id,
-                                   format::HandleId device_id,
-                                   format::HandleId tensor_id,
-                                   uint64_t         data_size,
-                                   const uint8_t*   data) override
-    {}
 
     virtual void DispatchInitImageCommand(format::ThreadId             thread_id,
                                           format::HandleId             device_id,

--- a/framework/decode/openxr_decoder_base.h
+++ b/framework/decode/openxr_decoder_base.h
@@ -188,12 +188,6 @@ class OpenXrDecoderBase : public ApiDecoder
                                            uint64_t         data_size,
                                            const uint8_t*   data) override
     {}
-    void DispatchInitTensorCommand(format::ThreadId thread_id,
-                                   format::HandleId device_id,
-                                   format::HandleId tensor_id,
-                                   uint64_t         data_size,
-                                   const uint8_t*   data) override
-    {}
     virtual void DispatchInitImageCommand(format::ThreadId             thread_id,
                                           format::HandleId             device_id,
                                           format::HandleId             image_id,

--- a/framework/decode/stat_decoder_base.h
+++ b/framework/decode/stat_decoder_base.h
@@ -179,12 +179,6 @@ class StatDecoderBase : public ApiDecoder
                                            uint64_t         data_size,
                                            const uint8_t*   data) override
     {}
-    void DispatchInitTensorCommand(format::ThreadId thread_id,
-                                   format::HandleId device_id,
-                                   format::HandleId tensor_id,
-                                   uint64_t         data_size,
-                                   const uint8_t*   data) override
-    {}
 
     virtual void DispatchInitImageCommand(format::ThreadId             thread_id,
                                           format::HandleId             device_id,


### PR DESCRIPTION
Remove the need for every decoder to have to implement the DispatchInitTensorCommand prototype.