### PR TITLE
[Capture/Convert]: fix HDR metadata leak and AS JSON assignment typos

### DIFF
--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -253,9 +253,9 @@ struct IDXGISwapChainInfo : public DxgiWrapperInfo
     bool                   set_color_space{ false };
     bool                   set_hdr_metadata{ false };
     DXGI_COLOR_SPACE_TYPE  color_space_type{};
-    DXGI_HDR_METADATA_TYPE   hdr_metadata_type{};
-    UINT                     hdr_metadata_size{ 0 };
-    std::vector<uint8_t>     hdr_metadata;
+    DXGI_HDR_METADATA_TYPE hdr_metadata_type{};
+    UINT                   hdr_metadata_size{ 0 };
+    std::vector<uint8_t>   hdr_metadata;
 };
 
 struct IDXGIDeviceInfo : public DxgiWrapperInfo

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -35,9 +35,11 @@
 #include <dxgi1_5.h>
 
 #include <array>
-#include <unordered_set>
+#include <cstdint>
 #include <map>
 #include <memory>
+#include <unordered_set>
+#include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
@@ -251,9 +253,9 @@ struct IDXGISwapChainInfo : public DxgiWrapperInfo
     bool                   set_color_space{ false };
     bool                   set_hdr_metadata{ false };
     DXGI_COLOR_SPACE_TYPE  color_space_type{};
-    DXGI_HDR_METADATA_TYPE hdr_metadata_type{};
-    UINT                   hdr_metadata_size{ 0 };
-    void*                  hdr_metadata{ nullptr };
+    DXGI_HDR_METADATA_TYPE   hdr_metadata_type{};
+    UINT                     hdr_metadata_size{ 0 };
+    std::vector<uint8_t>     hdr_metadata;
 };
 
 struct IDXGIDeviceInfo : public DxgiWrapperInfo

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -1251,10 +1251,14 @@ void Dx12StateTracker::TrackSetHDRMetaData(
     wrapper_info->hdr_metadata_type = Type;
     wrapper_info->hdr_metadata_size = Size;
 
-    if (pMetaData != nullptr)
+    if (pMetaData != nullptr && Size > 0)
     {
-        wrapper_info->hdr_metadata = new char[Size]();
-        memcpy(wrapper_info->hdr_metadata, pMetaData, Size);
+        wrapper_info->hdr_metadata.assign(static_cast<const uint8_t*>(pMetaData),
+                                          static_cast<const uint8_t*>(pMetaData) + Size);
+    }
+    else
+    {
+        wrapper_info->hdr_metadata.clear();
     }
 }
 

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1519,7 +1519,8 @@ void Dx12StateWriter::WriteSwapChainState(const Dx12StateTable& state_table)
         {
             encoder_.EncodeEnumValue(swapchain_info->hdr_metadata_type);
             encoder_.EncodeUInt32Value(swapchain_info->hdr_metadata_size);
-            encoder_.EncodeVoidArray(swapchain_info->hdr_metadata.empty() ? nullptr : swapchain_info->hdr_metadata.data(),
+            encoder_.EncodeVoidArray(swapchain_info->hdr_metadata.empty() ? nullptr
+                                                                          : swapchain_info->hdr_metadata.data(),
                                      swapchain_info->hdr_metadata_size);
             encoder_.EncodeInt32Value(S_OK);
             WriteMethodCall(format::ApiCallId::ApiCall_IDXGISwapChain4_SetHDRMetaData,

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1519,7 +1519,8 @@ void Dx12StateWriter::WriteSwapChainState(const Dx12StateTable& state_table)
         {
             encoder_.EncodeEnumValue(swapchain_info->hdr_metadata_type);
             encoder_.EncodeUInt32Value(swapchain_info->hdr_metadata_size);
-            encoder_.EncodeVoidArray(swapchain_info->hdr_metadata, swapchain_info->hdr_metadata_size);
+            encoder_.EncodeVoidArray(swapchain_info->hdr_metadata.empty() ? nullptr : swapchain_info->hdr_metadata.data(),
+                                     swapchain_info->hdr_metadata_size);
             encoder_.EncodeInt32Value(S_OK);
             WriteMethodCall(format::ApiCallId::ApiCall_IDXGISwapChain4_SetHDRMetaData,
                             swapchain_wrapper->GetCaptureId(),

--- a/framework/util/json_util.cpp
+++ b/framework/util/json_util.cpp
@@ -252,8 +252,8 @@ void FieldToJson(nlohmann::ordered_json& jdata, const format::InitDx12Accelerati
     /// @todo handle enums and so on.
     jdata["geometry_type"]  = static_cast<D3D12_RAYTRACING_GEOMETRY_TYPE>(data.geometry_type);
     jdata["geometry_flags"] = static_cast<D3D12_RAYTRACING_GEOMETRY_FLAGS_t>(data.geometry_flags);
-    jdata["aabbs_count"], data.aabbs_count;
-    jdata["aabbs_stride"], data.aabbs_stride;
+    jdata["aabbs_count"]    = data.aabbs_count;
+    jdata["aabbs_stride"]   = data.aabbs_stride;
     Bool32ToJson(jdata["triangles_has_transform"], data.triangles_has_transform);
     jdata["triangles_index_format"]  = static_cast<DXGI_FORMAT>(data.triangles_index_format);
     jdata["triangles_vertex_format"] = static_cast<DXGI_FORMAT>(data.triangles_vertex_format);


### PR DESCRIPTION
## Problem

Two bugs identified through static analysis affecting capture state writing and convert output.

## Solution

- `framework/encode/dx12_object_wrapper_info.h`, `dx12_state_tracker.cpp`, `dx12_state_writer.cpp`: `TrackSetHDRMetaData` allocated a new `char` buffer on every `SetHDRMetaData` call without freeing the previous one; the owning struct had no destructor. Replace `void* hdr_metadata` with `std::vector<uint8_t>`, use `assign()` in the tracker so repeat calls replace the previous contents, `clear()` when `pMetaData` is null or `Size` is 0 to keep the vector and `hdr_metadata_size` in sync, and pass `nullptr` to `EncodeVoidArray` when the buffer is empty.

- `framework/util/json_util.cpp`: Two lines in `FieldToJson` for `InitDx12AccelerationStructureGeometryDesc` used the comma operator instead of `=` for `aabbs_count` and `aabbs_stride`, silently discarding both values and emitting `null` in `gfxrecon-convert` JSON output for DXR acceleration-structure geometry. Replace `,` with `=` on both lines.

## Testing

- ✅ All test suites passed: `gfxrecon_util_test`, `gfxrecon_encode_test`, `gfxrecon_decode_test`, `gfxrecon_graphics_test`, and `gfxrecon_replay_event_plugin_loader_test`.

⚠️ May cause CI tests involving golden files to fail and require them to be regenerated.