### PR TITLE
Remove duplicate fields and track device earlier

### DIFF
--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -517,26 +517,6 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBindImageMemory2KHR>
 };
 
 template <>
-struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBuffer>
-{
-    template <typename... Args>
-    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
-    {
-        manager->PostProcess_vkCreateBuffer(result, args...);
-    }
-};
-
-template <>
-struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImage>
-{
-    template <typename... Args>
-    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
-    {
-        manager->PostProcess_vkCreateImage(result, args...);
-    }
-};
-
-template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginRenderPass>
 {
     template <typename... Args>

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -861,10 +861,9 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
                                                     const VkAllocationCallbacks* pAllocator,
                                                     VkBuffer*                    pBuffer)
 {
-    VkResult result           = VK_SUCCESS;
-    auto     device_wrapper   = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
-    VkDevice device_unwrapped = device_wrapper->handle;
-    auto     device_table     = vulkan_wrappers::GetDeviceTable(device);
+    VkResult result         = VK_SUCCESS;
+    auto     device_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    auto     device_table   = vulkan_wrappers::GetDeviceTable(device);
 
     // we need to deep-copy, potentially contains VkBufferUsageFlags2CreateInfoKHR in pNext-chain
     std::unique_ptr<uint8_t[]> struct_storage;
@@ -920,7 +919,7 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
     }
 
     // create buffer with augmented create- and usage-flags
-    result = device_table->CreateBuffer(device_unwrapped, modified_create_info, pAllocator, pBuffer);
+    result = device_table->CreateBuffer(device, modified_create_info, pAllocator, pBuffer);
 
     if ((result == VK_SUCCESS) && (pBuffer != nullptr))
     {
@@ -931,7 +930,7 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
 
         auto* buffer_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::BufferWrapper>(*pBuffer);
         GFXRECON_ASSERT(buffer_wrapper);
-        buffer_wrapper->device         = device;
+        buffer_wrapper->device         = device_wrapper;
         buffer_wrapper->size           = modified_create_info->size;
         buffer_wrapper->usage          = pCreateInfo->usage;
         buffer_wrapper->modified_flags = modified_create_info->flags;
@@ -948,11 +947,11 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
 
             if (device_wrapper->physical_device->parent_info.api_version >= VK_MAKE_VERSION(1, 2, 0))
             {
-                opaque_address = device_table->GetBufferOpaqueCaptureAddress(device_unwrapped, &info);
+                opaque_address = device_table->GetBufferOpaqueCaptureAddress(device, &info);
             }
             else
             {
-                opaque_address = device_table->GetBufferOpaqueCaptureAddressKHR(device_unwrapped, &info);
+                opaque_address = device_table->GetBufferOpaqueCaptureAddressKHR(device, &info);
             }
             WriteSetOpaqueAddressCommand(device_wrapper->handle_id, buffer_wrapper->handle_id, opaque_address);
 
@@ -973,7 +972,7 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
             };
             descriptor_data_info_ext.buffer = buffer_wrapper->handle;
             VkResult get_data_result        = device_table->GetBufferOpaqueCaptureDescriptorDataEXT(
-                device_unwrapped, &descriptor_data_info_ext, opaque_data.data());
+                device, &descriptor_data_info_ext, opaque_data.data());
             GFXRECON_ASSERT(get_data_result == VK_SUCCESS);
 
             WriteSetOpaqueCaptureDescriptorData(
@@ -1063,7 +1062,7 @@ VkResult VulkanCaptureManager::OverrideCreateImage(VkDevice                     
 
         auto* image_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::ImageWrapper>(*pImage);
         GFXRECON_ASSERT(image_wrapper);
-        image_wrapper->bind_device = device_wrapper;
+        image_wrapper->device = device_wrapper;
 
         // These are required to generate a fill command in case external memory is bound to this image
         image_wrapper->image_type     = modified_create_info.imageType;

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -852,10 +852,9 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
                                                     const VkAllocationCallbacks* pAllocator,
                                                     VkBuffer*                    pBuffer)
 {
-    VkResult result           = VK_SUCCESS;
-    auto     device_wrapper   = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
-    VkDevice device_unwrapped = device_wrapper->handle;
-    auto     device_table     = vulkan_wrappers::GetDeviceTable(device);
+    VkResult result         = VK_SUCCESS;
+    auto     device_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    auto     device_table   = vulkan_wrappers::GetDeviceTable(device);
 
     // we need to deep-copy, potentially contains VkBufferUsageFlags2CreateInfoKHR in pNext-chain
     std::unique_ptr<uint8_t[]> struct_storage;
@@ -911,7 +910,7 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
     }
 
     // create buffer with augmented create- and usage-flags
-    result = device_table->CreateBuffer(device_unwrapped, modified_create_info, pAllocator, pBuffer);
+    result = device_table->CreateBuffer(device, modified_create_info, pAllocator, pBuffer);
 
     if ((result == VK_SUCCESS) && (pBuffer != nullptr))
     {
@@ -922,7 +921,7 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
 
         auto* buffer_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::BufferWrapper>(*pBuffer);
         GFXRECON_ASSERT(buffer_wrapper);
-        buffer_wrapper->device         = device;
+        buffer_wrapper->device         = device_wrapper;
         buffer_wrapper->size           = modified_create_info->size;
         buffer_wrapper->usage          = pCreateInfo->usage;
         buffer_wrapper->modified_flags = modified_create_info->flags;
@@ -939,11 +938,11 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
 
             if (device_wrapper->physical_device->parent_info.api_version >= VK_MAKE_VERSION(1, 2, 0))
             {
-                opaque_address = device_table->GetBufferOpaqueCaptureAddress(device_unwrapped, &info);
+                opaque_address = device_table->GetBufferOpaqueCaptureAddress(device, &info);
             }
             else
             {
-                opaque_address = device_table->GetBufferOpaqueCaptureAddressKHR(device_unwrapped, &info);
+                opaque_address = device_table->GetBufferOpaqueCaptureAddressKHR(device, &info);
             }
             WriteSetOpaqueAddressCommand(device_wrapper->handle_id, buffer_wrapper->handle_id, opaque_address);
 
@@ -964,7 +963,7 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
             };
             descriptor_data_info_ext.buffer = buffer_wrapper->handle;
             VkResult get_data_result        = device_table->GetBufferOpaqueCaptureDescriptorDataEXT(
-                device_unwrapped, &descriptor_data_info_ext, opaque_data.data());
+                device, &descriptor_data_info_ext, opaque_data.data());
             GFXRECON_ASSERT(get_data_result == VK_SUCCESS);
 
             WriteSetOpaqueCaptureDescriptorData(
@@ -1047,7 +1046,7 @@ VkResult VulkanCaptureManager::OverrideCreateImage(VkDevice                     
 
         auto* image_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::ImageWrapper>(*pImage);
         GFXRECON_ASSERT(image_wrapper);
-        image_wrapper->bind_device = device_wrapper;
+        image_wrapper->device = device_wrapper;
 
         // These are required to generate a fill command in case external memory is bound to this image
         image_wrapper->image_type     = modified_create_info.imageType;

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -927,20 +927,6 @@ class VulkanCaptureManager : public ApiCaptureManager
                                         uint32_t                     bindInfoCount,
                                         const VkBindImageMemoryInfo* pBindInfos);
 
-    void PostProcess_vkCreateBuffer(VkResult                     result,
-                                    VkDevice                     device,
-                                    const VkBufferCreateInfo*    pCreateInfo,
-                                    const VkAllocationCallbacks* pAllocator,
-                                    VkBuffer*                    pBuffer)
-    {}
-
-    void PostProcess_vkCreateImage(VkResult                     result,
-                                   VkDevice                     device,
-                                   const VkImageCreateInfo*     pCreateInfo,
-                                   const VkAllocationCallbacks* pAllocator,
-                                   VkImage*                     pImage)
-    {}
-
     void PostProcess_vkCmdBeginRenderPass(VkCommandBuffer              commandBuffer,
                                           const VkRenderPassBeginInfo* pRenderPassBegin,
                                           VkSubpassContents)

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -932,44 +932,14 @@ class VulkanCaptureManager : public ApiCaptureManager
                                     const VkBufferCreateInfo*    pCreateInfo,
                                     const VkAllocationCallbacks* pAllocator,
                                     VkBuffer*                    pBuffer)
-    {
-        if (IsCaptureModeTrack() && (result == VK_SUCCESS) && (pCreateInfo != nullptr))
-        {
-            GFXRECON_ASSERT(state_tracker_ != nullptr);
-
-            auto buffer_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::BufferWrapper>(*pBuffer);
-
-            if (buffer_wrapper->is_sparse_buffer)
-            {
-                // We will need to set the bind_device for handling sparse buffers. There will be no subsequent
-                // vkBindBufferMemory, vkBindBufferMemory2 or vkBindBufferMemory2KHR calls for sparse buffer, so we
-                // assign bind_device to the device that created the buffer.
-                buffer_wrapper->bind_device = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
-            }
-        }
-    }
+    {}
 
     void PostProcess_vkCreateImage(VkResult                     result,
                                    VkDevice                     device,
                                    const VkImageCreateInfo*     pCreateInfo,
                                    const VkAllocationCallbacks* pAllocator,
                                    VkImage*                     pImage)
-    {
-        if (IsCaptureModeTrack() && (result == VK_SUCCESS) && (pCreateInfo != nullptr))
-        {
-            GFXRECON_ASSERT(state_tracker_ != nullptr);
-
-            auto image_wrapper = vulkan_wrappers::GetWrapper<vulkan_wrappers::ImageWrapper>(*pImage);
-
-            if (image_wrapper->is_sparse_image)
-            {
-                // We will need to set the bind_device for handling sparse images. There will be no subsequent
-                // vkBindImageMemory, vkBindImageMemory2, or vkBindImageMemory2KHR calls for sparse image, so we assign
-                // bind_device to the device that created the image.
-                image_wrapper->bind_device = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
-            }
-        }
-    }
+    {}
 
     void PostProcess_vkCmdBeginRenderPass(VkCommandBuffer              commandBuffer,
                                           const VkRenderPassBeginInfo* pRenderPassBegin,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -203,7 +203,9 @@ struct EventWrapper : public HandleWrapper<VkEvent>
 struct DescriptorSetWrapper;
 struct AssetWrapperBase
 {
-    DeviceWrapper*             device{ nullptr };
+    // device this object was created on
+    DeviceWrapper* device{ nullptr };
+
     const void*                bind_pnext{ nullptr };
     std::unique_ptr<uint8_t[]> bind_pnext_memory;
 

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -198,7 +198,7 @@ struct EventWrapper : public HandleWrapper<VkEvent>
 struct DescriptorSetWrapper;
 struct AssetWrapperBase
 {
-    DeviceWrapper*             bind_device{ nullptr };
+    DeviceWrapper*             device{ nullptr };
     const void*                bind_pnext{ nullptr };
     std::unique_ptr<uint8_t[]> bind_pnext_memory;
 
@@ -215,7 +215,6 @@ struct BufferViewWrapper;
 struct BufferWrapper : public HandleWrapper<VkBuffer>, AssetWrapperBase
 {
     // State tracking info for buffers with device addresses.
-    VkDevice            device{ VK_NULL_HANDLE };
     VkDeviceAddress     address{ 0 };
     VkDeviceAddress     opaque_address{ 0 };
     VkBufferUsageFlags  usage{ 0 };
@@ -226,8 +225,6 @@ struct BufferWrapper : public HandleWrapper<VkBuffer>, AssetWrapperBase
     bool                                       is_sparse_buffer{ false };
     std::map<VkDeviceSize, VkSparseMemoryBind> sparse_memory_bind_map;
     VkQueue                                    sparse_bind_queue;
-
-    VkDeviceSize created_size{ 0 };
 
     std::unordered_map<VkDeviceAddress, AccelerationStructureBuildState> acceleration_structures;
 

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -203,7 +203,7 @@ struct EventWrapper : public HandleWrapper<VkEvent>
 struct DescriptorSetWrapper;
 struct AssetWrapperBase
 {
-    DeviceWrapper*             bind_device{ nullptr };
+    DeviceWrapper*             device{ nullptr };
     const void*                bind_pnext{ nullptr };
     std::unique_ptr<uint8_t[]> bind_pnext_memory;
 
@@ -220,7 +220,6 @@ struct BufferViewWrapper;
 struct BufferWrapper : public HandleWrapper<VkBuffer>, AssetWrapperBase
 {
     // State tracking info for buffers with device addresses.
-    VkDevice            device{ VK_NULL_HANDLE };
     VkDeviceAddress     address{ 0 };
     VkDeviceAddress     opaque_address{ 0 };
     VkBufferUsageFlags  usage{ 0 };
@@ -231,8 +230,6 @@ struct BufferWrapper : public HandleWrapper<VkBuffer>, AssetWrapperBase
     bool                                       is_sparse_buffer{ false };
     std::map<VkDeviceSize, VkSparseMemoryBind> sparse_memory_bind_map;
     VkQueue                                    sparse_bind_queue{ VK_NULL_HANDLE };
-
-    VkDeviceSize created_size{ 0 };
 
     std::unordered_map<VkDeviceAddress, AccelerationStructureBuildState> acceleration_structures;
 

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -390,7 +390,7 @@ void VulkanStateTracker::TrackBufferMemoryBinding(
     assert((device != VK_NULL_HANDLE) && (buffer != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
     auto wrapper            = vulkan_wrappers::GetWrapper<vulkan_wrappers::BufferWrapper>(buffer);
-    wrapper->bind_device    = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    wrapper->device         = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->bind_memory_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
@@ -414,7 +414,7 @@ void VulkanStateTracker::TrackTensorMemoryBinding(
     GFXRECON_ASSERT((device != VK_NULL_HANDLE) && (tensor != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
     auto wrapper            = vulkan_wrappers::GetWrapper<vulkan_wrappers::TensorARMWrapper>(tensor);
-    wrapper->bind_device    = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    wrapper->device         = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->bind_memory_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
@@ -441,7 +441,7 @@ void VulkanStateTracker::TrackDataGraphPipelineSessionMemoryBinding(VkDevice    
     GFXRECON_ASSERT((device != VK_NULL_HANDLE) && (session != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
     auto wrapper            = vulkan_wrappers::GetWrapper<vulkan_wrappers::DataGraphPipelineSessionARMWrapper>(session);
-    wrapper->bind_device    = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    wrapper->device         = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->bind_memory_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
@@ -548,7 +548,7 @@ void VulkanStateTracker::TrackAccelerationStructureBuildCommand(
                     buffer.capture_address    = target_buffer_wrapper->address;
                     buffer.handle             = target_buffer_wrapper->handle;
                     buffer.handle_id          = target_buffer_wrapper->handle_id;
-                    buffer.bind_device        = target_buffer_wrapper->bind_device;
+                    buffer.bind_device        = target_buffer_wrapper->device;
                     buffer.queue_family_index = target_buffer_wrapper->queue_family_index;
                     buffer.created_size       = target_buffer_wrapper->size;
                     buffer.usage              = target_buffer_wrapper->usage;
@@ -661,7 +661,7 @@ void VulkanStateTracker::TrackImageMemoryBinding(
     assert((device != VK_NULL_HANDLE) && (image != VK_NULL_HANDLE));
 
     auto wrapper            = vulkan_wrappers::GetWrapper<vulkan_wrappers::ImageWrapper>(image);
-    wrapper->bind_device    = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    wrapper->device         = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->bind_memory_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
@@ -2241,7 +2241,7 @@ void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferW
 
     if (buffer_wrapper != nullptr && buffer_wrapper->device != nullptr)
     {
-        device_address_trackers_[buffer_wrapper->device].RemoveBuffer(buffer_wrapper);
+        device_address_trackers_[buffer_wrapper->device->handle].RemoveBuffer(buffer_wrapper);
     }
 
     state_table_.VisitWrappers([this, buffer_wrapper](vulkan_wrappers::AccelerationStructureKHRWrapper* acc_wrapper) {

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -387,7 +387,7 @@ void VulkanStateTracker::TrackBufferMemoryBinding(
     assert((device != VK_NULL_HANDLE) && (buffer != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
     auto wrapper            = vulkan_wrappers::GetWrapper<vulkan_wrappers::BufferWrapper>(buffer);
-    wrapper->bind_device    = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    wrapper->device         = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->bind_memory_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
@@ -411,7 +411,7 @@ void VulkanStateTracker::TrackTensorMemoryBinding(
     GFXRECON_ASSERT((device != VK_NULL_HANDLE) && (tensor != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
     auto wrapper            = vulkan_wrappers::GetWrapper<vulkan_wrappers::TensorARMWrapper>(tensor);
-    wrapper->bind_device    = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    wrapper->device         = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->bind_memory_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
@@ -438,7 +438,7 @@ void VulkanStateTracker::TrackDataGraphPipelineSessionMemoryBinding(VkDevice    
     GFXRECON_ASSERT((device != VK_NULL_HANDLE) && (session != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
     auto wrapper            = vulkan_wrappers::GetWrapper<vulkan_wrappers::DataGraphPipelineSessionARMWrapper>(session);
-    wrapper->bind_device    = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    wrapper->device         = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->bind_memory_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
@@ -545,7 +545,7 @@ void VulkanStateTracker::TrackAccelerationStructureBuildCommand(
                     buffer.capture_address    = target_buffer_wrapper->address;
                     buffer.handle             = target_buffer_wrapper->handle;
                     buffer.handle_id          = target_buffer_wrapper->handle_id;
-                    buffer.bind_device        = target_buffer_wrapper->bind_device;
+                    buffer.bind_device        = target_buffer_wrapper->device;
                     buffer.queue_family_index = target_buffer_wrapper->queue_family_index;
                     buffer.created_size       = target_buffer_wrapper->size;
                     buffer.usage              = target_buffer_wrapper->usage;
@@ -658,7 +658,7 @@ void VulkanStateTracker::TrackImageMemoryBinding(
     assert((device != VK_NULL_HANDLE) && (image != VK_NULL_HANDLE));
 
     auto wrapper            = vulkan_wrappers::GetWrapper<vulkan_wrappers::ImageWrapper>(image);
-    wrapper->bind_device    = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    wrapper->device         = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->bind_memory_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
@@ -2247,7 +2247,7 @@ void gfxrecon::encode::VulkanStateTracker::DestroyState(vulkan_wrappers::BufferW
 
     if (buffer_wrapper != nullptr && buffer_wrapper->device != nullptr)
     {
-        device_address_trackers_[buffer_wrapper->device].RemoveBuffer(buffer_wrapper);
+        device_address_trackers_[buffer_wrapper->device->handle].RemoveBuffer(buffer_wrapper);
     }
 
     state_table_.VisitWrappers([this, buffer_wrapper](vulkan_wrappers::AccelerationStructureKHRWrapper* acc_wrapper) {

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -641,8 +641,7 @@ InitializeState<VkDevice, vulkan_wrappers::DataGraphPipelineSessionARMWrapper, V
     GFXRECON_ASSERT(wrapper != nullptr);
     GFXRECON_ASSERT(create_parameters != nullptr);
 
-    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
-
+    wrapper->device            = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
@@ -694,12 +693,11 @@ inline void InitializeState<VkDevice, vulkan_wrappers::BufferWrapper, VkBufferCr
     assert(create_info != nullptr);
     assert(create_parameters != nullptr);
 
-    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
-
+    wrapper->device            = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->created_size = create_info->size;
+    wrapper->size = create_info->size;
 
     if ((create_info->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0)
     {
@@ -725,6 +723,7 @@ inline void InitializeState<VkDevice, vulkan_wrappers::TensorARMWrapper, VkTenso
     GFXRECON_ASSERT(create_info != nullptr);
     GFXRECON_ASSERT(create_parameters != nullptr);
 
+    wrapper->device            = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
@@ -778,8 +777,7 @@ inline void InitializeState<VkDevice, vulkan_wrappers::ImageWrapper, VkImageCrea
     assert(create_info != nullptr);
     assert(create_parameters != nullptr);
 
-    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
-
+    wrapper->device            = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
@@ -819,7 +817,7 @@ inline void InitializeState<VkDevice, vulkan_wrappers::ImageWrapper, VkImageCrea
     else
     {
         const graphics::VulkanDeviceTable* device_table = vulkan_wrappers::GetDeviceTable(parent_handle);
-        VkMemoryRequirements     image_mem_reqs;
+        VkMemoryRequirements               image_mem_reqs;
         assert(wrapper->handle != VK_NULL_HANDLE);
         device_table->GetImageMemoryRequirements(parent_handle, wrapper->handle, &image_mem_reqs);
         wrapper->size = image_mem_reqs.size;

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -693,11 +693,10 @@ inline void InitializeState<VkDevice, vulkan_wrappers::BufferWrapper, VkBufferCr
     assert(create_info != nullptr);
     assert(create_parameters != nullptr);
 
-    wrapper->device            = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
-
-    wrapper->size = create_info->size;
 
     if ((create_info->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0)
     {
@@ -777,7 +776,6 @@ inline void InitializeState<VkDevice, vulkan_wrappers::ImageWrapper, VkImageCrea
     assert(create_info != nullptr);
     assert(create_parameters != nullptr);
 
-    wrapper->device            = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1532,7 +1532,7 @@ void VulkanStateWriter::WriteDeviceMemoryState(const VulkanStateTable& state_tab
 void VulkanStateWriter::WriteBufferDeviceAddressState(const VulkanStateTable& state_table)
 {
     state_table.VisitWrappers([&](const vulkan_wrappers::BufferWrapper* wrapper) {
-        GFXRECON_ASSERT(wrapper != nullptr && wrapper->device != VK_NULL_HANDLE);
+        GFXRECON_ASSERT(wrapper != nullptr && wrapper->device != nullptr);
         if (wrapper->device != nullptr && wrapper->address != 0)
         {
             const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper =

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -5109,12 +5109,7 @@ void VulkanStateWriter::WriteTensorSnapshotState(const VulkanStateTable& state_t
         GFXRECON_ASSERT(wrapper != nullptr);
 
         const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
-        if (device_wrapper == nullptr)
-        {
-            GFXRECON_LOG_WARNING("Skipping tensor trim snapshot for tensor %" PRIu64 ": no bound device is tracked",
-                                 wrapper->handle_id);
-            return;
-        }
+        GFXRECON_ASSERT(device_wrapper != nullptr);
 
         const auto* memory_wrapper = state_table.GetVulkanDeviceMemoryWrapper(wrapper->bind_memory_id);
         if (memory_wrapper == nullptr)

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1533,7 +1533,7 @@ void VulkanStateWriter::WriteBufferDeviceAddressState(const VulkanStateTable& st
 {
     state_table.VisitWrappers([&](const vulkan_wrappers::BufferWrapper* wrapper) {
         GFXRECON_ASSERT(wrapper != nullptr && wrapper->device != VK_NULL_HANDLE);
-        if (wrapper->device != VK_NULL_HANDLE && wrapper->address != 0)
+        if (wrapper->device != nullptr && wrapper->address != 0)
         {
             const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper =
                 state_table.GetVulkanDeviceMemoryWrapper(wrapper->bind_memory_id);
@@ -1551,13 +1551,13 @@ void VulkanStateWriter::WriteBufferDeviceAddressState(const VulkanStateTable& st
             // if the memory still exists.
             if (memory_wrapper != nullptr || wrapper->is_sparse_buffer)
             {
-                auto physical_device_wrapper = wrapper->bind_device->physical_device;
+                auto physical_device_wrapper = wrapper->device->physical_device;
                 auto call_id = physical_device_wrapper->parent_info.api_version >= VK_MAKE_VERSION(1, 2, 0)
                                    ? format::ApiCall_vkGetBufferDeviceAddress
                                    : format::ApiCall_vkGetBufferDeviceAddressKHR;
 
                 parameter_stream_.Clear();
-                encoder_.EncodeHandleIdValue(wrapper->bind_device->handle_id);
+                encoder_.EncodeHandleIdValue(wrapper->device->handle_id);
                 VkBufferDeviceAddressInfoKHR info{ VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO,
                                                    nullptr,
                                                    wrapper->handle };
@@ -1573,11 +1573,11 @@ void VulkanStateWriter::WriteBufferDeviceAddressState(const VulkanStateTable& st
 void VulkanStateWriter::WriteBufferState(const VulkanStateTable& state_table)
 {
     state_table.VisitWrappers([&](const vulkan_wrappers::BufferWrapper* wrapper) {
-        GFXRECON_ASSERT(wrapper != nullptr && wrapper->device != VK_NULL_HANDLE);
+        GFXRECON_ASSERT(wrapper != nullptr && wrapper->device != nullptr);
 
-        if (wrapper->device != VK_NULL_HANDLE)
+        if (wrapper->device != nullptr)
         {
-            auto device_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceWrapper>(wrapper->device, true);
+            auto device_id = wrapper->device->handle_id;
 
             if (wrapper->opaque_address != 0)
             {
@@ -1613,7 +1613,7 @@ void VulkanStateWriter::WriteImageState(const VulkanStateTable& state_table)
 
         if (!image_wrapper->opaque_descriptor_data.empty())
         {
-            WriteSetOpaqueCaptureDescriptorData(image_wrapper->bind_device->handle_id,
+            WriteSetOpaqueCaptureDescriptorData(image_wrapper->device->handle_id,
                                                 image_wrapper->handle_id,
                                                 image_wrapper->opaque_descriptor_data.size(),
                                                 image_wrapper->opaque_descriptor_data.data());
@@ -1957,15 +1957,16 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
     size_t                                                      max_resource_size = 0;
 
     state_table.VisitWrappers([&](vulkan_wrappers::BufferWrapper* buffer_wrapper) {
-        GFXRECON_ASSERT(buffer_wrapper != nullptr && buffer_wrapper->device != VK_NULL_HANDLE);
+        GFXRECON_ASSERT(buffer_wrapper != nullptr && buffer_wrapper->device != nullptr);
 
-        if (buffer_wrapper->acceleration_structures.empty() || !device_address_trackers_.count(buffer_wrapper->device))
+        if (buffer_wrapper->acceleration_structures.empty() ||
+            !device_address_trackers_.count(buffer_wrapper->device->handle))
         {
             return;
         }
         auto        get_id          = vulkan_wrappers::GetWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>;
-        const auto& address_tracker = device_address_trackers_.at(buffer_wrapper->device);
-        auto&       per_device_container = commands[buffer_wrapper->device];
+        const auto& address_tracker = device_address_trackers_.at(buffer_wrapper->device->handle);
+        auto&       per_device_container = commands[buffer_wrapper->device->handle];
 
         for (auto& [device_address, as_build_state] : buffer_wrapper->acceleration_structures)
         {
@@ -2950,7 +2951,7 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
         GFXRECON_ASSERT(wrapper != nullptr);
         if (!wrapper->is_sparse_buffer)
         {
-            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             assert(device_wrapper != nullptr);
             // Perform memory binding for non-sparse buffer.
             const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper =
@@ -3017,13 +3018,13 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
 
                 if (snapshot_info.need_staging_copy)
                 {
-                    if (*max_staging_copy_size < wrapper->created_size)
+                    if (*max_staging_copy_size < wrapper->size)
                     {
-                        *max_staging_copy_size = wrapper->created_size;
+                        *max_staging_copy_size = wrapper->size;
                     }
 
                     // sum staging-copy sizes
-                    *total_staging_copy_size += wrapper->created_size;
+                    *total_staging_copy_size += wrapper->size;
                 }
                 snapshot_entry.buffers.emplace_back(snapshot_info);
             }
@@ -3031,7 +3032,7 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
         else
         {
             // Perform memory binding for sparse buffer.
-            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             const graphics::VulkanDeviceTable*    device_table   = &device_wrapper->layer_table;
             GFXRECON_ASSERT((device_wrapper != nullptr) && (device_table != nullptr));
 
@@ -3157,11 +3158,11 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
         const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper =
             state_table.GetVulkanDeviceMemoryWrapper(wrapper->bind_memory_id);
 
-        if ((wrapper->is_swapchain_image && memory_wrapper == nullptr && wrapper->bind_device != nullptr) ||
+        if ((wrapper->is_swapchain_image && memory_wrapper == nullptr && wrapper->device != nullptr) ||
             (!wrapper->is_swapchain_image && memory_wrapper != nullptr) ||
-            (!wrapper->is_swapchain_image && wrapper->is_sparse_image && wrapper->bind_device != nullptr))
+            (!wrapper->is_swapchain_image && wrapper->is_sparse_image && wrapper->device != nullptr))
         {
-            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             assert(device_wrapper != nullptr);
 
             // Write memory requirements query before bind command.
@@ -3407,7 +3408,7 @@ void VulkanStateWriter::WriteImageSubresourceLayouts(const vulkan_wrappers::Imag
 {
     assert((image_wrapper != nullptr) && (aspect_flags != 0));
 
-    const vulkan_wrappers::DeviceWrapper* device_wrapper = image_wrapper->bind_device;
+    const vulkan_wrappers::DeviceWrapper* device_wrapper = image_wrapper->device;
     const graphics::VulkanDeviceTable*    device_table   = &device_wrapper->layer_table;
 
     assert((device_wrapper != nullptr) && (device_table != nullptr));
@@ -5138,7 +5139,7 @@ void VulkanStateWriter::WriteDataGraphPipelineSessionMemoryState(const VulkanSta
             info.bindPoint    = binding.bind_point;
             info.objectIndex  = binding.object_index;
 
-            encoder_.EncodeHandleIdValue(wrapper->bind_device->handle_id);
+            encoder_.EncodeHandleIdValue(wrapper->device->handle_id);
             encoder_.EncodeUInt32Value(1);
             EncodeStructArray(&encoder_, &info, 1);
             encoder_.EncodeEnumValue(VK_SUCCESS);
@@ -5164,7 +5165,7 @@ void VulkanStateWriter::WriteTensorSnapshotState(const VulkanStateTable& state_t
     state_table.VisitWrappers([&](vulkan_wrappers::TensorARMWrapper* wrapper) {
         GFXRECON_ASSERT(wrapper != nullptr);
 
-        const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
+        const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
         if (device_wrapper == nullptr)
         {
             GFXRECON_LOG_WARNING("Skipping tensor trim snapshot for tensor %" PRIu64 ": no bound device is tracked",

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1533,7 +1533,7 @@ void VulkanStateWriter::WriteBufferDeviceAddressState(const VulkanStateTable& st
 {
     state_table.VisitWrappers([&](const vulkan_wrappers::BufferWrapper* wrapper) {
         GFXRECON_ASSERT(wrapper != nullptr && wrapper->device != VK_NULL_HANDLE);
-        if (wrapper->device != VK_NULL_HANDLE && wrapper->address != 0)
+        if (wrapper->device != nullptr && wrapper->address != 0)
         {
             const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper =
                 state_table.GetVulkanDeviceMemoryWrapper(wrapper->bind_memory_id);
@@ -1551,13 +1551,13 @@ void VulkanStateWriter::WriteBufferDeviceAddressState(const VulkanStateTable& st
             // if the memory still exists.
             if (memory_wrapper != nullptr || wrapper->is_sparse_buffer)
             {
-                auto physical_device_wrapper = wrapper->bind_device->physical_device;
+                auto physical_device_wrapper = wrapper->device->physical_device;
                 auto call_id = physical_device_wrapper->parent_info.api_version >= VK_MAKE_VERSION(1, 2, 0)
                                    ? format::ApiCall_vkGetBufferDeviceAddress
                                    : format::ApiCall_vkGetBufferDeviceAddressKHR;
 
                 parameter_stream_.Clear();
-                encoder_.EncodeHandleIdValue(wrapper->bind_device->handle_id);
+                encoder_.EncodeHandleIdValue(wrapper->device->handle_id);
                 VkBufferDeviceAddressInfoKHR info{ VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO,
                                                    nullptr,
                                                    wrapper->handle };
@@ -1573,11 +1573,11 @@ void VulkanStateWriter::WriteBufferDeviceAddressState(const VulkanStateTable& st
 void VulkanStateWriter::WriteBufferState(const VulkanStateTable& state_table)
 {
     state_table.VisitWrappers([&](const vulkan_wrappers::BufferWrapper* wrapper) {
-        GFXRECON_ASSERT(wrapper != nullptr && wrapper->device != VK_NULL_HANDLE);
+        GFXRECON_ASSERT(wrapper != nullptr && wrapper->device != nullptr);
 
-        if (wrapper->device != VK_NULL_HANDLE)
+        if (wrapper->device != nullptr)
         {
-            auto device_id = vulkan_wrappers::GetWrappedId<vulkan_wrappers::DeviceWrapper>(wrapper->device, true);
+            auto device_id = wrapper->device->handle_id;
 
             if (wrapper->opaque_address != 0)
             {
@@ -1613,7 +1613,7 @@ void VulkanStateWriter::WriteImageState(const VulkanStateTable& state_table)
 
         if (!image_wrapper->opaque_descriptor_data.empty())
         {
-            WriteSetOpaqueCaptureDescriptorData(image_wrapper->bind_device->handle_id,
+            WriteSetOpaqueCaptureDescriptorData(image_wrapper->device->handle_id,
                                                 image_wrapper->handle_id,
                                                 image_wrapper->opaque_descriptor_data.size(),
                                                 image_wrapper->opaque_descriptor_data.data());
@@ -1957,15 +1957,16 @@ void VulkanStateWriter::WriteAccelerationStructureStateMetaCommands(const Vulkan
     size_t                                                      max_resource_size = 0;
 
     state_table.VisitWrappers([&](vulkan_wrappers::BufferWrapper* buffer_wrapper) {
-        GFXRECON_ASSERT(buffer_wrapper != nullptr && buffer_wrapper->device != VK_NULL_HANDLE);
+        GFXRECON_ASSERT(buffer_wrapper != nullptr && buffer_wrapper->device != nullptr);
 
-        if (buffer_wrapper->acceleration_structures.empty() || !device_address_trackers_.count(buffer_wrapper->device))
+        if (buffer_wrapper->acceleration_structures.empty() ||
+            !device_address_trackers_.count(buffer_wrapper->device->handle))
         {
             return;
         }
         auto        get_id          = vulkan_wrappers::GetWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>;
-        const auto& address_tracker = device_address_trackers_.at(buffer_wrapper->device);
-        auto&       per_device_container = commands[buffer_wrapper->device];
+        const auto& address_tracker = device_address_trackers_.at(buffer_wrapper->device->handle);
+        auto&       per_device_container = commands[buffer_wrapper->device->handle];
 
         for (auto& [device_address, as_build_state] : buffer_wrapper->acceleration_structures)
         {
@@ -2950,7 +2951,7 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
         GFXRECON_ASSERT(wrapper != nullptr);
         if (!wrapper->is_sparse_buffer)
         {
-            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             assert(device_wrapper != nullptr);
             // Perform memory binding for non-sparse buffer.
             const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper =
@@ -3017,13 +3018,13 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
 
                 if (snapshot_info.need_staging_copy)
                 {
-                    if (*max_staging_copy_size < wrapper->created_size)
+                    if (*max_staging_copy_size < wrapper->size)
                     {
-                        *max_staging_copy_size = wrapper->created_size;
+                        *max_staging_copy_size = wrapper->size;
                     }
 
                     // sum staging-copy sizes
-                    *total_staging_copy_size += wrapper->created_size;
+                    *total_staging_copy_size += wrapper->size;
                 }
                 snapshot_entry.buffers.emplace_back(snapshot_info);
             }
@@ -3033,7 +3034,7 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
             // Sparse object has to vkQueueBindSparse first.
 
             // Perform memory binding for sparse buffer.
-            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             const graphics::VulkanDeviceTable*    device_table   = &device_wrapper->layer_table;
             GFXRECON_ASSERT((device_wrapper != nullptr) && (device_table != nullptr));
 
@@ -3159,11 +3160,11 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
         const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper =
             state_table.GetVulkanDeviceMemoryWrapper(wrapper->bind_memory_id);
 
-        if ((wrapper->is_swapchain_image && memory_wrapper == nullptr && wrapper->bind_device != nullptr) ||
+        if ((wrapper->is_swapchain_image && memory_wrapper == nullptr && wrapper->device != nullptr) ||
             (!wrapper->is_swapchain_image && memory_wrapper != nullptr) ||
-            (!wrapper->is_swapchain_image && wrapper->is_sparse_image && wrapper->bind_device != nullptr))
+            (!wrapper->is_swapchain_image && wrapper->is_sparse_image && wrapper->device != nullptr))
         {
-            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             assert(device_wrapper != nullptr);
 
             // Write memory requirements query before bind command.
@@ -3412,7 +3413,7 @@ void VulkanStateWriter::WriteImageSubresourceLayouts(const vulkan_wrappers::Imag
 {
     assert((image_wrapper != nullptr) && (aspect_flags != 0));
 
-    const vulkan_wrappers::DeviceWrapper* device_wrapper = image_wrapper->bind_device;
+    const vulkan_wrappers::DeviceWrapper* device_wrapper = image_wrapper->device;
     const graphics::VulkanDeviceTable*    device_table   = &device_wrapper->layer_table;
 
     assert((device_wrapper != nullptr) && (device_table != nullptr));
@@ -5081,7 +5082,7 @@ void VulkanStateWriter::WriteDataGraphPipelineSessionMemoryState(const VulkanSta
             GFXRECON_CHECK_CONVERSION_DATA_LOSS(uint32_t, bind_infos.size());
             const uint32_t bind_info_count = static_cast<uint32_t>(bind_infos.size());
 
-            encoder_.EncodeHandleIdValue(wrapper->bind_device->handle_id);
+            encoder_.EncodeHandleIdValue(wrapper->device->handle_id);
             encoder_.EncodeUInt32Value(bind_info_count);
             EncodeStructArray(&encoder_, bind_infos.data(), bind_info_count);
             encoder_.EncodeEnumValue(VK_SUCCESS);
@@ -5107,7 +5108,7 @@ void VulkanStateWriter::WriteTensorSnapshotState(const VulkanStateTable& state_t
     state_table.VisitWrappers([&](vulkan_wrappers::TensorARMWrapper* wrapper) {
         GFXRECON_ASSERT(wrapper != nullptr);
 
-        const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
+        const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
         if (device_wrapper == nullptr)
         {
             GFXRECON_LOG_WARNING("Skipping tensor trim snapshot for tensor %" PRIu64 ": no bound device is tracked",


### PR DESCRIPTION
1. Remove the fields from BufferWrapper that are already present in superclass.
2. In AssetWrappers (BufferWrapper and ImageWrapper) track the parent device on creation (hence the rename to just "device")