### PR TITLE
Detect Vulkan API on `vkCreateInstance` instead of `vkCreateDevice`

### DIFF
--- a/framework/decode/vulkan_detection_consumer.h
+++ b/framework/decode/vulkan_detection_consumer.h
@@ -42,8 +42,8 @@ class VulkanDetectionConsumer : public VulkanConsumer
     VulkanDetectionConsumer(uint64_t block_limit = kDefaultBlockLimit) :
         block_limit_(block_limit), vulkan_consumer_usage_(false)
     {}
-    bool         WasVulkanAPIDetected() const { return vulkan_consumer_usage_; }
-    void         Process_vkCreateDevice(const ApiCallInfo& call_info, args::CreateDevice& args) override
+    bool WasVulkanAPIDetected() const { return vulkan_consumer_usage_; }
+    void Process_vkCreateInstance(const ApiCallInfo& call_info, args::CreateInstance& args) override
     {
         vulkan_consumer_usage_ = true;
     }

--- a/framework/decode/vulkan_detection_consumer.h
+++ b/framework/decode/vulkan_detection_consumer.h
@@ -39,15 +39,18 @@ class VulkanDetectionConsumer : public VulkanConsumer
     static constexpr uint64_t kDefaultBlockLimit = 1000;
     static constexpr uint64_t kNoBlockLimit      = 0;
 
-    VulkanDetectionConsumer(uint64_t block_limit = kDefaultBlockLimit) :
+    explicit VulkanDetectionConsumer(uint64_t block_limit = kDefaultBlockLimit) :
         block_limit_(block_limit), vulkan_consumer_usage_(false)
     {}
-    bool WasVulkanAPIDetected() const { return vulkan_consumer_usage_; }
+
+    [[nodiscard]] bool WasVulkanAPIDetected() const { return vulkan_consumer_usage_; }
+
     void Process_vkCreateInstance(const ApiCallInfo& call_info, args::CreateInstance& args) override
     {
-        vulkan_consumer_usage_ = true;
+        vulkan_consumer_usage_ |= args.result == VK_SUCCESS;
     }
-    virtual bool IsComplete(uint64_t block_index) override
+
+    bool IsComplete(uint64_t block_index) override
     {
         return ((block_limit_ != kNoBlockLimit) && (block_index > block_limit_)) || WasVulkanAPIDetected();
     }


### PR DESCRIPTION
The entry point to any Vulkan program is instance creation, not device creation, and a program that would create an instance, query supported physical devices and their properties/other instance level calls without ever creating a device would still be a valid Vulkan program and could still benefit from some sort of optimization.
