### PR TITLE
Erase last iteration fence when destroyed during frame looping

### DIFF
--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -282,7 +282,8 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateFence(const ApiCallInfo& cal
 
 void VulkanReplayFrameLoopConsumer::Process_vkDestroyFence(const ApiCallInfo& call_info, args::DestroyFence& args)
 {
-    if (allocatedLoopResources.contains(args.fence))
+    VulkanReplayFrameLoopConsumerBase::Process_vkDestroyFence(call_info, args);
+    if (GetObjectInfoTable().GetVkFenceInfo(args.fence) == nullptr)
     {
         if (per_device_fence_tracking_.contains(args.device))
         {
@@ -293,7 +294,6 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyFence(const ApiCallInfo& ca
             t.initial_fence_states_.erase(args.fence);
         }
     }
-    VulkanReplayFrameLoopConsumerBase::Process_vkDestroyFence(call_info, args);
 }
 
 void VulkanReplayFrameLoopConsumer::TrackFenceState(format::HandleId device, format::HandleId fence)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -283,7 +283,8 @@ void VulkanReplayFrameLoopConsumer::Process_vkCreateFence(const ApiCallInfo& cal
 void VulkanReplayFrameLoopConsumer::Process_vkDestroyFence(const ApiCallInfo& call_info, args::DestroyFence& args)
 {
     VulkanReplayFrameLoopConsumerBase::Process_vkDestroyFence(call_info, args);
-    if (GetObjectInfoTable().GetVkFenceInfo(args.fence) == nullptr)
+    bool destroyed = (GetObjectInfoTable().GetVkFenceInfo(args.fence) == nullptr);
+    if (destroyed)
     {
         if (per_device_fence_tracking_.contains(args.device))
         {


### PR DESCRIPTION
`VulkanReplayFrameLoopConsumer::FixupDeviceFences` seems to crash as there are cases where it is trying to reset a fence that is already destroyed, but is still in `initial_fence_states_`.

The fence in question is a fence that was created in a previous frame, and will be destroyed in the current frame at the last iteration. This is due to `VulkanReplayFrameLoopConsumer::Process_vkDestroyFence`, where we remove the fence from `initial_fence_states_` if `allocatedLoopResources.contains(args.fence)`.

However, `allocatedLoopResources` is only populated by fences that are created within the current frame, so fences created before aren't erased from the map, which results in GFXR later trying to reset a fence that was destroyed.

Since `VulkanReplayFrameLoopConsumerBase::Process_vkDestroyFence` seems to destroy the fence correctly:
```
// Call Process_vkDestroyFence if:
//    We are not looping
//    We are looping and args.fence is in allocatedLoopResources
//    We are looping and this is the last iteration
```
we can reuse this logic by first calling `VulkanReplayFrameLoopConsumerBase::Process_vkDestroyFence(call_info, args);` (currently at the end) and then checking if it was actually removed with `GetObjectInfoTable().GetVkFenceInfo(args.fence) == nullptr`. 

Fixes https://github.com/LunarG/gfxreconstruct/issues/3168