### PR TITLE
[Decode] Harden file parser against malformed capture input

### DIFF
--- a/framework/decode/block_parser.cpp
+++ b/framework/decode/block_parser.cpp
@@ -86,6 +86,9 @@ BlockIOError BlockParser::ReadBlockBuffer(FileInputStreamPtr& input_stream, Bloc
             // as it may need to allocate a new BlockBatch (in enqueued/retained modes)
             // Also, depending on operation mode, decompression policy and block type, we may use working storage
             // or block allocator storage for the raw block data
+            GFXRECON_LOG_DEBUG("Allocating block of %" PRIu64 " bytes (block type 0x%x).",
+                               static_cast<uint64_t>(block_header.size),
+                               static_cast<uint32_t>(block_header.type));
             BlockAllocator::BlockAllocationInfo alloc_info  = GetAllocationInfo(block_header.type, actual_block_size);
             uint8_t*                            block_store = block_allocator_.StartBlock(alloc_info);
 

--- a/framework/util/monotonic_allocator.h
+++ b/framework/util/monotonic_allocator.h
@@ -25,6 +25,7 @@
 #define GFXRECON_UTIL_MONOTONIC_ALLOCATOR_H
 
 #include "util/defines.h"
+#include "util/logging.h"
 
 #include <memory>
 #include <vector>
@@ -51,6 +52,11 @@ class MonotonicAllocator
     template <typename T>
     T* Allocate(size_t count = 1, bool initialize = true)
     {
+        if (count > (std::numeric_limits<size_t>::max() / sizeof(T)))
+        {
+            GFXRECON_ASSERT(false && "Allocate: count * sizeof(T) would overflow size_t");
+            return nullptr;
+        }
         T* result = reinterpret_cast<T*>(Allocate(sizeof(T) * count, alignof(T)));
         assert(result != nullptr);
         if ((result != nullptr) && initialize)


### PR DESCRIPTION
## Problem

Two decode-path issues identified through static analysis that can cause silent failures or difficult-to-diagnose crashes when processing malformed or corrupt capture files.

## Solution

- `framework/decode/block_parser.cpp`: `block_header.size` is read from the file with no upper bound, allowing a crafted block to trigger a multi-gigabyte heap allocation before the read fails, causing `std::bad_alloc` or OOM with no diagnostic. Add a `DEBUG` log of the block size and type immediately before the allocation so that the last log line provides actionable context if `std::bad_alloc` is thrown.

- `framework/util/monotonic_allocator.h`: Array length read from the capture file is multiplied by `sizeof(T)` with no overflow check. The multiplication can wrap, under-allocating the buffer while the write loop iterates the full attacker-controlled count — a heap OOB write reachable on every D3D12 capture. Return `nullptr` when `count * sizeof(T)` would overflow, and use `GFXRECON_ASSERT` in debug builds to make the violation visible to callers.

## Testing

- ✅ All test suites passed: `gfxrecon_util_test`, `gfxrecon_encode_test`, `gfxrecon_decode_test`, `gfxrecon_graphics_test`, and
  `gfxrecon_replay_event_plugin_loader_test`.