### PR TITLE
Fix Android Virtual Swapchain ANativeWindow collision after AdHoc presentation

### DIFF
--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -1383,7 +1383,7 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
     VkSemaphore semaphore = semaphore_info == nullptr ? VK_NULL_HANDLE : semaphore_info->handle;
 
     // If there is no image to present, do nothing
-    if (image == VK_NULL_HANDLE)
+    if (image == VK_NULL_HANDLE || application_surface_created_)
     {
         return;
     }
@@ -1483,7 +1483,7 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
         // empty -> automatic wsi deduction
         std::string wsi_extension;
 
-        result = CreateSurface(
+        result = VulkanSwapchain::CreateSurface(
             VK_SUCCESS, instance_info, wsi_extension, 0, &swapchain.surface_ptr, instance_table, application);
         GFXRECON_ASSERT(result == VK_SUCCESS);
 
@@ -1914,6 +1914,24 @@ VkResult VulkanVirtualSwapchain::CreateVirtualSwapchainImage(const VulkanDeviceI
         }
     }
     return result;
+}
+
+VkResult VulkanVirtualSwapchain::CreateSurface(VkResult                             original_result,
+                                               VulkanInstanceInfo*                  instance_info,
+                                               const std::string&                   wsi_extension,
+                                               VkFlags                              flags,
+                                               HandlePointerDecoder<VkSurfaceKHR>*  surface,
+                                               const graphics::VulkanInstanceTable* instance_table,
+                                               application::Application*            application)
+{
+    // The application trace is attempting to create a genuine Surface, so it will need to attach to
+    // the single ANativeWindow. If we have used an AdHoc surface to bypass android splash screens,
+    // we must destroy that surface immediately so we release the NativeWindow cleanly before the trace tries.
+    application_surface_created_ = true;
+    adhoc_device_data_.clear();
+
+    return VulkanSwapchain::CreateSurface(
+        original_result, instance_info, wsi_extension, flags, surface, instance_table, application);
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -38,20 +38,22 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 void VulkanVirtualSwapchain::CleanDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table)
 {
+    GFXRECON_UNREFERENCED_PARAMETER(device_table);
     GFXRECON_ASSERT(device != VK_NULL_HANDLE);
-    GFXRECON_ASSERT(device_table != nullptr);
 
-    if (const auto it = adhoc_device_data_.find(device); it != adhoc_device_data_.end())
+    // AdhocDeviceData releases its swapchains and command-pool
+    adhoc_device_data_.erase(device);
+}
+
+VulkanVirtualSwapchain::AdhocDeviceData::~AdhocDeviceData()
+{
+    // free swapchains before command-pool
+    swapchains.clear();
+
+    if (command_pool != VK_NULL_HANDLE)
     {
-        auto& adhoc_data = it->second;
-
-        // free swapchains before command-pool
-        adhoc_data.swapchains.clear();
-
-        if (adhoc_data.command_pool != VK_NULL_HANDLE)
-        {
-            device_table->DestroyCommandPool(device, adhoc_data.command_pool, nullptr);
-        }
+        GFXRECON_ASSERT(device != VK_NULL_HANDLE && device_table != nullptr);
+        device_table->DestroyCommandPool(device, command_pool, nullptr);
     }
 }
 
@@ -1383,7 +1385,7 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
     VkSemaphore semaphore = semaphore_info == nullptr ? VK_NULL_HANDLE : semaphore_info->handle;
 
     // If there is no image to present, do nothing
-    if (image == VK_NULL_HANDLE || application_surface_created_)
+    if (image == VK_NULL_HANDLE || disable_adhoc_presentation_)
     {
         return;
     }
@@ -1404,6 +1406,9 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
     // init OFBData
     if (ofb_data.command_pool == VK_NULL_HANDLE)
     {
+        ofb_data.device       = device;
+        ofb_data.device_table = device_table;
+
         // Retrieve the queue that will be used for presentation/image copy and create a command pool
         device_table->GetDeviceQueue(device, 0, 0, &ofb_data.queue);
 
@@ -1483,6 +1488,7 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
         // empty -> automatic wsi deduction
         std::string wsi_extension;
 
+        // must bypass VulkanVirtualSwapchain::CreateSurface here, it would destroy the swapchain in use
         result = VulkanSwapchain::CreateSurface(
             VK_SUCCESS, instance_info, wsi_extension, 0, &swapchain.surface_ptr, instance_table, application);
         GFXRECON_ASSERT(result == VK_SUCCESS);
@@ -1924,11 +1930,18 @@ VkResult VulkanVirtualSwapchain::CreateSurface(VkResult                         
                                                const graphics::VulkanInstanceTable* instance_table,
                                                application::Application*            application)
 {
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
     // The application trace is attempting to create a genuine Surface, so it will need to attach to
     // the single ANativeWindow. If we have used an AdHoc surface to bypass android splash screens,
     // we must destroy that surface immediately so we release the NativeWindow cleanly before the trace tries.
-    application_surface_created_ = true;
+    //
+    // Android-only: every AndroidWindowFactory::Create() hands out the same ANativeWindow, so the two
+    // surfaces collide. Desktop WSIs create independent windows, where AdHoc presentation
+    // (--present-override, vkFrameBoundary) is expected to keep working alongside the application's own
+    // swapchain.
+    disable_adhoc_presentation_ = true;
     adhoc_device_data_.clear();
+#endif
 
     return VulkanSwapchain::CreateSurface(
         original_result, instance_info, wsi_extension, flags, surface, instance_table, application);

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -36,6 +36,14 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
 
     void CleanDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table) override;
 
+    VkResult CreateSurface(VkResult                             original_result,
+                           VulkanInstanceInfo*                  instance_info,
+                           const std::string&                   wsi_extension,
+                           VkFlags                              flags,
+                           HandlePointerDecoder<VkSurfaceKHR>*  surface,
+                           const graphics::VulkanInstanceTable* instance_table,
+                           application::Application*            application) override;
+
     virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
                                         PFN_vkCreateSwapchainKHR              func,
                                         const VulkanDeviceInfo*               device_info,
@@ -177,14 +185,6 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
 
     void CleanSwapchainResourceData(const VulkanDeviceInfo* device_info, const VulkanSwapchainKHRInfo* swapchain_info);
 
-    virtual VkResult CreateSurface(VkResult                             original_result,
-                                   VulkanInstanceInfo*                  instance_info,
-                                   const std::string&                   wsi_extension,
-                                   VkFlags                              flags,
-                                   HandlePointerDecoder<VkSurfaceKHR>*  surface,
-                                   const graphics::VulkanInstanceTable* instance_table,
-                                   application::Application*            application) override;
-
     VkResult CreateVirtualSwapchainImage(const VulkanDeviceInfo*  device_info,
                                          const VkImageCreateInfo& image_create_info,
                                          VirtualImage&            image);
@@ -288,6 +288,15 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
     // This structure groups device-specific, custom/adhoc surfaces/swapchains and shared resources for those.
     struct AdhocDeviceData
     {
+        AdhocDeviceData() = default;
+        ~AdhocDeviceData();
+        AdhocDeviceData(AdhocDeviceData&&)            = delete;
+        AdhocDeviceData& operator=(AdhocDeviceData&&) = delete;
+
+        // required for lifetime-management
+        VkDevice                           device{ VK_NULL_HANDLE };
+        const graphics::VulkanDeviceTable* device_table{ nullptr };
+
         // command-pool for all AdhocSwapChains
         VkCommandPool command_pool{ VK_NULL_HANDLE };
 
@@ -302,7 +311,8 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
     std::unordered_map<VkDevice, uint32_t>        copy_queue_family_index_;
     std::unordered_map<VkDevice, VkQueue>         initial_copy_queue_;
 
-    bool application_surface_created_{ false };
+    // set on android once the application owns the ANativeWindow, never cleared
+    bool disable_adhoc_presentation_{ false };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -177,6 +177,14 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
 
     void CleanSwapchainResourceData(const VulkanDeviceInfo* device_info, const VulkanSwapchainKHRInfo* swapchain_info);
 
+    virtual VkResult CreateSurface(VkResult                             original_result,
+                                   VulkanInstanceInfo*                  instance_info,
+                                   const std::string&                   wsi_extension,
+                                   VkFlags                              flags,
+                                   HandlePointerDecoder<VkSurfaceKHR>*  surface,
+                                   const graphics::VulkanInstanceTable* instance_table,
+                                   application::Application*            application) override;
+
     VkResult CreateVirtualSwapchainImage(const VulkanDeviceInfo*  device_info,
                                          const VkImageCreateInfo& image_create_info,
                                          VirtualImage&            image);
@@ -293,6 +301,8 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
     std::unordered_map<VkDevice, AdhocDeviceData> adhoc_device_data_;
     std::unordered_map<VkDevice, uint32_t>        copy_queue_family_index_;
     std::unordered_map<VkDevice, VkQueue>         initial_copy_queue_;
+
+    bool application_surface_created_{ false };
 };
 
 GFXRECON_END_NAMESPACE(decode)


### PR DESCRIPTION
This is reproducible if application uses swapchain, but also at the same time uses vkFrameBoundaryANDROID.

Fix Android Virtual Swapchain ANativeWindow collision after AdHoc presentation
When replaying Android traces, the replay runtime sometimes utilizes an AdHoc surface presentation layer to visualize headless loading phases. However, in the original architecture, this AdHoc surface held onto system OS Window resources permanently.

When the trace finally attempted to create its genuine swapchain surface (e.g. vkCreateAndroidSurfaceKHR), it would fail with VK_ERROR_NATIVE_WINDOW_IN_USE_KHR because the window was still bound to the AdHoc surface.

Changes:

- Overrode CreateSurface in VulkanVirtualSwapchain to intercept the application's genuine hardware surface request.

- When a real surface is requested, we now preemptively clear the internal adhoc_device_data_ and gracefully release the underlying ANativeWindow before delegating instantiation back to the base class.

- Introduced application_surface_created_ latch to permanently halt artificial AdHoc FrameBoundary renders once the application trace has successfully transitioned to rendering its own native pipeline....