### PR TITLE
file_processor: Add filename accessor

### DIFF
--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -132,6 +132,7 @@ bool FileProcessor::Initialize(const std::string& filename)
         // Cache header and options so they remain accessible after block_processor_ transfers to AsyncProcessor.
         file_header_  = block_processor_->GetFileHeader();
         file_options_ = block_processor_->GetFileOptions();
+        filename_     = filename;
     }
     else
     {

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -96,6 +96,7 @@ class FileProcessor
     }
 
     bool Initialize(const std::string& filename);
+    const std::string& GetFilename() const { return filename_; }
 
     // Called implicitly by ProcessAllFrames() and directly by Application::Run()
     // Must be called at most once after Initialize() and before ProcessNextFrame()
@@ -183,12 +184,13 @@ class FileProcessor
     void SetDecoderFrameNumber(uint64_t frame_number);
 
   private:
-    bool     frame_processing_initialized_{ false };
-    uint64_t dispatch_bytes_read_{ 0 };
-    bool     dispatch_capture_uses_frame_markers_{ false };
-    bool     dispatch_file_supports_frame_markers_{ false };
-    bool     dispatch_skipping_finished_{ true };
-    bool     loading_trimmed_capture_state_{ false };
+    bool        frame_processing_initialized_{ false };
+    uint64_t    dispatch_bytes_read_{ 0 };
+    bool        dispatch_capture_uses_frame_markers_{ false };
+    bool        dispatch_file_supports_frame_markers_{ false };
+    bool        dispatch_skipping_finished_{ true };
+    bool        loading_trimmed_capture_state_{ false };
+    std::string filename_;
 
     // Stored at FileProcessor level so they survive a BlockProcessor re-creation in Initialize().
     // Transferred to BlockProcessor in InitializeFrameProcessing().


### PR DESCRIPTION
Some of the components in tools don't have easy access to the filename that is initialized into the FileProcessor. So, simply add a filename accessor for them.