### PR TITLE
rebind: Fixes for Aliasing

### DIFF
--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -761,9 +761,12 @@ VulkanRebindAllocator::AllocateMemoryForBuffer(VkBuffer                         
     create_info.pool           = VK_NULL_HANDLE;
     create_info.pUserData      = nullptr;
 
-    // The captured byte-extent: the memory-requirement size when recorded, else the buffer's create
-    // size (always present). Used to detect aliasing against resources already bound to this memory.
-    const VkDeviceSize footprint = capture_req.size > 0 ? capture_req.size : resource_alloc_info.create_size;
+    // The captured byte-extent, used to detect aliasing. Prefer the smaller of requirement- and
+    // create-size: page-guard tracking rewrites the recorded requirement to a page multiple (a
+    // 168-byte buffer can read as 65536), which would overlap every neighbour within that page.
+    const VkDeviceSize footprint = (capture_req.size > 0 && resource_alloc_info.create_size > 0)
+                                       ? std::min(capture_req.size, resource_alloc_info.create_size)
+                                       : std::max(capture_req.size, resource_alloc_info.create_size);
 
     if (VmaMemoryInfo* aliased = FindAliasedMemoryInfo(memory_alloc_info,
                                                        memory_offset,

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -622,11 +622,12 @@ void VulkanRebindAllocator::FreeMemory(VkDeviceMemory               memory,
 }
 
 VulkanRebindAllocator::VmaMemoryInfo*
-VulkanRebindAllocator::FindAliasedMemoryInfo(MemoryAllocInfo&            memory_alloc_info,
+VulkanRebindAllocator::FindAliasedMemoryInfo(const MemoryAllocInfo&      memory_alloc_info,
                                              VkDeviceSize                memory_offset,
                                              VkDeviceSize                footprint,
                                              const VkMemoryRequirements& replay_req,
-                                             bool                        requires_dedicated_allocation)
+                                             bool                        requires_dedicated_allocation,
+                                             bool                        prefers_dedicated_allocation)
 {
     // Without a captured byte-extent we cannot test overlap (e.g. a size-0 image with no
     // create_size proxy); fall back to the per-resource path.
@@ -654,26 +655,26 @@ VulkanRebindAllocator::FindAliasedMemoryInfo(MemoryAllocInfo&            memory_
         VmaMemoryInfo*     existing = range.vma_mem_info;
         const VkDeviceSize base     = existing->offset_from_original_device_memory;
 
-        // A dedicated allocation backs a single resource over the whole memory object, so an existing
-        // dedicated allocation being overlapped cannot happen in a valid capture: the capture is inconsistent.
-        if (existing->requires_dedicated_allocation)
+        // VMA turns both "requires" and "prefers" into dedicated allocations
+        if (existing->requires_dedicated_allocation || existing->prefers_dedicated_allocation)
         {
-            GFXRECON_LOG_FATAL("Rebind aliasing: captured range overlaps an existing dedicated allocation; "
-                               "the capture is inconsistent.");
+            GFXRECON_LOG_WARNING("Rebind aliasing: the aliased resource holds a dedicated allocation at replay. "
+                                 "cannot reproduce the share.");
+            return nullptr;
         }
 
-        // The newcomer needs a dedicated allocation at replay and therefore cannot share the existing memory.
-        if (requires_dedicated_allocation)
+        // The newcomer gets its own dedicated allocation at replay and therefore cannot share the existing memory.
+        if (requires_dedicated_allocation || prefers_dedicated_allocation)
         {
             GFXRECON_LOG_WARNING(
-                "Rebind aliasing: a dedicated allocation is required at replay; cannot reproduce the share.");
+                "Rebind aliasing: a dedicated allocation is required at replay. cannot reproduce the share.");
             return nullptr;
         }
 
         // The existing allocation's memory type must be allowed for the newcomer at replay.
         if ((replay_req.memoryTypeBits & (1u << existing->allocation_info.memoryType)) == 0)
         {
-            GFXRECON_LOG_WARNING("Rebind aliasing: memory type %u is not supported by the resource at replay; cannot "
+            GFXRECON_LOG_WARNING("Rebind aliasing: memory type %u is not supported by the resource at replay. cannot "
                                  "reproduce the share.",
                                  existing->allocation_info.memoryType);
             return nullptr;
@@ -685,7 +686,7 @@ VulkanRebindAllocator::FindAliasedMemoryInfo(MemoryAllocInfo&            memory_
         if (memory_offset < base)
         {
             GFXRECON_LOG_WARNING("Rebind aliasing: resource at captured offset %" PRIu64
-                                 " precedes the aliased resource at offset %" PRIu64 "; cannot reproduce the share.",
+                                 " precedes the aliased resource at offset %" PRIu64 ". cannot reproduce the share.",
                                  memory_offset,
                                  base);
             return nullptr;
@@ -698,7 +699,7 @@ VulkanRebindAllocator::FindAliasedMemoryInfo(MemoryAllocInfo&            memory_
         if (local + replay_req.size > existing->replay_mem_req.size)
         {
             GFXRECON_LOG_WARNING("Rebind aliasing: resource at relative offset %" PRIu64 " (size %" PRIu64
-                                 ") exceeds the aliased allocation size %" PRIu64 "; cannot reproduce the share.",
+                                 ") exceeds the aliased allocation size %" PRIu64 ". cannot reproduce the share.",
                                  local,
                                  replay_req.size,
                                  existing->replay_mem_req.size);
@@ -710,7 +711,7 @@ VulkanRebindAllocator::FindAliasedMemoryInfo(MemoryAllocInfo&            memory_
         if (replay_req.alignment != 0 && device_offset % replay_req.alignment != 0)
         {
             GFXRECON_LOG_WARNING("Rebind aliasing: device offset %" PRIu64 " does not satisfy replay alignment %" PRIu64
-                                 "; cannot reproduce the share.",
+                                 ". cannot reproduce the share.",
                                  device_offset,
                                  replay_req.alignment);
             return nullptr;
@@ -764,8 +765,12 @@ VulkanRebindAllocator::AllocateMemoryForBuffer(VkBuffer                         
     // size (always present). Used to detect aliasing against resources already bound to this memory.
     const VkDeviceSize footprint = capture_req.size > 0 ? capture_req.size : resource_alloc_info.create_size;
 
-    if (VmaMemoryInfo* aliased = FindAliasedMemoryInfo(
-            memory_alloc_info, memory_offset, footprint, replay_req, requires_dedicated_allocation))
+    if (VmaMemoryInfo* aliased = FindAliasedMemoryInfo(memory_alloc_info,
+                                                       memory_offset,
+                                                       footprint,
+                                                       replay_req,
+                                                       requires_dedicated_allocation,
+                                                       prefers_dedicated_allocation))
     {
         memory_alloc_info.bound_ranges.push_back({ VK_HANDLE_TO_UINT64(buffer), memory_offset, footprint, aliased });
         *vma_mem_info = aliased;
@@ -1084,8 +1089,12 @@ VkResult VulkanRebindAllocator::AllocateMemoryForImage(VkImage                  
     // requirement size was recorded; otherwise overlap is untestable and we use the per-resource path.
     const VkDeviceSize footprint = capture_req.size;
 
-    if (VmaMemoryInfo* aliased = FindAliasedMemoryInfo(
-            memory_alloc_info, memory_offset, footprint, replay_req, requires_dedicated_allocation))
+    if (VmaMemoryInfo* aliased = FindAliasedMemoryInfo(memory_alloc_info,
+                                                       memory_offset,
+                                                       footprint,
+                                                       replay_req,
+                                                       requires_dedicated_allocation,
+                                                       prefers_dedicated_allocation))
     {
         memory_alloc_info.bound_ranges.push_back({ VK_HANDLE_TO_UINT64(image), memory_offset, footprint, aliased });
         *vma_mem_info = aliased;
@@ -3656,8 +3665,12 @@ VulkanRebindAllocator::AllocateMemoryForTensor(VkTensorARM                      
 
     const VkDeviceSize footprint = capture_req.size;
 
-    if (VmaMemoryInfo* aliased = FindAliasedMemoryInfo(
-            memory_alloc_info, memory_offset, footprint, replay_req, requires_dedicated_allocation))
+    if (VmaMemoryInfo* aliased = FindAliasedMemoryInfo(memory_alloc_info,
+                                                       memory_offset,
+                                                       footprint,
+                                                       replay_req,
+                                                       requires_dedicated_allocation,
+                                                       prefers_dedicated_allocation))
     {
         memory_alloc_info.bound_ranges.push_back({ VK_HANDLE_TO_UINT64(tensor), memory_offset, footprint, aliased });
         *vma_mem_info = aliased;

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -716,9 +716,59 @@ VulkanRebindAllocator::FindAliasedMemoryInfo(const MemoryAllocInfo&      memory_
                                  replay_req.alignment);
             return nullptr;
         }
+
+        // avoid unintended aliasing
+        if (OverlapsUnaliasedResource(memory_alloc_info, existing, memory_offset, footprint, local, replay_req.size))
+        {
+            return nullptr;
+        }
+
         return existing;
     }
     return nullptr;
+}
+
+// True if placing a resource at [local, local + replay_size) inside `allocation` would overlap a
+// resource already bound there whose *captured* range is disjoint from [memory_offset, +footprint).
+bool VulkanRebindAllocator::OverlapsUnaliasedResource(const MemoryAllocInfo& memory_alloc_info,
+                                                     const VmaMemoryInfo*   allocation,
+                                                     VkDeviceSize           memory_offset,
+                                                     VkDeviceSize           footprint,
+                                                     VkDeviceSize           local,
+                                                     VkDeviceSize           replay_size) const
+{
+    const VkDeviceSize base = allocation->offset_from_original_device_memory;
+
+    for (const auto& other : memory_alloc_info.bound_ranges)
+    {
+        // Only resources sharing this allocation can collide, and only if their extents are known.
+        if (other.vma_mem_info != allocation || other.replay_size == 0 || other.offset < base)
+        {
+            continue;
+        }
+
+        const VkDeviceSize other_local = other.offset - base;
+        if (local >= other_local + other.replay_size || other_local >= local + replay_size)
+        {
+            continue; // disjoint at replay
+        }
+
+        if (memory_offset < other.offset + other.footprint && other.offset < memory_offset + footprint)
+        {
+            continue; // they aliased in the capture too: this is the share being reproduced
+        }
+
+        GFXRECON_LOG_WARNING("Rebind aliasing: replay extent [%" PRIu64 ", %" PRIu64 ") would overlap resource %" PRIu64
+                             " at [%" PRIu64 ", %" PRIu64 "), which it does not alias in the capture. cannot "
+                             "reproduce the share.",
+                             local,
+                             local + replay_size,
+                             other.object_handle,
+                             other_local,
+                             other_local + other.replay_size);
+        return true;
+    }
+    return false;
 }
 
 void VulkanRebindAllocator::RemoveBoundRange(MemoryAllocInfo& memory_alloc_info, uint64_t object_handle)
@@ -775,7 +825,8 @@ VulkanRebindAllocator::AllocateMemoryForBuffer(VkBuffer                         
                                                        requires_dedicated_allocation,
                                                        prefers_dedicated_allocation))
     {
-        memory_alloc_info.bound_ranges.push_back({ VK_HANDLE_TO_UINT64(buffer), memory_offset, footprint, aliased });
+        memory_alloc_info.bound_ranges.push_back(
+            { VK_HANDLE_TO_UINT64(buffer), memory_offset, footprint, aliased, replay_req.size });
         *vma_mem_info = aliased;
         return VK_SUCCESS;
     }
@@ -790,7 +841,7 @@ VulkanRebindAllocator::AllocateMemoryForBuffer(VkBuffer                         
                           vma_mem_info))
     {
         memory_alloc_info.bound_ranges.push_back(
-            { VK_HANDLE_TO_UINT64(buffer), memory_offset, footprint, *vma_mem_info });
+            { VK_HANDLE_TO_UINT64(buffer), memory_offset, footprint, *vma_mem_info, replay_req.size });
         return VK_SUCCESS;
     }
 
@@ -811,7 +862,7 @@ VulkanRebindAllocator::AllocateMemoryForBuffer(VkBuffer                         
         memory_alloc_info.vma_mem_infos.emplace_back(std::make_unique<VmaMemoryInfo>(mem_info));
         *vma_mem_info = memory_alloc_info.vma_mem_infos.back().get();
         memory_alloc_info.bound_ranges.push_back(
-            { VK_HANDLE_TO_UINT64(buffer), memory_offset, footprint, *vma_mem_info });
+            { VK_HANDLE_TO_UINT64(buffer), memory_offset, footprint, *vma_mem_info, replay_req.size });
     }
     return result;
 }
@@ -1099,7 +1150,8 @@ VkResult VulkanRebindAllocator::AllocateMemoryForImage(VkImage                  
                                                        requires_dedicated_allocation,
                                                        prefers_dedicated_allocation))
     {
-        memory_alloc_info.bound_ranges.push_back({ VK_HANDLE_TO_UINT64(image), memory_offset, footprint, aliased });
+        memory_alloc_info.bound_ranges.push_back(
+            { VK_HANDLE_TO_UINT64(image), memory_offset, footprint, aliased, replay_req.size });
         *vma_mem_info = aliased;
         return VK_SUCCESS;
     }
@@ -1114,7 +1166,7 @@ VkResult VulkanRebindAllocator::AllocateMemoryForImage(VkImage                  
                           vma_mem_info))
     {
         memory_alloc_info.bound_ranges.push_back(
-            { VK_HANDLE_TO_UINT64(image), memory_offset, footprint, *vma_mem_info });
+            { VK_HANDLE_TO_UINT64(image), memory_offset, footprint, *vma_mem_info, replay_req.size });
         return VK_SUCCESS;
     }
 
@@ -1135,7 +1187,7 @@ VkResult VulkanRebindAllocator::AllocateMemoryForImage(VkImage                  
         memory_alloc_info.vma_mem_infos.emplace_back(std::make_unique<VmaMemoryInfo>(mem_info));
         *vma_mem_info = memory_alloc_info.vma_mem_infos.back().get();
         memory_alloc_info.bound_ranges.push_back(
-            { VK_HANDLE_TO_UINT64(image), memory_offset, footprint, *vma_mem_info });
+            { VK_HANDLE_TO_UINT64(image), memory_offset, footprint, *vma_mem_info, replay_req.size });
     }
     return result;
 }
@@ -3675,7 +3727,8 @@ VulkanRebindAllocator::AllocateMemoryForTensor(VkTensorARM                      
                                                        requires_dedicated_allocation,
                                                        prefers_dedicated_allocation))
     {
-        memory_alloc_info.bound_ranges.push_back({ VK_HANDLE_TO_UINT64(tensor), memory_offset, footprint, aliased });
+        memory_alloc_info.bound_ranges.push_back(
+            { VK_HANDLE_TO_UINT64(tensor), memory_offset, footprint, aliased, replay_req.size });
         *vma_mem_info = aliased;
         return VK_SUCCESS;
     }
@@ -3690,7 +3743,7 @@ VulkanRebindAllocator::AllocateMemoryForTensor(VkTensorARM                      
                           vma_mem_info))
     {
         memory_alloc_info.bound_ranges.push_back(
-            { VK_HANDLE_TO_UINT64(tensor), memory_offset, footprint, *vma_mem_info });
+            { VK_HANDLE_TO_UINT64(tensor), memory_offset, footprint, *vma_mem_info, replay_req.size });
         return VK_SUCCESS;
     }
 
@@ -3711,7 +3764,7 @@ VulkanRebindAllocator::AllocateMemoryForTensor(VkTensorARM                      
         memory_alloc_info.vma_mem_infos.emplace_back(std::make_unique<VmaMemoryInfo>(mem_info));
         *vma_mem_info = memory_alloc_info.vma_mem_infos.back().get();
         memory_alloc_info.bound_ranges.push_back(
-            { VK_HANDLE_TO_UINT64(tensor), memory_offset, footprint, *vma_mem_info });
+            { VK_HANDLE_TO_UINT64(tensor), memory_offset, footprint, *vma_mem_info, replay_req.size });
     }
     return result;
 }

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -655,8 +655,14 @@ VulkanRebindAllocator::FindAliasedMemoryInfo(const MemoryAllocInfo&      memory_
         VmaMemoryInfo*     existing = range.vma_mem_info;
         const VkDeviceSize base     = existing->offset_from_original_device_memory;
 
-        // VMA turns both "requires" and "prefers" into dedicated allocations
-        if (existing->requires_dedicated_allocation || existing->prefers_dedicated_allocation)
+        // VMA 'can' create dedicated blocks with neither 'prefers/requires dedicated' flag set.
+        // -> query the VMA-allocation
+        VmaAllocationInfo2 existing_info{};
+        if (existing->allocation != VK_NULL_HANDLE)
+        {
+            vmaGetAllocationInfo2(allocator_, existing->allocation, &existing_info);
+        }
+        if (existing_info.dedicatedMemory == VK_TRUE)
         {
             GFXRECON_LOG_WARNING("Rebind aliasing: the aliased resource holds a dedicated allocation at replay. "
                                  "cannot reproduce the share.");
@@ -731,11 +737,11 @@ VulkanRebindAllocator::FindAliasedMemoryInfo(const MemoryAllocInfo&      memory_
 // True if placing a resource at [local, local + replay_size) inside `allocation` would overlap a
 // resource already bound there whose *captured* range is disjoint from [memory_offset, +footprint).
 bool VulkanRebindAllocator::OverlapsUnaliasedResource(const MemoryAllocInfo& memory_alloc_info,
-                                                     const VmaMemoryInfo*   allocation,
-                                                     VkDeviceSize           memory_offset,
-                                                     VkDeviceSize           footprint,
-                                                     VkDeviceSize           local,
-                                                     VkDeviceSize           replay_size) const
+                                                      const VmaMemoryInfo*   allocation,
+                                                      VkDeviceSize           memory_offset,
+                                                      VkDeviceSize           footprint,
+                                                      VkDeviceSize           local,
+                                                      VkDeviceSize           replay_size) const
 {
     const VkDeviceSize base = allocation->offset_from_original_device_memory;
 

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -587,6 +587,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         VkDeviceSize   offset{ 0 };             // captured memoryOffset
         VkDeviceSize   footprint{ 0 };          // captured byte-extent (capture_req.size, else create_size)
         VmaMemoryInfo* vma_mem_info{ nullptr }; // allocation this resource landed in
+        VkDeviceSize   replay_size{ 0 };        // replay byte-extent (replay_req.size) inside that allocation
     };
 
     struct MemoryAllocInfo
@@ -744,6 +745,16 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                          const VkMemoryRequirements& replay_req,
                                          bool                        requires_dedicated_allocation,
                                          bool                        prefers_dedicated_allocation);
+
+    // True if placing a resource at [local, local + replay_size) inside an allocation would overlap
+    // a resource already bound there that it does not alias in the capture. Replay sizes differ from
+    // captured ones, so a join can collide with a resource the application kept separate.
+    bool OverlapsUnaliasedResource(const MemoryAllocInfo& memory_alloc_info,
+                                   const VmaMemoryInfo*   allocation,
+                                   VkDeviceSize           memory_offset,
+                                   VkDeviceSize           footprint,
+                                   VkDeviceSize           local,
+                                   VkDeviceSize           replay_size) const;
 
     // Drop an object's entries from bound_ranges (on destroy or after a failed bind), so later
     // binds do not test overlap against a resource that is not actually bound.

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -738,11 +738,12 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     // VmaMemoryInfo so the newcomer binds into the same allocation at its captured relative offset;
     // the existing GetRebindOffsetFromVMA math then places it. Returns nullptr when there is no
     // overlap (use the per-resource path) or when the alias cannot be reproduced (warns).
-    VmaMemoryInfo* FindAliasedMemoryInfo(MemoryAllocInfo&            memory_alloc_info,
+    VmaMemoryInfo* FindAliasedMemoryInfo(const MemoryAllocInfo&      memory_alloc_info,
                                          VkDeviceSize                memory_offset,
                                          VkDeviceSize                footprint,
                                          const VkMemoryRequirements& replay_req,
-                                         bool                        requires_dedicated_allocation);
+                                         bool                        requires_dedicated_allocation,
+                                         bool                        prefers_dedicated_allocation);
 
     // Drop an object's entries from bound_ranges (on destroy or after a failed bind), so later
     // binds do not test overlap against a resource that is not actually bound.


### PR DESCRIPTION
- VMA turns both requiresDedicatedAllocation, prefersDedicatedAllocation
   into a dedicated block, but also in cases when neither flag is set.
-> check with vmaGetAllocationInfo2().dedicatedMemory, reject sharing
- don't alias on page-guard inflated requirement sizes
- Additional check for range-overlap at replay-time, reject sharing

follow-up for https://github.com/LunarG/gfxreconstruct/pull/3100
(introduced reproduction of memory-aliasing when using `-m rebind`)