### PR TITLE
[Frame Looping] Handle VK_EXT_frame_boundary

### DIFF
--- a/framework/decode/struct_pointer_decoder.h
+++ b/framework/decode/struct_pointer_decoder.h
@@ -85,9 +85,13 @@ class StructPointerDecoder : public PointerDecoderBase
 
     std::span<typename T::struct_type> GetSpan() { return std::span(GetPointer(), GetLength()); }
 
+    std::span<T> GetMetaStructSpan() { return std::span(GetMetaStructPointer(), GetLength()); }
+
     const typename T::struct_type* GetPointer() const { return struct_memory_; }
 
     const std::span<typename T::struct_type> GetSpan() const { return std::span(GetPointer(), GetLength()); }
+
+    const std::span<T> GetMetaStructSpan() const { return std::span(GetMetaStructPointer(), GetLength()); }
 
     size_t GetOutputLength() const { return output_len_; }
 

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -467,6 +467,29 @@ void VulkanReplayFrameLoopConsumer::Process_vkMapMemory(const ApiCallInfo& call_
     VulkanReplayConsumer::Process_vkMapMemory(call_info, args);
 }
 
+void VulkanReplayFrameLoopConsumer::Process_vkQueueSubmit(const ApiCallInfo& call_info, args::QueueSubmit& args)
+{
+    VulkanReplayConsumer::Process_vkQueueSubmit(call_info, args);
+
+    auto frame_boundary = GetPNextMetaStruct<Decoded_VkFrameBoundaryEXT>(args.pSubmits.GetMetaStructPointer()->pNext);
+    if (frame_boundary != nullptr)
+    {
+        // This submit is being used as a frame boundary
+        CommonObjectInfoTable& table      = GetObjectInfoTable();
+        VulkanQueueInfo*       queue_info = table.GetVkQueueInfo(args.queue);
+        VkDevice               device     = queue_info->parent;
+        GFXRECON_ASSERT(device != 0);
+        const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device);
+        GFXRECON_ASSERT(device_table != nullptr);
+
+        GFXRECON_LOG_DEBUG("Waiting for device to idle...");
+        VkResult result = device_table->DeviceWaitIdle(device);
+        CHECK_VK_RESULT(result, "vkDeviceWaitIdle");
+
+        FixupDeviceFences(queue_info->parent_id, args.queue);
+    }
+}
+
 void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(const ApiCallInfo& call_info, args::QueuePresentKHR& args)
 {
     VulkanReplayConsumer::Process_vkQueuePresentKHR(call_info, args);

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -487,9 +487,15 @@ void VulkanReplayFrameLoopConsumer::FrameBoundaryEndOfFrame(format::HandleId que
             VkResult result = device_table->DeviceWaitIdle(device);
             CHECK_VK_RESULT(result, "vkDeviceWaitIdle");
 
-            FixupDeviceFences(queue_info->parent_id, queue);
+            FixupDeviceObjects(queue_info->parent_id, queue);
         }
     }
+}
+
+void VulkanReplayFrameLoopConsumer::FixupDeviceObjects(format::HandleId device, format::HandleId queue)
+{
+    FixupDeviceEvents(device);
+    FixupDeviceFences(device, queue);
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkQueueBindSparse(const ApiCallInfo& call_info, args::QueueBindSparse& args)
@@ -548,8 +554,7 @@ void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(const ApiCallInfo&
         VkResult result = device_table->DeviceWaitIdle(device);
         CHECK_VK_RESULT(result, "vkDeviceWaitIdle");
 
-        FixupDeviceFences(queue_info->parent_id, args.queue);
-        FixupDeviceEvents(queue_info->parent_id);
+        FixupDeviceObjects(queue_info->parent_id, args.queue);
     }
 }
 

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -494,6 +494,10 @@ void VulkanReplayFrameLoopConsumer::FrameBoundaryEndOfFrame(format::HandleId que
 
 void VulkanReplayFrameLoopConsumer::FixupDeviceObjects(format::HandleId device, format::HandleId queue)
 {
+    if (!frame_loop_info_.IsLooping() || frame_loop_info_.IsFinalIteration())
+    {
+        return;
+    }
     FixupDeviceEvents(device);
     FixupDeviceFences(device, queue);
 }

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -500,7 +500,7 @@ void VulkanReplayFrameLoopConsumer::FixupDeviceObjects(format::HandleId device, 
 
 void VulkanReplayFrameLoopConsumer::Process_vkQueueBindSparse(const ApiCallInfo& call_info, args::QueueBindSparse& args)
 {
-    VulkanReplayConsumer::Process_vkQueueBindSparse(call_info, args);
+    VulkanReplayFrameLoopConsumerBase::Process_vkQueueBindSparse(call_info, args);
 
     if (frame_loop_info_.IsLooping())
     {

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -467,26 +467,67 @@ void VulkanReplayFrameLoopConsumer::Process_vkMapMemory(const ApiCallInfo& call_
     VulkanReplayConsumer::Process_vkMapMemory(call_info, args);
 }
 
+void VulkanReplayFrameLoopConsumer::FrameBoundaryEndOfFrame(format::HandleId queue, PNextNode* pNext)
+{
+    const Decoded_VkFrameBoundaryEXT* frame_boundary = GetPNextMetaStruct<Decoded_VkFrameBoundaryEXT>(pNext);
+    if (frame_boundary != nullptr)
+    {
+        if ((frame_boundary->decoded_value->flags & VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT) ==
+            VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT)
+        {
+            // This submit is being used as a frame boundary
+            CommonObjectInfoTable& table      = GetObjectInfoTable();
+            VulkanQueueInfo*       queue_info = table.GetVkQueueInfo(queue);
+            VkDevice               device     = queue_info->parent;
+            GFXRECON_ASSERT(device != 0);
+            const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device);
+            GFXRECON_ASSERT(device_table != nullptr);
+
+            GFXRECON_LOG_DEBUG("Waiting for device to idle...");
+            VkResult result = device_table->DeviceWaitIdle(device);
+            CHECK_VK_RESULT(result, "vkDeviceWaitIdle");
+
+            FixupDeviceFences(queue_info->parent_id, queue);
+        }
+    }
+}
+
+void VulkanReplayFrameLoopConsumer::Process_vkQueueBindSparse(const ApiCallInfo& call_info, args::QueueBindSparse& args)
+{
+    VulkanReplayConsumer::Process_vkQueueBindSparse(call_info, args);
+
+    if (frame_loop_info_.IsLooping())
+    {
+        for (Decoded_VkBindSparseInfo submit : args.pBindInfo.GetMetaStructSpan())
+        {
+            FrameBoundaryEndOfFrame(args.queue, submit.pNext);
+        }
+    }
+}
+
 void VulkanReplayFrameLoopConsumer::Process_vkQueueSubmit(const ApiCallInfo& call_info, args::QueueSubmit& args)
 {
     VulkanReplayConsumer::Process_vkQueueSubmit(call_info, args);
 
-    auto frame_boundary = GetPNextMetaStruct<Decoded_VkFrameBoundaryEXT>(args.pSubmits.GetMetaStructPointer()->pNext);
-    if (frame_boundary != nullptr)
+    if (frame_loop_info_.IsLooping())
     {
-        // This submit is being used as a frame boundary
-        CommonObjectInfoTable& table      = GetObjectInfoTable();
-        VulkanQueueInfo*       queue_info = table.GetVkQueueInfo(args.queue);
-        VkDevice               device     = queue_info->parent;
-        GFXRECON_ASSERT(device != 0);
-        const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device);
-        GFXRECON_ASSERT(device_table != nullptr);
+        for (Decoded_VkSubmitInfo submit : args.pSubmits.GetMetaStructSpan())
+        {
+            FrameBoundaryEndOfFrame(args.queue, submit.pNext);
+        }
+    }
+}
 
-        GFXRECON_LOG_DEBUG("Waiting for device to idle...");
-        VkResult result = device_table->DeviceWaitIdle(device);
-        CHECK_VK_RESULT(result, "vkDeviceWaitIdle");
+void VulkanReplayFrameLoopConsumer::Process_vkQueueSubmit2(const ApiCallInfo& call_info, args::QueueSubmit2& args)
+{
+    VulkanReplayConsumer::Process_vkQueueSubmit2(call_info, args);
 
-        FixupDeviceFences(queue_info->parent_id, args.queue);
+    if (frame_loop_info_.IsLooping())
+    {
+        for (Decoded_VkSubmitInfo2 submit : args.pSubmits.GetMetaStructSpan())
+        {
+            FrameBoundaryEndOfFrame(args.queue, submit.pNext);
+        }
     }
 }
 

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -58,6 +58,8 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
     void Process_vkCreateFence(const ApiCallInfo& call_info, args::CreateFence& args) override;
 
     void Process_vkDestroyFence(const ApiCallInfo& call_info, args::DestroyFence& args) override;
+    
+    void Process_vkQueueSubmit(const ApiCallInfo& call_info, args::QueueSubmit& args) override;
 
     void Process_vkCreateEvent(const ApiCallInfo& call_info, args::CreateEvent& args) override;
 

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -58,12 +58,16 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
     void Process_vkCreateFence(const ApiCallInfo& call_info, args::CreateFence& args) override;
 
     void Process_vkDestroyFence(const ApiCallInfo& call_info, args::DestroyFence& args) override;
-    
+
+    void Process_vkQueueBindSparse(const ApiCallInfo& call_info, args::QueueBindSparse& args) override;
+
     void Process_vkQueueSubmit(const ApiCallInfo& call_info, args::QueueSubmit& args) override;
 
     void Process_vkCreateEvent(const ApiCallInfo& call_info, args::CreateEvent& args) override;
 
     void Process_vkDestroyEvent(const ApiCallInfo& call_info, args::DestroyEvent& args) override;
+
+    void Process_vkQueueSubmit2(const ApiCallInfo& call_info, args::QueueSubmit2& args) override;
 
     void Process_vkQueuePresentKHR(const ApiCallInfo& call_info, args::QueuePresentKHR& args) override;
 
@@ -88,6 +92,7 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
     void TrackFenceStates();
     void TrackFenceState(format::HandleId device, format::HandleId fence);
     void FixupDeviceFences(format::HandleId device, format::HandleId queue);
+    void FrameBoundaryEndOfFrame(format::HandleId queue, PNextNode* pNext);
 
     struct EventTracking
     {

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -101,6 +101,7 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
     void TrackEventStates();
     void TrackEventState(format::HandleId device, format::HandleId event);
     void FixupDeviceEvents(format::HandleId device);
+    void FixupDeviceObjects(format::HandleId device, format::HandleId queue);
 
     // Private data
   private:


### PR DESCRIPTION
At present, frame looping assumes frames will be delimited by `vkQueuePresentKHR`. This PR adds support for `VK_EXT_frame_boundary`, adding checks to the other queue operations so that end-of-frame cleanup work happens when a frame boundary struct defines the end of a frame.