### PR TITLE
Remove frame number assert in block_processor

### DIFF
--- a/framework/decode/block_processor.cpp
+++ b/framework/decode/block_processor.cpp
@@ -344,7 +344,13 @@ bool BlockProcessor::ProcessFrameDelimiter(format::ApiCallId call_id)
 
 bool BlockProcessor::ProcessFrameDelimiter(const FrameEndMarkerArgs& end_frame)
 {
-    GFXRECON_ASSERT((!capture_uses_frame_markers_) || (frame_number_ == (end_frame.frame_number - first_frame_)));
+    if (capture_uses_frame_markers_ && (frame_number_ != (end_frame.frame_number - first_frame_)))
+    {
+        GFXRECON_LOG_ERROR("Frame end marker frame number (%" PRIu64 ") does not match current frame number (%" PRIu64
+                           ")",
+                           end_frame.frame_number - first_frame_,
+                           frame_number_);
+    }
     if (IsFrameDelimiter(format::BlockType::kFrameMarkerBlock, format::MarkerType::kEndMarker))
     {
         if (!capture_uses_frame_markers_)


### PR DESCRIPTION
Currently block processor asserts on frame number mismatch between internal counter and frame number provided by frame end marker. This assert would make sense for replayer, but block processor is a core module used by all other tools, including convert and optimize. This makes it impossible to do any kind of processing on traces that captured unexpected application behavior. Change downgrades this assert to an error log allowing the execution to continue.
