### PR TITLE
Scope-based marking for Vulkan api calls synthesized by replay

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -807,6 +807,7 @@ usage: gfxrecon.py replay [-h] [-p LOCAL_FILE] [--version] [--log-level LEVEL]
                           [--replay-event-plugin-params PARAMS]
                           [--isolate-render-passes]
                           [--serialize-compute-and-transfer]
+                          [--annotate-injected-commands]
                           [file]
 
 Launch the replay tool.
@@ -1055,6 +1056,10 @@ options:
   --serialize-compute-and-transfer
                         Prevent compute dispatches from overlapping adjacent transfer work by injecting a barrier before
                         and after each dispatch. (forwarded to replay tool)
+  --annotate-injected-commands
+                        Wrap commands injected by replay (not present in the capture,
+                        e.g. virtual-swapchain copies and ray-tracing SBT fixups) in
+                        VK_EXT_debug_utils labels named "GFXR Replay: <category>"
 ```
 
 The command will force-stop an active replay process before starting the replay

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -643,6 +643,7 @@ gfxrecon-replay         [-h | --help] [--version] [--cpu-mask <binary-mask>] [--
                         [--replay-event-plugin-path <path>] [--replay-event-plugin-params <params>]
                         [--isolate-render-passes]
                         [--serialize-compute-and-transfer]
+                        [--annotate-injected-commands]
 
 
 Required arguments:
@@ -922,6 +923,10 @@ Optional arguments:
   --serialize-compute-and-transfer
               Prevent compute dispatches from overlapping adjacent transfer work by injecting a barrier before and after
               each dispatch.
+  --annotate-injected-commands
+              Wrap commands injected by replay (not present in the capture,
+              e.g. virtual-swapchain copies and ray-tracing SBT fixups) in
+              VK_EXT_debug_utils labels named "GFXR Replay: <category>"
 ```
 
 ### Frame Warm-Up

--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -80,9 +80,9 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                                    VkImageLayout                              image_layout,
                                    VkSurfaceTransformFlagBitsKHR              pre_transform)
 {
-    if (allocator == nullptr)
+    if (!injected_calls.IsValid() || allocator == nullptr)
     {
-        GFXRECON_LOG_ERROR("Screenshot could not be created: missing allocator");
+        GFXRECON_LOG_ERROR("Screenshot could not be created: missing device table or allocator");
         return;
     }
 
@@ -532,8 +532,11 @@ void ScreenshotHandler::DestroyDeviceResources(VkDevice                         
     {
         auto& copy_resource = entry->second;
 
-        auto injected = injected_calls.Open();
-        injected->DestroyCommandPool(entry->first, copy_resource.command_pool, nullptr);
+        if (injected_calls.IsValid())
+        {
+            auto injected = injected_calls.Open();
+            injected->DestroyCommandPool(entry->first, copy_resource.command_pool, nullptr);
+        }
 
         DestroyCopyResource(device, &copy_resource);
 

--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -68,7 +68,7 @@ inline void WriteImageFile(
 
 void ScreenshotHandler::WriteImage(const std::string&                         filename_prefix,
                                    const VulkanDeviceInfo*                    device_info,
-                                   const graphics::VulkanDeviceTable*         device_table,
+                                   const graphics::VulkanInjectedDeviceCalls& injected_calls,
                                    const VkPhysicalDeviceMemoryProperties&    memory_properties,
                                    VulkanResourceAllocator*                   allocator,
                                    VkImage                                    image,
@@ -80,11 +80,14 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                                    VkImageLayout                              image_layout,
                                    VkSurfaceTransformFlagBitsKHR              pre_transform)
 {
-    if (device_table == nullptr || allocator == nullptr)
+    if (allocator == nullptr)
     {
-        GFXRECON_LOG_ERROR("Screenshot could not be created: missing device table or allocator");
+        GFXRECON_LOG_ERROR("Screenshot could not be created: missing allocator");
         return;
     }
+
+    // The screenshot copy below is made by replay and is not in the capture file.
+    auto injected = injected_calls.Open();
 
     if (width == 0 || height == 0)
     {
@@ -125,7 +128,7 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
         create_info.queueFamilyIndex        = kDefaultQueueFamilyIndex;
 
         VkCommandPool command_pool = VK_NULL_HANDLE;
-        result                     = device_table->CreateCommandPool(device, &create_info, nullptr, &command_pool);
+        result                     = injected->CreateCommandPool(device, &create_info, nullptr, &command_pool);
 
         if (result == VK_SUCCESS)
         {
@@ -149,7 +152,7 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
         VkQueue queue         = VK_NULL_HANDLE;
 
         // Get a queue.
-        queue = GetDeviceQueue(device_table, device_info, kDefaultQueueFamilyIndex, kDefaultQueueIndex);
+        queue = GetDeviceQueue(injected.GetTable(), device_info, kDefaultQueueFamilyIndex, kDefaultQueueIndex);
 
         // Get a buffer size.
         VkDeviceSize buffer_size     = copy_resource.buffer_size;
@@ -159,7 +162,7 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
         if (buffer_size == 0 || copy_resource.width != copy_width || copy_resource.height != copy_height ||
             copy_resource.format != copy_format || copy_resource.flip_x != flip_x || copy_resource.flip_y != flip_y)
         {
-            buffer_size     = GetCopyBufferSize(device, device_table, copy_format, copy_width, copy_height);
+            buffer_size     = GetCopyBufferSize(device, injected, copy_format, copy_width, copy_height);
             create_resource = true;
         }
 
@@ -169,7 +172,7 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
             DestroyCopyResource(device, &copy_resource);
 
             result = CreateCopyResource(device,
-                                        device_table,
+                                        injected,
                                         memory_properties,
                                         buffer_size,
                                         format,
@@ -199,7 +202,7 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
             allocate_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
             allocate_info.commandBufferCount          = 1;
 
-            result = device_table->AllocateCommandBuffers(device, &allocate_info, &command_buffer);
+            result = injected->AllocateCommandBuffers(device, &allocate_info, &command_buffer);
             if (result == VK_SUCCESS)
             {
                 VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
@@ -207,7 +210,7 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                 begin_info.flags                    = 0;
                 begin_info.pInheritanceInfo         = nullptr;
 
-                result = device_table->BeginCommandBuffer(command_buffer, &begin_info);
+                result = injected.BeginCommandBuffer(command_buffer, &begin_info);
             }
 
             if (result == VK_SUCCESS)
@@ -230,16 +233,16 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                 src_image_barrier.subresourceRange.baseMipLevel   = 0;
                 src_image_barrier.subresourceRange.levelCount     = 1;
 
-                device_table->CmdPipelineBarrier(command_buffer,
-                                                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 0,
-                                                 nullptr,
-                                                 1,
-                                                 &src_image_barrier);
+                injected->CmdPipelineBarrier(command_buffer,
+                                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                             0,
+                                             0,
+                                             nullptr,
+                                             0,
+                                             nullptr,
+                                             1,
+                                             &src_image_barrier);
 
                 // The 'copy_image' is the image to be used with the image to buffer copy.
                 VkImage copy_image             = image;
@@ -266,16 +269,16 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                     convert_image_barrier.subresourceRange.baseMipLevel   = 0;
                     convert_image_barrier.subresourceRange.levelCount     = 1;
 
-                    device_table->CmdPipelineBarrier(command_buffer,
-                                                     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                                     VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                                     0,
-                                                     0,
-                                                     nullptr,
-                                                     0,
-                                                     nullptr,
-                                                     1,
-                                                     &convert_image_barrier);
+                    injected->CmdPipelineBarrier(command_buffer,
+                                                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 0,
+                                                 nullptr,
+                                                 1,
+                                                 &convert_image_barrier);
 
                     VkImageBlit blit_region;
                     blit_region.srcSubresource.aspectMask     = image_aspect_mask;
@@ -299,14 +302,14 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                     blit_region.dstOffsets[1].y               = flip_y ? 0 : copy_height;
                     blit_region.dstOffsets[1].z               = 1;
 
-                    device_table->CmdBlitImage(command_buffer,
-                                               image,
-                                               VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                               copy_image,
-                                               VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                               1,
-                                               &blit_region,
-                                               VK_FILTER_NEAREST);
+                    injected->CmdBlitImage(command_buffer,
+                                           image,
+                                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                           copy_image,
+                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                           1,
+                                           &blit_region,
+                                           VK_FILTER_NEAREST);
 
                     // Transition blit target from the TRANSFER_DST layout to TRANSFER_SRC layout for the image to
                     // buffer copy.
@@ -315,16 +318,16 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                     convert_image_barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
                     convert_image_barrier.newLayout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
 
-                    device_table->CmdPipelineBarrier(command_buffer,
-                                                     VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                                     VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                                     0,
-                                                     0,
-                                                     nullptr,
-                                                     0,
-                                                     nullptr,
-                                                     1,
-                                                     &convert_image_barrier);
+                    injected->CmdPipelineBarrier(command_buffer,
+                                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 0,
+                                                 nullptr,
+                                                 1,
+                                                 &convert_image_barrier);
                 }
 
                 VkBufferImageCopy copy_region;
@@ -338,12 +341,12 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                 copy_region.imageOffset                     = { 0, 0, 0 };
                 copy_region.imageExtent                     = { copy_width, copy_height, 1 };
 
-                device_table->CmdCopyImageToBuffer(command_buffer,
-                                                   copy_image,
-                                                   VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                                   copy_resource.buffer,
-                                                   1,
-                                                   &copy_region);
+                injected->CmdCopyImageToBuffer(command_buffer,
+                                               copy_image,
+                                               VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                               copy_resource.buffer,
+                                               1,
+                                               &copy_region);
 
                 // Transition source image back to image_layout after the screenshot.
                 src_image_barrier.srcAccessMask       = VK_ACCESS_TRANSFER_READ_BIT;
@@ -353,22 +356,22 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                 src_image_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
                 src_image_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 
-                device_table->CmdPipelineBarrier(command_buffer,
-                                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                                 VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 0,
-                                                 nullptr,
-                                                 1,
-                                                 &src_image_barrier);
+                injected->CmdPipelineBarrier(command_buffer,
+                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                             0,
+                                             0,
+                                             nullptr,
+                                             0,
+                                             nullptr,
+                                             1,
+                                             &src_image_barrier);
 
-                device_table->EndCommandBuffer(command_buffer);
+                injected->EndCommandBuffer(command_buffer);
 
                 // Make sure any pending work is finished, as we are not waiting on any semaphores from previous
                 // submissions.
-                result = device_table->DeviceWaitIdle(device);
+                result = injected->DeviceWaitIdle(device);
                 if (result != VK_SUCCESS)
                 {
                     GFXRECON_LOG_ERROR("ScreenshotHandler: DeviceWaitIdle failed with %s",
@@ -386,7 +389,7 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                     submit_info.signalSemaphoreCount = 0;
                     submit_info.pSignalSemaphores    = nullptr;
 
-                    result = device_table->QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
+                    result = injected->QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
                     if (result != VK_SUCCESS)
                     {
                         GFXRECON_LOG_ERROR("ScreenshotHandler: Queue submission %sfailed with %s",
@@ -397,7 +400,7 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
 
                 if (result == VK_SUCCESS)
                 {
-                    result = device_table->QueueWaitIdle(queue);
+                    result = injected->QueueWaitIdle(queue);
                     if (result != VK_SUCCESS)
                     {
                         GFXRECON_LOG_ERROR("ScreenshotHandler: Queue wait failed with %s",
@@ -511,7 +514,7 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                     GFXRECON_LOG_ERROR("Screenshot could not be created: failed to execute image transfer");
                 }
 
-                device_table->FreeCommandBuffers(device, copy_resource.command_pool, 1, &command_buffer);
+                injected->FreeCommandBuffers(device, copy_resource.command_pool, 1, &command_buffer);
             }
         }
         else
@@ -521,17 +524,16 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
     }
 }
 
-void ScreenshotHandler::DestroyDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table)
+void ScreenshotHandler::DestroyDeviceResources(VkDevice                                   device,
+                                               const graphics::VulkanInjectedDeviceCalls& injected_calls)
 {
     auto entry = copy_resources_.find(device);
     if (entry != copy_resources_.end())
     {
         auto& copy_resource = entry->second;
 
-        if (device_table != nullptr)
-        {
-            device_table->DestroyCommandPool(entry->first, copy_resource.command_pool, nullptr);
-        }
+        auto injected = injected_calls.Open();
+        injected->DestroyCommandPool(entry->first, copy_resource.command_pool, nullptr);
 
         DestroyCopyResource(device, &copy_resource);
 
@@ -587,11 +589,11 @@ VkFormat ScreenshotHandler::GetConversionFormat(VkFormat image_format) const
     return IsSrgbFormat(image_format) ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8A8_UNORM;
 }
 
-VkDeviceSize ScreenshotHandler::GetCopyBufferSize(VkDevice                           device,
-                                                  const graphics::VulkanDeviceTable* device_table,
-                                                  VkFormat                           format,
-                                                  uint32_t                           width,
-                                                  uint32_t                           height) const
+VkDeviceSize ScreenshotHandler::GetCopyBufferSize(VkDevice                                          device,
+                                                  const graphics::VulkanInjectedDeviceCalls::Scope& injected,
+                                                  VkFormat                                          format,
+                                                  uint32_t                                          width,
+                                                  uint32_t                                          height) const
 {
     VkImageCreateInfo create_info     = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
     create_info.pNext                 = nullptr;
@@ -612,11 +614,11 @@ VkDeviceSize ScreenshotHandler::GetCopyBufferSize(VkDevice                      
     VkImage              image               = VK_NULL_HANDLE;
     VkMemoryRequirements memory_requirements = {};
 
-    VkResult result = device_table->CreateImage(device, &create_info, nullptr, &image);
+    VkResult result = injected->CreateImage(device, &create_info, nullptr, &image);
     if (result == VK_SUCCESS)
     {
-        device_table->GetImageMemoryRequirements(device, image, &memory_requirements);
-        device_table->DestroyImage(device, image, nullptr);
+        injected->GetImageMemoryRequirements(device, image, &memory_requirements);
+        injected->DestroyImage(device, image, nullptr);
     }
     else
     {
@@ -626,22 +628,20 @@ VkDeviceSize ScreenshotHandler::GetCopyBufferSize(VkDevice                      
     return memory_requirements.size;
 }
 
-VkResult ScreenshotHandler::CreateCopyResource(VkDevice                                device,
-                                               const graphics::VulkanDeviceTable*      device_table,
-                                               const VkPhysicalDeviceMemoryProperties& memory_properties,
-                                               VkDeviceSize                            buffer_size,
-                                               VkFormat                                image_format,
-                                               VkFormat                                screenshot_format,
-                                               uint32_t                                width,
-                                               uint32_t                                height,
-                                               uint32_t                                copy_width,
-                                               uint32_t                                copy_height,
-                                               bool                                    flip_x,
-                                               bool                                    flip_y,
-                                               CopyResource*                           copy_resource) const
+VkResult ScreenshotHandler::CreateCopyResource(VkDevice                                          device,
+                                               const graphics::VulkanInjectedDeviceCalls::Scope& injected,
+                                               const VkPhysicalDeviceMemoryProperties&           memory_properties,
+                                               VkDeviceSize                                      buffer_size,
+                                               VkFormat                                          image_format,
+                                               VkFormat                                          screenshot_format,
+                                               uint32_t                                          width,
+                                               uint32_t                                          height,
+                                               uint32_t                                          copy_width,
+                                               uint32_t                                          copy_height,
+                                               bool                                              flip_x,
+                                               bool                                              flip_y,
+                                               CopyResource*                                     copy_resource) const
 {
-    assert(device_table != nullptr);
-
     if ((buffer_size == 0) || (copy_resource == nullptr))
     {
         return VK_ERROR_INITIALIZATION_FAILED;
@@ -664,7 +664,7 @@ VkResult ScreenshotHandler::CreateCopyResource(VkDevice                         
     if (result == VK_SUCCESS)
     {
         VkMemoryRequirements memory_requirements;
-        device_table->GetBufferMemoryRequirements(device, copy_resource->buffer, &memory_requirements);
+        injected->GetBufferMemoryRequirements(device, copy_resource->buffer, &memory_requirements);
 
         uint32_t memory_type_index =
             graphics::GetMemoryTypeIndex(memory_properties,
@@ -728,7 +728,7 @@ VkResult ScreenshotHandler::CreateCopyResource(VkDevice                         
         if (result == VK_SUCCESS)
         {
             VkMemoryRequirements memory_requirements;
-            device_table->GetImageMemoryRequirements(device, copy_resource->convert_image, &memory_requirements);
+            injected->GetImageMemoryRequirements(device, copy_resource->convert_image, &memory_requirements);
 
             uint32_t memory_type_index = graphics::GetMemoryTypeIndex(
                 memory_properties, memory_requirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);

--- a/framework/decode/screenshot_handler.h
+++ b/framework/decode/screenshot_handler.h
@@ -28,6 +28,7 @@
 #include "decode/vulkan_replay_options.h"
 #include "decode/vulkan_resource_allocator.h"
 #include "generated/generated_vulkan_dispatch_table.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "util/defines.h"
 
 #include "vulkan/vulkan.h"
@@ -58,7 +59,7 @@ class ScreenshotHandler : public ScreenshotHandlerBase
 
     void WriteImage(const std::string&                         filename_prefix,
                     const VulkanDeviceInfo*                    device_info,
-                    const graphics::VulkanDeviceTable*         device_table,
+                    const graphics::VulkanInjectedDeviceCalls& injected_calls,
                     const VkPhysicalDeviceMemoryProperties&    memory_properties,
                     VulkanResourceAllocator*                   allocator,
                     VkImage                                    image,
@@ -70,7 +71,7 @@ class ScreenshotHandler : public ScreenshotHandlerBase
                     VkImageLayout                              image_layout,
                     VkSurfaceTransformFlagBitsKHR              pre_transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
 
-    void DestroyDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table);
+    void DestroyDeviceResources(VkDevice device, const graphics::VulkanInjectedDeviceCalls& injected_calls);
 
   private:
     struct CopyResource
@@ -103,25 +104,25 @@ class ScreenshotHandler : public ScreenshotHandlerBase
 
     VkFormat GetConversionFormat(VkFormat image_format) const;
 
-    VkDeviceSize GetCopyBufferSize(VkDevice                           device,
-                                   const graphics::VulkanDeviceTable* device_table,
-                                   VkFormat                           format,
-                                   uint32_t                           width,
-                                   uint32_t                           height) const;
+    VkDeviceSize GetCopyBufferSize(VkDevice                                          device,
+                                   const graphics::VulkanInjectedDeviceCalls::Scope& injected,
+                                   VkFormat                                          format,
+                                   uint32_t                                          width,
+                                   uint32_t                                          height) const;
 
-    VkResult CreateCopyResource(VkDevice                                device,
-                                const graphics::VulkanDeviceTable*      device_table,
-                                const VkPhysicalDeviceMemoryProperties& memory_properties,
-                                VkDeviceSize                            buffer_size,
-                                VkFormat                                image_format,
-                                VkFormat                                screenshot_format,
-                                uint32_t                                width,
-                                uint32_t                                height,
-                                uint32_t                                copy_width,
-                                uint32_t                                copy_height,
-                                bool                                    flip_x,
-                                bool                                    flip_y,
-                                CopyResource*                           copy_resource) const;
+    VkResult CreateCopyResource(VkDevice                                          device,
+                                const graphics::VulkanInjectedDeviceCalls::Scope& injected,
+                                const VkPhysicalDeviceMemoryProperties&           memory_properties,
+                                VkDeviceSize                                      buffer_size,
+                                VkFormat                                          image_format,
+                                VkFormat                                          screenshot_format,
+                                uint32_t                                          width,
+                                uint32_t                                          height,
+                                uint32_t                                          copy_width,
+                                uint32_t                                          copy_height,
+                                bool                                              flip_x,
+                                bool                                              flip_y,
+                                CopyResource*                                     copy_resource) const;
 
     void DestroyCopyResource(VkDevice device, CopyResource* copy_resource) const;
 

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -251,7 +251,7 @@ VulkanAddressReplacer::VulkanAddressReplacer(const VulkanDeviceInfo*            
                                              const graphics::VulkanInjectedDeviceCalls& injected_calls,
                                              const graphics::VulkanInstanceTable*       instance_table,
                                              decode::CommonObjectInfoTable&             object_table) :
-    device_table_(injected_calls),
+    device_table_(std::make_unique<graphics::VulkanInjectedDeviceCalls>(injected_calls)),
     object_table_(&object_table)
 {
     GFXRECON_ASSERT(device_info != nullptr && instance_table != nullptr);
@@ -310,9 +310,9 @@ void VulkanAddressReplacer::SetRaytracingProperties(const decode::VulkanPhysical
 
 VulkanAddressReplacer::~VulkanAddressReplacer()
 {
-    if (!device_table_.has_value())
+    if (device_table_ == nullptr)
     {
-        // default-constructed or moved-from: nothing was created
+        // default-constructed or moved-from: nothing to destroy here
         return;
     }
     auto injected = device_table_->Open();
@@ -447,7 +447,7 @@ VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*     
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            device_table_.get(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         VulkanCommandBufferInfo fake_info = {};
         fake_info.handle                  = submit_asset_.command_buffer;
@@ -928,7 +928,7 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
     const decode::VulkanDeviceAddressTracker&                                                   address_tracker,
     const std::unordered_map<graphics::shader_group_handle_t, graphics::shader_group_handle_t>& group_handle_map)
 {
-    GFXRECON_ASSERT(device_table_.has_value());
+    GFXRECON_ASSERT(device_table_ != nullptr);
 
     // NOTE: we expect this map to be populated here, but not for older captures (before #1844) using trimming.
     if (group_handle_map.empty())
@@ -1231,7 +1231,7 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
     VkAccelerationStructureBuildRangeInfoKHR**   build_range_infos,
     VulkanDeviceAddressTracker&                  address_tracker)
 {
-    GFXRECON_ASSERT(device_table_.has_value());
+    GFXRECON_ASSERT(device_table_ != nullptr);
 
     auto injected = device_table_->Open();
 
@@ -1741,7 +1741,7 @@ void VulkanAddressReplacer::ProcessBuildVulkanAccelerationStructuresMetaCommand(
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            device_table_.get(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         // dummy-wrapper
         VulkanCommandBufferInfo command_buffer_info = {};
@@ -1765,7 +1765,7 @@ void VulkanAddressReplacer::ProcessCopyVulkanAccelerationStructuresMetaCommand(
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            device_table_.get(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         auto injected = device_table_->Open();
 
@@ -1803,7 +1803,7 @@ void VulkanAddressReplacer::ProcessVulkanAccelerationStructuresWritePropertiesMe
     // reset/submit/sync command-buffer
     {
         QueueSubmitHelper queue_submit_helper(
-            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            device_table_.get(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         ProcessCmdWriteAccelerationStructuresPropertiesKHR(
             1, &acceleration_structure, query_type, query_pool_, 0, address_tracker);
@@ -2250,7 +2250,7 @@ bool VulkanAddressReplacer::create_acceleration_asset(VulkanAddressReplacer::acc
     auto injected = device_table_->Open();
 
     as_asset.device         = device_;
-    as_asset.injected_calls = device_table_;
+    as_asset.injected_calls = *device_table_;
 
     // create a replacement acceleration-structure with proper sized buffer
     bool success = create_buffer(as_asset.storage,
@@ -2296,7 +2296,7 @@ bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
     // clear previous content and setup
     submit_asset.device         = device_;
     submit_asset.command_pool   = command_pool_;
-    submit_asset.injected_calls = device_table_;
+    submit_asset.injected_calls = *device_table_;
 
     if (submit_asset.command_buffer == VK_NULL_HANDLE)
     {
@@ -2620,7 +2620,7 @@ void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer
 
             // reset/submit/sync command-buffer
             queue_submit_helper = QueueSubmitHelper(
-                &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+                device_table_.get(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
             command_buffer = submit_asset_.command_buffer;
         }
 

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -20,6 +20,7 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
+#include "graphics/vulkan_injected_calls.h"
 #include "graphics/vulkan_util.h"
 #include "graphics/vulkan_struct_get_pnext.h"
 #include "decode/vulkan_address_replacer.h"
@@ -37,11 +38,11 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 //! RAII helper submit a command-buffer to a queue and synchronize via fence
 struct QueueSubmitHelper
 {
-    const graphics::VulkanDeviceTable* device_table   = nullptr;
-    VkDevice                           device         = VK_NULL_HANDLE;
-    VkCommandBuffer                    command_buffer = VK_NULL_HANDLE;
-    VkFence                            fence          = VK_NULL_HANDLE;
-    VkQueue                            queue          = VK_NULL_HANDLE;
+    const graphics::VulkanInjectedDeviceCalls* device_table   = nullptr;
+    VkDevice                                   device         = VK_NULL_HANDLE;
+    VkCommandBuffer                            command_buffer = VK_NULL_HANDLE;
+    VkFence                                    fence          = VK_NULL_HANDLE;
+    VkQueue                                    queue          = VK_NULL_HANDLE;
 
     QueueSubmitHelper()                         = default;
     QueueSubmitHelper(const QueueSubmitHelper&) = delete;
@@ -52,33 +53,31 @@ struct QueueSubmitHelper
         swap(other);
         return *this;
     }
-    QueueSubmitHelper(const graphics::VulkanDeviceTable* device_table_,
-                      VkDevice                           device_,
-                      VkCommandBuffer                    command_buffer_,
-                      VkQueue                            queue_,
-                      VkFence                            fence_) :
+    QueueSubmitHelper(const graphics::VulkanInjectedDeviceCalls* device_table_,
+                      VkDevice                                   device_,
+                      VkCommandBuffer                            command_buffer_,
+                      VkQueue                                    queue_,
+                      VkFence                                    fence_) :
         device_table(device_table_),
         device(device_), command_buffer(command_buffer_), fence(fence_), queue(queue_)
     {
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-
-        device_table->ResetFences(device, 1, &fence);
+        auto injected = device_table_->Open();
+        injected->ResetFences(device, 1, &fence);
 
         VkCommandBufferBeginInfo command_buffer_begin_info;
         command_buffer_begin_info.sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
         command_buffer_begin_info.pNext            = nullptr;
         command_buffer_begin_info.flags            = 0;
         command_buffer_begin_info.pInheritanceInfo = nullptr;
-        device_table->BeginCommandBuffer(command_buffer, &command_buffer_begin_info);
+        injected.BeginCommandBuffer(command_buffer, &command_buffer_begin_info);
     }
 
     ~QueueSubmitHelper()
     {
         if (device_table != nullptr)
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-
-            device_table->EndCommandBuffer(command_buffer);
+            auto injected = device_table->Open();
+            injected->EndCommandBuffer(command_buffer);
 
             VkSubmitInfo submit_info         = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
             submit_info.pNext                = nullptr;
@@ -91,10 +90,10 @@ struct QueueSubmitHelper
             submit_info.pSignalSemaphores    = nullptr;
 
             // submit
-            device_table->QueueSubmit(queue, 1, &submit_info, fence);
+            injected->QueueSubmit(queue, 1, &submit_info, fence);
 
             // sync
-            device_table->WaitForFences(device, 1, &fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
+            injected->WaitForFences(device, 1, &fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
         }
     }
 
@@ -173,6 +172,10 @@ decode::VulkanAddressReplacer::buffer_context_t::~buffer_context_t()
 {
     if (resource_allocator != nullptr)
     {
+        // allocator-internal Vulkan calls below are replay-injected; destruction can run outside
+        // any caller-provided scope (e.g. from member-destruction), so mark it here
+        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+
         if (buffer != VK_NULL_HANDLE)
         {
             // unmap/destroy buffer
@@ -195,9 +198,10 @@ decode::VulkanAddressReplacer::buffer_context_t::~buffer_context_t()
 
 decode::VulkanAddressReplacer::acceleration_structure_asset_t::~acceleration_structure_asset_t()
 {
-    if (handle != VK_NULL_HANDLE && destroy_fn != nullptr && device != VK_NULL_HANDLE)
+    if (handle != VK_NULL_HANDLE && injected_calls.has_value() && device != VK_NULL_HANDLE)
     {
-        destroy_fn(device, handle, nullptr);
+        auto injected = injected_calls->Open();
+        injected->DestroyAccelerationStructureKHR(device, handle, nullptr);
     }
 }
 
@@ -220,49 +224,51 @@ void decode::VulkanAddressReplacer::submit_asset_t::swap(submit_asset_t& other) 
     std::swap(command_buffer, other.command_buffer);
     std::swap(fence, other.fence);
     std::swap(signal_semaphore, other.signal_semaphore);
-    std::swap(destroy_fence_fn, other.destroy_fence_fn);
-    std::swap(free_command_buffers_fn, other.free_command_buffers_fn);
-    std::swap(destroy_semaphore_fn, other.destroy_semaphore_fn);
+    std::swap(injected_calls, other.injected_calls);
 }
 
 decode::VulkanAddressReplacer::submit_asset_t::~submit_asset_t()
 {
-    if (device != VK_NULL_HANDLE)
+    if (device != VK_NULL_HANDLE && injected_calls.has_value())
     {
-        if (destroy_fence_fn != nullptr && fence != VK_NULL_HANDLE)
+        auto injected = injected_calls->Open();
+        if (fence != VK_NULL_HANDLE)
         {
-            destroy_fence_fn(device, fence, nullptr);
+            injected->DestroyFence(device, fence, nullptr);
         }
-        if (free_command_buffers_fn != nullptr && command_buffer != VK_NULL_HANDLE)
+        if (command_buffer != VK_NULL_HANDLE)
         {
-            free_command_buffers_fn(device, command_pool, 1, &command_buffer);
+            injected->FreeCommandBuffers(device, command_pool, 1, &command_buffer);
         }
-        if (destroy_semaphore_fn != nullptr && signal_semaphore.semaphore != VK_NULL_HANDLE)
+        if (signal_semaphore.semaphore != VK_NULL_HANDLE)
         {
-            destroy_semaphore_fn(device, signal_semaphore.semaphore, nullptr);
+            injected->DestroySemaphore(device, signal_semaphore.semaphore, nullptr);
         }
     }
 }
 
-VulkanAddressReplacer::VulkanAddressReplacer(const VulkanDeviceInfo*              device_info,
-                                             const graphics::VulkanDeviceTable*   device_table,
-                                             const graphics::VulkanInstanceTable* instance_table,
-                                             decode::CommonObjectInfoTable&       object_table) :
-    device_table_(device_table),
+VulkanAddressReplacer::VulkanAddressReplacer(const VulkanDeviceInfo*                    device_info,
+                                             const graphics::VulkanInjectedDeviceCalls& injected_calls,
+                                             const graphics::VulkanInstanceTable*       instance_table,
+                                             decode::CommonObjectInfoTable&             object_table) :
+    device_table_(injected_calls),
     object_table_(&object_table)
 {
-    GFXRECON_ASSERT(device_info != nullptr && device_table != nullptr && instance_table != nullptr);
+    GFXRECON_ASSERT(device_info != nullptr && instance_table != nullptr);
+
+    auto injected = device_table_->Open();
+
     physical_device_info_ = object_table.GetVkPhysicalDeviceInfo(device_info->parent_id);
     GFXRECON_ASSERT(physical_device_info_ != nullptr);
     device_                = device_info->handle;
     resource_allocator_    = device_info->allocator.get();
     get_device_address_fn_ = physical_device_info_->parent_info.api_version >= VK_API_VERSION_1_2
-                                 ? device_table->GetBufferDeviceAddress
-                                 : device_table->GetBufferDeviceAddressKHR;
+                                 ? injected.GetTable()->GetBufferDeviceAddress
+                                 : injected.GetTable()->GetBufferDeviceAddressKHR;
 
     get_physical_device_properties_fn_ = instance_table->GetPhysicalDeviceProperties2;
     set_debug_utils_object_name_fn_    = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(
-        device_table_->GetDeviceProcAddr(device_, "vkSetDebugUtilsObjectNameEXT"));
+        injected->GetDeviceProcAddr(device_, "vkSetDebugUtilsObjectNameEXT"));
     SetRaytracingProperties(physical_device_info_);
 }
 
@@ -304,7 +310,12 @@ void VulkanAddressReplacer::SetRaytracingProperties(const decode::VulkanPhysical
 
 VulkanAddressReplacer::~VulkanAddressReplacer()
 {
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+    if (!device_table_.has_value())
+    {
+        // default-constructed or moved-from: nothing was created
+        return;
+    }
+    auto injected = device_table_->Open();
 
     // explicitly free resources here, in order to mark destruction API-calls as injected
     pipeline_context_map_.clear();
@@ -316,27 +327,27 @@ VulkanAddressReplacer::~VulkanAddressReplacer()
 
     if (pipeline_bda_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyPipeline(device_, pipeline_bda_, nullptr);
+        injected->DestroyPipeline(device_, pipeline_bda_, nullptr);
     }
     if (pipeline_bda_rehash_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyPipeline(device_, pipeline_bda_rehash_, nullptr);
+        injected->DestroyPipeline(device_, pipeline_bda_rehash_, nullptr);
     }
     if (pipeline_sbt_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyPipeline(device_, pipeline_sbt_, nullptr);
+        injected->DestroyPipeline(device_, pipeline_sbt_, nullptr);
     }
     if (pipeline_layout_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyPipelineLayout(device_, pipeline_layout_, nullptr);
+        injected->DestroyPipelineLayout(device_, pipeline_layout_, nullptr);
     }
     if (query_pool_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyQueryPool(device_, query_pool_, nullptr);
+        injected->DestroyQueryPool(device_, query_pool_, nullptr);
     }
     if (command_pool_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyCommandPool(device_, command_pool_, nullptr);
+        injected->DestroyCommandPool(device_, command_pool_, nullptr);
     }
 }
 
@@ -351,6 +362,8 @@ VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*     
         // nothing to replace
         return graphics::VulkanSemaphore{ VK_NULL_HANDLE };
     }
+
+    auto injected = device_table_->Open();
 
     GFXRECON_LOG_INFO_ONCE("VulkanAddressReplacer::UpdateBufferAddresses(): Replay is adjusting "
                            "buffer-device-addresses in-place using a compute-dispatch");
@@ -382,20 +395,20 @@ VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*     
                 return graphics::VulkanSemaphore{ VK_NULL_HANDLE };
             }
 
-            device_table_->ResetFences(device_, 1, &submit_asset.fence);
+            injected->ResetFences(device_, 1, &submit_asset.fence);
 
             VkCommandBufferBeginInfo command_buffer_begin_info;
             command_buffer_begin_info.sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
             command_buffer_begin_info.pNext            = nullptr;
             command_buffer_begin_info.flags            = 0;
             command_buffer_begin_info.pInheritanceInfo = nullptr;
-            device_table_->BeginCommandBuffer(submit_asset.command_buffer, &command_buffer_begin_info);
+            injected.BeginCommandBuffer(submit_asset.command_buffer, &command_buffer_begin_info);
 
             VulkanCommandBufferInfo fake_info = {};
             fake_info.handle                  = submit_asset.command_buffer;
             run_compute_replace(&fake_info, addresses_to_replace, address_tracker, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 
-            device_table_->EndCommandBuffer(submit_asset.command_buffer);
+            injected->EndCommandBuffer(submit_asset.command_buffer);
 
             std::vector<VkSemaphore>          semaphore_handles(wait_semaphores.size());
             std::vector<uint64_t>             semaphore_values(wait_semaphores.size());
@@ -424,7 +437,7 @@ VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*     
             submit_info.pSignalSemaphores    = &submit_asset.signal_semaphore.semaphore;
 
             // submit
-            device_table_->QueueSubmit(queue_, 1, &submit_info, submit_asset.fence);
+            injected->QueueSubmit(queue_, 1, &submit_info, submit_asset.fence);
 
             // return signal-semaphore
             return submit_asset.signal_semaphore;
@@ -434,7 +447,7 @@ VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*     
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            device_table_, device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         VulkanCommandBufferInfo fake_info = {};
         fake_info.handle                  = submit_asset_.command_buffer;
@@ -703,13 +716,14 @@ void VulkanAddressReplacer::ProcessCmdBindPipeline(VulkanCommandBufferInfo*     
         GFXRECON_LOG_INFO_ONCE("VulkanAddressReplacer::ProcessCmdBindPipeline(): Replay is re-issuing "
                                "push-constants to patch buffer-device-addresses recorded before pipeline bind");
 
-        util::MarkInjectedCommandsHelper injected_commands_helper;
-        device_table_->CmdPushConstants(command_buffer_info->handle,
-                                        command_buffer_info->push_constant_pipeline_layout,
-                                        command_buffer_info->push_constant_stage_flags,
-                                        0,
-                                        static_cast<uint32_t>(push_constant_copy.size()),
-                                        push_constant_copy.data());
+        auto injected = device_table_->Open();
+        auto label    = device_table_->Label(injected, command_buffer_info->handle, "Address replacer");
+        injected->CmdPushConstants(command_buffer_info->handle,
+                                   command_buffer_info->push_constant_pipeline_layout,
+                                   command_buffer_info->push_constant_stage_flags,
+                                   0,
+                                   static_cast<uint32_t>(push_constant_copy.size()),
+                                   push_constant_copy.data());
         command_buffer_info->push_constant_data = std::move(push_constant_copy);
     }
 }
@@ -727,6 +741,8 @@ void VulkanAddressReplacer::ProcessCmdBindDescriptorSets(VulkanCommandBufferInfo
     {
         return;
     };
+
+    auto injected = device_table_->Open();
 
     std::map<std::pair<VkDescriptorSet, uint32_t>, VkWriteDescriptorSetInlineUniformBlock> sets_requiring_update;
 
@@ -796,14 +812,12 @@ void VulkanAddressReplacer::ProcessCmdBindDescriptorSets(VulkanCommandBufferInfo
                 else
                 {
                     // patch an existing uniform-buffer and retrieve a buffer-address for it
-                    util::BeginInjectedCommands();
                     VkBufferDeviceAddressInfo address_info = {};
                     address_info.sType                     = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
                     address_info.buffer                    = buffer_info->handle;
                     buffer_info->capture_address           = buffer_info->replay_address =
                         get_device_address_fn_(device_, &address_info);
                     GFXRECON_ASSERT(buffer_info->replay_address != 0);
-                    util::EndInjectedCommands();
 
                     // track newly acquired buffer/address
                     address_tracker.TrackBuffer(buffer_info);
@@ -889,13 +903,11 @@ void VulkanAddressReplacer::ProcessCmdBindDescriptorSets(VulkanCommandBufferInfo
 
     if (!descriptor_updates.empty())
     {
-        // mark injected commands
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        device_table_->UpdateDescriptorSets(device_,
-                                            GFXRECON_NARROWING_CAST(uint32_t, descriptor_updates.size()),
-                                            descriptor_updates.data(),
-                                            0,
-                                            nullptr);
+        injected->UpdateDescriptorSets(device_,
+                                       GFXRECON_NARROWING_CAST(uint32_t, descriptor_updates.size()),
+                                       descriptor_updates.data(),
+                                       0,
+                                       nullptr);
     }
 
     if (!command_buffer_info->in_rendering_scope)
@@ -916,7 +928,7 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
     const decode::VulkanDeviceAddressTracker&                                                   address_tracker,
     const std::unordered_map<graphics::shader_group_handle_t, graphics::shader_group_handle_t>& group_handle_map)
 {
-    GFXRECON_ASSERT(device_table_ != nullptr);
+    GFXRECON_ASSERT(device_table_.has_value());
 
     // NOTE: we expect this map to be populated here, but not for older captures (before #1844) using trimming.
     if (group_handle_map.empty())
@@ -982,8 +994,7 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
 
     if (!valid_sbt_alignment_ || !valid_group_handles)
     {
-        // mark injected commands
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+        auto injected = device_table_->Open();
 
         if (pipeline_sbt_ == VK_NULL_HANDLE)
         {
@@ -1158,19 +1169,19 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
             GFXRECON_ASSERT(out_index == num_addresses);
         }
 
-        device_table_->CmdBindPipeline(command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_sbt_);
+        auto label = device_table_->Label(injected, command_buffer_info->handle, "Address replacer");
+        injected->CmdBindPipeline(command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_sbt_);
 
         // NOTE: using push-constants here requires us to re-establish the previous data, if any
-        device_table_->CmdPushConstants(command_buffer_info->handle,
-                                        pipeline_layout_,
-                                        VK_SHADER_STAGE_COMPUTE_BIT,
-                                        0,
-                                        sizeof(replacer_params_sbt_t),
-                                        &replacer_params);
+        injected->CmdPushConstants(command_buffer_info->handle,
+                                   pipeline_layout_,
+                                   VK_SHADER_STAGE_COMPUTE_BIT,
+                                   0,
+                                   sizeof(replacer_params_sbt_t),
+                                   &replacer_params);
         // run a single workgroup
         constexpr uint32_t wg_size = 32;
-        device_table_->CmdDispatch(
-            command_buffer_info->handle, util::div_up(replacer_params.num_handles, wg_size), 1, 1);
+        injected->CmdDispatch(command_buffer_info->handle, util::div_up(replacer_params.num_handles, wg_size), 1, 1);
 
         // post memory-barrier
         for (const auto& buf : buffer_set)
@@ -1194,7 +1205,7 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
                 GFXRECON_LOG_INFO_ONCE(
                     "VulkanAddressReplacer::ProcessCmdTraceRays: Replay is injecting compute-dispatches, "
                     "originally bound compute-pipelines are restored.");
-                device_table_->CmdBindPipeline(
+                injected->CmdBindPipeline(
                     command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, previous_pipeline->handle);
             }
         }
@@ -1202,7 +1213,7 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
         // set previous push-constant data, if any
         if (!command_buffer_info->push_constant_data.empty())
         {
-            device_table_->CmdPushConstants(
+            injected->CmdPushConstants(
                 command_buffer_info->handle,
                 command_buffer_info->push_constant_pipeline_layout,
                 command_buffer_info->push_constant_stage_flags,
@@ -1220,7 +1231,9 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
     VkAccelerationStructureBuildRangeInfoKHR**   build_range_infos,
     VulkanDeviceAddressTracker&                  address_tracker)
 {
-    GFXRECON_ASSERT(device_table_ != nullptr);
+    GFXRECON_ASSERT(device_table_.has_value());
+
+    auto injected = device_table_->Open();
 
     bool force_replace = false;
 
@@ -1276,12 +1289,11 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                     primitive_counts[j] = range_infos[j].primitiveCount;
                 }
 
-                util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-                device_table_->GetAccelerationStructureBuildSizesKHR(device_,
-                                                                     VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
-                                                                     &build_geometry_info,
-                                                                     primitive_counts.data(),
-                                                                     &build_size_info);
+                injected->GetAccelerationStructureBuildSizesKHR(device_,
+                                                                VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
+                                                                &build_geometry_info,
+                                                                primitive_counts.data(),
+                                                                &build_size_info);
             }
 
             bool as_buffer_usable = false;
@@ -1346,7 +1358,6 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
 
             if (!as_buffer_usable || !scratch_buffer_usable)
             {
-                util::MarkInjectedCommandsHelper mark_injected_commands_helper;
                 GFXRECON_LOG_INFO_ONCE(
                     "VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR: Replay is adjusting "
                     "acceleration-structures using shadow-structures and -buffers");
@@ -1364,7 +1375,6 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                     if (stale_shadow_as_it != shadow_as_map_.end() &&
                         stale_shadow_as_it->second.origin_handle != build_geometry_info.dstAccelerationStructure)
                     {
-                        util::MarkInjectedCommandsHelper mark_injected_commands_helper_erase;
                         shadow_as_map_.erase(stale_shadow_as_it);
                     }
 
@@ -1731,7 +1741,7 @@ void VulkanAddressReplacer::ProcessBuildVulkanAccelerationStructuresMetaCommand(
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            device_table_, device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         // dummy-wrapper
         VulkanCommandBufferInfo command_buffer_info = {};
@@ -1740,8 +1750,8 @@ void VulkanAddressReplacer::ProcessBuildVulkanAccelerationStructuresMetaCommand(
             &command_buffer_info, info_count, geometry_infos, range_infos, address_tracker);
 
         // issue build-command
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        device_table_->CmdBuildAccelerationStructuresKHR(
+        auto injected = device_table_->Open();
+        injected->CmdBuildAccelerationStructuresKHR(
             submit_asset_.command_buffer, info_count, geometry_infos, range_infos);
     }
 }
@@ -1755,7 +1765,9 @@ void VulkanAddressReplacer::ProcessCopyVulkanAccelerationStructuresMetaCommand(
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            device_table_, device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+
+        auto injected = device_table_->Open();
 
         for (uint32_t i = 0; i < info_count; ++i)
         {
@@ -1766,8 +1778,7 @@ void VulkanAddressReplacer::ProcessCopyVulkanAccelerationStructuresMetaCommand(
                 ProcessCmdCopyAccelerationStructuresKHR(copy_info, address_tracker);
 
                 // issue copy command
-                util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-                device_table_->CmdCopyAccelerationStructureKHR(submit_asset_.command_buffer, copy_info);
+                injected->CmdCopyAccelerationStructureKHR(submit_asset_.command_buffer, copy_info);
             }
             else
             {
@@ -1787,33 +1798,33 @@ void VulkanAddressReplacer::ProcessVulkanAccelerationStructuresWritePropertiesMe
         return;
     }
 
+    auto injected = device_table_->Open();
+
+    // reset/submit/sync command-buffer
     {
-        // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            device_table_, device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         ProcessCmdWriteAccelerationStructuresPropertiesKHR(
             1, &acceleration_structure, query_type, query_pool_, 0, address_tracker);
 
         // issue vkCmdResetQueryPool and vkCmdWriteAccelerationStructuresPropertiesKHR
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        device_table_->CmdResetQueryPool(submit_asset_.command_buffer, query_pool_, 0, 1);
-        device_table_->CmdWriteAccelerationStructuresPropertiesKHR(
+        injected->CmdResetQueryPool(submit_asset_.command_buffer, query_pool_, 0, 1);
+        injected->CmdWriteAccelerationStructuresPropertiesKHR(
             submit_asset_.command_buffer, 1, &acceleration_structure, query_type, query_pool_, 0);
     }
 
     VkDeviceSize compact_size = 0;
 
     // the above command-buffer is already synced here, retrieve result using vkGetQueryPoolResults
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-    device_table_->GetQueryPoolResults(device_,
-                                       query_pool_,
-                                       0,
-                                       1,
-                                       sizeof(VkDeviceSize),
-                                       &compact_size,
-                                       sizeof(VkDeviceSize),
-                                       VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+    injected->GetQueryPoolResults(device_,
+                                  query_pool_,
+                                  0,
+                                  1,
+                                  sizeof(VkDeviceSize),
+                                  &compact_size,
+                                  sizeof(VkDeviceSize),
+                                  VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
 
     // apply usual post-processing of queries
     ProcessGetQueryPoolResults(device_,
@@ -1833,6 +1844,9 @@ bool VulkanAddressReplacer::init_pipeline()
         // assume already initialized
         return true;
     }
+
+    auto injected = device_table_->Open();
+
     VkPushConstantRange push_constant_range = {};
     push_constant_range.stageFlags          = VK_SHADER_STAGE_COMPUTE_BIT;
     push_constant_range.offset              = 0;
@@ -1847,14 +1861,15 @@ bool VulkanAddressReplacer::init_pipeline()
     pipeline_layout_info.pushConstantRangeCount     = 1;
     pipeline_layout_info.pPushConstantRanges        = &push_constant_range;
 
-    VkResult result = device_table_->CreatePipelineLayout(device_, &pipeline_layout_info, nullptr, &pipeline_layout_);
+    VkResult result = injected->CreatePipelineLayout(device_, &pipeline_layout_info, nullptr, &pipeline_layout_);
 
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_FATAL("VulkanAddressReplacer: failed in vkCreatePipelineLayout");
     }
 
-    auto create_pipeline = [this](VkPipelineLayout layout, const auto& spirv, VkPipeline& out_pipeline) -> VkResult {
+    auto create_pipeline =
+        [this, &injected](VkPipelineLayout layout, const auto& spirv, VkPipeline& out_pipeline) -> VkResult {
         using elem_t                                       = typename std::decay_t<decltype(spirv)>::value_type;
         VkShaderModule           compute_module            = VK_NULL_HANDLE;
         VkShaderModuleCreateInfo shader_module_create_info = {};
@@ -1864,8 +1879,7 @@ bool VulkanAddressReplacer::init_pipeline()
         shader_module_create_info.codeSize                 = spirv.size() * sizeof(elem_t);
         shader_module_create_info.pCode                    = reinterpret_cast<const uint32_t*>(spirv.data());
 
-        VkResult result =
-            device_table_->CreateShaderModule(device_, &shader_module_create_info, nullptr, &compute_module);
+        VkResult result = injected->CreateShaderModule(device_, &shader_module_create_info, nullptr, &compute_module);
 
         if (result != VK_SUCCESS)
         {
@@ -1886,7 +1900,7 @@ bool VulkanAddressReplacer::init_pipeline()
         pipeline_create_info.layout                      = layout;
         pipeline_create_info.stage                       = stage_info;
 
-        result = device_table_->CreateComputePipelines(
+        result = injected->CreateComputePipelines(
             device_, VK_NULL_HANDLE, 1, &pipeline_create_info, VK_NULL_HANDLE, &out_pipeline);
 
         if (result != VK_SUCCESS)
@@ -1906,7 +1920,7 @@ bool VulkanAddressReplacer::init_pipeline()
 
         if (compute_module != VK_NULL_HANDLE)
         {
-            device_table_->DestroyShaderModule(device_, compute_module, nullptr);
+            injected->DestroyShaderModule(device_, compute_module, nullptr);
         }
 
         return result;
@@ -1939,20 +1953,22 @@ bool VulkanAddressReplacer::init_queue_assets()
         return true;
     };
 
+    auto injected = device_table_->Open();
+
     VkCommandPoolCreateInfo create_info = {};
     create_info.sType                   = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
     create_info.pNext                   = nullptr;
     create_info.flags                   = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     create_info.queueFamilyIndex        = 0;
 
-    VkResult result = device_table_->CreateCommandPool(device_, &create_info, nullptr, &command_pool_);
+    VkResult result = injected->CreateCommandPool(device_, &create_info, nullptr, &command_pool_);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal command-pool creation failed");
         return false;
     }
 
-    device_table_->GetDeviceQueue(device_, 0, 0, &queue_);
+    injected->GetDeviceQueue(device_, 0, 0, &queue_);
     GFXRECON_ASSERT(queue_ != VK_NULL_HANDLE);
 
     bool submit_asset_created = create_submit_asset(submit_asset_);
@@ -1966,6 +1982,8 @@ bool VulkanAddressReplacer::init_as_compact_query_pool()
         return true;
     }
 
+    auto injected = device_table_->Open();
+
     VkQueryPoolCreateInfo pool_info;
     pool_info.sType              = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
     pool_info.pNext              = nullptr;
@@ -1973,7 +1991,7 @@ bool VulkanAddressReplacer::init_as_compact_query_pool()
     pool_info.queryType          = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR;
     pool_info.queryCount         = 1;
     pool_info.pipelineStatistics = 0;
-    if (device_table_->CreateQueryPool(device_, &pool_info, nullptr, &query_pool_) != VK_SUCCESS)
+    if (injected->CreateQueryPool(device_, &pool_info, nullptr, &query_pool_) != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal query-pool creation failed");
         return false;
@@ -2000,6 +2018,8 @@ bool VulkanAddressReplacer::create_buffer(VulkanAddressReplacer::buffer_context_
         return true;
     }
 
+    auto injected = device_table_->Open();
+
     // free previous resources
     buffer_context                    = {};
     buffer_context.resource_allocator = resource_allocator_;
@@ -2022,7 +2042,7 @@ bool VulkanAddressReplacer::create_buffer(VulkanAddressReplacer::buffer_context_
     }
 
     VkMemoryRequirements memory_requirements;
-    device_table_->GetBufferMemoryRequirements(device_, buffer_context.buffer, &memory_requirements);
+    injected->GetBufferMemoryRequirements(device_, buffer_context.buffer, &memory_requirements);
 
     VkMemoryPropertyFlags memory_property_flags =
         use_host_mem ? VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
@@ -2118,7 +2138,9 @@ void VulkanAddressReplacer::barrier(VkCommandBuffer      command_buffer,
     barrier.srcAccessMask                                     = src_access;
     barrier.dstAccessMask                                     = dst_access;
 
-    device_table_->CmdPipelineBarrier(
+    auto injected = device_table_->Open();
+    auto label    = device_table_->Label(injected, command_buffer, "Address replacer");
+    injected->CmdPipelineBarrier(
         command_buffer, src_stage, dst_stage, VkDependencyFlags(0), 0, nullptr, 1, &barrier, 0, nullptr);
 }
 
@@ -2162,7 +2184,6 @@ void VulkanAddressReplacer::DestroyShadowResources(
         auto remove_shadow_as_it = shadow_as_map_.find(acceleration_structure_info->replay_address);
         if (remove_shadow_as_it != shadow_as_map_.end())
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             shadow_as_map_.erase(remove_shadow_as_it);
         }
 
@@ -2170,7 +2191,6 @@ void VulkanAddressReplacer::DestroyShadowResources(
         auto remove_scratch_it = shadow_scratch_map_.find(acceleration_structure_info->handle);
         if (remove_scratch_it != shadow_scratch_map_.end())
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             shadow_scratch_map_.erase(remove_scratch_it);
         }
     }
@@ -2191,7 +2211,6 @@ void VulkanAddressReplacer::DestroyShadowResources(const VulkanBufferInfo*      
                 auto remove_shadow_as_it = shadow_as_map_.find(replay_address_it->second);
                 if (remove_shadow_as_it != shadow_as_map_.end())
                 {
-                    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
                     shadow_as_map_.erase(remove_shadow_as_it);
                 }
             }
@@ -2206,21 +2225,18 @@ void VulkanAddressReplacer::DestroyShadowResources(VkCommandBuffer handle)
         auto shadow_sbt_it = shadow_sbt_map_.find(handle);
         if (shadow_sbt_it != shadow_sbt_map_.end())
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             shadow_sbt_map_.erase(shadow_sbt_it);
         }
 
         auto pipeline_sbt_it = pipeline_context_map_.find(handle);
         if (pipeline_sbt_it != pipeline_context_map_.end())
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             pipeline_context_map_.erase(pipeline_sbt_it);
         }
 
         auto submit_asset_it = submit_asset_map_.find(handle);
         if (submit_asset_it != submit_asset_map_.end())
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             submit_asset_map_.erase(submit_asset_it);
         }
     }
@@ -2231,8 +2247,10 @@ bool VulkanAddressReplacer::create_acceleration_asset(VulkanAddressReplacer::acc
                                                       size_t num_buffer_bytes,
                                                       size_t num_scratch_bytes)
 {
-    as_asset.device     = device_;
-    as_asset.destroy_fn = device_table_->DestroyAccelerationStructureKHR;
+    auto injected = device_table_->Open();
+
+    as_asset.device         = device_;
+    as_asset.injected_calls = device_table_;
 
     // create a replacement acceleration-structure with proper sized buffer
     bool success = create_buffer(as_asset.storage,
@@ -2255,7 +2273,7 @@ bool VulkanAddressReplacer::create_acceleration_asset(VulkanAddressReplacer::acc
     as_create_info.size                                 = num_buffer_bytes;
     as_create_info.type                                 = type;
 
-    VkResult res = device_table_->CreateAccelerationStructureKHR(device_, &as_create_info, nullptr, &as_asset.handle);
+    VkResult res = injected->CreateAccelerationStructureKHR(device_, &as_create_info, nullptr, &as_asset.handle);
 
     if (res != VK_SUCCESS || as_asset.handle == VK_NULL_HANDLE)
     {
@@ -2266,19 +2284,19 @@ bool VulkanAddressReplacer::create_acceleration_asset(VulkanAddressReplacer::acc
     VkAccelerationStructureDeviceAddressInfoKHR acceleration_address_info = {};
     acceleration_address_info.sType                 = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
     acceleration_address_info.accelerationStructure = as_asset.handle;
-    as_asset.address = device_table_->GetAccelerationStructureDeviceAddressKHR(device_, &acceleration_address_info);
+    as_asset.address = injected->GetAccelerationStructureDeviceAddressKHR(device_, &acceleration_address_info);
     GFXRECON_ASSERT(as_asset.address != 0);
     return true;
 }
 
 bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
 {
+    auto injected = device_table_->Open();
+
     // clear previous content and setup
-    submit_asset.device                  = device_;
-    submit_asset.command_pool            = command_pool_;
-    submit_asset.destroy_fence_fn        = device_table_->DestroyFence;
-    submit_asset.free_command_buffers_fn = device_table_->FreeCommandBuffers;
-    submit_asset.destroy_semaphore_fn    = device_table_->DestroySemaphore;
+    submit_asset.device         = device_;
+    submit_asset.command_pool   = command_pool_;
+    submit_asset.injected_calls = device_table_;
 
     if (submit_asset.command_buffer == VK_NULL_HANDLE)
     {
@@ -2288,7 +2306,7 @@ bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
         alloc_info.commandPool                 = command_pool_;
         alloc_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
         alloc_info.commandBufferCount          = 1;
-        VkResult result = device_table_->AllocateCommandBuffers(device_, &alloc_info, &submit_asset.command_buffer);
+        VkResult result = injected->AllocateCommandBuffers(device_, &alloc_info, &submit_asset.command_buffer);
         if (result != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal command-buffer creation failed");
@@ -2306,7 +2324,7 @@ bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
         fence_create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
         fence_create_info.pNext = nullptr;
         fence_create_info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-        VkResult result         = device_table_->CreateFence(device_, &fence_create_info, nullptr, &submit_asset.fence);
+        VkResult result         = injected->CreateFence(device_, &fence_create_info, nullptr, &submit_asset.fence);
         if (result != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal fence creation failed");
@@ -2319,7 +2337,7 @@ bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
     {
         VkSemaphoreCreateInfo semaphore_create_info = {};
         semaphore_create_info.sType                 = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-        VkResult result                             = device_table_->CreateSemaphore(
+        VkResult result                             = injected->CreateSemaphore(
             device_, &semaphore_create_info, nullptr, &submit_asset.signal_semaphore.semaphore);
         if (result != VK_SUCCESS)
         {
@@ -2355,8 +2373,7 @@ void VulkanAddressReplacer::run_compute_replace(const VulkanCommandBufferInfo*  
         }
     }
 
-    // mark injected commands
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+    auto injected = device_table_->Open();
 
     if (pipeline_bda_ == VK_NULL_HANDLE && !init_pipeline())
     {
@@ -2425,18 +2442,19 @@ void VulkanAddressReplacer::run_compute_replace(const VulkanCommandBufferInfo*  
                 VK_ACCESS_SHADER_WRITE_BIT);
     }
 
-    device_table_->CmdBindPipeline(command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_bda_);
+    auto label = device_table_->Label(injected, command_buffer_info->handle, "Address replacer");
+    injected->CmdBindPipeline(command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_bda_);
 
     // NOTE: using push-constants here requires us to re-establish the previous data, if any
-    device_table_->CmdPushConstants(command_buffer_info->handle,
-                                    pipeline_layout_,
-                                    VK_SHADER_STAGE_COMPUTE_BIT,
-                                    0,
-                                    sizeof(replacer_params_bda_t),
-                                    &replacer_params);
+    injected->CmdPushConstants(command_buffer_info->handle,
+                               pipeline_layout_,
+                               VK_SHADER_STAGE_COMPUTE_BIT,
+                               0,
+                               sizeof(replacer_params_bda_t),
+                               &replacer_params);
     // dispatch workgroups
     constexpr uint32_t wg_size = 32;
-    device_table_->CmdDispatch(command_buffer_info->handle, util::div_up(replacer_params.num_handles, wg_size), 1, 1);
+    injected->CmdDispatch(command_buffer_info->handle, util::div_up(replacer_params.num_handles, wg_size), 1, 1);
 
     // post memory-barrier
     for (const auto& buf : buffer_set)
@@ -2466,7 +2484,7 @@ void VulkanAddressReplacer::run_compute_replace(const VulkanCommandBufferInfo*  
 
         if (previous_pipeline != nullptr && previous_pipeline->handle != VK_NULL_HANDLE)
         {
-            device_table_->CmdBindPipeline(
+            injected->CmdBindPipeline(
                 command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, previous_pipeline->handle);
         }
     }
@@ -2474,18 +2492,19 @@ void VulkanAddressReplacer::run_compute_replace(const VulkanCommandBufferInfo*  
     // set previous push-constant data, if any
     if (!command_buffer_info->push_constant_data.empty())
     {
-        device_table_->CmdPushConstants(
-            command_buffer_info->handle,
-            command_buffer_info->push_constant_pipeline_layout,
-            command_buffer_info->push_constant_stage_flags,
-            0,
-            GFXRECON_NARROWING_CAST(uint32_t, command_buffer_info->push_constant_data.size()),
-            command_buffer_info->push_constant_data.data());
+        injected->CmdPushConstants(command_buffer_info->handle,
+                                   command_buffer_info->push_constant_pipeline_layout,
+                                   command_buffer_info->push_constant_stage_flags,
+                                   0,
+                                   GFXRECON_NARROWING_CAST(uint32_t, command_buffer_info->push_constant_data.size()),
+                                   command_buffer_info->push_constant_data.data());
     }
 }
 
 void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer)
 {
+    auto injected = device_table_->Open();
+
     // blacklist hashmap storage  >= 16 bytes * 2^12 slots (64kB)
     constexpr uint32_t hashmap_elem_size     = 2 * sizeof(VkDeviceSize);
     constexpr uint32_t hashmap_min_num_slots = 1U << 12U;
@@ -2533,8 +2552,8 @@ void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer
                              "GFXR VulkanAddressReplacer hashmap_storage_bda_binary_");
     };
 
-    auto init_storage = [this, hashmap_elem_size = hashmap_elem_size](VkCommandBuffer command_buffer) {
-        device_table_->CmdFillBuffer(
+    auto init_storage = [this, &injected, hashmap_elem_size = hashmap_elem_size](VkCommandBuffer command_buffer) {
+        injected->CmdFillBuffer(
             command_buffer, hashmap_storage_bda_binary_.buffer, 0, hashmap_storage_bda_binary_.num_bytes, 0);
         barrier(command_buffer,
                 hashmap_storage_bda_binary_.buffer,
@@ -2600,8 +2619,8 @@ void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer
             }
 
             // reset/submit/sync command-buffer
-            queue_submit_helper =
-                QueueSubmitHelper(device_table_, device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            queue_submit_helper = QueueSubmitHelper(
+                &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
             command_buffer = submit_asset_.command_buffer;
         }
 
@@ -2636,17 +2655,17 @@ void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer
             rehash_params.hashmap_old = hashmap_control_block_bda_binary_prev_.device_address;
             rehash_params.hashmap_new = hashmap_control_block_bda_binary_.device_address;
 
-            device_table_->CmdBindPipeline(
+            injected->CmdBindPipeline(
                 submit_asset_.command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_bda_rehash_);
-            device_table_->CmdPushConstants(submit_asset_.command_buffer,
-                                            pipeline_layout_,
-                                            VK_SHADER_STAGE_COMPUTE_BIT,
-                                            0,
-                                            sizeof(rehash_params_t),
-                                            &rehash_params);
+            injected->CmdPushConstants(submit_asset_.command_buffer,
+                                       pipeline_layout_,
+                                       VK_SHADER_STAGE_COMPUTE_BIT,
+                                       0,
+                                       sizeof(rehash_params_t),
+                                       &rehash_params);
             // dispatch workgroups
             constexpr uint32_t wg_size = 32;
-            device_table_->CmdDispatch(
+            injected->CmdDispatch(
                 submit_asset_.command_buffer, util::div_up(previous_control_block.capacity, wg_size), 1, 1);
         }
     }

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -251,7 +251,7 @@ VulkanAddressReplacer::VulkanAddressReplacer(const VulkanDeviceInfo*            
                                              const graphics::VulkanInjectedDeviceCalls& injected_calls,
                                              const graphics::VulkanInstanceTable*       instance_table,
                                              decode::CommonObjectInfoTable&             object_table) :
-    device_table_(injected_calls),
+    device_table_(std::make_unique<graphics::VulkanInjectedDeviceCalls>(injected_calls)),
     object_table_(&object_table)
 {
     GFXRECON_ASSERT(device_info != nullptr && instance_table != nullptr);
@@ -310,9 +310,9 @@ void VulkanAddressReplacer::SetRaytracingProperties(const decode::VulkanPhysical
 
 VulkanAddressReplacer::~VulkanAddressReplacer()
 {
-    if (!device_table_.has_value())
+    if (device_table_ == nullptr)
     {
-        // default-constructed or moved-from: nothing was created
+        // default-constructed or moved-from: nothing to destroy here
         return;
     }
     auto injected = device_table_->Open();
@@ -447,7 +447,7 @@ VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*     
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            device_table_.get(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         VulkanCommandBufferInfo fake_info = {};
         fake_info.handle                  = submit_asset_.command_buffer;
@@ -928,7 +928,7 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
     const decode::VulkanDeviceAddressTracker&                                                   address_tracker,
     const std::unordered_map<graphics::shader_group_handle_t, graphics::shader_group_handle_t>& group_handle_map)
 {
-    GFXRECON_ASSERT(device_table_.has_value());
+    GFXRECON_ASSERT(device_table_ != nullptr);
 
     // NOTE: we expect this map to be populated here, but not for older captures (before #1844) using trimming.
     if (group_handle_map.empty())
@@ -1231,7 +1231,7 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
     VkAccelerationStructureBuildRangeInfoKHR**   build_range_infos,
     VulkanDeviceAddressTracker&                  address_tracker)
 {
-    GFXRECON_ASSERT(device_table_.has_value());
+    GFXRECON_ASSERT(device_table_ != nullptr);
 
     auto injected = device_table_->Open();
 
@@ -1741,7 +1741,7 @@ void VulkanAddressReplacer::ProcessBuildVulkanAccelerationStructuresMetaCommand(
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            device_table_.get(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         // dummy-wrapper
         VulkanCommandBufferInfo command_buffer_info = {};
@@ -1765,7 +1765,7 @@ void VulkanAddressReplacer::ProcessCopyVulkanAccelerationStructuresMetaCommand(
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            device_table_.get(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         auto injected = device_table_->Open();
 
@@ -1803,7 +1803,7 @@ void VulkanAddressReplacer::ProcessVulkanAccelerationStructuresWritePropertiesMe
     // reset/submit/sync command-buffer
     {
         QueueSubmitHelper queue_submit_helper(
-            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            device_table_.get(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         ProcessCmdWriteAccelerationStructuresPropertiesKHR(
             1, &acceleration_structure, query_type, query_pool_, 0, address_tracker);
@@ -2246,7 +2246,7 @@ bool VulkanAddressReplacer::create_acceleration_asset(VulkanAddressReplacer::acc
     auto injected = device_table_->Open();
 
     as_asset.device         = device_;
-    as_asset.injected_calls = device_table_;
+    as_asset.injected_calls = *device_table_;
 
     // create a replacement acceleration-structure with proper sized buffer
     bool success = create_buffer(as_asset.storage,
@@ -2292,7 +2292,7 @@ bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
     // clear previous content and setup
     submit_asset.device         = device_;
     submit_asset.command_pool   = command_pool_;
-    submit_asset.injected_calls = device_table_;
+    submit_asset.injected_calls = *device_table_;
 
     if (submit_asset.command_buffer == VK_NULL_HANDLE)
     {
@@ -2616,7 +2616,7 @@ void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer
 
             // reset/submit/sync command-buffer
             queue_submit_helper = QueueSubmitHelper(
-                &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+                device_table_.get(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
             command_buffer = submit_asset_.command_buffer;
         }
 

--- a/framework/decode/vulkan_address_replacer.cpp
+++ b/framework/decode/vulkan_address_replacer.cpp
@@ -20,6 +20,7 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
+#include "graphics/vulkan_injected_calls.h"
 #include "graphics/vulkan_util.h"
 #include "graphics/vulkan_struct_get_pnext.h"
 #include "decode/vulkan_address_replacer.h"
@@ -37,11 +38,11 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 //! RAII helper submit a command-buffer to a queue and synchronize via fence
 struct QueueSubmitHelper
 {
-    const graphics::VulkanDeviceTable* device_table   = nullptr;
-    VkDevice                           device         = VK_NULL_HANDLE;
-    VkCommandBuffer                    command_buffer = VK_NULL_HANDLE;
-    VkFence                            fence          = VK_NULL_HANDLE;
-    VkQueue                            queue          = VK_NULL_HANDLE;
+    const graphics::VulkanInjectedDeviceCalls* device_table   = nullptr;
+    VkDevice                                   device         = VK_NULL_HANDLE;
+    VkCommandBuffer                            command_buffer = VK_NULL_HANDLE;
+    VkFence                                    fence          = VK_NULL_HANDLE;
+    VkQueue                                    queue          = VK_NULL_HANDLE;
 
     QueueSubmitHelper()                         = default;
     QueueSubmitHelper(const QueueSubmitHelper&) = delete;
@@ -52,33 +53,31 @@ struct QueueSubmitHelper
         swap(other);
         return *this;
     }
-    QueueSubmitHelper(const graphics::VulkanDeviceTable* device_table_,
-                      VkDevice                           device_,
-                      VkCommandBuffer                    command_buffer_,
-                      VkQueue                            queue_,
-                      VkFence                            fence_) :
+    QueueSubmitHelper(const graphics::VulkanInjectedDeviceCalls* device_table_,
+                      VkDevice                                   device_,
+                      VkCommandBuffer                            command_buffer_,
+                      VkQueue                                    queue_,
+                      VkFence                                    fence_) :
         device_table(device_table_),
         device(device_), command_buffer(command_buffer_), fence(fence_), queue(queue_)
     {
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-
-        device_table->ResetFences(device, 1, &fence);
+        auto injected = device_table_->Open();
+        injected->ResetFences(device, 1, &fence);
 
         VkCommandBufferBeginInfo command_buffer_begin_info;
         command_buffer_begin_info.sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
         command_buffer_begin_info.pNext            = nullptr;
         command_buffer_begin_info.flags            = 0;
         command_buffer_begin_info.pInheritanceInfo = nullptr;
-        device_table->BeginCommandBuffer(command_buffer, &command_buffer_begin_info);
+        injected.BeginCommandBuffer(command_buffer, &command_buffer_begin_info);
     }
 
     ~QueueSubmitHelper()
     {
         if (device_table != nullptr)
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-
-            device_table->EndCommandBuffer(command_buffer);
+            auto injected = device_table->Open();
+            injected->EndCommandBuffer(command_buffer);
 
             VkSubmitInfo submit_info         = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
             submit_info.pNext                = nullptr;
@@ -91,10 +90,10 @@ struct QueueSubmitHelper
             submit_info.pSignalSemaphores    = nullptr;
 
             // submit
-            device_table->QueueSubmit(queue, 1, &submit_info, fence);
+            injected->QueueSubmit(queue, 1, &submit_info, fence);
 
             // sync
-            device_table->WaitForFences(device, 1, &fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
+            injected->WaitForFences(device, 1, &fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
         }
     }
 
@@ -173,6 +172,10 @@ decode::VulkanAddressReplacer::buffer_context_t::~buffer_context_t()
 {
     if (resource_allocator != nullptr)
     {
+        // allocator-internal Vulkan calls below are replay-injected; destruction can run outside
+        // any caller-provided scope (e.g. from member-destruction), so mark it here
+        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+
         if (buffer != VK_NULL_HANDLE)
         {
             // unmap/destroy buffer
@@ -195,9 +198,10 @@ decode::VulkanAddressReplacer::buffer_context_t::~buffer_context_t()
 
 decode::VulkanAddressReplacer::acceleration_structure_asset_t::~acceleration_structure_asset_t()
 {
-    if (handle != VK_NULL_HANDLE && destroy_fn != nullptr && device != VK_NULL_HANDLE)
+    if (handle != VK_NULL_HANDLE && injected_calls.has_value() && device != VK_NULL_HANDLE)
     {
-        destroy_fn(device, handle, nullptr);
+        auto injected = injected_calls->Open();
+        injected->DestroyAccelerationStructureKHR(device, handle, nullptr);
     }
 }
 
@@ -220,49 +224,51 @@ void decode::VulkanAddressReplacer::submit_asset_t::swap(submit_asset_t& other) 
     std::swap(command_buffer, other.command_buffer);
     std::swap(fence, other.fence);
     std::swap(signal_semaphore, other.signal_semaphore);
-    std::swap(destroy_fence_fn, other.destroy_fence_fn);
-    std::swap(free_command_buffers_fn, other.free_command_buffers_fn);
-    std::swap(destroy_semaphore_fn, other.destroy_semaphore_fn);
+    std::swap(injected_calls, other.injected_calls);
 }
 
 decode::VulkanAddressReplacer::submit_asset_t::~submit_asset_t()
 {
-    if (device != VK_NULL_HANDLE)
+    if (device != VK_NULL_HANDLE && injected_calls.has_value())
     {
-        if (destroy_fence_fn != nullptr && fence != VK_NULL_HANDLE)
+        auto injected = injected_calls->Open();
+        if (fence != VK_NULL_HANDLE)
         {
-            destroy_fence_fn(device, fence, nullptr);
+            injected->DestroyFence(device, fence, nullptr);
         }
-        if (free_command_buffers_fn != nullptr && command_buffer != VK_NULL_HANDLE)
+        if (command_buffer != VK_NULL_HANDLE)
         {
-            free_command_buffers_fn(device, command_pool, 1, &command_buffer);
+            injected->FreeCommandBuffers(device, command_pool, 1, &command_buffer);
         }
-        if (destroy_semaphore_fn != nullptr && signal_semaphore.semaphore != VK_NULL_HANDLE)
+        if (signal_semaphore.semaphore != VK_NULL_HANDLE)
         {
-            destroy_semaphore_fn(device, signal_semaphore.semaphore, nullptr);
+            injected->DestroySemaphore(device, signal_semaphore.semaphore, nullptr);
         }
     }
 }
 
-VulkanAddressReplacer::VulkanAddressReplacer(const VulkanDeviceInfo*              device_info,
-                                             const graphics::VulkanDeviceTable*   device_table,
-                                             const graphics::VulkanInstanceTable* instance_table,
-                                             decode::CommonObjectInfoTable&       object_table) :
-    device_table_(device_table),
+VulkanAddressReplacer::VulkanAddressReplacer(const VulkanDeviceInfo*                    device_info,
+                                             const graphics::VulkanInjectedDeviceCalls& injected_calls,
+                                             const graphics::VulkanInstanceTable*       instance_table,
+                                             decode::CommonObjectInfoTable&             object_table) :
+    device_table_(injected_calls),
     object_table_(&object_table)
 {
-    GFXRECON_ASSERT(device_info != nullptr && device_table != nullptr && instance_table != nullptr);
+    GFXRECON_ASSERT(device_info != nullptr && instance_table != nullptr);
+
+    auto injected = device_table_->Open();
+
     physical_device_info_ = object_table.GetVkPhysicalDeviceInfo(device_info->parent_id);
     GFXRECON_ASSERT(physical_device_info_ != nullptr);
     device_                = device_info->handle;
     resource_allocator_    = device_info->allocator.get();
     get_device_address_fn_ = physical_device_info_->parent_info.api_version >= VK_API_VERSION_1_2
-                                 ? device_table->GetBufferDeviceAddress
-                                 : device_table->GetBufferDeviceAddressKHR;
+                                 ? injected.GetTable()->GetBufferDeviceAddress
+                                 : injected.GetTable()->GetBufferDeviceAddressKHR;
 
     get_physical_device_properties_fn_ = instance_table->GetPhysicalDeviceProperties2;
     set_debug_utils_object_name_fn_    = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(
-        device_table_->GetDeviceProcAddr(device_, "vkSetDebugUtilsObjectNameEXT"));
+        injected->GetDeviceProcAddr(device_, "vkSetDebugUtilsObjectNameEXT"));
     SetRaytracingProperties(physical_device_info_);
 }
 
@@ -304,7 +310,12 @@ void VulkanAddressReplacer::SetRaytracingProperties(const decode::VulkanPhysical
 
 VulkanAddressReplacer::~VulkanAddressReplacer()
 {
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+    if (!device_table_.has_value())
+    {
+        // default-constructed or moved-from: nothing was created
+        return;
+    }
+    auto injected = device_table_->Open();
 
     // explicitly free resources here, in order to mark destruction API-calls as injected
     pipeline_context_map_.clear();
@@ -316,27 +327,27 @@ VulkanAddressReplacer::~VulkanAddressReplacer()
 
     if (pipeline_bda_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyPipeline(device_, pipeline_bda_, nullptr);
+        injected->DestroyPipeline(device_, pipeline_bda_, nullptr);
     }
     if (pipeline_bda_rehash_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyPipeline(device_, pipeline_bda_rehash_, nullptr);
+        injected->DestroyPipeline(device_, pipeline_bda_rehash_, nullptr);
     }
     if (pipeline_sbt_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyPipeline(device_, pipeline_sbt_, nullptr);
+        injected->DestroyPipeline(device_, pipeline_sbt_, nullptr);
     }
     if (pipeline_layout_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyPipelineLayout(device_, pipeline_layout_, nullptr);
+        injected->DestroyPipelineLayout(device_, pipeline_layout_, nullptr);
     }
     if (query_pool_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyQueryPool(device_, query_pool_, nullptr);
+        injected->DestroyQueryPool(device_, query_pool_, nullptr);
     }
     if (command_pool_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyCommandPool(device_, command_pool_, nullptr);
+        injected->DestroyCommandPool(device_, command_pool_, nullptr);
     }
 }
 
@@ -351,6 +362,8 @@ VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*     
         // nothing to replace
         return graphics::VulkanSemaphore{ VK_NULL_HANDLE };
     }
+
+    auto injected = device_table_->Open();
 
     GFXRECON_LOG_INFO_ONCE("VulkanAddressReplacer::UpdateBufferAddresses(): Replay is adjusting "
                            "buffer-device-addresses in-place using a compute-dispatch");
@@ -382,20 +395,20 @@ VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*     
                 return graphics::VulkanSemaphore{ VK_NULL_HANDLE };
             }
 
-            device_table_->ResetFences(device_, 1, &submit_asset.fence);
+            injected->ResetFences(device_, 1, &submit_asset.fence);
 
             VkCommandBufferBeginInfo command_buffer_begin_info;
             command_buffer_begin_info.sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
             command_buffer_begin_info.pNext            = nullptr;
             command_buffer_begin_info.flags            = 0;
             command_buffer_begin_info.pInheritanceInfo = nullptr;
-            device_table_->BeginCommandBuffer(submit_asset.command_buffer, &command_buffer_begin_info);
+            injected.BeginCommandBuffer(submit_asset.command_buffer, &command_buffer_begin_info);
 
             VulkanCommandBufferInfo fake_info = {};
             fake_info.handle                  = submit_asset.command_buffer;
             run_compute_replace(&fake_info, addresses_to_replace, address_tracker, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 
-            device_table_->EndCommandBuffer(submit_asset.command_buffer);
+            injected->EndCommandBuffer(submit_asset.command_buffer);
 
             std::vector<VkSemaphore>          semaphore_handles(wait_semaphores.size());
             std::vector<uint64_t>             semaphore_values(wait_semaphores.size());
@@ -424,7 +437,7 @@ VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*     
             submit_info.pSignalSemaphores    = &submit_asset.signal_semaphore.semaphore;
 
             // submit
-            device_table_->QueueSubmit(queue_, 1, &submit_info, submit_asset.fence);
+            injected->QueueSubmit(queue_, 1, &submit_info, submit_asset.fence);
 
             // return signal-semaphore
             return submit_asset.signal_semaphore;
@@ -434,7 +447,7 @@ VulkanAddressReplacer::UpdateBufferAddresses(const VulkanCommandBufferInfo*     
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            device_table_, device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         VulkanCommandBufferInfo fake_info = {};
         fake_info.handle                  = submit_asset_.command_buffer;
@@ -703,13 +716,14 @@ void VulkanAddressReplacer::ProcessCmdBindPipeline(VulkanCommandBufferInfo*     
         GFXRECON_LOG_INFO_ONCE("VulkanAddressReplacer::ProcessCmdBindPipeline(): Replay is re-issuing "
                                "push-constants to patch buffer-device-addresses recorded before pipeline bind");
 
-        util::MarkInjectedCommandsHelper injected_commands_helper;
-        device_table_->CmdPushConstants(command_buffer_info->handle,
-                                        command_buffer_info->push_constant_pipeline_layout,
-                                        command_buffer_info->push_constant_stage_flags,
-                                        0,
-                                        static_cast<uint32_t>(push_constant_copy.size()),
-                                        push_constant_copy.data());
+        auto injected = device_table_->Open();
+        auto label    = device_table_->Label(injected, command_buffer_info->handle, "Address replacer");
+        injected->CmdPushConstants(command_buffer_info->handle,
+                                   command_buffer_info->push_constant_pipeline_layout,
+                                   command_buffer_info->push_constant_stage_flags,
+                                   0,
+                                   static_cast<uint32_t>(push_constant_copy.size()),
+                                   push_constant_copy.data());
         command_buffer_info->push_constant_data = std::move(push_constant_copy);
     }
 }
@@ -727,6 +741,8 @@ void VulkanAddressReplacer::ProcessCmdBindDescriptorSets(VulkanCommandBufferInfo
     {
         return;
     };
+
+    auto injected = device_table_->Open();
 
     std::map<std::pair<VkDescriptorSet, uint32_t>, VkWriteDescriptorSetInlineUniformBlock> sets_requiring_update;
 
@@ -796,14 +812,12 @@ void VulkanAddressReplacer::ProcessCmdBindDescriptorSets(VulkanCommandBufferInfo
                 else
                 {
                     // patch an existing uniform-buffer and retrieve a buffer-address for it
-                    util::BeginInjectedCommands();
                     VkBufferDeviceAddressInfo address_info = {};
                     address_info.sType                     = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
                     address_info.buffer                    = buffer_info->handle;
                     buffer_info->capture_address           = buffer_info->replay_address =
                         get_device_address_fn_(device_, &address_info);
                     GFXRECON_ASSERT(buffer_info->replay_address != 0);
-                    util::EndInjectedCommands();
 
                     // track newly acquired buffer/address
                     address_tracker.TrackBuffer(buffer_info);
@@ -889,13 +903,11 @@ void VulkanAddressReplacer::ProcessCmdBindDescriptorSets(VulkanCommandBufferInfo
 
     if (!descriptor_updates.empty())
     {
-        // mark injected commands
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        device_table_->UpdateDescriptorSets(device_,
-                                            GFXRECON_NARROWING_CAST(uint32_t, descriptor_updates.size()),
-                                            descriptor_updates.data(),
-                                            0,
-                                            nullptr);
+        injected->UpdateDescriptorSets(device_,
+                                       GFXRECON_NARROWING_CAST(uint32_t, descriptor_updates.size()),
+                                       descriptor_updates.data(),
+                                       0,
+                                       nullptr);
     }
 
     if (!command_buffer_info->in_rendering_scope)
@@ -916,7 +928,7 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
     const decode::VulkanDeviceAddressTracker&                                                   address_tracker,
     const std::unordered_map<graphics::shader_group_handle_t, graphics::shader_group_handle_t>& group_handle_map)
 {
-    GFXRECON_ASSERT(device_table_ != nullptr);
+    GFXRECON_ASSERT(device_table_.has_value());
 
     // NOTE: we expect this map to be populated here, but not for older captures (before #1844) using trimming.
     if (group_handle_map.empty())
@@ -982,8 +994,7 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
 
     if (!valid_sbt_alignment_ || !valid_group_handles)
     {
-        // mark injected commands
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+        auto injected = device_table_->Open();
 
         if (pipeline_sbt_ == VK_NULL_HANDLE)
         {
@@ -1158,19 +1169,19 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
             GFXRECON_ASSERT(out_index == num_addresses);
         }
 
-        device_table_->CmdBindPipeline(command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_sbt_);
+        auto label = device_table_->Label(injected, command_buffer_info->handle, "Address replacer");
+        injected->CmdBindPipeline(command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_sbt_);
 
         // NOTE: using push-constants here requires us to re-establish the previous data, if any
-        device_table_->CmdPushConstants(command_buffer_info->handle,
-                                        pipeline_layout_,
-                                        VK_SHADER_STAGE_COMPUTE_BIT,
-                                        0,
-                                        sizeof(replacer_params_sbt_t),
-                                        &replacer_params);
+        injected->CmdPushConstants(command_buffer_info->handle,
+                                   pipeline_layout_,
+                                   VK_SHADER_STAGE_COMPUTE_BIT,
+                                   0,
+                                   sizeof(replacer_params_sbt_t),
+                                   &replacer_params);
         // run a single workgroup
         constexpr uint32_t wg_size = 32;
-        device_table_->CmdDispatch(
-            command_buffer_info->handle, util::div_up(replacer_params.num_handles, wg_size), 1, 1);
+        injected->CmdDispatch(command_buffer_info->handle, util::div_up(replacer_params.num_handles, wg_size), 1, 1);
 
         // post memory-barrier
         for (const auto& buf : buffer_set)
@@ -1194,7 +1205,7 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
                 GFXRECON_LOG_INFO_ONCE(
                     "VulkanAddressReplacer::ProcessCmdTraceRays: Replay is injecting compute-dispatches, "
                     "originally bound compute-pipelines are restored.");
-                device_table_->CmdBindPipeline(
+                injected->CmdBindPipeline(
                     command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, previous_pipeline->handle);
             }
         }
@@ -1202,7 +1213,7 @@ void VulkanAddressReplacer::ProcessCmdTraceRays(
         // set previous push-constant data, if any
         if (!command_buffer_info->push_constant_data.empty())
         {
-            device_table_->CmdPushConstants(
+            injected->CmdPushConstants(
                 command_buffer_info->handle,
                 command_buffer_info->push_constant_pipeline_layout,
                 command_buffer_info->push_constant_stage_flags,
@@ -1220,7 +1231,9 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
     VkAccelerationStructureBuildRangeInfoKHR**   build_range_infos,
     VulkanDeviceAddressTracker&                  address_tracker)
 {
-    GFXRECON_ASSERT(device_table_ != nullptr);
+    GFXRECON_ASSERT(device_table_.has_value());
+
+    auto injected = device_table_->Open();
 
     bool force_replace = false;
 
@@ -1276,12 +1289,11 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                     primitive_counts[j] = range_infos[j].primitiveCount;
                 }
 
-                util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-                device_table_->GetAccelerationStructureBuildSizesKHR(device_,
-                                                                     VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
-                                                                     &build_geometry_info,
-                                                                     primitive_counts.data(),
-                                                                     &build_size_info);
+                injected->GetAccelerationStructureBuildSizesKHR(device_,
+                                                                VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
+                                                                &build_geometry_info,
+                                                                primitive_counts.data(),
+                                                                &build_size_info);
             }
 
             bool as_buffer_usable = false;
@@ -1346,7 +1358,6 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
 
             if (!as_buffer_usable || !scratch_buffer_usable)
             {
-                util::MarkInjectedCommandsHelper mark_injected_commands_helper;
                 GFXRECON_LOG_INFO_ONCE(
                     "VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR: Replay is adjusting "
                     "acceleration-structures using shadow-structures and -buffers");
@@ -1364,7 +1375,6 @@ void VulkanAddressReplacer::ProcessCmdBuildAccelerationStructuresKHR(
                     if (stale_shadow_as_it != shadow_as_map_.end() &&
                         stale_shadow_as_it->second.origin_handle != build_geometry_info.dstAccelerationStructure)
                     {
-                        util::MarkInjectedCommandsHelper mark_injected_commands_helper_erase;
                         shadow_as_map_.erase(stale_shadow_as_it);
                     }
 
@@ -1731,7 +1741,7 @@ void VulkanAddressReplacer::ProcessBuildVulkanAccelerationStructuresMetaCommand(
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            device_table_, device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         // dummy-wrapper
         VulkanCommandBufferInfo command_buffer_info = {};
@@ -1740,8 +1750,8 @@ void VulkanAddressReplacer::ProcessBuildVulkanAccelerationStructuresMetaCommand(
             &command_buffer_info, info_count, geometry_infos, range_infos, address_tracker);
 
         // issue build-command
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        device_table_->CmdBuildAccelerationStructuresKHR(
+        auto injected = device_table_->Open();
+        injected->CmdBuildAccelerationStructuresKHR(
             submit_asset_.command_buffer, info_count, geometry_infos, range_infos);
     }
 }
@@ -1755,7 +1765,9 @@ void VulkanAddressReplacer::ProcessCopyVulkanAccelerationStructuresMetaCommand(
     {
         // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            device_table_, device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+
+        auto injected = device_table_->Open();
 
         for (uint32_t i = 0; i < info_count; ++i)
         {
@@ -1766,8 +1778,7 @@ void VulkanAddressReplacer::ProcessCopyVulkanAccelerationStructuresMetaCommand(
                 ProcessCmdCopyAccelerationStructuresKHR(copy_info, address_tracker);
 
                 // issue copy command
-                util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-                device_table_->CmdCopyAccelerationStructureKHR(submit_asset_.command_buffer, copy_info);
+                injected->CmdCopyAccelerationStructureKHR(submit_asset_.command_buffer, copy_info);
             }
             else
             {
@@ -1787,33 +1798,33 @@ void VulkanAddressReplacer::ProcessVulkanAccelerationStructuresWritePropertiesMe
         return;
     }
 
+    auto injected = device_table_->Open();
+
+    // reset/submit/sync command-buffer
     {
-        // reset/submit/sync command-buffer
         QueueSubmitHelper queue_submit_helper(
-            device_table_, device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
 
         ProcessCmdWriteAccelerationStructuresPropertiesKHR(
             1, &acceleration_structure, query_type, query_pool_, 0, address_tracker);
 
         // issue vkCmdResetQueryPool and vkCmdWriteAccelerationStructuresPropertiesKHR
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        device_table_->CmdResetQueryPool(submit_asset_.command_buffer, query_pool_, 0, 1);
-        device_table_->CmdWriteAccelerationStructuresPropertiesKHR(
+        injected->CmdResetQueryPool(submit_asset_.command_buffer, query_pool_, 0, 1);
+        injected->CmdWriteAccelerationStructuresPropertiesKHR(
             submit_asset_.command_buffer, 1, &acceleration_structure, query_type, query_pool_, 0);
     }
 
     VkDeviceSize compact_size = 0;
 
     // the above command-buffer is already synced here, retrieve result using vkGetQueryPoolResults
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-    device_table_->GetQueryPoolResults(device_,
-                                       query_pool_,
-                                       0,
-                                       1,
-                                       sizeof(VkDeviceSize),
-                                       &compact_size,
-                                       sizeof(VkDeviceSize),
-                                       VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+    injected->GetQueryPoolResults(device_,
+                                  query_pool_,
+                                  0,
+                                  1,
+                                  sizeof(VkDeviceSize),
+                                  &compact_size,
+                                  sizeof(VkDeviceSize),
+                                  VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
 
     // apply usual post-processing of queries
     ProcessGetQueryPoolResults(device_,
@@ -1833,6 +1844,9 @@ bool VulkanAddressReplacer::init_pipeline()
         // assume already initialized
         return true;
     }
+
+    auto injected = device_table_->Open();
+
     VkPushConstantRange push_constant_range = {};
     push_constant_range.stageFlags          = VK_SHADER_STAGE_COMPUTE_BIT;
     push_constant_range.offset              = 0;
@@ -1847,14 +1861,15 @@ bool VulkanAddressReplacer::init_pipeline()
     pipeline_layout_info.pushConstantRangeCount     = 1;
     pipeline_layout_info.pPushConstantRanges        = &push_constant_range;
 
-    VkResult result = device_table_->CreatePipelineLayout(device_, &pipeline_layout_info, nullptr, &pipeline_layout_);
+    VkResult result = injected->CreatePipelineLayout(device_, &pipeline_layout_info, nullptr, &pipeline_layout_);
 
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_FATAL("VulkanAddressReplacer: failed in vkCreatePipelineLayout");
     }
 
-    auto create_pipeline = [this](VkPipelineLayout layout, const auto& spirv, VkPipeline& out_pipeline) -> VkResult {
+    auto create_pipeline =
+        [this, &injected](VkPipelineLayout layout, const auto& spirv, VkPipeline& out_pipeline) -> VkResult {
         using elem_t                                       = typename std::decay_t<decltype(spirv)>::value_type;
         VkShaderModule           compute_module            = VK_NULL_HANDLE;
         VkShaderModuleCreateInfo shader_module_create_info = {};
@@ -1864,8 +1879,7 @@ bool VulkanAddressReplacer::init_pipeline()
         shader_module_create_info.codeSize                 = spirv.size() * sizeof(elem_t);
         shader_module_create_info.pCode                    = reinterpret_cast<const uint32_t*>(spirv.data());
 
-        VkResult result =
-            device_table_->CreateShaderModule(device_, &shader_module_create_info, nullptr, &compute_module);
+        VkResult result = injected->CreateShaderModule(device_, &shader_module_create_info, nullptr, &compute_module);
 
         if (result != VK_SUCCESS)
         {
@@ -1886,7 +1900,7 @@ bool VulkanAddressReplacer::init_pipeline()
         pipeline_create_info.layout                      = layout;
         pipeline_create_info.stage                       = stage_info;
 
-        result = device_table_->CreateComputePipelines(
+        result = injected->CreateComputePipelines(
             device_, VK_NULL_HANDLE, 1, &pipeline_create_info, VK_NULL_HANDLE, &out_pipeline);
 
         if (result != VK_SUCCESS)
@@ -1906,7 +1920,7 @@ bool VulkanAddressReplacer::init_pipeline()
 
         if (compute_module != VK_NULL_HANDLE)
         {
-            device_table_->DestroyShaderModule(device_, compute_module, nullptr);
+            injected->DestroyShaderModule(device_, compute_module, nullptr);
         }
 
         return result;
@@ -1939,20 +1953,22 @@ bool VulkanAddressReplacer::init_queue_assets()
         return true;
     };
 
+    auto injected = device_table_->Open();
+
     VkCommandPoolCreateInfo create_info = {};
     create_info.sType                   = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
     create_info.pNext                   = nullptr;
     create_info.flags                   = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     create_info.queueFamilyIndex        = 0;
 
-    VkResult result = device_table_->CreateCommandPool(device_, &create_info, nullptr, &command_pool_);
+    VkResult result = injected->CreateCommandPool(device_, &create_info, nullptr, &command_pool_);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal command-pool creation failed");
         return false;
     }
 
-    device_table_->GetDeviceQueue(device_, 0, 0, &queue_);
+    injected->GetDeviceQueue(device_, 0, 0, &queue_);
     GFXRECON_ASSERT(queue_ != VK_NULL_HANDLE);
 
     bool submit_asset_created = create_submit_asset(submit_asset_);
@@ -1966,6 +1982,8 @@ bool VulkanAddressReplacer::init_as_compact_query_pool()
         return true;
     }
 
+    auto injected = device_table_->Open();
+
     VkQueryPoolCreateInfo pool_info;
     pool_info.sType              = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
     pool_info.pNext              = nullptr;
@@ -1973,7 +1991,7 @@ bool VulkanAddressReplacer::init_as_compact_query_pool()
     pool_info.queryType          = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR;
     pool_info.queryCount         = 1;
     pool_info.pipelineStatistics = 0;
-    if (device_table_->CreateQueryPool(device_, &pool_info, nullptr, &query_pool_) != VK_SUCCESS)
+    if (injected->CreateQueryPool(device_, &pool_info, nullptr, &query_pool_) != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal query-pool creation failed");
         return false;
@@ -2000,6 +2018,8 @@ bool VulkanAddressReplacer::create_buffer(VulkanAddressReplacer::buffer_context_
         return true;
     }
 
+    auto injected = device_table_->Open();
+
     // free previous resources
     buffer_context                    = {};
     buffer_context.resource_allocator = resource_allocator_;
@@ -2022,7 +2042,7 @@ bool VulkanAddressReplacer::create_buffer(VulkanAddressReplacer::buffer_context_
     }
 
     VkMemoryRequirements memory_requirements;
-    device_table_->GetBufferMemoryRequirements(device_, buffer_context.buffer, &memory_requirements);
+    injected->GetBufferMemoryRequirements(device_, buffer_context.buffer, &memory_requirements);
 
     VkMemoryPropertyFlags memory_property_flags =
         use_host_mem ? VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
@@ -2114,7 +2134,9 @@ void VulkanAddressReplacer::barrier(VkCommandBuffer      command_buffer,
     barrier.srcAccessMask                                     = src_access;
     barrier.dstAccessMask                                     = dst_access;
 
-    device_table_->CmdPipelineBarrier(
+    auto injected = device_table_->Open();
+    auto label    = device_table_->Label(injected, command_buffer, "Address replacer");
+    injected->CmdPipelineBarrier(
         command_buffer, src_stage, dst_stage, VkDependencyFlags(0), 0, nullptr, 1, &barrier, 0, nullptr);
 }
 
@@ -2158,7 +2180,6 @@ void VulkanAddressReplacer::DestroyShadowResources(
         auto remove_shadow_as_it = shadow_as_map_.find(acceleration_structure_info->replay_address);
         if (remove_shadow_as_it != shadow_as_map_.end())
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             shadow_as_map_.erase(remove_shadow_as_it);
         }
 
@@ -2166,7 +2187,6 @@ void VulkanAddressReplacer::DestroyShadowResources(
         auto remove_scratch_it = shadow_scratch_map_.find(acceleration_structure_info->handle);
         if (remove_scratch_it != shadow_scratch_map_.end())
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             shadow_scratch_map_.erase(remove_scratch_it);
         }
     }
@@ -2187,7 +2207,6 @@ void VulkanAddressReplacer::DestroyShadowResources(const VulkanBufferInfo*      
                 auto remove_shadow_as_it = shadow_as_map_.find(replay_address_it->second);
                 if (remove_shadow_as_it != shadow_as_map_.end())
                 {
-                    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
                     shadow_as_map_.erase(remove_shadow_as_it);
                 }
             }
@@ -2202,21 +2221,18 @@ void VulkanAddressReplacer::DestroyShadowResources(VkCommandBuffer handle)
         auto shadow_sbt_it = shadow_sbt_map_.find(handle);
         if (shadow_sbt_it != shadow_sbt_map_.end())
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             shadow_sbt_map_.erase(shadow_sbt_it);
         }
 
         auto pipeline_sbt_it = pipeline_context_map_.find(handle);
         if (pipeline_sbt_it != pipeline_context_map_.end())
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             pipeline_context_map_.erase(pipeline_sbt_it);
         }
 
         auto submit_asset_it = submit_asset_map_.find(handle);
         if (submit_asset_it != submit_asset_map_.end())
         {
-            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
             submit_asset_map_.erase(submit_asset_it);
         }
     }
@@ -2227,8 +2243,10 @@ bool VulkanAddressReplacer::create_acceleration_asset(VulkanAddressReplacer::acc
                                                       size_t num_buffer_bytes,
                                                       size_t num_scratch_bytes)
 {
-    as_asset.device     = device_;
-    as_asset.destroy_fn = device_table_->DestroyAccelerationStructureKHR;
+    auto injected = device_table_->Open();
+
+    as_asset.device         = device_;
+    as_asset.injected_calls = device_table_;
 
     // create a replacement acceleration-structure with proper sized buffer
     bool success = create_buffer(as_asset.storage,
@@ -2251,7 +2269,7 @@ bool VulkanAddressReplacer::create_acceleration_asset(VulkanAddressReplacer::acc
     as_create_info.size                                 = num_buffer_bytes;
     as_create_info.type                                 = type;
 
-    VkResult res = device_table_->CreateAccelerationStructureKHR(device_, &as_create_info, nullptr, &as_asset.handle);
+    VkResult res = injected->CreateAccelerationStructureKHR(device_, &as_create_info, nullptr, &as_asset.handle);
 
     if (res != VK_SUCCESS || as_asset.handle == VK_NULL_HANDLE)
     {
@@ -2262,19 +2280,19 @@ bool VulkanAddressReplacer::create_acceleration_asset(VulkanAddressReplacer::acc
     VkAccelerationStructureDeviceAddressInfoKHR acceleration_address_info = {};
     acceleration_address_info.sType                 = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
     acceleration_address_info.accelerationStructure = as_asset.handle;
-    as_asset.address = device_table_->GetAccelerationStructureDeviceAddressKHR(device_, &acceleration_address_info);
+    as_asset.address = injected->GetAccelerationStructureDeviceAddressKHR(device_, &acceleration_address_info);
     GFXRECON_ASSERT(as_asset.address != 0);
     return true;
 }
 
 bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
 {
+    auto injected = device_table_->Open();
+
     // clear previous content and setup
-    submit_asset.device                  = device_;
-    submit_asset.command_pool            = command_pool_;
-    submit_asset.destroy_fence_fn        = device_table_->DestroyFence;
-    submit_asset.free_command_buffers_fn = device_table_->FreeCommandBuffers;
-    submit_asset.destroy_semaphore_fn    = device_table_->DestroySemaphore;
+    submit_asset.device         = device_;
+    submit_asset.command_pool   = command_pool_;
+    submit_asset.injected_calls = device_table_;
 
     if (submit_asset.command_buffer == VK_NULL_HANDLE)
     {
@@ -2284,7 +2302,7 @@ bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
         alloc_info.commandPool                 = command_pool_;
         alloc_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
         alloc_info.commandBufferCount          = 1;
-        VkResult result = device_table_->AllocateCommandBuffers(device_, &alloc_info, &submit_asset.command_buffer);
+        VkResult result = injected->AllocateCommandBuffers(device_, &alloc_info, &submit_asset.command_buffer);
         if (result != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal command-buffer creation failed");
@@ -2302,7 +2320,7 @@ bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
         fence_create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
         fence_create_info.pNext = nullptr;
         fence_create_info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-        VkResult result         = device_table_->CreateFence(device_, &fence_create_info, nullptr, &submit_asset.fence);
+        VkResult result         = injected->CreateFence(device_, &fence_create_info, nullptr, &submit_asset.fence);
         if (result != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR("VulkanAddressReplacer: internal fence creation failed");
@@ -2315,7 +2333,7 @@ bool VulkanAddressReplacer::create_submit_asset(submit_asset_t& submit_asset)
     {
         VkSemaphoreCreateInfo semaphore_create_info = {};
         semaphore_create_info.sType                 = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-        VkResult result                             = device_table_->CreateSemaphore(
+        VkResult result                             = injected->CreateSemaphore(
             device_, &semaphore_create_info, nullptr, &submit_asset.signal_semaphore.semaphore);
         if (result != VK_SUCCESS)
         {
@@ -2351,8 +2369,7 @@ void VulkanAddressReplacer::run_compute_replace(const VulkanCommandBufferInfo*  
         }
     }
 
-    // mark injected commands
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+    auto injected = device_table_->Open();
 
     if (pipeline_bda_ == VK_NULL_HANDLE && !init_pipeline())
     {
@@ -2421,18 +2438,19 @@ void VulkanAddressReplacer::run_compute_replace(const VulkanCommandBufferInfo*  
                 VK_ACCESS_SHADER_WRITE_BIT);
     }
 
-    device_table_->CmdBindPipeline(command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_bda_);
+    auto label = device_table_->Label(injected, command_buffer_info->handle, "Address replacer");
+    injected->CmdBindPipeline(command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_bda_);
 
     // NOTE: using push-constants here requires us to re-establish the previous data, if any
-    device_table_->CmdPushConstants(command_buffer_info->handle,
-                                    pipeline_layout_,
-                                    VK_SHADER_STAGE_COMPUTE_BIT,
-                                    0,
-                                    sizeof(replacer_params_bda_t),
-                                    &replacer_params);
+    injected->CmdPushConstants(command_buffer_info->handle,
+                               pipeline_layout_,
+                               VK_SHADER_STAGE_COMPUTE_BIT,
+                               0,
+                               sizeof(replacer_params_bda_t),
+                               &replacer_params);
     // dispatch workgroups
     constexpr uint32_t wg_size = 32;
-    device_table_->CmdDispatch(command_buffer_info->handle, util::div_up(replacer_params.num_handles, wg_size), 1, 1);
+    injected->CmdDispatch(command_buffer_info->handle, util::div_up(replacer_params.num_handles, wg_size), 1, 1);
 
     // post memory-barrier
     for (const auto& buf : buffer_set)
@@ -2462,7 +2480,7 @@ void VulkanAddressReplacer::run_compute_replace(const VulkanCommandBufferInfo*  
 
         if (previous_pipeline != nullptr && previous_pipeline->handle != VK_NULL_HANDLE)
         {
-            device_table_->CmdBindPipeline(
+            injected->CmdBindPipeline(
                 command_buffer_info->handle, VK_PIPELINE_BIND_POINT_COMPUTE, previous_pipeline->handle);
         }
     }
@@ -2470,18 +2488,19 @@ void VulkanAddressReplacer::run_compute_replace(const VulkanCommandBufferInfo*  
     // set previous push-constant data, if any
     if (!command_buffer_info->push_constant_data.empty())
     {
-        device_table_->CmdPushConstants(
-            command_buffer_info->handle,
-            command_buffer_info->push_constant_pipeline_layout,
-            command_buffer_info->push_constant_stage_flags,
-            0,
-            GFXRECON_NARROWING_CAST(uint32_t, command_buffer_info->push_constant_data.size()),
-            command_buffer_info->push_constant_data.data());
+        injected->CmdPushConstants(command_buffer_info->handle,
+                                   command_buffer_info->push_constant_pipeline_layout,
+                                   command_buffer_info->push_constant_stage_flags,
+                                   0,
+                                   GFXRECON_NARROWING_CAST(uint32_t, command_buffer_info->push_constant_data.size()),
+                                   command_buffer_info->push_constant_data.data());
     }
 }
 
 void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer)
 {
+    auto injected = device_table_->Open();
+
     // blacklist hashmap storage  >= 16 bytes * 2^12 slots (64kB)
     constexpr uint32_t hashmap_elem_size     = 2 * sizeof(VkDeviceSize);
     constexpr uint32_t hashmap_min_num_slots = 1U << 12U;
@@ -2529,8 +2548,8 @@ void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer
                              "GFXR VulkanAddressReplacer hashmap_storage_bda_binary_");
     };
 
-    auto init_storage = [this, hashmap_elem_size = hashmap_elem_size](VkCommandBuffer command_buffer) {
-        device_table_->CmdFillBuffer(
+    auto init_storage = [this, &injected, hashmap_elem_size = hashmap_elem_size](VkCommandBuffer command_buffer) {
+        injected->CmdFillBuffer(
             command_buffer, hashmap_storage_bda_binary_.buffer, 0, hashmap_storage_bda_binary_.num_bytes, 0);
         barrier(command_buffer,
                 hashmap_storage_bda_binary_.buffer,
@@ -2596,8 +2615,8 @@ void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer
             }
 
             // reset/submit/sync command-buffer
-            queue_submit_helper =
-                QueueSubmitHelper(device_table_, device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
+            queue_submit_helper = QueueSubmitHelper(
+                &device_table_.value(), device_, submit_asset_.command_buffer, queue_, submit_asset_.fence);
             command_buffer = submit_asset_.command_buffer;
         }
 
@@ -2632,17 +2651,17 @@ void VulkanAddressReplacer::update_global_hashmap(VkCommandBuffer command_buffer
             rehash_params.hashmap_old = hashmap_control_block_bda_binary_prev_.device_address;
             rehash_params.hashmap_new = hashmap_control_block_bda_binary_.device_address;
 
-            device_table_->CmdBindPipeline(
+            injected->CmdBindPipeline(
                 submit_asset_.command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_bda_rehash_);
-            device_table_->CmdPushConstants(submit_asset_.command_buffer,
-                                            pipeline_layout_,
-                                            VK_SHADER_STAGE_COMPUTE_BIT,
-                                            0,
-                                            sizeof(rehash_params_t),
-                                            &rehash_params);
+            injected->CmdPushConstants(submit_asset_.command_buffer,
+                                       pipeline_layout_,
+                                       VK_SHADER_STAGE_COMPUTE_BIT,
+                                       0,
+                                       sizeof(rehash_params_t),
+                                       &rehash_params);
             // dispatch workgroups
             constexpr uint32_t wg_size = 32;
-            device_table_->CmdDispatch(
+            injected->CmdDispatch(
                 submit_asset_.command_buffer, util::div_up(previous_control_block.capacity, wg_size), 1, 1);
         }
     }

--- a/framework/decode/vulkan_address_replacer.h
+++ b/framework/decode/vulkan_address_replacer.h
@@ -28,6 +28,7 @@
 #include "util/linear_hashmap.h"
 #include "decode/common_object_info_table.h"
 #include "decode/vulkan_device_address_tracker.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "graphics/vulkan_semaphore_util.h"
 #include "graphics/vulkan_shader_group_handle.h"
 #include "format/platform_types.h"
@@ -38,18 +39,18 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 /**
  * @brief   VulkanAddressReplacer can be used to check and potentially sanitize input-parameters for various cases.
  *
- * Important note: all internal Vulkan-API calls performed by this class are expected to be wrapped by calls to:
- * - decode::BeginInjectedCommands() / decode::EndInjectedCommands()
+ * All internal Vulkan-API calls performed by this class are replay-injected, i.e. have no corresponding
+ * block in the capture file, and are marked internally via graphics::VulkanInjectedDeviceCalls scopes.
  */
 class VulkanAddressReplacer
 {
   public:
     VulkanAddressReplacer() = default;
 
-    VulkanAddressReplacer(const VulkanDeviceInfo*              device_info,
-                          const graphics::VulkanDeviceTable*   device_table,
-                          const graphics::VulkanInstanceTable* instance_table,
-                          decode::CommonObjectInfoTable&       object_table);
+    VulkanAddressReplacer(const VulkanDeviceInfo*                    device_info,
+                          const graphics::VulkanInjectedDeviceCalls& injected_calls,
+                          const graphics::VulkanInstanceTable*       instance_table,
+                          decode::CommonObjectInfoTable&             object_table);
 
     //! prevent copying
     VulkanAddressReplacer(const VulkanAddressReplacer&) = delete;
@@ -432,8 +433,8 @@ class VulkanAddressReplacer
         //! the acceleration-structure this asset was created for, used to detect stale entries after address-reuse
         VkAccelerationStructureKHR origin_handle = VK_NULL_HANDLE;
 
-        VkDevice                              device     = VK_NULL_HANDLE;
-        PFN_vkDestroyAccelerationStructureKHR destroy_fn = nullptr;
+        VkDevice                                           device = VK_NULL_HANDLE;
+        std::optional<graphics::VulkanInjectedDeviceCalls> injected_calls;
         ~acceleration_structure_asset_t();
     };
 
@@ -448,17 +449,14 @@ class VulkanAddressReplacer
     struct submit_asset_t
     {
         // members required for cleanup
-        VkDevice      device       = VK_NULL_HANDLE;
-        VkCommandPool command_pool = VK_NULL_HANDLE;
+        VkDevice                                           device       = VK_NULL_HANDLE;
+        VkCommandPool                                      command_pool = VK_NULL_HANDLE;
+        std::optional<graphics::VulkanInjectedDeviceCalls> injected_calls;
 
         // actual payload
-        VkCommandBuffer command_buffer   = VK_NULL_HANDLE;
-        VkFence         fence            = VK_NULL_HANDLE;
+        VkCommandBuffer           command_buffer = VK_NULL_HANDLE;
+        VkFence                   fence          = VK_NULL_HANDLE;
         graphics::VulkanSemaphore signal_semaphore{ VK_NULL_HANDLE };
-
-        PFN_vkDestroyFence       destroy_fence_fn        = nullptr;
-        PFN_vkFreeCommandBuffers free_command_buffers_fn = nullptr;
-        PFN_vkDestroySemaphore   destroy_semaphore_fn    = nullptr;
 
         submit_asset_t()                      = default;
         submit_asset_t(const submit_asset_t&) = delete;
@@ -506,7 +504,7 @@ class VulkanAddressReplacer
     bool swap_acceleration_structure_handle(VkAccelerationStructureKHR&               handle,
                                             const decode::VulkanDeviceAddressTracker& address_tracker);
 
-    const graphics::VulkanDeviceTable*                             device_table_              = nullptr;
+    std::optional<graphics::VulkanInjectedDeviceCalls>             device_table_;
     decode::CommonObjectInfoTable*                                 object_table_              = nullptr;
     VkPhysicalDeviceMemoryProperties                               capture_memory_properties_ = {};
     std::optional<VkPhysicalDeviceRayTracingPipelinePropertiesKHR> capture_ray_properties_{}, replay_ray_properties_{};

--- a/framework/decode/vulkan_address_replacer.h
+++ b/framework/decode/vulkan_address_replacer.h
@@ -23,6 +23,7 @@
 #ifndef GFXRECON_DECODE_VULKAN_ADDRESS_REPLACER_H
 #define GFXRECON_DECODE_VULKAN_ADDRESS_REPLACER_H
 
+#include <memory>
 #include <span>
 
 #include "util/linear_hashmap.h"
@@ -504,7 +505,9 @@ class VulkanAddressReplacer
     bool swap_acceleration_structure_handle(VkAccelerationStructureKHR&               handle,
                                             const decode::VulkanDeviceAddressTracker& address_tracker);
 
-    std::optional<graphics::VulkanInjectedDeviceCalls>             device_table_;
+    // unique_ptr (rather than std::optional) so the defaulted move disengages
+    // the moved-from replacer, whose destructor then skips teardown.
+    std::unique_ptr<graphics::VulkanInjectedDeviceCalls>           device_table_;
     decode::CommonObjectInfoTable*                                 object_table_              = nullptr;
     VkPhysicalDeviceMemoryProperties                               capture_memory_properties_ = {};
     std::optional<VkPhysicalDeviceRayTracingPipelinePropertiesKHR> capture_ray_properties_{}, replay_ray_properties_{};

--- a/framework/decode/vulkan_captured_swapchain.cpp
+++ b/framework/decode/vulkan_captured_swapchain.cpp
@@ -29,13 +29,13 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-VkResult VulkanCapturedSwapchain::CreateSwapchainKHR(VkResult                              original_result,
-                                                     PFN_vkCreateSwapchainKHR              func,
-                                                     const VulkanDeviceInfo*               device_info,
-                                                     const VkSwapchainCreateInfoKHR*       create_info,
-                                                     const VkAllocationCallbacks*          allocator,
-                                                     HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                                     const graphics::VulkanDeviceTable*    device_table)
+VkResult VulkanCapturedSwapchain::CreateSwapchainKHR(VkResult                                   original_result,
+                                                     PFN_vkCreateSwapchainKHR                   func,
+                                                     const VulkanDeviceInfo*                    device_info,
+                                                     const VkSwapchainCreateInfoKHR*            create_info,
+                                                     const VkAllocationCallbacks*               allocator,
+                                                     HandlePointerDecoder<VkSwapchainKHR>*      swapchain,
+                                                     const graphics::VulkanInjectedDeviceCalls& injected_calls)
 {
     VkDevice device = VK_NULL_HANDLE;
 
@@ -43,7 +43,7 @@ VkResult VulkanCapturedSwapchain::CreateSwapchainKHR(VkResult                   
     {
         device = device_info->handle;
     }
-    device_table_         = device_table;
+    injected_calls_       = injected_calls;
     auto replay_swapchain = swapchain->GetHandlePointer();
     return func(device, create_info, allocator, replay_swapchain);
 }
@@ -271,7 +271,7 @@ void VulkanCapturedSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*         
                                                 const VulkanImageInfo*                     image_info,
                                                 VulkanInstanceInfo*                        instance_info,
                                                 const graphics::VulkanInstanceTable*       instance_table,
-                                                const graphics::VulkanDeviceTable*         device_table,
+                                                const graphics::VulkanInjectedDeviceCalls& injected_calls,
                                                 application::Application*                  application,
                                                 const std::optional<std::array<float, 2>>& scale)
 {
@@ -280,7 +280,7 @@ void VulkanCapturedSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*         
     GFXRECON_UNREFERENCED_PARAMETER(image_info);
     GFXRECON_UNREFERENCED_PARAMETER(instance_info);
     GFXRECON_UNREFERENCED_PARAMETER(instance_table);
-    GFXRECON_UNREFERENCED_PARAMETER(device_table);
+    GFXRECON_UNREFERENCED_PARAMETER(injected_calls);
     GFXRECON_UNREFERENCED_PARAMETER(application);
     GFXRECON_UNREFERENCED_PARAMETER(scale);
 
@@ -308,7 +308,10 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateCommand(
     }
 
     VkSurfaceKHR surface = swapchain_info->surface;
-    assert((surface_info != nullptr) && (instance_table_ != nullptr) && (device_table_ != nullptr));
+    assert((surface_info != nullptr) && (instance_table_ != nullptr) && injected_calls_.has_value());
+
+    // Trim-state setup: none of the calls below have a corresponding block in the capture file.
+    auto injected = injected_calls_->Open();
 
     VkSurfaceCapabilitiesKHR surface_caps;
     uint32_t                 image_count = 0;
@@ -328,7 +331,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateCommand(
     {
         uint32_t capture_image_count = static_cast<uint32_t>(image_info.size());
         result                       = GetSwapchainImagesKHR(VK_SUCCESS,
-                                       device_table_->GetSwapchainImagesKHR,
+                                       injected->GetSwapchainImagesKHR,
                                        device_info,
                                        swapchain_info,
                                        capture_image_count,
@@ -371,7 +374,10 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
     SwapchainImageTracker&                              swapchain_image_tracker)
 {
     VkDevice device = device_info->handle;
-    assert(device_table_ != nullptr);
+    assert(injected_calls_.has_value());
+
+    // Trim-state setup: none of the calls below have a corresponding block in the capture file.
+    auto injected = injected_calls_->Open();
 
     VkResult        result             = VK_SUCCESS;
     VkQueue         transition_queue   = VK_NULL_HANDLE;
@@ -381,14 +387,14 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
     uint32_t        queue_family_index = swapchain_info->queue_family_indices[0];
 
     // TODO: Improved queue selection?
-    transition_queue = GetDeviceQueue(device_table_, device_info, queue_family_index, 0);
+    transition_queue = GetDeviceQueue(injected.GetTable(), device_info, queue_family_index, 0);
 
     VkCommandPoolCreateInfo pool_create_info = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
     pool_create_info.pNext                   = nullptr;
     pool_create_info.flags                   = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     pool_create_info.queueFamilyIndex        = queue_family_index;
 
-    result = device_table_->CreateCommandPool(device, &pool_create_info, nullptr, &transition_pool);
+    result = injected->CreateCommandPool(device, &pool_create_info, nullptr, &transition_pool);
 
     if (result == VK_SUCCESS)
     {
@@ -398,7 +404,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
         command_allocate_info.commandPool                 = transition_pool;
         command_allocate_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 
-        device_table_->AllocateCommandBuffers(device, &command_allocate_info, &transition_command);
+        injected->AllocateCommandBuffers(device, &command_allocate_info, &transition_command);
     }
 
     if (result == VK_SUCCESS)
@@ -448,18 +454,17 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
                 semaphore_create_info.pNext                 = nullptr;
                 semaphore_create_info.flags                 = 0;
 
-                result = device_table_->CreateFence(device, &fence_create_info, nullptr, &acquire_fence);
+                result = injected->CreateFence(device, &fence_create_info, nullptr, &acquire_fence);
 
                 if (result == VK_SUCCESS)
                 {
-                    result =
-                        device_table_->CreateSemaphore(device, &semaphore_create_info, nullptr, &acquire_semaphore);
+                    result = injected->CreateSemaphore(device, &semaphore_create_info, nullptr, &acquire_semaphore);
                 }
 
                 if (result == VK_SUCCESS)
                 {
                     result = AcquireNextImageKHR(VK_SUCCESS,
-                                                 device_table_->AcquireNextImageKHR,
+                                                 injected->AcquireNextImageKHR,
                                                  device_info,
                                                  swapchain_info,
                                                  std::numeric_limits<uint64_t>::max(),
@@ -470,43 +475,43 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
 
                     if ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR))
                     {
-                        result = device_table_->WaitForFences(
+                        result = injected->WaitForFences(
                             device, 1, &acquire_fence, true, std::numeric_limits<uint64_t>::max());
 
                         VkImageLayout image_layout = static_cast<VkImageLayout>(image_info[image_index].image_layout);
                         if ((result == VK_SUCCESS) && (image_layout != VK_IMAGE_LAYOUT_UNDEFINED))
                         {
-                            image_barrier.newLayout = image_layout;
-                            image_barrier.image     = image;
+                            image_barrier.newLayout                   = image_layout;
+                            image_barrier.image                       = image;
                             image_barrier.subresourceRange.aspectMask = graphics::GetFormatAspects(image_entry->format);
 
-                            result = device_table_->BeginCommandBuffer(transition_command, &begin_info);
+                            result = injected.BeginCommandBuffer(transition_command, &begin_info);
 
                             if (result == VK_SUCCESS)
                             {
-                                device_table_->CmdPipelineBarrier(transition_command,
-                                                                  VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                                                  VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                                                  0,
-                                                                  0,
-                                                                  nullptr,
-                                                                  0,
-                                                                  nullptr,
-                                                                  1,
-                                                                  &image_barrier);
-                                device_table_->EndCommandBuffer(transition_command);
+                                injected->CmdPipelineBarrier(transition_command,
+                                                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                                             0,
+                                                             0,
+                                                             nullptr,
+                                                             0,
+                                                             nullptr,
+                                                             1,
+                                                             &image_barrier);
+                                injected->EndCommandBuffer(transition_command);
 
-                                result = device_table_->ResetFences(device, 1, &acquire_fence);
+                                result = injected->ResetFences(device, 1, &acquire_fence);
                             }
 
                             if (result == VK_SUCCESS)
                             {
-                                result = device_table_->QueueSubmit(transition_queue, 1, &submit_info, acquire_fence);
+                                result = injected->QueueSubmit(transition_queue, 1, &submit_info, acquire_fence);
                             }
 
                             if (result == VK_SUCCESS)
                             {
-                                result = device_table_->WaitForFences(
+                                result = injected->WaitForFences(
                                     device, 1, &acquire_fence, true, std::numeric_limits<uint64_t>::max());
                             }
                         }
@@ -521,8 +526,8 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
                                 // used to acquire the image were already set to the appropriate signaled state when
                                 // created, so the temporary objects used to acquire the image here can be
                                 // destroyed.
-                                device_table_->DestroyFence(device, acquire_fence, nullptr);
-                                device_table_->DestroySemaphore(device, acquire_semaphore, nullptr);
+                                injected->DestroyFence(device, acquire_fence, nullptr);
+                                injected->DestroySemaphore(device, acquire_semaphore, nullptr);
                             }
                             else
                             {
@@ -558,7 +563,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
 
     if (transition_pool != VK_NULL_HANDLE)
     {
-        device_table_->DestroyCommandPool(device, transition_pool, nullptr);
+        injected->DestroyCommandPool(device, transition_pool, nullptr);
     }
 }
 
@@ -570,7 +575,10 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
     const CommonObjectInfoTable&                        object_info_table)
 {
     auto device = device_info->handle;
-    assert(device_table_ != nullptr);
+    assert(injected_calls_.has_value());
+
+    // Trim-state setup: none of the calls below have a corresponding block in the capture file.
+    auto injected = injected_calls_->Open();
 
     VkResult        result             = VK_SUCCESS;
     VkQueue         queue              = VK_NULL_HANDLE;
@@ -585,9 +593,9 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
     pool_create_info.flags                   = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     pool_create_info.queueFamilyIndex        = queue_family_index;
 
-    queue = GetDeviceQueue(device_table_, device_info, queue_family_index, 0);
+    queue = GetDeviceQueue(injected.GetTable(), device_info, queue_family_index, 0);
 
-    result = device_table_->CreateCommandPool(device, &pool_create_info, nullptr, &pool);
+    result = injected->CreateCommandPool(device, &pool_create_info, nullptr, &pool);
 
     if (result == VK_SUCCESS)
     {
@@ -597,7 +605,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
         command_allocate_info.commandPool                 = pool;
         command_allocate_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 
-        result = device_table_->AllocateCommandBuffers(device, &command_allocate_info, &command);
+        result = injected->AllocateCommandBuffers(device, &command_allocate_info, &command);
     }
 
     if (result == VK_SUCCESS)
@@ -606,7 +614,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
         fence_create_info.pNext             = nullptr;
         fence_create_info.flags             = VK_FENCE_CREATE_SIGNALED_BIT;
 
-        result = device_table_->CreateFence(device, &fence_create_info, nullptr, &wait_fence);
+        result = injected->CreateFence(device, &fence_create_info, nullptr, &wait_fence);
     }
 
     if (result == VK_SUCCESS)
@@ -654,12 +662,12 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
                 VkImage  image       = image_entry->handle;
                 uint32_t image_index = 0;
 
-                result = device_table_->ResetFences(device, 1, &wait_fence);
+                result = injected->ResetFences(device, 1, &wait_fence);
 
                 if (result == VK_SUCCESS)
                 {
                     result = AcquireNextImageKHR(VK_SUCCESS,
-                                                 device_table_->AcquireNextImageKHR,
+                                                 injected->AcquireNextImageKHR,
                                                  device_info,
                                                  swapchain_info,
                                                  std::numeric_limits<uint64_t>::max(),
@@ -671,8 +679,8 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
 
                 if ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR))
                 {
-                    result = device_table_->WaitForFences(
-                        device, 1, &wait_fence, true, std::numeric_limits<uint64_t>::max());
+                    result =
+                        injected->WaitForFences(device, 1, &wait_fence, true, std::numeric_limits<uint64_t>::max());
 
                     if (result == VK_SUCCESS)
                     {
@@ -680,45 +688,45 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
                         image_barrier.subresourceRange.aspectMask = graphics::GetFormatAspects(image_entry->format);
                         present_info.pImageIndices                = &image_index;
 
-                        result = device_table_->BeginCommandBuffer(command, &begin_info);
+                        result = injected.BeginCommandBuffer(command, &begin_info);
                     }
 
                     if (result == VK_SUCCESS)
                     {
-                        device_table_->CmdPipelineBarrier(command,
-                                                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                                          VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                                          0,
-                                                          0,
-                                                          nullptr,
-                                                          0,
-                                                          nullptr,
-                                                          1,
-                                                          &image_barrier);
-                        device_table_->EndCommandBuffer(command);
+                        injected->CmdPipelineBarrier(command,
+                                                     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                                     VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                                     0,
+                                                     0,
+                                                     nullptr,
+                                                     0,
+                                                     nullptr,
+                                                     1,
+                                                     &image_barrier);
+                        injected->EndCommandBuffer(command);
 
-                        result = device_table_->ResetFences(device, 1, &wait_fence);
+                        result = injected->ResetFences(device, 1, &wait_fence);
                     }
 
                     if (result == VK_SUCCESS)
                     {
-                        result = device_table_->QueueSubmit(queue, 1, &submit_info, wait_fence);
+                        result = injected->QueueSubmit(queue, 1, &submit_info, wait_fence);
                     }
 
                     if (result == VK_SUCCESS)
                     {
-                        result = device_table_->WaitForFences(
-                            device, 1, &wait_fence, true, std::numeric_limits<uint64_t>::max());
+                        result =
+                            injected->WaitForFences(device, 1, &wait_fence, true, std::numeric_limits<uint64_t>::max());
                     }
 
                     if (result == VK_SUCCESS)
                     {
-                        result = device_table_->QueuePresentKHR(queue, &present_info);
+                        result = injected->QueuePresentKHR(queue, &present_info);
                     }
 
                     if ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR))
                     {
-                        result = device_table_->QueueWaitIdle(queue);
+                        result = injected->QueueWaitIdle(queue);
                     }
                 }
 
@@ -750,12 +758,12 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
                 VkImage  image       = image_entry->handle;
                 uint32_t image_index = 0;
 
-                result = device_table_->ResetFences(device, 1, &wait_fence);
+                result = injected->ResetFences(device, 1, &wait_fence);
 
                 if (result == VK_SUCCESS)
                 {
                     result = AcquireNextImageKHR(VK_SUCCESS,
-                                                 device_table_->AcquireNextImageKHR,
+                                                 injected->AcquireNextImageKHR,
                                                  device_info,
                                                  swapchain_info,
                                                  std::numeric_limits<uint64_t>::max(),
@@ -767,8 +775,8 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
 
                 if ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR))
                 {
-                    result = device_table_->WaitForFences(
-                        device, 1, &wait_fence, true, std::numeric_limits<uint64_t>::max());
+                    result =
+                        injected->WaitForFences(device, 1, &wait_fence, true, std::numeric_limits<uint64_t>::max());
 
                     if (result == VK_SUCCESS)
                     {
@@ -785,33 +793,33 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
                                 image_barrier.newLayout = image_layout;
                                 image_barrier.image     = image;
 
-                                result = device_table_->BeginCommandBuffer(command, &begin_info);
+                                result = injected.BeginCommandBuffer(command, &begin_info);
 
                                 if (result == VK_SUCCESS)
                                 {
-                                    device_table_->CmdPipelineBarrier(command,
-                                                                      VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                                                      VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                                                      0,
-                                                                      0,
-                                                                      nullptr,
-                                                                      0,
-                                                                      nullptr,
-                                                                      1,
-                                                                      &image_barrier);
-                                    device_table_->EndCommandBuffer(command);
+                                    injected->CmdPipelineBarrier(command,
+                                                                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                                                 VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                                                 0,
+                                                                 0,
+                                                                 nullptr,
+                                                                 0,
+                                                                 nullptr,
+                                                                 1,
+                                                                 &image_barrier);
+                                    injected->EndCommandBuffer(command);
 
-                                    result = device_table_->ResetFences(device, 1, &wait_fence);
+                                    result = injected->ResetFences(device, 1, &wait_fence);
                                 }
 
                                 if (result == VK_SUCCESS)
                                 {
-                                    result = device_table_->QueueSubmit(queue, 1, &submit_info, wait_fence);
+                                    result = injected->QueueSubmit(queue, 1, &submit_info, wait_fence);
                                 }
 
                                 if (result == VK_SUCCESS)
                                 {
-                                    result = device_table_->WaitForFences(
+                                    result = injected->WaitForFences(
                                         device, 1, &wait_fence, true, std::numeric_limits<uint64_t>::max());
                                 }
                             }
@@ -821,11 +829,11 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
                             // Image is not expected to be in the acquired state, so present it.
                             present_info.pImageIndices = &image_index;
 
-                            result = device_table_->QueuePresentKHR(queue, &present_info);
+                            result = injected->QueuePresentKHR(queue, &present_info);
 
                             if ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR))
                             {
-                                result = device_table_->QueueWaitIdle(queue);
+                                result = injected->QueueWaitIdle(queue);
                             }
                         }
                     }
@@ -854,12 +862,12 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
 
     if (pool != VK_NULL_HANDLE)
     {
-        device_table_->DestroyCommandPool(device, pool, nullptr);
+        injected->DestroyCommandPool(device, pool, nullptr);
     }
 
     if (wait_fence != VK_NULL_HANDLE)
     {
-        device_table_->DestroyFence(device, wait_fence, nullptr);
+        injected->DestroyFence(device, wait_fence, nullptr);
     }
 }
 

--- a/framework/decode/vulkan_captured_swapchain.h
+++ b/framework/decode/vulkan_captured_swapchain.h
@@ -33,13 +33,13 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
   public:
     virtual ~VulkanCapturedSwapchain() override {}
 
-    virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
-                                        PFN_vkCreateSwapchainKHR              func,
-                                        const VulkanDeviceInfo*               device_info,
-                                        const VkSwapchainCreateInfoKHR*       create_info,
-                                        const VkAllocationCallbacks*          allocator,
-                                        HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const graphics::VulkanDeviceTable*    device_table) override;
+    virtual VkResult CreateSwapchainKHR(VkResult                                   original_result,
+                                        PFN_vkCreateSwapchainKHR                   func,
+                                        const VulkanDeviceInfo*                    device_info,
+                                        const VkSwapchainCreateInfoKHR*            create_info,
+                                        const VkAllocationCallbacks*               allocator,
+                                        HandlePointerDecoder<VkSwapchainKHR>*      swapchain,
+                                        const graphics::VulkanInjectedDeviceCalls& injected_calls) override;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
                                      const VulkanDeviceInfo*       device_info,
@@ -114,7 +114,7 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
                                    const VulkanImageInfo*                     image_info,
                                    VulkanInstanceInfo*                        instance_info,
                                    const graphics::VulkanInstanceTable*       instance_table,
-                                   const graphics::VulkanDeviceTable*         device_table,
+                                   const graphics::VulkanInjectedDeviceCalls& injected_calls,
                                    application::Application*                  application,
                                    const std::optional<std::array<float, 2>>& scale) override;
 

--- a/framework/decode/vulkan_command_buffer_util.cpp
+++ b/framework/decode/vulkan_command_buffer_util.cpp
@@ -28,15 +28,15 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-VulkanCommandBufferAssociatedInfo::VulkanCommandBufferAssociatedInfo(const VulkanDeviceInfo*            device_info,
-                                                                     const graphics::VulkanDeviceTable* device_table,
-                                                                     CommonObjectInfoTable*             object_table,
-                                                                     format::HandleId command_buffer_id) :
+VulkanCommandBufferAssociatedInfo::VulkanCommandBufferAssociatedInfo(
+    const VulkanDeviceInfo*                    device_info,
+    const graphics::VulkanInjectedDeviceCalls& device_table,
+    CommonObjectInfoTable*                     object_table,
+    format::HandleId                           command_buffer_id) :
     device_info_(device_info),
     device_table_(device_table), object_table_(object_table), split_semaphore_(device_info, device_table)
 {
     GFXRECON_ASSERT(device_info != nullptr);
-    GFXRECON_ASSERT(device_table != nullptr);
     GFXRECON_ASSERT(object_table != nullptr);
 
     // Store the original command buffer handle and map it to the command buffer ID for future reference.
@@ -68,7 +68,8 @@ void VulkanCommandBufferAssociatedInfo::ReplaceWithNewHandle(VulkanCommandBuffer
         alloc_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
         alloc_info.commandBufferCount          = NEW_COMMAND_BUFFER_COUNT;
 
-        VkResult result = device_table_->AllocateCommandBuffers(device_info_->handle, &alloc_info, new_handles_ptr);
+        auto     injected = device_table_.Open();
+        VkResult result   = injected->AllocateCommandBuffers(device_info_->handle, &alloc_info, new_handles_ptr);
         GFXRECON_ASSERT(result == VK_SUCCESS);
     }
 
@@ -78,15 +79,14 @@ void VulkanCommandBufferAssociatedInfo::ReplaceWithNewHandle(VulkanCommandBuffer
     command_buffer_info->handle = next_handle;
 }
 
-VulkanCommandBufferUtil::VulkanCommandBufferUtil(const VulkanDeviceInfo*            device_info,
-                                                 const graphics::VulkanDeviceTable* device_table,
-                                                 CommonObjectInfoTable*             object_table,
-                                                 VulkanStateRecordingDecoder*       decoder) :
+VulkanCommandBufferUtil::VulkanCommandBufferUtil(const VulkanDeviceInfo*                    device_info,
+                                                 const graphics::VulkanInjectedDeviceCalls& device_table,
+                                                 CommonObjectInfoTable*                     object_table,
+                                                 VulkanStateRecordingDecoder*               decoder) :
     device_info_(device_info),
     device_table_(device_table), object_table_(object_table), decoder_(decoder)
 {
     GFXRECON_ASSERT(device_info != nullptr);
-    GFXRECON_ASSERT(device_table != nullptr);
     GFXRECON_ASSERT(object_table != nullptr);
 }
 
@@ -119,7 +119,8 @@ VkCommandBuffer VulkanCommandBufferAssociatedInfo::ResetAssociatedHandles()
     // Reset all the associated command buffers.
     for (VkCommandBuffer handle : associated_handles_)
     {
-        VkResult result = device_table_->ResetCommandBuffer(handle, 0);
+        auto     injected = device_table_.Open();
+        VkResult result   = injected->ResetCommandBuffer(handle, 0);
         GFXRECON_ASSERT(result == VK_SUCCESS);
     }
 
@@ -134,8 +135,12 @@ void VulkanCommandBufferAssociatedInfo::FreeCommandBuffers(VkCommandPool pool)
 {
     GFXRECON_ASSERT(!associated_handles_.empty());
 
-    device_table_->FreeCommandBuffers(
+    auto injected = device_table_.Open();
+    injected->FreeCommandBuffers(
         device_info_->handle, pool, static_cast<uint32_t>(associated_handles_.size()), associated_handles_.data());
+
+    // The freed handles must not be reused.
+    associated_handles_.clear();
 }
 
 void VulkanCommandBufferUtil::ReplaceWithAssociatedCommandBuffer(VulkanCommandBufferInfo* command_buffer_info)
@@ -150,7 +155,8 @@ void VulkanCommandBufferUtil::ReplaceWithAssociatedCommandBuffer(VulkanCommandBu
     original_command_buffer_id_[command_buffer_info->handle] = command_buffer_info->capture_id;
 
     // Reset the command buffer just in case it was recycled.
-    VkResult result = device_table_->ResetCommandBuffer(command_buffer_info->handle, 0);
+    auto     injected = device_table_.Open();
+    VkResult result   = injected->ResetCommandBuffer(command_buffer_info->handle, 0);
     GFXRECON_ASSERT(result == VK_SUCCESS);
 }
 
@@ -161,13 +167,16 @@ void VulkanCommandBufferUtil::SplitCommandBuffer(VulkanCommandBufferInfo* comman
         return;
     }
 
-    device_table_->EndCommandBuffer(command_buffer_info->handle);
+    {
+        auto injected = device_table_.Open();
+        injected->EndCommandBuffer(command_buffer_info->handle);
 
-    GetOrCreateAssociatedInfo(command_buffer_info->capture_id).PushSplitHandle(command_buffer_info->handle);
-    ReplaceWithAssociatedCommandBuffer(command_buffer_info);
+        GetOrCreateAssociatedInfo(command_buffer_info->capture_id).PushSplitHandle(command_buffer_info->handle);
+        ReplaceWithAssociatedCommandBuffer(command_buffer_info);
 
-    VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-    device_table_->BeginCommandBuffer(command_buffer_info->handle, &begin_info);
+        VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
+        injected->BeginCommandBuffer(command_buffer_info->handle, &begin_info);
+    }
 
     reissuing_command_buffer_state_ = true;
     decoder_->ReissueCommandBufferState(command_buffer_info->capture_id);
@@ -197,8 +206,9 @@ graphics::VulkanSemaphore VulkanCommandBufferUtil::SubmitPreviouslySplitCommandB
     const std::span<std::vector<VkCommandBuffer>> current_submits_cmdbufs,
     const std::span<graphics::VulkanSemaphore>    wait_semaphores)
 {
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-    graphics::VulkanSemaphore        signal_semaphore{ VK_NULL_HANDLE, 0 };
+    auto injected = device_table_.Open();
+
+    graphics::VulkanSemaphore signal_semaphore{ VK_NULL_HANDLE, 0 };
 
     // A QueueSubmit might have multiple submit infos (current_submits_span).
     // Each submit info might have multiple command buffers.
@@ -279,7 +289,7 @@ graphics::VulkanSemaphore VulkanCommandBufferUtil::SubmitPreviouslySplitCommandB
 
             prev_submits[i] = submit_info;
 
-            VkResult result = device_table_->QueueSubmit(queue_info->handle, 1, &prev_submits[i], VK_NULL_HANDLE);
+            VkResult result = injected->QueueSubmit(queue_info->handle, 1, &prev_submits[i], VK_NULL_HANDLE);
             GFXRECON_ASSERT(result == VK_SUCCESS);
         }
     }
@@ -390,7 +400,8 @@ void VulkanCommandBufferUtil::BeginCommandBuffer(VulkanCommandBufferInfo* comman
         if (original_command_buffer_id_.contains(command_buffer_info->handle))
         {
             // Reset current handle and let `ResetCommandBuffer` handle the rest of the split handles.
-            device_table_->ResetCommandBuffer(command_buffer_info->handle, 0);
+            auto injected = device_table_.Open();
+            injected->ResetCommandBuffer(command_buffer_info->handle, 0);
             ResetCommandBuffer(command_buffer_info);
         }
     }

--- a/framework/decode/vulkan_command_buffer_util.cpp
+++ b/framework/decode/vulkan_command_buffer_util.cpp
@@ -167,16 +167,16 @@ void VulkanCommandBufferUtil::SplitCommandBuffer(VulkanCommandBufferInfo* comman
         return;
     }
 
-    {
-        auto injected = device_table_.Open();
-        injected->EndCommandBuffer(command_buffer_info->handle);
+    auto injected = device_table_.Open();
+    injected->EndCommandBuffer(command_buffer_info->handle);
 
-        GetOrCreateAssociatedInfo(command_buffer_info->capture_id).PushSplitHandle(command_buffer_info->handle);
-        ReplaceWithAssociatedCommandBuffer(command_buffer_info);
+    GetOrCreateAssociatedInfo(command_buffer_info->capture_id).PushSplitHandle(command_buffer_info->handle);
+    ReplaceWithAssociatedCommandBuffer(command_buffer_info);
 
-        VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-        injected->BeginCommandBuffer(command_buffer_info->handle, &begin_info);
-    }
+    VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
+    injected->BeginCommandBuffer(command_buffer_info->handle, &begin_info);
+    auto reinstate_cb_scope =
+        device_table_.Label(injected, command_buffer_info->handle, "Restore command buffer's state");
 
     reissuing_command_buffer_state_ = true;
     decoder_->ReissueCommandBufferState(command_buffer_info->capture_id);

--- a/framework/decode/vulkan_command_buffer_util.cpp
+++ b/framework/decode/vulkan_command_buffer_util.cpp
@@ -170,16 +170,16 @@ void VulkanCommandBufferUtil::SplitCommandBuffer(VulkanCommandBufferInfo* comman
         return;
     }
 
-    {
-        auto injected = device_table_.Open();
-        injected->EndCommandBuffer(command_buffer_info->handle);
+    auto injected = device_table_.Open();
+    injected->EndCommandBuffer(command_buffer_info->handle);
 
-        GetOrCreateAssociatedInfo(command_buffer_info->capture_id).PushSplitHandle(command_buffer_info->handle);
-        ReplaceWithAssociatedCommandBuffer(command_buffer_info);
+    GetOrCreateAssociatedInfo(command_buffer_info->capture_id).PushSplitHandle(command_buffer_info->handle);
+    ReplaceWithAssociatedCommandBuffer(command_buffer_info);
 
-        VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-        injected->BeginCommandBuffer(command_buffer_info->handle, &begin_info);
-    }
+    VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
+    injected->BeginCommandBuffer(command_buffer_info->handle, &begin_info);
+    auto reinstate_cb_scope =
+        device_table_.Label(injected, command_buffer_info->handle, "Restore command buffer's state");
 
     reissuing_command_buffer_state_ = true;
     decoder_->ReissueCommandBufferState(command_buffer_info->capture_id);

--- a/framework/decode/vulkan_command_buffer_util.cpp
+++ b/framework/decode/vulkan_command_buffer_util.cpp
@@ -28,15 +28,15 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-VulkanCommandBufferAssociatedInfo::VulkanCommandBufferAssociatedInfo(const VulkanDeviceInfo*            device_info,
-                                                                     const graphics::VulkanDeviceTable* device_table,
-                                                                     CommonObjectInfoTable*             object_table,
-                                                                     format::HandleId command_buffer_id) :
+VulkanCommandBufferAssociatedInfo::VulkanCommandBufferAssociatedInfo(
+    const VulkanDeviceInfo*                    device_info,
+    const graphics::VulkanInjectedDeviceCalls& device_table,
+    CommonObjectInfoTable*                     object_table,
+    format::HandleId                           command_buffer_id) :
     device_info_(device_info),
     device_table_(device_table), object_table_(object_table), split_semaphore_(device_info, device_table)
 {
     GFXRECON_ASSERT(device_info != nullptr);
-    GFXRECON_ASSERT(device_table != nullptr);
     GFXRECON_ASSERT(object_table != nullptr);
 
     // Store the original command buffer handle and map it to the command buffer ID for future reference.
@@ -68,7 +68,8 @@ void VulkanCommandBufferAssociatedInfo::ReplaceWithNewHandle(VulkanCommandBuffer
         alloc_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
         alloc_info.commandBufferCount          = NEW_COMMAND_BUFFER_COUNT;
 
-        VkResult result = device_table_->AllocateCommandBuffers(device_info_->handle, &alloc_info, new_handles_ptr);
+        auto     injected = device_table_.Open();
+        VkResult result   = injected->AllocateCommandBuffers(device_info_->handle, &alloc_info, new_handles_ptr);
         GFXRECON_ASSERT(result == VK_SUCCESS);
     }
 
@@ -78,15 +79,14 @@ void VulkanCommandBufferAssociatedInfo::ReplaceWithNewHandle(VulkanCommandBuffer
     command_buffer_info->handle = next_handle;
 }
 
-VulkanCommandBufferUtil::VulkanCommandBufferUtil(const VulkanDeviceInfo*            device_info,
-                                                 const graphics::VulkanDeviceTable* device_table,
-                                                 CommonObjectInfoTable*             object_table,
-                                                 VulkanStateRecordingDecoder*       decoder) :
+VulkanCommandBufferUtil::VulkanCommandBufferUtil(const VulkanDeviceInfo*                    device_info,
+                                                 const graphics::VulkanInjectedDeviceCalls& device_table,
+                                                 CommonObjectInfoTable*                     object_table,
+                                                 VulkanStateRecordingDecoder*               decoder) :
     device_info_(device_info),
     device_table_(device_table), object_table_(object_table), decoder_(decoder)
 {
     GFXRECON_ASSERT(device_info != nullptr);
-    GFXRECON_ASSERT(device_table != nullptr);
     GFXRECON_ASSERT(object_table != nullptr);
 }
 
@@ -119,7 +119,8 @@ VkCommandBuffer VulkanCommandBufferAssociatedInfo::ResetAssociatedHandles()
     // Reset all the associated command buffers.
     for (VkCommandBuffer handle : associated_handles_)
     {
-        VkResult result = device_table_->ResetCommandBuffer(handle, 0);
+        auto     injected = device_table_.Open();
+        VkResult result   = injected->ResetCommandBuffer(handle, 0);
         GFXRECON_ASSERT(result == VK_SUCCESS);
     }
 
@@ -134,7 +135,8 @@ VkCommandBuffer VulkanCommandBufferAssociatedInfo::FreeAssociatedHandles(VkComma
 {
     GFXRECON_ASSERT(!associated_handles_.empty());
 
-    device_table_->FreeCommandBuffers(
+    auto injected = device_table_.Open();
+    injected->FreeCommandBuffers(
         device_info_->handle, pool, static_cast<uint32_t>(associated_handles_.size()), associated_handles_.data());
 
     associated_handles_.clear();
@@ -156,7 +158,8 @@ void VulkanCommandBufferUtil::ReplaceWithAssociatedCommandBuffer(VulkanCommandBu
     original_command_buffer_id_[command_buffer_info->handle] = command_buffer_info->capture_id;
 
     // Reset the command buffer just in case it was recycled.
-    VkResult result = device_table_->ResetCommandBuffer(command_buffer_info->handle, 0);
+    auto     injected = device_table_.Open();
+    VkResult result   = injected->ResetCommandBuffer(command_buffer_info->handle, 0);
     GFXRECON_ASSERT(result == VK_SUCCESS);
 }
 
@@ -167,13 +170,16 @@ void VulkanCommandBufferUtil::SplitCommandBuffer(VulkanCommandBufferInfo* comman
         return;
     }
 
-    device_table_->EndCommandBuffer(command_buffer_info->handle);
+    {
+        auto injected = device_table_.Open();
+        injected->EndCommandBuffer(command_buffer_info->handle);
 
-    GetOrCreateAssociatedInfo(command_buffer_info->capture_id).PushSplitHandle(command_buffer_info->handle);
-    ReplaceWithAssociatedCommandBuffer(command_buffer_info);
+        GetOrCreateAssociatedInfo(command_buffer_info->capture_id).PushSplitHandle(command_buffer_info->handle);
+        ReplaceWithAssociatedCommandBuffer(command_buffer_info);
 
-    VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-    device_table_->BeginCommandBuffer(command_buffer_info->handle, &begin_info);
+        VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
+        injected->BeginCommandBuffer(command_buffer_info->handle, &begin_info);
+    }
 
     reissuing_command_buffer_state_ = true;
     decoder_->ReissueCommandBufferState(command_buffer_info->capture_id);
@@ -203,8 +209,9 @@ graphics::VulkanSemaphore VulkanCommandBufferUtil::SubmitPreviouslySplitCommandB
     const std::span<std::vector<VkCommandBuffer>> current_submits_cmdbufs,
     const std::span<graphics::VulkanSemaphore>    wait_semaphores)
 {
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-    graphics::VulkanSemaphore        signal_semaphore{ VK_NULL_HANDLE, 0 };
+    auto injected = device_table_.Open();
+
+    graphics::VulkanSemaphore signal_semaphore{ VK_NULL_HANDLE, 0 };
 
     // A QueueSubmit might have multiple submit infos (current_submits_span).
     // Each submit info might have multiple command buffers.
@@ -285,7 +292,7 @@ graphics::VulkanSemaphore VulkanCommandBufferUtil::SubmitPreviouslySplitCommandB
 
             prev_submits[i] = submit_info;
 
-            VkResult result = device_table_->QueueSubmit(queue_info->handle, 1, &prev_submits[i], VK_NULL_HANDLE);
+            VkResult result = injected->QueueSubmit(queue_info->handle, 1, &prev_submits[i], VK_NULL_HANDLE);
             GFXRECON_ASSERT(result == VK_SUCCESS);
         }
     }
@@ -393,7 +400,8 @@ void VulkanCommandBufferUtil::BeginCommandBuffer(VulkanCommandBufferInfo* comman
         if (original_command_buffer_id_.contains(command_buffer_info->handle))
         {
             // Reset current handle and let `ResetCommandBuffer` handle the rest of the split handles.
-            device_table_->ResetCommandBuffer(command_buffer_info->handle, 0);
+            auto injected = device_table_.Open();
+            injected->ResetCommandBuffer(command_buffer_info->handle, 0);
             ResetCommandBuffer(command_buffer_info);
         }
     }

--- a/framework/decode/vulkan_command_buffer_util.h
+++ b/framework/decode/vulkan_command_buffer_util.h
@@ -26,6 +26,7 @@
 #include "decode/vulkan_object_info.h"
 #include "decode/vulkan_state_recording_decoder.h"
 #include "decode/vulkan_submit_job.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "util/defines.h"
 
 #include <unordered_map>
@@ -39,9 +40,9 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class VulkanCommandBufferAssociatedInfo
 {
   private:
-    const VulkanDeviceInfo*            device_info_  = nullptr;
-    const graphics::VulkanDeviceTable* device_table_ = nullptr;
-    CommonObjectInfoTable*             object_table_ = nullptr;
+    const VulkanDeviceInfo*             device_info_ = nullptr;
+    graphics::VulkanInjectedDeviceCalls device_table_;
+    CommonObjectInfoTable*              object_table_ = nullptr;
 
     VulkanInjectedSemaphore split_semaphore_;
 
@@ -64,10 +65,10 @@ class VulkanCommandBufferAssociatedInfo
     std::vector<VkCommandBuffer> split_handles_;
 
   public:
-    VulkanCommandBufferAssociatedInfo(const VulkanDeviceInfo*            device_info,
-                                      const graphics::VulkanDeviceTable* device_table,
-                                      CommonObjectInfoTable*             object_table,
-                                      format::HandleId                   command_buffer_id);
+    VulkanCommandBufferAssociatedInfo(const VulkanDeviceInfo*                    device_info,
+                                      const graphics::VulkanInjectedDeviceCalls& device_table,
+                                      CommonObjectInfoTable*                     object_table,
+                                      format::HandleId                           command_buffer_id);
 
     VulkanCommandBufferAssociatedInfo(const VulkanCommandBufferAssociatedInfo&)            = delete;
     VulkanCommandBufferAssociatedInfo& operator=(const VulkanCommandBufferAssociatedInfo&) = delete;
@@ -92,10 +93,10 @@ class VulkanCommandBufferAssociatedInfo
 class VulkanCommandBufferUtil
 {
   public:
-    VulkanCommandBufferUtil(const VulkanDeviceInfo*            device_info,
-                            const graphics::VulkanDeviceTable* device_table,
-                            CommonObjectInfoTable*             object_table,
-                            VulkanStateRecordingDecoder*       decoder);
+    VulkanCommandBufferUtil(const VulkanDeviceInfo*                    device_info,
+                            const graphics::VulkanInjectedDeviceCalls& device_table,
+                            CommonObjectInfoTable*                     object_table,
+                            VulkanStateRecordingDecoder*               decoder);
 
     ~VulkanCommandBufferUtil() = default;
 
@@ -140,10 +141,10 @@ class VulkanCommandBufferUtil
     VulkanCommandBufferAssociatedInfo& GetOrCreateAssociatedInfo(format::HandleId command_buffer_id);
     VulkanCommandBufferAssociatedInfo* GetAssociatedInfo(format::HandleId command_buffer_id);
 
-    const VulkanDeviceInfo*            device_info_  = nullptr;
-    const graphics::VulkanDeviceTable* device_table_ = nullptr;
-    CommonObjectInfoTable*             object_table_ = nullptr;
-    VulkanStateRecordingDecoder*       decoder_      = nullptr;
+    const VulkanDeviceInfo*             device_info_ = nullptr;
+    graphics::VulkanInjectedDeviceCalls device_table_;
+    CommonObjectInfoTable*              object_table_ = nullptr;
+    VulkanStateRecordingDecoder*        decoder_      = nullptr;
 
     /// Map from the command buffer ID to the structure representing the split.
     std::unordered_map<format::HandleId, VulkanCommandBufferAssociatedInfo> split_infos_;

--- a/framework/decode/vulkan_command_buffer_util.h
+++ b/framework/decode/vulkan_command_buffer_util.h
@@ -26,6 +26,7 @@
 #include "decode/vulkan_object_info.h"
 #include "decode/vulkan_state_recording_decoder.h"
 #include "decode/vulkan_submit_job.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "util/defines.h"
 
 #include <unordered_map>
@@ -44,9 +45,9 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class VulkanCommandBufferAssociatedInfo
 {
   private:
-    const VulkanDeviceInfo*            device_info_  = nullptr;
-    const graphics::VulkanDeviceTable* device_table_ = nullptr;
-    CommonObjectInfoTable*             object_table_ = nullptr;
+    const VulkanDeviceInfo*             device_info_ = nullptr;
+    graphics::VulkanInjectedDeviceCalls device_table_;
+    CommonObjectInfoTable*              object_table_ = nullptr;
 
     VulkanInjectedSemaphore split_semaphore_;
 
@@ -74,10 +75,10 @@ class VulkanCommandBufferAssociatedInfo
     /// @param device_table Dispatch table of that device.
     /// @param object_table Table that maps capture IDs to replay objects.
     /// @param command_buffer_id Capture ID of the original command buffer.
-    VulkanCommandBufferAssociatedInfo(const VulkanDeviceInfo*            device_info,
-                                      const graphics::VulkanDeviceTable* device_table,
-                                      CommonObjectInfoTable*             object_table,
-                                      format::HandleId                   command_buffer_id);
+    VulkanCommandBufferAssociatedInfo(const VulkanDeviceInfo*                    device_info,
+                                      const graphics::VulkanInjectedDeviceCalls& device_table,
+                                      CommonObjectInfoTable*                     object_table,
+                                      format::HandleId                           command_buffer_id);
 
     VulkanCommandBufferAssociatedInfo(const VulkanCommandBufferAssociatedInfo&)            = delete;
     VulkanCommandBufferAssociatedInfo& operator=(const VulkanCommandBufferAssociatedInfo&) = delete;
@@ -132,10 +133,10 @@ class VulkanCommandBufferUtil
     /// @param device_table Dispatch table of that device.
     /// @param object_table Table that maps capture IDs to replay objects.
     /// @param decoder Decoder that records and reissues command buffer state.
-    VulkanCommandBufferUtil(const VulkanDeviceInfo*            device_info,
-                            const graphics::VulkanDeviceTable* device_table,
-                            CommonObjectInfoTable*             object_table,
-                            VulkanStateRecordingDecoder*       decoder);
+    VulkanCommandBufferUtil(const VulkanDeviceInfo*                    device_info,
+                            const graphics::VulkanInjectedDeviceCalls& device_table,
+                            CommonObjectInfoTable*                     object_table,
+                            VulkanStateRecordingDecoder*               decoder);
 
     ~VulkanCommandBufferUtil() = default;
 
@@ -228,10 +229,10 @@ class VulkanCommandBufferUtil
     /// Returns the split info of the command buffer, or nullptr if it was never split.
     VulkanCommandBufferAssociatedInfo* GetAssociatedInfo(format::HandleId command_buffer_id);
 
-    const VulkanDeviceInfo*            device_info_  = nullptr;
-    const graphics::VulkanDeviceTable* device_table_ = nullptr;
-    CommonObjectInfoTable*             object_table_ = nullptr;
-    VulkanStateRecordingDecoder*       decoder_      = nullptr;
+    const VulkanDeviceInfo*             device_info_ = nullptr;
+    graphics::VulkanInjectedDeviceCalls device_table_;
+    CommonObjectInfoTable*              object_table_ = nullptr;
+    VulkanStateRecordingDecoder*        decoder_      = nullptr;
 
     /// Map from the command buffer ID to the structure representing the split.
     std::unordered_map<format::HandleId, VulkanCommandBufferAssociatedInfo> split_infos_;

--- a/framework/decode/vulkan_frame_warm_up.cpp
+++ b/framework/decode/vulkan_frame_warm_up.cpp
@@ -26,38 +26,36 @@
 #include "generated/generated_vulkan_enum_to_string.h"
 #include "graphics/vulkan_device_util.h"
 #include "graphics/vulkan_resources_util.h"
-#include "util/callbacks.h"
 #include "util/logging.h"
 #include "util/platform.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device_info,
-                                     const graphics::VulkanDeviceTable*   device_table,
-                                     const graphics::VulkanInstanceTable* instance_table,
-                                     CommonObjectInfoTable&               object_table,
-                                     const std::string&                   spirv_path,
-                                     uint32_t                             warm_up_load) :
-    device_table_(device_table),
+VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*                    device_info,
+                                     const graphics::VulkanInjectedDeviceCalls& injected_calls,
+                                     const graphics::VulkanInstanceTable*       instance_table,
+                                     CommonObjectInfoTable&                     object_table,
+                                     const std::string&                         spirv_path,
+                                     uint32_t                                   warm_up_load) :
+    injected_calls_(injected_calls),
     spirv_path_(spirv_path), warm_up_load_(warm_up_load)
 {
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+    auto injected = injected_calls_->Open();
 
     GFXRECON_ASSERT(device_info != nullptr);
-    GFXRECON_ASSERT(device_table != nullptr);
     GFXRECON_ASSERT(instance_table != nullptr);
 
     device_ = device_info->handle;
     GFXRECON_ASSERT(device_ != VK_NULL_HANDLE);
 
-    device_table->GetDeviceQueue(device_, 0, 0, &queue_);
+    injected->GetDeviceQueue(device_, 0, 0, &queue_);
     GFXRECON_ASSERT(queue_ != VK_NULL_HANDLE);
 
     VkCommandPoolCreateInfo cmd_pool_info = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
     cmd_pool_info.queueFamilyIndex        = 0;
     cmd_pool_info.flags                   = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
-    VkResult result = device_table->CreateCommandPool(device_, &cmd_pool_info, nullptr, &command_pool_);
+    VkResult result = injected->CreateCommandPool(device_, &cmd_pool_info, nullptr, &command_pool_);
 
     if (result != VK_SUCCESS)
     {
@@ -119,7 +117,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     VkShaderModuleCreateInfo sm_create_info = { VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
     sm_create_info.codeSize                 = spirv_size;
     sm_create_info.pCode                    = (uint32_t*)spirv_code.get();
-    result = device_table->CreateShaderModule(device_, &sm_create_info, nullptr, &shader_module_);
+    result = injected->CreateShaderModule(device_, &sm_create_info, nullptr, &shader_module_);
 
     if (result != VK_SUCCESS)
     {
@@ -134,7 +132,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     buffer_info.size               = buffer_size;
     buffer_info.usage              = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     buffer_info.sharingMode        = VK_SHARING_MODE_EXCLUSIVE;
-    result                         = device_table->CreateBuffer(device_, &buffer_info, nullptr, &buffer_);
+    result                         = injected->CreateBuffer(device_, &buffer_info, nullptr, &buffer_);
 
     if (result != VK_SUCCESS)
     {
@@ -147,7 +145,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     VkPhysicalDeviceMemoryProperties capture_memory_properties = physical_device_info->capture_memory_properties;
 
     VkMemoryRequirements mem_requirements;
-    device_table->GetBufferMemoryRequirements(device_, buffer_, &mem_requirements);
+    injected->GetBufferMemoryRequirements(device_, buffer_, &mem_requirements);
 
     VkMemoryAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
     alloc_info.allocationSize       = mem_requirements.size;
@@ -164,14 +162,14 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
                            mem_requirements.memoryTypeBits);
     }
 
-    result = device_table->AllocateMemory(device_, &alloc_info, nullptr, &buffer_memory_);
+    result = injected->AllocateMemory(device_, &alloc_info, nullptr, &buffer_memory_);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_FATAL("VulkanFrameWarmUp: Failed in vkAllocateMemory: %s.",
                            util::ToString<VkResult>(result).c_str());
     }
 
-    result = device_table->BindBufferMemory(device_, buffer_, buffer_memory_, 0);
+    result = injected->BindBufferMemory(device_, buffer_, buffer_memory_, 0);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_FATAL("VulkanFrameWarmUp: Failed in vkBindBufferMemory: %s.",
@@ -187,7 +185,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     VkDescriptorSetLayoutCreateInfo layout_info = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
     layout_info.bindingCount                    = 1;
     layout_info.pBindings                       = &layout_binding;
-    result = device_table->CreateDescriptorSetLayout(device_, &layout_info, nullptr, &descriptor_set_layout_);
+    result = injected->CreateDescriptorSetLayout(device_, &layout_info, nullptr, &descriptor_set_layout_);
 
     if (result != VK_SUCCESS)
     {
@@ -198,7 +196,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     VkPipelineLayoutCreateInfo pl_create_info = { VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
     pl_create_info.setLayoutCount             = 1;
     pl_create_info.pSetLayouts                = &descriptor_set_layout_; // Link the layout
-    result = device_table->CreatePipelineLayout(device_, &pl_create_info, nullptr, &pipeline_layout_);
+    result = injected->CreatePipelineLayout(device_, &pl_create_info, nullptr, &pipeline_layout_);
 
     if (result != VK_SUCCESS)
     {
@@ -214,7 +212,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     pool_info.poolSizeCount              = 1;
     pool_info.pPoolSizes                 = &pool_size;
     pool_info.maxSets                    = 1;
-    result = device_table->CreateDescriptorPool(device_, &pool_info, nullptr, &descriptor_pool_);
+    result = injected->CreateDescriptorPool(device_, &pool_info, nullptr, &descriptor_pool_);
 
     if (result != VK_SUCCESS)
     {
@@ -226,7 +224,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     set_alloc_info.descriptorPool              = descriptor_pool_;
     set_alloc_info.descriptorSetCount          = 1;
     set_alloc_info.pSetLayouts                 = &descriptor_set_layout_;
-    result = device_table->AllocateDescriptorSets(device_, &set_alloc_info, &descriptor_set_);
+    result = injected->AllocateDescriptorSets(device_, &set_alloc_info, &descriptor_set_);
 
     if (result != VK_SUCCESS)
     {
@@ -246,7 +244,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     descriptor_write.descriptorType       = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     descriptor_write.descriptorCount      = 1;
     descriptor_write.pBufferInfo          = &buffer_info_for_descriptor;
-    device_table->UpdateDescriptorSets(device_, 1, &descriptor_write, 0, nullptr);
+    injected->UpdateDescriptorSets(device_, 1, &descriptor_write, 0, nullptr);
 
     VkComputePipelineCreateInfo cp_create_info = { VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO };
     cp_create_info.stage.sType                 = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
@@ -254,7 +252,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     cp_create_info.stage.module                = shader_module_;
     cp_create_info.stage.pName                 = "main";
     cp_create_info.layout                      = pipeline_layout_;
-    result = device_table->CreateComputePipelines(device_, VK_NULL_HANDLE, 1, &cp_create_info, nullptr, &pipeline_);
+    result = injected->CreateComputePipelines(device_, VK_NULL_HANDLE, 1, &cp_create_info, nullptr, &pipeline_);
 
     if (result != VK_SUCCESS)
     {
@@ -263,7 +261,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     }
 
     VkSemaphoreCreateInfo semaphore_info = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
-    result = device_table->CreateSemaphore(device_, &semaphore_info, nullptr, &semaphore_.semaphore);
+    result = injected->CreateSemaphore(device_, &semaphore_info, nullptr, &semaphore_.semaphore);
 
     if (result != VK_SUCCESS)
     {
@@ -275,7 +273,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
     cmd_buf_alloc_info.commandPool                 = command_pool_;
     cmd_buf_alloc_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
     cmd_buf_alloc_info.commandBufferCount          = 1;
-    result = device_table->AllocateCommandBuffers(device_, &cmd_buf_alloc_info, &command_buffer_);
+    result = injected->AllocateCommandBuffers(device_, &cmd_buf_alloc_info, &command_buffer_);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_FATAL("VulkanFrameWarmUp: Failed in vkAllocateCommandBuffers: %s.",
@@ -284,72 +282,72 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*              device
 
     VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
     begin_info.flags                    = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
-    device_table->BeginCommandBuffer(command_buffer_, &begin_info);
-    device_table->CmdBindPipeline(command_buffer_, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_);
-    device_table->CmdBindDescriptorSets(
+    injected.BeginCommandBuffer(command_buffer_, &begin_info);
+    injected->CmdBindPipeline(command_buffer_, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_);
+    injected->CmdBindDescriptorSets(
         command_buffer_, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_, 0, 1, &descriptor_set_, 0, nullptr);
-    device_table->CmdDispatch(command_buffer_, warm_up_load_ * 64, 1, 1);
-    device_table->EndCommandBuffer(command_buffer_);
+    injected->CmdDispatch(command_buffer_, warm_up_load_ * 64, 1, 1);
+    injected->EndCommandBuffer(command_buffer_);
 }
 
 VulkanFrameWarmUp::~VulkanFrameWarmUp()
 {
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-
-    if (device_table_ != nullptr && device_ != VK_NULL_HANDLE)
+    if (injected_calls_.has_value() && device_ != VK_NULL_HANDLE)
     {
+        auto injected = injected_calls_->Open();
+
         if (semaphore_.semaphore != VK_NULL_HANDLE)
         {
-            device_table_->DestroySemaphore(device_, semaphore_.semaphore, nullptr);
+            injected->DestroySemaphore(device_, semaphore_.semaphore, nullptr);
         }
         if (buffer_memory_ != VK_NULL_HANDLE)
         {
-            device_table_->FreeMemory(device_, buffer_memory_, nullptr);
+            injected->FreeMemory(device_, buffer_memory_, nullptr);
         }
         if (buffer_ != VK_NULL_HANDLE)
         {
-            device_table_->DestroyBuffer(device_, buffer_, nullptr);
+            injected->DestroyBuffer(device_, buffer_, nullptr);
         }
         if (pipeline_ != VK_NULL_HANDLE)
         {
-            device_table_->DestroyPipeline(device_, pipeline_, nullptr);
+            injected->DestroyPipeline(device_, pipeline_, nullptr);
         }
         if (pipeline_layout_ != VK_NULL_HANDLE)
         {
-            device_table_->DestroyPipelineLayout(device_, pipeline_layout_, nullptr);
+            injected->DestroyPipelineLayout(device_, pipeline_layout_, nullptr);
         }
         if (descriptor_set_layout_ != VK_NULL_HANDLE)
         {
-            device_table_->DestroyDescriptorSetLayout(device_, descriptor_set_layout_, nullptr);
+            injected->DestroyDescriptorSetLayout(device_, descriptor_set_layout_, nullptr);
         }
         if (descriptor_pool_ != VK_NULL_HANDLE)
         {
-            device_table_->DestroyDescriptorPool(device_, descriptor_pool_, nullptr);
+            injected->DestroyDescriptorPool(device_, descriptor_pool_, nullptr);
         }
         if (shader_module_ != VK_NULL_HANDLE)
         {
-            device_table_->DestroyShaderModule(device_, shader_module_, nullptr);
+            injected->DestroyShaderModule(device_, shader_module_, nullptr);
         }
         if (command_buffer_ != VK_NULL_HANDLE)
         {
-            device_table_->FreeCommandBuffers(device_, command_pool_, 1, &command_buffer_);
+            injected->FreeCommandBuffers(device_, command_pool_, 1, &command_buffer_);
         }
         if (command_pool_ != VK_NULL_HANDLE)
         {
-            device_table_->DestroyCommandPool(device_, command_pool_, nullptr);
+            injected->DestroyCommandPool(device_, command_pool_, nullptr);
         }
     }
 }
 
 VulkanFrameWarmUp::VulkanFrameWarmUp(VulkanFrameWarmUp&& other) noexcept :
-    device_table_(other.device_table_), warm_up_load_(other.warm_up_load_), device_(other.device_),
+    injected_calls_(other.injected_calls_), warm_up_load_(other.warm_up_load_), device_(other.device_),
     queue_(other.queue_), command_pool_(other.command_pool_), command_buffer_(other.command_buffer_),
     shader_module_(other.shader_module_), descriptor_pool_(other.descriptor_pool_),
     descriptor_set_layout_(other.descriptor_set_layout_), descriptor_set_(other.descriptor_set_),
     pipeline_layout_(other.pipeline_layout_), pipeline_(other.pipeline_), buffer_(other.buffer_),
     buffer_memory_(other.buffer_memory_), semaphore_(other.semaphore_)
 {
-    other.device_table_          = nullptr;
+    other.injected_calls_.reset();
     other.device_                = VK_NULL_HANDLE;
     other.queue_                 = VK_NULL_HANDLE;
     other.command_pool_          = VK_NULL_HANDLE;
@@ -367,7 +365,7 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(VulkanFrameWarmUp&& other) noexcept :
 
 graphics::VulkanSemaphore VulkanFrameWarmUp::WarmUp(const std::span<graphics::VulkanSemaphore> wait_semaphores)
 {
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+    auto injected = injected_calls_->Open();
 
     std::vector<VkSemaphore>          semaphore_handles(wait_semaphores.size());
     std::vector<uint64_t>             semaphore_values(wait_semaphores.size());
@@ -396,7 +394,7 @@ graphics::VulkanSemaphore VulkanFrameWarmUp::WarmUp(const std::span<graphics::Vu
     submit_info.signalSemaphoreCount = 1;
     submit_info.pSignalSemaphores    = &semaphore_.semaphore;
 
-    VkResult result = device_table_->QueueSubmit(queue_, 1, &submit_info, VK_NULL_HANDLE);
+    VkResult result = injected->QueueSubmit(queue_, 1, &submit_info, VK_NULL_HANDLE);
 
     if (result != VK_SUCCESS)
     {

--- a/framework/decode/vulkan_frame_warm_up.h
+++ b/framework/decode/vulkan_frame_warm_up.h
@@ -24,12 +24,14 @@
 #ifndef GFXRECON_VULKAN_FRAME_WARMUP_H
 #define GFXRECON_VULKAN_FRAME_WARMUP_H
 
+#include <optional>
 #include <vector>
 #include <unordered_map>
 #include <vulkan/vulkan.h>
 
 #include "decode/common_object_info_table.h"
 #include "decode/vulkan_object_info.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "graphics/vulkan_semaphore_util.h"
 #include "util/defines.h"
 
@@ -42,12 +44,12 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class VulkanFrameWarmUp
 {
   public:
-    VulkanFrameWarmUp(const VulkanDeviceInfo*              device_info,
-                      const graphics::VulkanDeviceTable*   device_table,
-                      const graphics::VulkanInstanceTable* instance_table,
-                      CommonObjectInfoTable&               object_table,
-                      const std::string&                   spirv_path,
-                      uint32_t                             warm_up_load);
+    VulkanFrameWarmUp(const VulkanDeviceInfo*                    device_info,
+                      const graphics::VulkanInjectedDeviceCalls& injected_calls,
+                      const graphics::VulkanInstanceTable*       instance_table,
+                      CommonObjectInfoTable&                     object_table,
+                      const std::string&                         spirv_path,
+                      uint32_t                                   warm_up_load);
     ~VulkanFrameWarmUp();
 
     VulkanFrameWarmUp(VulkanFrameWarmUp&&) noexcept;
@@ -58,23 +60,24 @@ class VulkanFrameWarmUp
     graphics::VulkanSemaphore WarmUp(const std::span<graphics::VulkanSemaphore> wait_semaphores = {});
 
   private:
-    const graphics::VulkanDeviceTable* device_table_{ nullptr };
+    // Every device call this class makes is replay-injected. Empty only in the moved-from state.
+    std::optional<graphics::VulkanInjectedDeviceCalls> injected_calls_;
 
     std::string spirv_path_;
     uint32_t    warm_up_load_{ 0 };
 
-    VkDevice              device_{ VK_NULL_HANDLE };
-    VkQueue               queue_{ VK_NULL_HANDLE };
-    VkCommandPool         command_pool_{ VK_NULL_HANDLE };
-    VkCommandBuffer       command_buffer_{ VK_NULL_HANDLE };
-    VkShaderModule        shader_module_{ VK_NULL_HANDLE };
-    VkDescriptorPool      descriptor_pool_{ VK_NULL_HANDLE };
-    VkDescriptorSetLayout descriptor_set_layout_{ VK_NULL_HANDLE };
-    VkDescriptorSet       descriptor_set_{ VK_NULL_HANDLE };
-    VkPipelineLayout      pipeline_layout_{ VK_NULL_HANDLE };
-    VkPipeline            pipeline_{ VK_NULL_HANDLE };
-    VkBuffer              buffer_{ VK_NULL_HANDLE };
-    VkDeviceMemory        buffer_memory_{ VK_NULL_HANDLE };
+    VkDevice                  device_{ VK_NULL_HANDLE };
+    VkQueue                   queue_{ VK_NULL_HANDLE };
+    VkCommandPool             command_pool_{ VK_NULL_HANDLE };
+    VkCommandBuffer           command_buffer_{ VK_NULL_HANDLE };
+    VkShaderModule            shader_module_{ VK_NULL_HANDLE };
+    VkDescriptorPool          descriptor_pool_{ VK_NULL_HANDLE };
+    VkDescriptorSetLayout     descriptor_set_layout_{ VK_NULL_HANDLE };
+    VkDescriptorSet           descriptor_set_{ VK_NULL_HANDLE };
+    VkPipelineLayout          pipeline_layout_{ VK_NULL_HANDLE };
+    VkPipeline                pipeline_{ VK_NULL_HANDLE };
+    VkBuffer                  buffer_{ VK_NULL_HANDLE };
+    VkDeviceMemory            buffer_memory_{ VK_NULL_HANDLE };
     graphics::VulkanSemaphore semaphore_{ VK_NULL_HANDLE };
 };
 

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -158,12 +158,12 @@ void ClearObjects(CommonObjectInfoTable* table,
     }
 }
 
-void FreeAllLiveObjects(CommonObjectInfoTable*                                           table,
-                        bool                                                             remove_entries,
-                        bool                                                             report_leaks,
-                        std::function<const graphics::VulkanInstanceTable*(const void*)> get_instance_table,
-                        std::function<const graphics::VulkanDeviceTable*(const void*)>   get_device_table,
-                        VulkanSwapchain*                                                 swapchain)
+void FreeAllLiveObjects(CommonObjectInfoTable*                                                table,
+                        bool                                                                  remove_entries,
+                        bool                                                                  report_leaks,
+                        std::function<const graphics::VulkanInstanceTable*(const void*)>      get_instance_table,
+                        std::function<const graphics::VulkanInjectedDeviceCalls(const void*)> get_injected_calls_table,
+                        VulkanSwapchain*                                                      swapchain)
 {
     FreeChildObjects<VulkanDeviceInfo, VulkanEventInfo>(
         table,
@@ -176,7 +176,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkEventInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanEventInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)->DestroyEvent(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyEvent(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanFenceInfo>(
@@ -190,7 +192,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkFenceInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanFenceInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)->DestroyFence(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyFence(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanSemaphoreInfo>(
@@ -204,7 +208,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkSemaphoreInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanSemaphoreInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)->DestroySemaphore(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroySemaphore(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanQueryPoolInfo>(
@@ -218,7 +224,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkQueryPoolInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanQueryPoolInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)->DestroyQueryPool(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyQueryPool(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanRenderPassInfo>(
@@ -232,7 +240,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkRenderPassInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanRenderPassInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)->DestroyRenderPass(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyRenderPass(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanSamplerInfo>(
@@ -246,7 +256,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkSamplerInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanSamplerInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)->DestroySampler(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroySampler(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanSamplerYcbcrConversionInfo>(
@@ -260,8 +272,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkSamplerYcbcrConversionInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanSamplerYcbcrConversionInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroySamplerYcbcrConversion(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroySamplerYcbcrConversion(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanFramebufferInfo>(
@@ -275,8 +288,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkFramebufferInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanFramebufferInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyFramebuffer(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyFramebuffer(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanImageViewInfo>(
@@ -290,7 +304,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkImageViewInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanImageViewInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)->DestroyImageView(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyImageView(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanImageInfo>(
@@ -322,7 +338,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkBufferViewInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanBufferViewInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)->DestroyBufferView(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyBufferView(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanBufferInfo>(
@@ -372,8 +390,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkPipelineCacheInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPipelineCacheInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyPipelineCache(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyPipelineCache(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanPipelineInfo>(
@@ -387,7 +406,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkPipelineInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPipelineInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)->DestroyPipeline(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyPipeline(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanPipelineLayoutInfo>(
@@ -401,8 +422,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkPipelineLayoutInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPipelineLayoutInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyPipelineLayout(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyPipelineLayout(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanShaderModuleInfo>(
@@ -416,8 +438,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkShaderModuleInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanShaderModuleInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyShaderModule(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyShaderModule(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanShaderEXTInfo>(
@@ -431,7 +454,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkShaderEXTInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanShaderEXTInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)->DestroyShaderEXT(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyShaderEXT(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanPipelineBinaryKHRInfo>(
@@ -445,8 +470,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkPipelineBinaryKHRInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPipelineBinaryKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyPipelineBinaryKHR(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyPipelineBinaryKHR(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanDescriptorSetLayoutInfo>(
@@ -460,8 +486,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkDescriptorSetLayoutInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanDescriptorSetLayoutInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyDescriptorSetLayout(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyDescriptorSetLayout(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanDescriptorUpdateTemplateInfo>(
@@ -475,8 +502,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkDescriptorUpdateTemplateInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanDescriptorUpdateTemplateInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyDescriptorUpdateTemplate(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyDescriptorUpdateTemplate(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanCommandPoolInfo>(
@@ -490,8 +518,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkCommandPoolInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanCommandPoolInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyCommandPool(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyCommandPool(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanIndirectCommandsLayoutNVInfo>(
@@ -505,8 +534,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkIndirectCommandsLayoutNVInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanIndirectCommandsLayoutNVInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyIndirectCommandsLayoutNV(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyIndirectCommandsLayoutNV(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanValidationCacheEXTInfo>(
@@ -520,8 +550,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkValidationCacheEXTInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanValidationCacheEXTInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyValidationCacheEXT(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyValidationCacheEXT(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanAccelerationStructureKHRInfo>(
@@ -535,8 +566,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkAccelerationStructureKHRInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanAccelerationStructureKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyAccelerationStructureKHR(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyAccelerationStructureKHR(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanAccelerationStructureNVInfo>(
@@ -550,8 +582,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkAccelerationStructureNVInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanAccelerationStructureNVInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyAccelerationStructureNV(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyAccelerationStructureNV(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanPerformanceConfigurationINTELInfo>(
@@ -565,8 +598,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkPerformanceConfigurationINTELInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPerformanceConfigurationINTELInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->ReleasePerformanceConfigurationINTEL(parent_info->handle, object_info->handle);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->ReleasePerformanceConfigurationINTEL(parent_info->handle, object_info->handle);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanDeferredOperationKHRInfo>(
@@ -580,8 +614,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkDeferredOperationKHRInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanDeferredOperationKHRInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyDeferredOperationKHR(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyDeferredOperationKHR(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanPrivateDataSlotInfo>(
@@ -595,8 +630,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkPrivateDataSlotInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanPrivateDataSlotInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyPrivateDataSlot(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyPrivateDataSlot(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanDeviceInfo, VulkanMicromapEXTInfo>(
@@ -610,8 +646,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         &CommonObjectInfoTable::RemoveVkMicromapEXTInfo,
         [&](const VulkanDeviceInfo* parent_info, const VulkanMicromapEXTInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
-            get_device_table(parent_info->handle)
-                ->DestroyMicromapEXT(parent_info->handle, object_info->handle, nullptr);
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
+            injected->DestroyMicromapEXT(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<VulkanInstanceInfo, VulkanDebugReportCallbackEXTInfo>(
@@ -658,14 +695,14 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
         [&](const VulkanDeviceInfo* parent_info, const VulkanDescriptorPoolInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
 
+            const auto device_table = get_injected_calls_table(parent_info->handle);
+            auto       injected     = device_table.Open();
             for (auto retired_pool : object_info->retired_pools)
             {
-                get_device_table(parent_info->handle)
-                    ->DestroyDescriptorPool(parent_info->handle, retired_pool, nullptr);
+                injected->DestroyDescriptorPool(parent_info->handle, retired_pool, nullptr);
             }
 
-            get_device_table(parent_info->handle)
-                ->DestroyDescriptorPool(parent_info->handle, object_info->handle, nullptr);
+            injected->DestroyDescriptorPool(parent_info->handle, object_info->handle, nullptr);
         });
 
     // VkSwapchainKHR objects have a special destroy function to ignore the object when it has a null surface handle.
@@ -683,8 +720,9 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
             assert((parent_info != nullptr) && (object_info != nullptr));
             if (object_info->surface != VK_NULL_HANDLE)
             {
-                swapchain->DestroySwapchainKHR(
-                    get_device_table(parent_info->handle)->DestroySwapchainKHR, parent_info, object_info, nullptr);
+                const auto device_table = get_injected_calls_table(parent_info->handle);
+                auto       injected     = device_table.Open();
+                swapchain->DestroySwapchainKHR(injected->DestroySwapchainKHR, parent_info, object_info, nullptr);
             }
             else
             {
@@ -724,10 +762,11 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
                                         [&](const VulkanDeviceInfo* object_info) {
                                             GFXRECON_ASSERT(object_info != nullptr);
                                             GFXRECON_ASSERT(swapchain != nullptr)
-                                            auto* device_table = get_device_table(object_info->handle);
-                                            swapchain->CleanDeviceResources(object_info->handle, device_table);
+                                            const auto device_table = get_injected_calls_table(object_info->handle);
+                                            auto       injected     = device_table.Open();
+                                            swapchain->CleanDeviceResources(object_info->handle, &device_table);
                                             object_info->allocator->Destroy();
-                                            device_table->DestroyDevice(object_info->handle, nullptr);
+                                            injected->DestroyDevice(object_info->handle, nullptr);
                                         });
 
     // Remove the objects that are not destroyed from the table.

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -808,8 +808,7 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
 void FreeAllLiveInstances(CommonObjectInfoTable*                                           table,
                           bool                                                             remove_entries,
                           bool                                                             report_leaks,
-                          std::function<const graphics::VulkanInstanceTable*(const void*)> get_instance_table,
-                          std::function<const graphics::VulkanDeviceTable*(const void*)>   get_device_table)
+                          std::function<const graphics::VulkanInstanceTable*(const void*)> get_instance_table)
 {
     FreeParentObjects<VulkanInstanceInfo>(table,
                                           remove_entries,

--- a/framework/decode/vulkan_object_cleanup_util.h
+++ b/framework/decode/vulkan_object_cleanup_util.h
@@ -45,8 +45,7 @@ void FreeAllLiveObjects(CommonObjectInfoTable*                                  
 void FreeAllLiveInstances(CommonObjectInfoTable*                                           table,
                           bool                                                             remove_entries,
                           bool                                                             report_leaks,
-                          std::function<const graphics::VulkanInstanceTable*(const void*)> get_instance_table,
-                          std::function<const graphics::VulkanDeviceTable*(const void*)>   get_device_table);
+                          std::function<const graphics::VulkanInstanceTable*(const void*)> get_instance_table);
 
 GFXRECON_END_NAMESPACE(object_cleanup)
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_object_cleanup_util.h
+++ b/framework/decode/vulkan_object_cleanup_util.h
@@ -26,6 +26,7 @@
 #include "decode/vulkan_swapchain.h"
 #include "decode/common_object_info_table.h"
 #include "generated/generated_vulkan_dispatch_table.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "util/defines.h"
 
 #include <functional>
@@ -34,12 +35,12 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 GFXRECON_BEGIN_NAMESPACE(object_cleanup)
 
-void FreeAllLiveObjects(CommonObjectInfoTable*                                           table,
-                        bool                                                             remove_entries,
-                        bool                                                             report_leaks,
-                        std::function<const graphics::VulkanInstanceTable*(const void*)> get_instance_table,
-                        std::function<const graphics::VulkanDeviceTable*(const void*)>   get_device_table,
-                        VulkanSwapchain*                                                 swapchain);
+void FreeAllLiveObjects(CommonObjectInfoTable*                                                table,
+                        bool                                                                  remove_entries,
+                        bool                                                                  report_leaks,
+                        std::function<const graphics::VulkanInstanceTable*(const void*)>      get_instance_table,
+                        std::function<const graphics::VulkanInjectedDeviceCalls(const void*)> get_injected_calls_table,
+                        VulkanSwapchain*                                                      swapchain);
 
 void FreeAllLiveInstances(CommonObjectInfoTable*                                           table,
                           bool                                                             remove_entries,

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -24,12 +24,12 @@
 #include "encode/vulkan_handle_wrapper_util.h"
 #include "decode/decoder_util.h"
 #include "generated/generated_vulkan_enum_to_string.h"
-#include "util/callbacks.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-void VulkanOffscreenSwapchain::CleanDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table)
+void VulkanOffscreenSwapchain::CleanDeviceResources(VkDevice                                   device,
+                                                    const graphics::VulkanInjectedDeviceCalls* device_table)
 {
     VulkanVirtualSwapchain::CleanDeviceResources(device, device_table);
 
@@ -88,16 +88,16 @@ void VulkanOffscreenSwapchain::DestroySurface(PFN_vkDestroySurfaceKHR      func,
                                               const VkAllocationCallbacks* allocator)
 {}
 
-VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                              original_result,
-                                                      PFN_vkCreateSwapchainKHR              func,
-                                                      const VulkanDeviceInfo*               device_info,
-                                                      const VkSwapchainCreateInfoKHR*       create_info,
-                                                      const VkAllocationCallbacks*          allocator,
-                                                      HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                                      const graphics::VulkanDeviceTable*    device_table)
+VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                                   original_result,
+                                                      PFN_vkCreateSwapchainKHR                   func,
+                                                      const VulkanDeviceInfo*                    device_info,
+                                                      const VkSwapchainCreateInfoKHR*            create_info,
+                                                      const VkAllocationCallbacks*               allocator,
+                                                      HandlePointerDecoder<VkSwapchainKHR>*      swapchain,
+                                                      const graphics::VulkanInjectedDeviceCalls& injected_calls)
 {
     GFXRECON_ASSERT(device_info);
-    device_table_ = device_table;
+    injected_calls_ = injected_calls;
 
     const format::HandleId* id               = swapchain->GetPointer();
     VkSwapchainKHR*         replay_swapchain = swapchain->GetHandlePointer();
@@ -111,7 +111,9 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
     }
     swapchain_resources_[*replay_swapchain]->forced_offscreen = true;
 
-    default_queue_ = GetDeviceQueue(device_table_, device_info, default_queue_family_index_, 0);
+    // The device-queue query has no corresponding block in the capture file.
+    auto injected  = injected_calls_->Open();
+    default_queue_ = GetDeviceQueue(injected.GetTable(), device_info, default_queue_family_index_, 0);
 
     // If this option is set, a command buffer submission with a `VkFrameBoundaryEXT` must be called each time
     // `vkQueuePresentKHR` should have been called by the offscreen swapchain. So a maximum of work must be done at
@@ -256,8 +258,8 @@ VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                     
 
     if (swapchain_options_.offscreen_swapchain_frame_boundary || present_info->waitSemaphoreCount > 0)
     {
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        result = device_table_->QueueSubmit(queue_info->handle, 1, &submit_info, VK_NULL_HANDLE);
+        auto injected = injected_calls_->Open();
+        result        = injected->QueueSubmit(queue_info->handle, 1, &submit_info, VK_NULL_HANDLE);
 
         if (result != VK_SUCCESS)
         {
@@ -274,7 +276,7 @@ void VulkanOffscreenSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*        
                                                  const VulkanImageInfo*                     image_info,
                                                  VulkanInstanceInfo*                        instance_info,
                                                  const graphics::VulkanInstanceTable*       instance_table,
-                                                 const graphics::VulkanDeviceTable*         device_table,
+                                                 const graphics::VulkanInjectedDeviceCalls& injected_calls,
                                                  application::Application*                  application,
                                                  const std::optional<std::array<float, 2>>& scale)
 {
@@ -283,7 +285,7 @@ void VulkanOffscreenSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*        
     GFXRECON_UNREFERENCED_PARAMETER(image_info);
     GFXRECON_UNREFERENCED_PARAMETER(instance_info);
     GFXRECON_UNREFERENCED_PARAMETER(instance_table);
-    GFXRECON_UNREFERENCED_PARAMETER(device_table);
+    GFXRECON_UNREFERENCED_PARAMETER(injected_calls);
     GFXRECON_UNREFERENCED_PARAMETER(application);
     GFXRECON_UNREFERENCED_PARAMETER(scale);
 
@@ -300,7 +302,7 @@ VkResult VulkanOffscreenSwapchain::SignalAcquireNextImageSemaphoreFence(const Vu
 
     VkResult result = VK_ERROR_UNKNOWN;
 
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+    auto injected = injected_calls_->Open();
 
     switch (external_sync_type)
     {
@@ -317,7 +319,7 @@ VkResult VulkanOffscreenSwapchain::SignalAcquireNextImageSemaphoreFence(const Vu
             submit_info.signalSemaphoreCount = (semaphore == VK_NULL_HANDLE ? 0 : 1);
             submit_info.pSignalSemaphores    = (semaphore == VK_NULL_HANDLE ? nullptr : &semaphore);
 
-            result = device_table_->QueueSubmit(default_queue_, 1, &submit_info, fence);
+            result = injected->QueueSubmit(default_queue_, 1, &submit_info, fence);
 
             if (result != VK_SUCCESS)
             {
@@ -340,7 +342,7 @@ VkResult VulkanOffscreenSwapchain::SignalAcquireNextImageSemaphoreFence(const Vu
                 import_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
                 import_info.fd         = -1;
 
-                result = device_table_->ImportSemaphoreFdKHR(device_info->handle, &import_info);
+                result = injected->ImportSemaphoreFdKHR(device_info->handle, &import_info);
 
                 if (result != VK_SUCCESS)
                 {
@@ -362,7 +364,7 @@ VkResult VulkanOffscreenSwapchain::SignalAcquireNextImageSemaphoreFence(const Vu
                 import_info.handleType = VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT;
                 import_info.fd         = -1;
 
-                result = device_table_->ImportFenceFdKHR(device_info->handle, &import_info);
+                result = injected->ImportFenceFdKHR(device_info->handle, &import_info);
 
                 if (result != VK_SUCCESS)
                 {

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -35,7 +35,8 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
   public:
     virtual ~VulkanOffscreenSwapchain() override {}
 
-    virtual void CleanDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table) override;
+    virtual void CleanDeviceResources(VkDevice                                   device,
+                                      const graphics::VulkanInjectedDeviceCalls* device_table) override;
 
     virtual void SetExternalSyncType(VkDevice device, ExternalSyncType external_sync_type) override;
 
@@ -52,13 +53,13 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                 const VulkanSurfaceKHRInfo*  surface_info,
                                 const VkAllocationCallbacks* allocator) override;
 
-    virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
-                                        PFN_vkCreateSwapchainKHR              func,
-                                        const VulkanDeviceInfo*               device_info,
-                                        const VkSwapchainCreateInfoKHR*       create_info,
-                                        const VkAllocationCallbacks*          allocator,
-                                        HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const graphics::VulkanDeviceTable*    device_table) override;
+    virtual VkResult CreateSwapchainKHR(VkResult                                   original_result,
+                                        PFN_vkCreateSwapchainKHR                   func,
+                                        const VulkanDeviceInfo*                    device_info,
+                                        const VkSwapchainCreateInfoKHR*            create_info,
+                                        const VkAllocationCallbacks*               allocator,
+                                        HandlePointerDecoder<VkSwapchainKHR>*      swapchain,
+                                        const graphics::VulkanInjectedDeviceCalls& injected_calls) override;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
                                      const VulkanDeviceInfo*       device_info,
@@ -103,7 +104,7 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                            const VulkanImageInfo*                     image_info,
                            VulkanInstanceInfo*                        instance_info,
                            const graphics::VulkanInstanceTable*       instance_table,
-                           const graphics::VulkanDeviceTable*         device_table,
+                           const graphics::VulkanInjectedDeviceCalls& injected_calls,
                            application::Application*                  application,
                            const std::optional<std::array<float, 2>>& scale) override;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3185,6 +3185,12 @@ void VulkanReplayConsumerBase::ModifyCreateInstanceInfo(
             GFXRECON_LOG_WARNING("Failed to create debug utils callback. VK_EXT_debug_utils extension is not available "
                                  "for the replay instance.");
 
+            if (options_.annotate_injected_commands)
+            {
+                GFXRECON_LOG_WARNING("--annotate-injected-commands was requested but VK_EXT_debug_utils is not "
+                                     "available for the replay instance; injected commands will not be labeled.");
+            }
+
             if (ext_debug_utils_it != modified_extensions.end())
             {
                 GFXRECON_LOG_INFO("VK_EXT_debug_utils was queried by the application but is not available on the "

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -363,11 +363,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
 
     // Finally destroy vkInstances
     object_cleanup::FreeAllLiveInstances(
-        object_info_table_,
-        false,
-        true,
-        [this](const void* handle) { return GetInstanceTable(handle); },
-        [this](const void* handle) { return GetDeviceTable(handle); });
+        object_info_table_, false, true, [this](const void* handle) { return GetInstanceTable(handle); });
 
     if (loader_handle_ != nullptr)
     {
@@ -1078,9 +1074,6 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
         auto allocator = device_info->allocator.get();
         GFXRECON_ASSERT(allocator != nullptr);
 
-        auto table = GetDeviceTable(device);
-        GFXRECON_ASSERT(table != nullptr);
-
         VkPhysicalDevice physical_device = device_info->parent;
         GFXRECON_ASSERT(physical_device != VK_NULL_HANDLE);
 
@@ -1102,15 +1095,14 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
             have_shader_stencil_write = true;
         }
 
-        device_info->resource_initializer =
-            std::make_shared<VulkanResourceInitializer>(device_info,
-                                                        total_copy_size,
-                                                        max_copy_size,
-                                                        properties,
-                                                        memory_properties,
-                                                        have_shader_stencil_write,
-                                                        allocator,
-                                                        graphics::VulkanInjectedDeviceCalls(table));
+        device_info->resource_initializer = std::make_shared<VulkanResourceInitializer>(device_info,
+                                                                                        total_copy_size,
+                                                                                        max_copy_size,
+                                                                                        properties,
+                                                                                        memory_properties,
+                                                                                        have_shader_stencil_write,
+                                                                                        allocator,
+                                                                                        GetInjectedDeviceCalls(device));
     }
 }
 
@@ -12411,7 +12403,8 @@ VulkanCommandBufferUtil& VulkanReplayConsumerBase::GetDeviceCommandBufferUtil(co
 
     auto [new_it, success] = device_command_buffer_utils_.insert(
         { device_info,
-          VulkanCommandBufferUtil(device_info, GetDeviceTable(device_info->handle), object_info_table_, decoder) });
+          VulkanCommandBufferUtil(
+              device_info, GetInjectedDeviceCalls(device_info->handle), object_info_table_, decoder) });
     GFXRECON_ASSERT(success);
     return new_it->second;
 }
@@ -12424,7 +12417,7 @@ VulkanSubmitJobExecutor& VulkanReplayConsumerBase::GetDeviceSubmitJobExecutor(co
     }
 
     auto [new_it, success] = device_submit_job_executors_.insert(
-        { device_info, VulkanSubmitJobExecutor(device_info, GetDeviceTable(device_info->handle)) });
+        { device_info, VulkanSubmitJobExecutor(device_info, GetInjectedDeviceCalls(device_info->handle)) });
     GFXRECON_ASSERT(success);
     return new_it->second;
 }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -34,6 +34,7 @@
 #include "decode/vulkan_address_replacer.h"
 #include "decode/vulkan_enum_util.h"
 #include "encode/capture_manager.h"
+#include "graphics/vulkan_injected_calls.h"
 
 #if defined(GFXRECON_ENABLE_VULKAN)
 #include "encode/vulkan_capture_manager.h"
@@ -251,6 +252,10 @@ VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::
     swapchain_options.present_mode_option                = options_.present_mode_option;
     swapchain_->SetOptions(swapchain_options);
 
+    // Enable/disable debug-utils labels around replay-injected commands (--annotate-injected-commands).
+    // This is a process-wide flag read by VulkanInjectedDeviceCalls at each injection site.
+    graphics::SetAnnotateInjectedCommands(options_.annotate_injected_commands);
+
     if (options_.enable_debug_device_lost)
     {
         GFXRECON_LOG_WARNING("This debugging feature has not been implemented for Vulkan.");
@@ -336,12 +341,9 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
         assert(info != nullptr);
         VkDevice device = info->handle;
 
-        auto device_table = GetDeviceTable(device);
-        assert(device_table != nullptr);
-
         if (screenshot_handler_ != nullptr)
         {
-            screenshot_handler_->DestroyDeviceResources(device, device_table);
+            screenshot_handler_->DestroyDeviceResources(device, GetInjectedDeviceCalls(device));
         }
     });
 
@@ -350,7 +352,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
         false,
         true,
         [this](const void* handle) { return GetInstanceTable(handle); },
-        [this](const void* handle) { return GetDeviceTable(handle); },
+        [this](const void* handle) { return GetInjectedDeviceCalls(handle); },
         swapchain_.get());
 
     swapchain_->Clean();
@@ -382,10 +384,9 @@ void VulkanReplayConsumerBase::WaitDevicesIdle()
         assert(info != nullptr);
         VkDevice device = info->handle;
 
-        auto device_table = GetDeviceTable(device);
-        assert(device_table != nullptr);
-
-        device_table->DeviceWaitIdle(device);
+        auto device_table = GetInjectedDeviceCalls(device);
+        auto injected     = device_table.Open();
+        injected->DeviceWaitIdle(device);
     });
 }
 
@@ -517,7 +518,8 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
 
                 VulkanDeviceInfo* device_info  = object_info_table_->GetVkDeviceInfo(buffer_info.device_id);
                 VkDevice          device       = device_info->handle;
-                auto              device_table = GetDeviceTable(device);
+                auto              device_table = GetInjectedDeviceCalls(device);
+                auto              injected     = device_table.Open();
                 auto physical_device_info      = object_info_table_->GetVkPhysicalDeviceInfo(device_info->parent_id);
                 auto memory_properties         = &physical_device_info->capture_memory_properties;
 
@@ -530,7 +532,7 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
                 properties.pNext = &format_properties;
 
                 if (vk_result == VK_SUCCESS)
-                    vk_result = device_table->GetAndroidHardwareBufferPropertiesANDROID(
+                    vk_result = injected->GetAndroidHardwareBufferPropertiesANDROID(
                         device, buffer_info.hardware_buffer, &properties);
 
                 // External format data cannot be refilled at replay time, therefore we expect format to be defined.
@@ -585,7 +587,7 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
 
                 VkImage ahb_image = VK_NULL_HANDLE;
                 if (vk_result == VK_SUCCESS)
-                    vk_result = device_table->CreateImage(device, &image_info, nullptr, &ahb_image);
+                    vk_result = injected->CreateImage(device, &image_info, nullptr, &ahb_image);
 
                 VkImportAndroidHardwareBufferInfoANDROID import_ahb_info = {};
                 import_ahb_info.sType  = VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID;
@@ -618,10 +620,10 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
 
                 VkDeviceMemory image_memory = VK_NULL_HANDLE;
                 if (vk_result == VK_SUCCESS)
-                    vk_result = device_table->AllocateMemory(device, &memory_allocate_info, nullptr, &image_memory);
+                    vk_result = injected->AllocateMemory(device, &memory_allocate_info, nullptr, &image_memory);
 
                 if (vk_result == VK_SUCCESS)
-                    vk_result = device_table->BindImageMemory(device, ahb_image, image_memory, 0);
+                    vk_result = injected->BindImageMemory(device, ahb_image, image_memory, 0);
 
                 ProcessBeginResourceInitCommand(buffer_info.device_id, size, size);
 
@@ -657,8 +659,8 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
 
                 ProcessEndResourceInitCommand(buffer_info.device_id);
 
-                device_table->FreeMemory(device, image_memory, nullptr);
-                device_table->DestroyImage(device, ahb_image, nullptr);
+                injected->FreeMemory(device, image_memory, nullptr);
+                injected->DestroyImage(device, ahb_image, nullptr);
 
                 if (vk_result != VK_SUCCESS)
                     GFXRECON_LOG_ERROR("Failed to copy data to AHardwareBuffer that is not cpu readable");
@@ -1100,14 +1102,15 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
             have_shader_stencil_write = true;
         }
 
-        device_info->resource_initializer = std::make_shared<VulkanResourceInitializer>(device_info,
-                                                                                        total_copy_size,
-                                                                                        max_copy_size,
-                                                                                        properties,
-                                                                                        memory_properties,
-                                                                                        have_shader_stencil_write,
-                                                                                        allocator,
-                                                                                        table);
+        device_info->resource_initializer =
+            std::make_shared<VulkanResourceInitializer>(device_info,
+                                                        total_copy_size,
+                                                        max_copy_size,
+                                                        properties,
+                                                        memory_properties,
+                                                        have_shader_stencil_write,
+                                                        allocator,
+                                                        graphics::VulkanInjectedDeviceCalls(table));
     }
 }
 
@@ -1559,6 +1562,11 @@ const graphics::VulkanDeviceTable* VulkanReplayConsumerBase::GetDeviceTable(cons
     auto table = device_tables_.find(graphics::GetVulkanDispatchKey(handle));
     assert(table != device_tables_.end());
     return (table != device_tables_.end()) ? &table->second : nullptr;
+}
+
+graphics::VulkanInjectedDeviceCalls VulkanReplayConsumerBase::GetInjectedDeviceCalls(const void* handle) const
+{
+    return graphics::VulkanInjectedDeviceCalls(GetDeviceTable(handle));
 }
 
 void* VulkanReplayConsumerBase::PreProcessExternalObject(uint64_t          object_id,
@@ -2807,7 +2815,7 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
                     screenshot_handler_->WriteImage(
                         num_layers > 1 ? filename_prefix + "_layer_" + std::to_string(layer) : filename_prefix,
                         device_info,
-                        GetDeviceTable(device_info->handle),
+                        GetInjectedDeviceCalls(device_info->handle),
                         memory_properties,
                         device_info->allocator.get(),
                         image,
@@ -2835,13 +2843,16 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
         {
             VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(command_buffer_info->parent_id);
 
-            auto instance_table = GetInstanceTable(device_info->parent);
-            GFXRECON_ASSERT(instance_table != nullptr);
-
-            // TODO: This should be stored in the VulkanDeviceInfo structure to avoid the need for frequent
-            // queries.
             VkPhysicalDeviceMemoryProperties memory_properties;
-            instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+            {
+                util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+                auto                             instance_table = GetInstanceTable(device_info->parent);
+                GFXRECON_ASSERT(instance_table != nullptr);
+
+                // TODO: This should be stored in the VulkanDeviceInfo structure to avoid the need for frequent
+                // queries.
+                instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+            }
 
             for (size_t i = 0; i < command_buffer_info->frame_buffer_ids.size(); ++i)
             {
@@ -2888,7 +2899,7 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
 
                     screenshot_handler_->WriteImage(filename_prefix,
                                                     device_info,
-                                                    GetDeviceTable(device_info->handle),
+                                                    GetInjectedDeviceCalls(device_info->handle),
                                                     memory_properties,
                                                     device_info->allocator.get(),
                                                     image_info->handle,
@@ -2918,11 +2929,14 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDevic
         return false;
     }
 
-    auto instance_table = GetInstanceTable(device_info->parent);
-    GFXRECON_ASSERT(instance_table != nullptr);
-
     VkPhysicalDeviceMemoryProperties memory_properties;
-    instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+    {
+        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+        auto                             instance_table = GetInstanceTable(device_info->parent);
+        GFXRECON_ASSERT(instance_table != nullptr);
+
+        instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+    }
 
     if (screenshot_handler_->IsScreenshotFrame())
     {
@@ -2951,7 +2965,7 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDevic
 
             screenshot_handler_->WriteImage(filename_prefix,
                                             device_info,
-                                            GetDeviceTable(device_info->handle),
+                                            GetInjectedDeviceCalls(device_info->handle),
                                             memory_properties,
                                             device_info->allocator.get(),
                                             image_info->handle,
@@ -3963,13 +3977,11 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
     if (device_info != nullptr && device_info->duplicate_source_id == format::kNullHandleId)
     {
         device                  = device_info->handle;
-        const auto device_table = GetDeviceTable(device);
+        const auto device_table = GetInjectedDeviceCalls(device);
 
         if (screenshot_handler_ != nullptr)
         {
-            util::BeginInjectedCommands();
             screenshot_handler_->DestroyDeviceResources(device, device_table);
-            util::EndInjectedCommands();
         }
 
         // free replacer internal vulkan-resources for the device
@@ -3979,7 +3991,7 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
 
         // free potential swapchain-resources for the device
         GFXRECON_ASSERT(swapchain_)
-        swapchain_->CleanDeviceResources(device_info->handle, device_table);
+        swapchain_->CleanDeviceResources(device_info->handle, &device_table);
 
         // free frame warm up resources before the device is destroyed
         device_frame_warmups_.erase(device_info);
@@ -4645,10 +4657,9 @@ VkResult VulkanReplayConsumerBase::OverrideGetFenceStatus(PFN_vkGetFenceStatus  
     {
         // Replay is usually faster than the original application, so there is a good chance the fence is still not
         // ready. In this case, we make sure the fence is signaled by waiting for it.
-        util::BeginInjectedCommands();
-        result =
-            GetDeviceTable(device)->WaitForFences(device, 1, &fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
-        util::EndInjectedCommands();
+        auto device_table = GetInjectedDeviceCalls(device);
+        auto injected     = device_table.Open();
+        result            = injected->WaitForFences(device, 1, &fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
         GFXRECON_ASSERT(result == VK_SUCCESS);
     }
 
@@ -4726,7 +4737,9 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
 
     if (options_.idle_before_submit)
     {
-        GetDeviceTable(device_info->handle)->DeviceWaitIdle(device_info->handle);
+        auto device_table = GetInjectedDeviceCalls(device_info->handle);
+        auto injected     = device_table.Open();
+        injected->DeviceWaitIdle(device_info->handle);
     }
 
     VulkanSubmitJobPlan plan;
@@ -4895,15 +4908,14 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
 
     if ((options_.sync_queue_submissions) && (result == VK_SUCCESS))
     {
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        event_result      = GetDeviceTable(queue_info->handle)->QueueWaitIdle(queue_info->handle);
+        auto device_table = GetInjectedDeviceCalls(queue_info->handle);
+        auto injected     = device_table.Open();
+        event_result      = injected->QueueWaitIdle(queue_info->handle);
         completion_source = GFXR_REPLAY_QUEUE_SUBMIT_COMPLETION_SOURCE_QUEUE_IDLE;
     }
 
     if (screenshot_handler_ != nullptr)
     {
-        util::BeginInjectedCommands();
-
         VulkanCommandBufferInfo* frame_boundary_command_buffer_info = nullptr;
         for (uint32_t i = 0; i < submitCount; ++i)
         {
@@ -4939,8 +4951,6 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
                 }
             }
         }
-
-        util::EndInjectedCommands();
     }
 
     fps_info_->SetFirstSubmitDone(true);
@@ -4990,7 +5000,9 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
 
     if (options_.idle_before_submit)
     {
-        GetDeviceTable(device_info->handle)->DeviceWaitIdle(device_info->handle);
+        auto device_table = GetInjectedDeviceCalls(device_info->handle);
+        auto injected     = device_table.Open();
+        injected->DeviceWaitIdle(device_info->handle);
     }
 
     VulkanSubmitJobPlan plan;
@@ -5166,16 +5178,15 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
 
     if ((options_.sync_queue_submissions) && (result == VK_SUCCESS))
     {
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        event_result      = GetDeviceTable(queue_info->handle)->QueueWaitIdle(queue_info->handle);
+        auto device_table = GetInjectedDeviceCalls(queue_info->handle);
+        auto injected     = device_table.Open();
+        event_result      = injected->QueueWaitIdle(queue_info->handle);
         completion_source = GFXR_REPLAY_QUEUE_SUBMIT_COMPLETION_SOURCE_QUEUE_IDLE;
     }
 
     // Check whether any of the submitted command buffers are frame boundaries.
     if (screenshot_handler_ != nullptr)
     {
-        util::BeginInjectedCommands();
-
         bool is_frame_boundary = false;
         for (uint32_t i = 0; i < submitCount; ++i)
         {
@@ -5200,8 +5211,6 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
                 }
             }
         }
-
-        util::EndInjectedCommands();
     }
 
     fps_info_->SetFirstSubmitDone(true);
@@ -5719,8 +5728,6 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
 
         if ((original_result >= 0) && (result == VK_ERROR_OUT_OF_POOL_MEMORY))
         {
-            util::BeginInjectedCommands();
-
             // Handle case where replay runs out of descriptor pool memory when capture did not by creating a new
             // descriptor pool and attempting the allocation a second time.
             VkDescriptorPool new_pool  = VK_NULL_HANDLE;
@@ -5744,8 +5751,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
                 create_info.pNext = &inline_uniform_block;
             }
 
-            result = GetDeviceTable(device_info->handle)
-                         ->CreateDescriptorPool(device_info->handle, &create_info, nullptr, &new_pool);
+            auto device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto injected     = device_table.Open();
+            result            = injected->CreateDescriptorPool(device_info->handle, &create_info, nullptr, &new_pool);
 
             if (result == VK_SUCCESS)
             {
@@ -5767,8 +5775,6 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
 
                 result = func(device_info->handle, &modified_allocate_info, pDescriptorSets->GetHandlePointer());
             }
-
-            util::EndInjectedCommands();
         }
 
         // The information gathered here is only relevant when dumping or for portability-features
@@ -6047,8 +6053,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
             // allocationSize needs to be equal to VkMemoryDedicatedAllocateInfo::image VkMemoryRequirements::size
             VkMemoryRequirements memory_requirements = {};
             VkDevice             device              = device_info->handle;
-            GetDeviceTable(device)->GetImageMemoryRequirements(
-                device, dedicated_alloc_info->image, &memory_requirements);
+            auto                 device_table        = GetInjectedDeviceCalls(device);
+            auto                 injected            = device_table.Open();
+            injected->GetImageMemoryRequirements(device, dedicated_alloc_info->image, &memory_requirements);
             modified_allocate_info->allocationSize = memory_requirements.size;
         }
 
@@ -6057,10 +6064,11 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
         {
             // allocationSize needs to be equal to VkAndroidHardwareBufferPropertiesANDROID::allocationSize
             VkAndroidHardwareBufferPropertiesANDROID properties = {};
-            properties.sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID;
-            VkDevice device  = device_info->handle;
-            GetDeviceTable(device)->GetAndroidHardwareBufferPropertiesANDROID(
-                device, import_ahb_info->buffer, &properties);
+            properties.sType      = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID;
+            VkDevice device       = device_info->handle;
+            auto     device_table = GetInjectedDeviceCalls(device);
+            auto     injected     = device_table.Open();
+            injected->GetAndroidHardwareBufferPropertiesANDROID(device, import_ahb_info->buffer, &properties);
             modified_allocate_info->allocationSize = properties.allocationSize;
         }
 #endif
@@ -6080,7 +6088,8 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
         if (import_fd_info != nullptr)
         {
-            const auto* device_table = GetDeviceTable(device_info->handle);
+            auto device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto injected     = device_table.Open();
 
             VkExportMemoryAllocateInfo backing_export_info = { VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO };
             backing_export_info.handleTypes                = import_fd_info->handleType;
@@ -6101,7 +6110,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
                 backing_allocate_info.pNext   = &backing_dedicated_info;
             }
 
-            VkResult backing_result = device_table->AllocateMemory(
+            VkResult backing_result = injected->AllocateMemory(
                 device_info->handle, &backing_allocate_info, nullptr, &external_fd_backing_memory);
 
             if (backing_result == VK_SUCCESS)
@@ -6110,8 +6119,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
                 get_fd_info.memory               = external_fd_backing_memory;
                 get_fd_info.handleType           = import_fd_info->handleType;
 
-                backing_result =
-                    device_table->GetMemoryFdKHR(device_info->handle, &get_fd_info, &replacement_import_fd);
+                backing_result = injected->GetMemoryFdKHR(device_info->handle, &get_fd_info, &replacement_import_fd);
                 if (backing_result != VK_SUCCESS)
                 {
                     replacement_import_fd = -1;
@@ -6135,7 +6143,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
                 if (external_fd_backing_memory != VK_NULL_HANDLE)
                 {
-                    device_table->FreeMemory(device_info->handle, external_fd_backing_memory, nullptr);
+                    injected->FreeMemory(device_info->handle, external_fd_backing_memory, nullptr);
                     external_fd_backing_memory = VK_NULL_HANDLE;
                 }
             }
@@ -6255,7 +6263,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
         // On failure the import did not consume the FD, so close it to avoid a leak.
         if (external_fd_backing_memory != VK_NULL_HANDLE)
         {
-            GetDeviceTable(device_info->handle)->FreeMemory(device_info->handle, external_fd_backing_memory, nullptr);
+            auto device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto injected     = device_table.Open();
+            injected->FreeMemory(device_info->handle, external_fd_backing_memory, nullptr);
 
             if (result != VK_SUCCESS && replacement_import_fd >= 0)
             {
@@ -6543,8 +6553,9 @@ VkResult VulkanReplayConsumerBase::OverrideBindImageMemory(PFN_vkBindImageMemory
     if (image_info->external_format || image_info->external_memory_android)
     {
         VkMemoryRequirements image_mem_reqs;
-        GetDeviceTable(device_info->handle)
-            ->GetImageMemoryRequirements(device_info->handle, image_info->handle, &image_mem_reqs);
+        auto                 device_table = GetInjectedDeviceCalls(device_info->handle);
+        auto                 injected     = device_table.Open();
+        injected->GetImageMemoryRequirements(device_info->handle, image_info->handle, &image_mem_reqs);
         image_info->size = image_mem_reqs.size;
     }
 
@@ -7070,8 +7081,9 @@ VulkanReplayConsumerBase::OverrideCreateImage(PFN_vkCreateImage                 
         if (!image_info->external_memory_android && !image_info->external_format)
         {
             VkMemoryRequirements image_mem_reqs;
-            GetDeviceTable(device_info->handle)
-                ->GetImageMemoryRequirements(device_info->handle, *replay_image, &image_mem_reqs);
+            auto                 device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto                 injected     = device_table.Open();
+            injected->GetImageMemoryRequirements(device_info->handle, *replay_image, &image_mem_reqs);
             image_info->size = image_mem_reqs.size;
         }
     }
@@ -8662,7 +8674,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
                                                 &modified_create_info,
                                                 GetAllocationCallbacks(pAllocator),
                                                 pSwapchain,
-                                                GetDeviceTable(device_info->handle));
+                                                GetInjectedDeviceCalls(device_info->handle));
     }
     else
     {
@@ -8948,9 +8960,6 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
         if (swapchain_image_tracker_.RetrievePreAcquiredImage(
                 swapchain, captured_index, &preacquire_semaphore, &preacquire_fence))
         {
-            auto table = GetDeviceTable(device);
-            assert(table != nullptr);
-
             if (captured_index >= static_cast<uint32_t>(swapchain_info->acquired_indices.size()))
             {
                 swapchain_info->acquired_indices.resize(captured_index + 1);
@@ -8977,8 +8986,10 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
                 preacquire_fence = fence;
             }
 
-            table->DestroySemaphore(device, preacquire_semaphore, nullptr);
-            table->DestroyFence(device, preacquire_fence, nullptr);
+            auto device_table = GetInjectedDeviceCalls(device);
+            auto injected     = device_table.Open();
+            injected->DestroySemaphore(device, preacquire_semaphore, nullptr);
+            injected->DestroyFence(device, preacquire_fence, nullptr);
         }
         else
         {
@@ -9071,9 +9082,6 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
         if (swapchain_image_tracker_.RetrievePreAcquiredImage(
                 replay_acquire_info->swapchain, captured_index, &preacquire_semaphore, &preacquire_fence))
         {
-            auto table = GetDeviceTable(device);
-            assert(table != nullptr);
-
             if (captured_index >= static_cast<uint32_t>(swapchain_info->acquired_indices.size()))
             {
                 swapchain_info->acquired_indices.resize(captured_index + 1);
@@ -9103,8 +9111,10 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
                 preacquire_fence = replay_acquire_info->fence;
             }
 
-            table->DestroySemaphore(device, preacquire_semaphore, nullptr);
-            table->DestroyFence(device, preacquire_fence, nullptr);
+            auto device_table = GetInjectedDeviceCalls(device);
+            auto injected     = device_table.Open();
+            injected->DestroySemaphore(device, preacquire_semaphore, nullptr);
+            injected->DestroyFence(device, preacquire_fence, nullptr);
         }
         else
         {
@@ -9199,22 +9209,26 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
 
     struct local_fence_t
     {
-        VkFence                            fence        = VK_NULL_HANDLE;
-        VkDevice                           device       = VK_NULL_HANDLE;
-        const graphics::VulkanDeviceTable* device_table = nullptr;
+        VkFence                                    fence  = VK_NULL_HANDLE;
+        VkDevice                                   device = VK_NULL_HANDLE;
+        const graphics::VulkanInjectedDeviceCalls& device_table;
 
-        local_fence_t(VkDevice d, const graphics::VulkanDeviceTable* t) : device(d), device_table(t)
+        local_fence_t() = delete;
+        local_fence_t(VkDevice d, const graphics::VulkanInjectedDeviceCalls& t) : device(d), device_table(t)
         {
             VkFenceCreateInfo fence_create_info = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
             fence_create_info.pNext             = nullptr;
             fence_create_info.flags             = 0;
-            VkResult result = device_table->CreateFence(device, &fence_create_info, nullptr, &fence);
+            auto     injected                   = device_table.Open();
+            VkResult result                     = injected->CreateFence(device, &fence_create_info, nullptr, &fence);
             GFXRECON_ASSERT(result == VK_SUCCESS);
         }
-        ~local_fence_t() { device_table->DestroyFence(device, fence, nullptr); }
+        ~local_fence_t()
+        {
+            auto injected = device_table.Open();
+            injected->DestroyFence(device, fence, nullptr);
+        }
     };
-
-    util::BeginInjectedCommands();
 
     if ((screenshot_handler_ != nullptr) && (screenshot_handler_->IsScreenshotFrame()))
     {
@@ -9253,14 +9267,15 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                     VkDevice device = swapchain_info->device_info->handle;
                     GFXRECON_ASSERT(device);
 
-                    auto device_table = GetDeviceTable(device);
+                    auto device_table = GetInjectedDeviceCalls(device);
+                    auto injected     = device_table.Open();
 
                     // create a local fence
                     local_fence_t acquire_fence(device, device_table);
 
                     uint32_t replay_index = 0;
                     result                = swapchain_->AcquireNextImageKHR(original_result,
-                                                             device_table->AcquireNextImageKHR,
+                                                             injected->AcquireNextImageKHR,
                                                              swapchain_info->device_info,
                                                              swapchain_info,
                                                              std::numeric_limits<uint64_t>::max(),
@@ -9270,7 +9285,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                                                              &replay_index);
                     GFXRECON_ASSERT((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR));
 
-                    result = device_table->WaitForFences(
+                    result = injected->WaitForFences(
                         device, 1, &acquire_fence.fence, true, std::numeric_limits<uint64_t>::max());
                     GFXRECON_ASSERT(result == VK_SUCCESS);
 
@@ -9400,15 +9415,15 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                     VkDevice device = swapchain_info->device_info->handle;
                     GFXRECON_ASSERT(device);
 
-                    auto device_table = GetDeviceTable(device);
-                    GFXRECON_ASSERT(device_table);
+                    auto device_table = GetInjectedDeviceCalls(device);
+                    auto injected     = device_table.Open();
 
                     // create a local fence
                     local_fence_t acquire_fence(device, device_table);
 
                     uint32_t replay_index = 0;
                     result                = swapchain_->AcquireNextImageKHR(original_result,
-                                                             device_table->AcquireNextImageKHR,
+                                                             injected->AcquireNextImageKHR,
                                                              swapchain_info->device_info,
                                                              swapchain_info,
                                                              std::numeric_limits<uint64_t>::max(),
@@ -9418,7 +9433,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                                                              &replay_index);
                     GFXRECON_ASSERT((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR));
 
-                    result = device_table->WaitForFences(
+                    result = injected->WaitForFences(
                         device, 1, &acquire_fence.fence, true, std::numeric_limits<uint64_t>::max());
                     GFXRECON_ASSERT(result == VK_SUCCESS);
 
@@ -9443,14 +9458,14 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                         GFXRECON_ASSERT(instance_info != nullptr);
 
                         const graphics::VulkanInstanceTable* instance_table = GetInstanceTable(instance_info->handle);
-                        auto* device_table = GetDeviceTable(swapchain_info->device_info->handle);
+                        const auto injected_calls = GetInjectedDeviceCalls(swapchain_info->device_info->handle);
 
                         swapchain_->PresentImageAdHoc(swapchain_info->device_info,
                                                       nullptr,
                                                       override_img_info,
                                                       instance_info,
                                                       instance_table,
-                                                      device_table,
+                                                      injected_calls,
                                                       application_.get(),
                                                       options_.screenshot_scale);
                     }
@@ -9471,10 +9486,10 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
     if (options_.wait_before_present)
     {
         VkDevice device = MapHandle<VulkanDeviceInfo>(queue_info->parent_id, &CommonObjectInfoTable::GetVkDeviceInfo);
-        GetDeviceTable(device)->DeviceWaitIdle(device);
+        auto     device_table = GetInjectedDeviceCalls(device);
+        auto     injected     = device_table.Open();
+        injected->DeviceWaitIdle(device);
     }
-
-    util::EndInjectedCommands();
 
     // Only attempt to find imported or shadow semaphores if we know at least one around.
     if (!have_imported_semaphores_ && shadow_semaphores_.empty() && modified_present_info.swapchainCount != 0)
@@ -10336,13 +10351,13 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
             created_pipelines = out_pPipelines;
         }
 
-        result = GetDeviceTable(device)->CreateRayTracingPipelinesKHR(device,
-                                                                      in_deferredOperation,
-                                                                      overridePipelineCache,
-                                                                      createInfoCount,
-                                                                      modified_create_infos.data(),
-                                                                      in_pAllocator,
-                                                                      created_pipelines);
+        result = func(device,
+                      in_deferredOperation,
+                      overridePipelineCache,
+                      createInfoCount,
+                      modified_create_infos.data(),
+                      in_pAllocator,
+                      created_pipelines);
 
         if ((result == VK_SUCCESS) || (result == VK_OPERATION_NOT_DEFERRED_KHR) ||
             (result == VK_PIPELINE_COMPILE_REQUIRED_EXT))
@@ -10395,13 +10410,13 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
             created_pipelines = out_pPipelines;
         }
 
-        result = GetDeviceTable(device)->CreateRayTracingPipelinesKHR(device,
-                                                                      in_deferredOperation,
-                                                                      overridePipelineCache,
-                                                                      createInfoCount,
-                                                                      in_pCreateInfos,
-                                                                      in_pAllocator,
-                                                                      created_pipelines);
+        result = func(device,
+                      in_deferredOperation,
+                      overridePipelineCache,
+                      createInfoCount,
+                      in_pCreateInfos,
+                      in_pAllocator,
+                      created_pipelines);
 
         if ((result == VK_SUCCESS) || (result == VK_OPERATION_NOT_DEFERRED_KHR) ||
             (result == VK_PIPELINE_COMPILE_REQUIRED_EXT))
@@ -10457,8 +10472,11 @@ VulkanReplayConsumerBase::OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperati
     VkDevice               device             = device_info->handle;
     VkDeferredOperationKHR deferred_operation = deferred_operation_info->handle;
 
+    auto device_table = GetInjectedDeviceCalls(device);
+    auto injected     = device_table.Open();
+
     PFN_vkGetDeferredOperationMaxConcurrencyKHR vkGetDeferredOperationMaxConcurrencyKHR =
-        GetDeviceTable(device)->GetDeferredOperationMaxConcurrencyKHR;
+        injected->GetDeferredOperationMaxConcurrencyKHR;
 
     uint32_t max_threads  = std::thread::hardware_concurrency();
     uint32_t thread_count = std::min(vkGetDeferredOperationMaxConcurrencyKHR(device, deferred_operation), max_threads);
@@ -11093,26 +11111,23 @@ void VulkanReplayConsumerBase::MaybeInjectExecutionBarrier(const VulkanCommandBu
         return;
     }
 
-    util::BeginInjectedCommands();
-
     const VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
     GFXRECON_ASSERT(device_info != nullptr);
-    const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device_info->handle);
-    GFXRECON_ASSERT(device_table != nullptr);
+    const auto device_table = GetInjectedDeviceCalls(device_info->handle);
+    auto       injected     = device_table.Open();
 
     // Make sure graphics work before this barrier is completed before doing other graphics work.
-    device_table->CmdPipelineBarrier(command_buffer_info->handle,
-                                     VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-                                     VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-                                     0,
-                                     0,
-                                     nullptr,
-                                     0,
-                                     nullptr,
-                                     0,
-                                     nullptr);
-
-    util::EndInjectedCommands();
+    injected.InsertLabel(command_buffer_info->handle, "Serialize rendering");
+    injected->CmdPipelineBarrier(command_buffer_info->handle,
+                                 VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                                 VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                                 0,
+                                 0,
+                                 nullptr,
+                                 0,
+                                 nullptr,
+                                 0,
+                                 nullptr);
 }
 
 std::vector<format::HandleId> VulkanReplayConsumerBase::GetRenderPassAttachmentImageViewIds(
@@ -11622,12 +11637,8 @@ void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryA
 {
     GFXRECON_ASSERT(device_info != nullptr);
 
-    const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device_info->handle);
-
     if (screenshot_handler_ != nullptr && !options_.screenshot_ignore_frameBoundaryAndroid)
     {
-        util::BeginInjectedCommands();
-
         if (screenshot_handler_->IsScreenshotFrame() && image_info != nullptr)
         {
             const std::string filename_prefix =
@@ -11651,7 +11662,7 @@ void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryA
 
             screenshot_handler_->WriteImage(filename_prefix,
                                             device_info,
-                                            device_table,
+                                            GetInjectedDeviceCalls(device_info->handle),
                                             memory_properties,
                                             device_info->allocator.get(),
                                             image_info->handle,
@@ -11664,8 +11675,6 @@ void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryA
         }
 
         screenshot_handler_->EndFrame();
-
-        util::EndInjectedCommands();
     }
 
     if (options_.swapchain_option == util::SwapchainOption::kVirtual)
@@ -11681,16 +11690,14 @@ void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryA
 
         const graphics::VulkanInstanceTable* instance_table = GetInstanceTable(instance_info->handle);
 
-        util::BeginInjectedCommands();
         swapchain_->PresentImageAdHoc(device_info,
                                       semaphore_info,
                                       image_info,
                                       instance_info,
                                       instance_table,
-                                      device_table,
+                                      GetInjectedDeviceCalls(device_info->handle),
                                       application_.get(),
                                       {});
-        util::EndInjectedCommands();
     }
     else
     {
@@ -12152,7 +12159,11 @@ VkResult VulkanReplayConsumerBase::CreateSwapchainImage(const VulkanDeviceInfo* 
         VulkanResourceAllocator::MemoryData allocator_memory_data = 0;
         VkMemoryRequirements                memory_reqs;
 
-        GetDeviceTable(device_info->handle)->GetImageMemoryRequirements(device_info->handle, *image, &memory_reqs);
+        {
+            auto device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto injected     = device_table.Open();
+            injected->GetImageMemoryRequirements(device_info->handle, *image, &memory_reqs);
+        }
 
         // TODO - Move this and VulkanResourceInitializer::GetVkMemoryTypeIndex to common place
         // Can be any flag
@@ -12357,7 +12368,7 @@ VulkanAddressReplacer& VulkanReplayConsumerBase::GetDeviceAddressReplacer(const 
     auto [new_it, success] =
         device_address_replacers_.insert({ device_info,
                                            VulkanAddressReplacer(device_info,
-                                                                 GetDeviceTable(device_info->handle),
+                                                                 GetInjectedDeviceCalls(device_info->handle),
                                                                  GetInstanceTable(device_info->parent),
                                                                  *object_info_table_) });
     GFXRECON_ASSERT(success);
@@ -12371,13 +12382,14 @@ VulkanFrameWarmUp& VulkanReplayConsumerBase::GetDeviceFrameWarmUp(const VulkanDe
         return it->second;
     }
 
-    auto [new_it, success] = device_frame_warmups_.insert({ device_info,
-                                                            VulkanFrameWarmUp(device_info,
-                                                                              GetDeviceTable(device_info->handle),
-                                                                              GetInstanceTable(device_info->parent),
-                                                                              *object_info_table_,
-                                                                              options_.frame_warm_up_spirv_path,
-                                                                              options_.frame_warm_up_load) });
+    auto [new_it, success] =
+        device_frame_warmups_.insert({ device_info,
+                                       VulkanFrameWarmUp(device_info,
+                                                         GetInjectedDeviceCalls(device_info->handle),
+                                                         GetInstanceTable(device_info->parent),
+                                                         *object_info_table_,
+                                                         options_.frame_warm_up_spirv_path,
+                                                         options_.frame_warm_up_load) });
     GFXRECON_ASSERT(success);
     return new_it->second;
 }
@@ -13128,8 +13140,9 @@ void VulkanReplayConsumerBase::OverrideDestroyPipeline(
                 {
                     SavePipelineCache(id, itTracked->second);
                 }
-                auto device_table = GetDeviceTable(device_info->handle);
-                device_table->DestroyPipelineCache(
+                auto device_table = GetInjectedDeviceCalls(device_info->handle);
+                auto injected     = device_table.Open();
+                injected->DestroyPipelineCache(
                     itTracked->second.device_info->handle, itTracked->second.vk_cache, nullptr);
                 tracked_pipeline_caches_.erase(itTracked);
             }
@@ -13790,10 +13803,11 @@ void VulkanReplayConsumerBase::SavePipelineCache(format::HandleId id, const Trac
     GFXRECON_ASSERT(tracked_cache.device_info != nullptr);
     GFXRECON_ASSERT(tracked_cache.vk_cache != VK_NULL_HANDLE);
 
-    auto device_table = GetDeviceTable(tracked_cache.device_info->handle);
+    auto device_table = GetInjectedDeviceCalls(tracked_cache.device_info->handle);
+    auto injected     = device_table.Open();
 
     size_t cacheSize = 0;
-    device_table->GetPipelineCacheData(tracked_cache.device_info->handle, tracked_cache.vk_cache, &cacheSize, nullptr);
+    injected->GetPipelineCacheData(tracked_cache.device_info->handle, tracked_cache.vk_cache, &cacheSize, nullptr);
     if (cacheSize == 0)
     {
         GFXRECON_LOG_INFO("Attempted to save an empty pipeline cache.");
@@ -13802,7 +13816,7 @@ void VulkanReplayConsumerBase::SavePipelineCache(format::HandleId id, const Trac
     }
 
     std::vector<char> buffer(cacheSize);
-    device_table->GetPipelineCacheData(
+    injected->GetPipelineCacheData(
         tracked_cache.device_info->handle, tracked_cache.vk_cache, &cacheSize, buffer.data());
 
     uint64_t writtenCacheSize = static_cast<uint64_t>(cacheSize);
@@ -13850,11 +13864,12 @@ VkPipelineCache VulkanReplayConsumerBase::CreateNewPipelineCache(const VulkanDev
         }
     }
 
-    auto device_table = GetDeviceTable(device_info->handle);
+    auto device_table = GetInjectedDeviceCalls(device_info->handle);
+    auto injected     = device_table.Open();
 
     VkPipelineCache pipelineCache;
     VkResult        result =
-        device_table->CreatePipelineCache(device_info->handle, &pipelineCacheCreateInfo, nullptr, &pipelineCache);
+        injected->CreatePipelineCache(device_info->handle, &pipelineCacheCreateInfo, nullptr, &pipelineCache);
 
     if (result != VK_SUCCESS)
     {
@@ -14337,13 +14352,11 @@ void VulkanReplayConsumerBase::MaybeInjectComputeTransferBarrier(
         return;
     }
 
-    util::BeginInjectedCommands();
-
     GFXRECON_ASSERT(command_buffer_info != nullptr);
     const VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
     GFXRECON_ASSERT(device_info != nullptr);
-    const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device_info->handle);
-    GFXRECON_ASSERT(device_table != nullptr);
+    const auto device_table = GetInjectedDeviceCalls(device_info->handle);
+    auto       injected     = device_table.Open();
 
     VkMemoryBarrier memory_barrier = { VK_STRUCTURE_TYPE_MEMORY_BARRIER };
     memory_barrier.srcAccessMask   = VK_ACCESS_MEMORY_WRITE_BIT;
@@ -14355,10 +14368,9 @@ void VulkanReplayConsumerBase::MaybeInjectComputeTransferBarrier(
 
     // Make sure compute and transfer write operations before this barrier are completed
     // before doing other compute and transfer read/write operations.
-    device_table->CmdPipelineBarrier(
+    injected.InsertLabel(command_buffer_info->handle, "Serialize compute");
+    injected->CmdPipelineBarrier(
         command_buffer_info->handle, stages, stages, 0, 1, &memory_barrier, 0, nullptr, 0, nullptr);
-
-    util::EndInjectedCommands();
 }
 
 void VulkanReplayConsumerBase::OverrideCmdDispatch(PFN_vkCmdDispatch              func,
@@ -14727,8 +14739,9 @@ VulkanReplayConsumerBase::OverrideCreateTensorARM(PFN_vkCreateTensorARM         
 
         // call directly (not via allocator) so capture_mem_reqs is not polluted with zeros;
         // the decoded vkGetTensorMemoryRequirementsARM replay sets them from the actual captured values.
-        GetDeviceTable(device_info->handle)
-            ->GetTensorMemoryRequirementsARM(device_info->handle, &tensor_mem_req, &replay_req_2);
+        auto device_table = GetInjectedDeviceCalls(device_info->handle);
+        auto injected     = device_table.Open();
+        injected->GetTensorMemoryRequirementsARM(device_info->handle, &tensor_mem_req, &replay_req_2);
         tensor_info->size = replay_req_2.memoryRequirements.size;
 
         if (replay_create_info->sharingMode == VK_SHARING_MODE_CONCURRENT &&

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -363,11 +363,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
 
     // Finally destroy vkInstances
     object_cleanup::FreeAllLiveInstances(
-        object_info_table_,
-        false,
-        true,
-        [this](const void* handle) { return GetInstanceTable(handle); },
-        [this](const void* handle) { return GetDeviceTable(handle); });
+        object_info_table_, false, true, [this](const void* handle) { return GetInstanceTable(handle); });
 
     if (loader_handle_ != nullptr)
     {
@@ -1078,9 +1074,6 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
         auto allocator = device_info->allocator.get();
         GFXRECON_ASSERT(allocator != nullptr);
 
-        auto table = GetDeviceTable(device);
-        GFXRECON_ASSERT(table != nullptr);
-
         VkPhysicalDevice physical_device = device_info->parent;
         GFXRECON_ASSERT(physical_device != VK_NULL_HANDLE);
 
@@ -1102,15 +1095,14 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
             have_shader_stencil_write = true;
         }
 
-        device_info->resource_initializer =
-            std::make_shared<VulkanResourceInitializer>(device_info,
-                                                        total_copy_size,
-                                                        max_copy_size,
-                                                        properties,
-                                                        memory_properties,
-                                                        have_shader_stencil_write,
-                                                        allocator,
-                                                        graphics::VulkanInjectedDeviceCalls(table));
+        device_info->resource_initializer = std::make_shared<VulkanResourceInitializer>(device_info,
+                                                                                        total_copy_size,
+                                                                                        max_copy_size,
+                                                                                        properties,
+                                                                                        memory_properties,
+                                                                                        have_shader_stencil_write,
+                                                                                        allocator,
+                                                                                        GetInjectedDeviceCalls(device));
     }
 }
 
@@ -12080,7 +12072,8 @@ VulkanCommandBufferUtil& VulkanReplayConsumerBase::GetDeviceCommandBufferUtil(co
 
     auto [new_it, success] = device_command_buffer_utils_.insert(
         { device_info,
-          VulkanCommandBufferUtil(device_info, GetDeviceTable(device_info->handle), object_info_table_, decoder) });
+          VulkanCommandBufferUtil(
+              device_info, GetInjectedDeviceCalls(device_info->handle), object_info_table_, decoder) });
     GFXRECON_ASSERT(success);
     return new_it->second;
 }
@@ -12093,7 +12086,7 @@ VulkanSubmitJobExecutor& VulkanReplayConsumerBase::GetDeviceSubmitJobExecutor(co
     }
 
     auto [new_it, success] = device_submit_job_executors_.insert(
-        { device_info, VulkanSubmitJobExecutor(device_info, GetDeviceTable(device_info->handle)) });
+        { device_info, VulkanSubmitJobExecutor(device_info, GetInjectedDeviceCalls(device_info->handle)) });
     GFXRECON_ASSERT(success);
     return new_it->second;
 }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -34,6 +34,7 @@
 #include "decode/vulkan_address_replacer.h"
 #include "decode/vulkan_enum_util.h"
 #include "encode/capture_manager.h"
+#include "graphics/vulkan_injected_calls.h"
 
 #if defined(GFXRECON_ENABLE_VULKAN)
 #include "encode/vulkan_capture_manager.h"
@@ -251,6 +252,10 @@ VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::
     swapchain_options.present_mode_option                = options_.present_mode_option;
     swapchain_->SetOptions(swapchain_options);
 
+    // Enable/disable debug-utils labels around replay-injected commands (--annotate-injected-commands).
+    // This is a process-wide flag read by VulkanInjectedDeviceCalls at each injection site.
+    graphics::SetAnnotateInjectedCommands(options_.annotate_injected_commands);
+
     if (options_.enable_debug_device_lost)
     {
         GFXRECON_LOG_WARNING("This debugging feature has not been implemented for Vulkan.");
@@ -336,12 +341,9 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
         assert(info != nullptr);
         VkDevice device = info->handle;
 
-        auto device_table = GetDeviceTable(device);
-        assert(device_table != nullptr);
-
         if (screenshot_handler_ != nullptr)
         {
-            screenshot_handler_->DestroyDeviceResources(device, device_table);
+            screenshot_handler_->DestroyDeviceResources(device, GetInjectedDeviceCalls(device));
         }
     });
 
@@ -350,7 +352,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
         false,
         true,
         [this](const void* handle) { return GetInstanceTable(handle); },
-        [this](const void* handle) { return GetDeviceTable(handle); },
+        [this](const void* handle) { return GetInjectedDeviceCalls(handle); },
         swapchain_.get());
 
     swapchain_->Clean();
@@ -382,10 +384,9 @@ void VulkanReplayConsumerBase::WaitDevicesIdle()
         assert(info != nullptr);
         VkDevice device = info->handle;
 
-        auto device_table = GetDeviceTable(device);
-        assert(device_table != nullptr);
-
-        device_table->DeviceWaitIdle(device);
+        auto device_table = GetInjectedDeviceCalls(device);
+        auto injected     = device_table.Open();
+        injected->DeviceWaitIdle(device);
     });
 }
 
@@ -517,7 +518,8 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
 
                 VulkanDeviceInfo* device_info  = object_info_table_->GetVkDeviceInfo(buffer_info.device_id);
                 VkDevice          device       = device_info->handle;
-                auto              device_table = GetDeviceTable(device);
+                auto              device_table = GetInjectedDeviceCalls(device);
+                auto              injected     = device_table.Open();
                 auto physical_device_info      = object_info_table_->GetVkPhysicalDeviceInfo(device_info->parent_id);
                 auto memory_properties         = &physical_device_info->capture_memory_properties;
 
@@ -530,7 +532,7 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
                 properties.pNext = &format_properties;
 
                 if (vk_result == VK_SUCCESS)
-                    vk_result = device_table->GetAndroidHardwareBufferPropertiesANDROID(
+                    vk_result = injected->GetAndroidHardwareBufferPropertiesANDROID(
                         device, buffer_info.hardware_buffer, &properties);
 
                 // External format data cannot be refilled at replay time, therefore we expect format to be defined.
@@ -585,7 +587,7 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
 
                 VkImage ahb_image = VK_NULL_HANDLE;
                 if (vk_result == VK_SUCCESS)
-                    vk_result = device_table->CreateImage(device, &image_info, nullptr, &ahb_image);
+                    vk_result = injected->CreateImage(device, &image_info, nullptr, &ahb_image);
 
                 VkImportAndroidHardwareBufferInfoANDROID import_ahb_info = {};
                 import_ahb_info.sType  = VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID;
@@ -618,10 +620,10 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
 
                 VkDeviceMemory image_memory = VK_NULL_HANDLE;
                 if (vk_result == VK_SUCCESS)
-                    vk_result = device_table->AllocateMemory(device, &memory_allocate_info, nullptr, &image_memory);
+                    vk_result = injected->AllocateMemory(device, &memory_allocate_info, nullptr, &image_memory);
 
                 if (vk_result == VK_SUCCESS)
-                    vk_result = device_table->BindImageMemory(device, ahb_image, image_memory, 0);
+                    vk_result = injected->BindImageMemory(device, ahb_image, image_memory, 0);
 
                 ProcessBeginResourceInitCommand(buffer_info.device_id, size, size);
 
@@ -657,8 +659,8 @@ void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id
 
                 ProcessEndResourceInitCommand(buffer_info.device_id);
 
-                device_table->FreeMemory(device, image_memory, nullptr);
-                device_table->DestroyImage(device, ahb_image, nullptr);
+                injected->FreeMemory(device, image_memory, nullptr);
+                injected->DestroyImage(device, ahb_image, nullptr);
 
                 if (vk_result != VK_SUCCESS)
                     GFXRECON_LOG_ERROR("Failed to copy data to AHardwareBuffer that is not cpu readable");
@@ -1100,14 +1102,15 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
             have_shader_stencil_write = true;
         }
 
-        device_info->resource_initializer = std::make_shared<VulkanResourceInitializer>(device_info,
-                                                                                        total_copy_size,
-                                                                                        max_copy_size,
-                                                                                        properties,
-                                                                                        memory_properties,
-                                                                                        have_shader_stencil_write,
-                                                                                        allocator,
-                                                                                        table);
+        device_info->resource_initializer =
+            std::make_shared<VulkanResourceInitializer>(device_info,
+                                                        total_copy_size,
+                                                        max_copy_size,
+                                                        properties,
+                                                        memory_properties,
+                                                        have_shader_stencil_write,
+                                                        allocator,
+                                                        graphics::VulkanInjectedDeviceCalls(table));
     }
 }
 
@@ -1559,6 +1562,11 @@ const graphics::VulkanDeviceTable* VulkanReplayConsumerBase::GetDeviceTable(cons
     auto table = device_tables_.find(graphics::GetVulkanDispatchKey(handle));
     assert(table != device_tables_.end());
     return (table != device_tables_.end()) ? &table->second : nullptr;
+}
+
+graphics::VulkanInjectedDeviceCalls VulkanReplayConsumerBase::GetInjectedDeviceCalls(const void* handle) const
+{
+    return graphics::VulkanInjectedDeviceCalls(GetDeviceTable(handle));
 }
 
 void* VulkanReplayConsumerBase::PreProcessExternalObject(uint64_t          object_id,
@@ -2807,7 +2815,7 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
                     screenshot_handler_->WriteImage(
                         num_layers > 1 ? filename_prefix + "_layer_" + std::to_string(layer) : filename_prefix,
                         device_info,
-                        GetDeviceTable(device_info->handle),
+                        GetInjectedDeviceCalls(device_info->handle),
                         memory_properties,
                         device_info->allocator.get(),
                         image,
@@ -2835,13 +2843,16 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
         {
             VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(command_buffer_info->parent_id);
 
-            auto instance_table = GetInstanceTable(device_info->parent);
-            GFXRECON_ASSERT(instance_table != nullptr);
-
-            // TODO: This should be stored in the VulkanDeviceInfo structure to avoid the need for frequent
-            // queries.
             VkPhysicalDeviceMemoryProperties memory_properties;
-            instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+            {
+                util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+                auto                             instance_table = GetInstanceTable(device_info->parent);
+                GFXRECON_ASSERT(instance_table != nullptr);
+
+                // TODO: This should be stored in the VulkanDeviceInfo structure to avoid the need for frequent
+                // queries.
+                instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+            }
 
             for (size_t i = 0; i < command_buffer_info->frame_buffer_ids.size(); ++i)
             {
@@ -2888,7 +2899,7 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
 
                     screenshot_handler_->WriteImage(filename_prefix,
                                                     device_info,
-                                                    GetDeviceTable(device_info->handle),
+                                                    GetInjectedDeviceCalls(device_info->handle),
                                                     memory_properties,
                                                     device_info->allocator.get(),
                                                     image_info->handle,
@@ -2918,11 +2929,14 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDevic
         return false;
     }
 
-    auto instance_table = GetInstanceTable(device_info->parent);
-    GFXRECON_ASSERT(instance_table != nullptr);
-
     VkPhysicalDeviceMemoryProperties memory_properties;
-    instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+    {
+        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+        auto                             instance_table = GetInstanceTable(device_info->parent);
+        GFXRECON_ASSERT(instance_table != nullptr);
+
+        instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+    }
 
     if (screenshot_handler_->IsScreenshotFrame())
     {
@@ -2951,7 +2965,7 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDevic
 
             screenshot_handler_->WriteImage(filename_prefix,
                                             device_info,
-                                            GetDeviceTable(device_info->handle),
+                                            GetInjectedDeviceCalls(device_info->handle),
                                             memory_properties,
                                             device_info->allocator.get(),
                                             image_info->handle,
@@ -3868,13 +3882,11 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
     if (device_info != nullptr && device_info->duplicate_source_id == format::kNullHandleId)
     {
         device                  = device_info->handle;
-        const auto device_table = GetDeviceTable(device);
+        const auto device_table = GetInjectedDeviceCalls(device);
 
         if (screenshot_handler_ != nullptr)
         {
-            util::BeginInjectedCommands();
             screenshot_handler_->DestroyDeviceResources(device, device_table);
-            util::EndInjectedCommands();
         }
 
         // free replacer internal vulkan-resources for the device
@@ -3884,7 +3896,7 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
 
         // free potential swapchain-resources for the device
         GFXRECON_ASSERT(swapchain_)
-        swapchain_->CleanDeviceResources(device_info->handle, device_table);
+        swapchain_->CleanDeviceResources(device_info->handle, &device_table);
 
         // free frame warm up resources before the device is destroyed
         device_frame_warmups_.erase(device_info);
@@ -4399,10 +4411,9 @@ VkResult VulkanReplayConsumerBase::OverrideGetFenceStatus(PFN_vkGetFenceStatus  
     {
         // Replay is usually faster than the original application, so there is a good chance the fence is still not
         // ready. In this case, we make sure the fence is signaled by waiting for it.
-        util::BeginInjectedCommands();
-        result =
-            GetDeviceTable(device)->WaitForFences(device, 1, &fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
-        util::EndInjectedCommands();
+        auto device_table = GetInjectedDeviceCalls(device);
+        auto injected     = device_table.Open();
+        result            = injected->WaitForFences(device, 1, &fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
         GFXRECON_ASSERT(result == VK_SUCCESS);
     }
 
@@ -4480,7 +4491,9 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
 
     if (options_.idle_before_submit)
     {
-        GetDeviceTable(device_info->handle)->DeviceWaitIdle(device_info->handle);
+        auto device_table = GetInjectedDeviceCalls(device_info->handle);
+        auto injected     = device_table.Open();
+        injected->DeviceWaitIdle(device_info->handle);
     }
 
     VulkanSubmitJobPlan plan;
@@ -4649,15 +4662,14 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
 
     if ((options_.sync_queue_submissions) && (result == VK_SUCCESS))
     {
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        event_result      = GetDeviceTable(queue_info->handle)->QueueWaitIdle(queue_info->handle);
+        auto device_table = GetInjectedDeviceCalls(queue_info->handle);
+        auto injected     = device_table.Open();
+        event_result      = injected->QueueWaitIdle(queue_info->handle);
         completion_source = GFXR_REPLAY_QUEUE_SUBMIT_COMPLETION_SOURCE_QUEUE_IDLE;
     }
 
     if (screenshot_handler_ != nullptr)
     {
-        util::BeginInjectedCommands();
-
         VulkanCommandBufferInfo* frame_boundary_command_buffer_info = nullptr;
         for (uint32_t i = 0; i < submitCount; ++i)
         {
@@ -4693,8 +4705,6 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
                 }
             }
         }
-
-        util::EndInjectedCommands();
     }
 
     fps_info_->SetFirstSubmitDone(true);
@@ -4744,7 +4754,9 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
 
     if (options_.idle_before_submit)
     {
-        GetDeviceTable(device_info->handle)->DeviceWaitIdle(device_info->handle);
+        auto device_table = GetInjectedDeviceCalls(device_info->handle);
+        auto injected     = device_table.Open();
+        injected->DeviceWaitIdle(device_info->handle);
     }
 
     VulkanSubmitJobPlan plan;
@@ -4920,16 +4932,15 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
 
     if ((options_.sync_queue_submissions) && (result == VK_SUCCESS))
     {
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        event_result      = GetDeviceTable(queue_info->handle)->QueueWaitIdle(queue_info->handle);
+        auto device_table = GetInjectedDeviceCalls(queue_info->handle);
+        auto injected     = device_table.Open();
+        event_result      = injected->QueueWaitIdle(queue_info->handle);
         completion_source = GFXR_REPLAY_QUEUE_SUBMIT_COMPLETION_SOURCE_QUEUE_IDLE;
     }
 
     // Check whether any of the submitted command buffers are frame boundaries.
     if (screenshot_handler_ != nullptr)
     {
-        util::BeginInjectedCommands();
-
         bool is_frame_boundary = false;
         for (uint32_t i = 0; i < submitCount; ++i)
         {
@@ -4954,8 +4965,6 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
                 }
             }
         }
-
-        util::EndInjectedCommands();
     }
 
     fps_info_->SetFirstSubmitDone(true);
@@ -5473,8 +5482,6 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
 
         if ((original_result >= 0) && (result == VK_ERROR_OUT_OF_POOL_MEMORY))
         {
-            util::BeginInjectedCommands();
-
             // Handle case where replay runs out of descriptor pool memory when capture did not by creating a new
             // descriptor pool and attempting the allocation a second time.
             VkDescriptorPool new_pool  = VK_NULL_HANDLE;
@@ -5498,8 +5505,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
                 create_info.pNext = &inline_uniform_block;
             }
 
-            result = GetDeviceTable(device_info->handle)
-                         ->CreateDescriptorPool(device_info->handle, &create_info, nullptr, &new_pool);
+            auto device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto injected     = device_table.Open();
+            result            = injected->CreateDescriptorPool(device_info->handle, &create_info, nullptr, &new_pool);
 
             if (result == VK_SUCCESS)
             {
@@ -5521,8 +5529,6 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
 
                 result = func(device_info->handle, &modified_allocate_info, pDescriptorSets->GetHandlePointer());
             }
-
-            util::EndInjectedCommands();
         }
 
         // The information gathered here is only relevant when dumping or for portability-features
@@ -5801,8 +5807,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
             // allocationSize needs to be equal to VkMemoryDedicatedAllocateInfo::image VkMemoryRequirements::size
             VkMemoryRequirements memory_requirements = {};
             VkDevice             device              = device_info->handle;
-            GetDeviceTable(device)->GetImageMemoryRequirements(
-                device, dedicated_alloc_info->image, &memory_requirements);
+            auto                 device_table        = GetInjectedDeviceCalls(device);
+            auto                 injected            = device_table.Open();
+            injected->GetImageMemoryRequirements(device, dedicated_alloc_info->image, &memory_requirements);
             modified_allocate_info->allocationSize = memory_requirements.size;
         }
 
@@ -5811,10 +5818,11 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
         {
             // allocationSize needs to be equal to VkAndroidHardwareBufferPropertiesANDROID::allocationSize
             VkAndroidHardwareBufferPropertiesANDROID properties = {};
-            properties.sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID;
-            VkDevice device  = device_info->handle;
-            GetDeviceTable(device)->GetAndroidHardwareBufferPropertiesANDROID(
-                device, import_ahb_info->buffer, &properties);
+            properties.sType      = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID;
+            VkDevice device       = device_info->handle;
+            auto     device_table = GetInjectedDeviceCalls(device);
+            auto     injected     = device_table.Open();
+            injected->GetAndroidHardwareBufferPropertiesANDROID(device, import_ahb_info->buffer, &properties);
             modified_allocate_info->allocationSize = properties.allocationSize;
         }
 #endif
@@ -5834,7 +5842,8 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
         if (import_fd_info != nullptr)
         {
-            const auto* device_table = GetDeviceTable(device_info->handle);
+            auto device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto injected     = device_table.Open();
 
             VkExportMemoryAllocateInfo backing_export_info = { VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO };
             backing_export_info.handleTypes                = import_fd_info->handleType;
@@ -5855,7 +5864,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
                 backing_allocate_info.pNext   = &backing_dedicated_info;
             }
 
-            VkResult backing_result = device_table->AllocateMemory(
+            VkResult backing_result = injected->AllocateMemory(
                 device_info->handle, &backing_allocate_info, nullptr, &external_fd_backing_memory);
 
             if (backing_result == VK_SUCCESS)
@@ -5864,8 +5873,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
                 get_fd_info.memory               = external_fd_backing_memory;
                 get_fd_info.handleType           = import_fd_info->handleType;
 
-                backing_result =
-                    device_table->GetMemoryFdKHR(device_info->handle, &get_fd_info, &replacement_import_fd);
+                backing_result = injected->GetMemoryFdKHR(device_info->handle, &get_fd_info, &replacement_import_fd);
                 if (backing_result != VK_SUCCESS)
                 {
                     replacement_import_fd = -1;
@@ -5889,7 +5897,7 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
                 if (external_fd_backing_memory != VK_NULL_HANDLE)
                 {
-                    device_table->FreeMemory(device_info->handle, external_fd_backing_memory, nullptr);
+                    injected->FreeMemory(device_info->handle, external_fd_backing_memory, nullptr);
                     external_fd_backing_memory = VK_NULL_HANDLE;
                 }
             }
@@ -6009,7 +6017,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
         // On failure the import did not consume the FD, so close it to avoid a leak.
         if (external_fd_backing_memory != VK_NULL_HANDLE)
         {
-            GetDeviceTable(device_info->handle)->FreeMemory(device_info->handle, external_fd_backing_memory, nullptr);
+            auto device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto injected     = device_table.Open();
+            injected->FreeMemory(device_info->handle, external_fd_backing_memory, nullptr);
 
             if (result != VK_SUCCESS && replacement_import_fd >= 0)
             {
@@ -6297,8 +6307,9 @@ VkResult VulkanReplayConsumerBase::OverrideBindImageMemory(PFN_vkBindImageMemory
     if (image_info->external_format || image_info->external_memory_android)
     {
         VkMemoryRequirements image_mem_reqs;
-        GetDeviceTable(device_info->handle)
-            ->GetImageMemoryRequirements(device_info->handle, image_info->handle, &image_mem_reqs);
+        auto                 device_table = GetInjectedDeviceCalls(device_info->handle);
+        auto                 injected     = device_table.Open();
+        injected->GetImageMemoryRequirements(device_info->handle, image_info->handle, &image_mem_reqs);
         image_info->size = image_mem_reqs.size;
     }
 
@@ -6824,8 +6835,9 @@ VulkanReplayConsumerBase::OverrideCreateImage(PFN_vkCreateImage                 
         if (!image_info->external_memory_android && !image_info->external_format)
         {
             VkMemoryRequirements image_mem_reqs;
-            GetDeviceTable(device_info->handle)
-                ->GetImageMemoryRequirements(device_info->handle, *replay_image, &image_mem_reqs);
+            auto                 device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto                 injected     = device_table.Open();
+            injected->GetImageMemoryRequirements(device_info->handle, *replay_image, &image_mem_reqs);
             image_info->size = image_mem_reqs.size;
         }
     }
@@ -8364,7 +8376,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
                                                 &modified_create_info,
                                                 GetAllocationCallbacks(pAllocator),
                                                 pSwapchain,
-                                                GetDeviceTable(device_info->handle));
+                                                GetInjectedDeviceCalls(device_info->handle));
     }
     else
     {
@@ -8643,9 +8655,6 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
         if (swapchain_image_tracker_.RetrievePreAcquiredImage(
                 swapchain, captured_index, &preacquire_semaphore, &preacquire_fence))
         {
-            auto table = GetDeviceTable(device);
-            assert(table != nullptr);
-
             if (captured_index >= static_cast<uint32_t>(swapchain_info->acquired_indices.size()))
             {
                 swapchain_info->acquired_indices.resize(captured_index + 1);
@@ -8672,8 +8681,10 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
                 preacquire_fence = fence;
             }
 
-            table->DestroySemaphore(device, preacquire_semaphore, nullptr);
-            table->DestroyFence(device, preacquire_fence, nullptr);
+            auto device_table = GetInjectedDeviceCalls(device);
+            auto injected     = device_table.Open();
+            injected->DestroySemaphore(device, preacquire_semaphore, nullptr);
+            injected->DestroyFence(device, preacquire_fence, nullptr);
         }
         else
         {
@@ -8766,9 +8777,6 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
         if (swapchain_image_tracker_.RetrievePreAcquiredImage(
                 replay_acquire_info->swapchain, captured_index, &preacquire_semaphore, &preacquire_fence))
         {
-            auto table = GetDeviceTable(device);
-            assert(table != nullptr);
-
             if (captured_index >= static_cast<uint32_t>(swapchain_info->acquired_indices.size()))
             {
                 swapchain_info->acquired_indices.resize(captured_index + 1);
@@ -8798,8 +8806,10 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
                 preacquire_fence = replay_acquire_info->fence;
             }
 
-            table->DestroySemaphore(device, preacquire_semaphore, nullptr);
-            table->DestroyFence(device, preacquire_fence, nullptr);
+            auto device_table = GetInjectedDeviceCalls(device);
+            auto injected     = device_table.Open();
+            injected->DestroySemaphore(device, preacquire_semaphore, nullptr);
+            injected->DestroyFence(device, preacquire_fence, nullptr);
         }
         else
         {
@@ -8894,22 +8904,26 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
 
     struct local_fence_t
     {
-        VkFence                            fence        = VK_NULL_HANDLE;
-        VkDevice                           device       = VK_NULL_HANDLE;
-        const graphics::VulkanDeviceTable* device_table = nullptr;
+        VkFence                                    fence  = VK_NULL_HANDLE;
+        VkDevice                                   device = VK_NULL_HANDLE;
+        const graphics::VulkanInjectedDeviceCalls& device_table;
 
-        local_fence_t(VkDevice d, const graphics::VulkanDeviceTable* t) : device(d), device_table(t)
+        local_fence_t() = delete;
+        local_fence_t(VkDevice d, const graphics::VulkanInjectedDeviceCalls& t) : device(d), device_table(t)
         {
             VkFenceCreateInfo fence_create_info = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
             fence_create_info.pNext             = nullptr;
             fence_create_info.flags             = 0;
-            VkResult result = device_table->CreateFence(device, &fence_create_info, nullptr, &fence);
+            auto     injected                   = device_table.Open();
+            VkResult result                     = injected->CreateFence(device, &fence_create_info, nullptr, &fence);
             GFXRECON_ASSERT(result == VK_SUCCESS);
         }
-        ~local_fence_t() { device_table->DestroyFence(device, fence, nullptr); }
+        ~local_fence_t()
+        {
+            auto injected = device_table.Open();
+            injected->DestroyFence(device, fence, nullptr);
+        }
     };
-
-    util::BeginInjectedCommands();
 
     if ((screenshot_handler_ != nullptr) && (screenshot_handler_->IsScreenshotFrame()))
     {
@@ -8948,14 +8962,15 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                     VkDevice device = swapchain_info->device_info->handle;
                     GFXRECON_ASSERT(device);
 
-                    auto device_table = GetDeviceTable(device);
+                    auto device_table = GetInjectedDeviceCalls(device);
+                    auto injected     = device_table.Open();
 
                     // create a local fence
                     local_fence_t acquire_fence(device, device_table);
 
                     uint32_t replay_index = 0;
                     result                = swapchain_->AcquireNextImageKHR(original_result,
-                                                             device_table->AcquireNextImageKHR,
+                                                             injected->AcquireNextImageKHR,
                                                              swapchain_info->device_info,
                                                              swapchain_info,
                                                              std::numeric_limits<uint64_t>::max(),
@@ -8965,7 +8980,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                                                              &replay_index);
                     GFXRECON_ASSERT((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR));
 
-                    result = device_table->WaitForFences(
+                    result = injected->WaitForFences(
                         device, 1, &acquire_fence.fence, true, std::numeric_limits<uint64_t>::max());
                     GFXRECON_ASSERT(result == VK_SUCCESS);
 
@@ -9095,15 +9110,15 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                     VkDevice device = swapchain_info->device_info->handle;
                     GFXRECON_ASSERT(device);
 
-                    auto device_table = GetDeviceTable(device);
-                    GFXRECON_ASSERT(device_table);
+                    auto device_table = GetInjectedDeviceCalls(device);
+                    auto injected     = device_table.Open();
 
                     // create a local fence
                     local_fence_t acquire_fence(device, device_table);
 
                     uint32_t replay_index = 0;
                     result                = swapchain_->AcquireNextImageKHR(original_result,
-                                                             device_table->AcquireNextImageKHR,
+                                                             injected->AcquireNextImageKHR,
                                                              swapchain_info->device_info,
                                                              swapchain_info,
                                                              std::numeric_limits<uint64_t>::max(),
@@ -9113,7 +9128,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                                                              &replay_index);
                     GFXRECON_ASSERT((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR));
 
-                    result = device_table->WaitForFences(
+                    result = injected->WaitForFences(
                         device, 1, &acquire_fence.fence, true, std::numeric_limits<uint64_t>::max());
                     GFXRECON_ASSERT(result == VK_SUCCESS);
 
@@ -9138,14 +9153,14 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
                         GFXRECON_ASSERT(instance_info != nullptr);
 
                         const graphics::VulkanInstanceTable* instance_table = GetInstanceTable(instance_info->handle);
-                        auto* device_table = GetDeviceTable(swapchain_info->device_info->handle);
+                        const auto injected_calls = GetInjectedDeviceCalls(swapchain_info->device_info->handle);
 
                         swapchain_->PresentImageAdHoc(swapchain_info->device_info,
                                                       nullptr,
                                                       override_img_info,
                                                       instance_info,
                                                       instance_table,
-                                                      device_table,
+                                                      injected_calls,
                                                       application_.get(),
                                                       options_.screenshot_scale);
                     }
@@ -9166,10 +9181,10 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
     if (options_.wait_before_present)
     {
         VkDevice device = MapHandle<VulkanDeviceInfo>(queue_info->parent_id, &CommonObjectInfoTable::GetVkDeviceInfo);
-        GetDeviceTable(device)->DeviceWaitIdle(device);
+        auto     device_table = GetInjectedDeviceCalls(device);
+        auto     injected     = device_table.Open();
+        injected->DeviceWaitIdle(device);
     }
-
-    util::EndInjectedCommands();
 
     // Only attempt to find imported or shadow semaphores if we know at least one around.
     if (!have_imported_semaphores_ && shadow_semaphores_.empty() && modified_present_info.swapchainCount != 0)
@@ -10031,13 +10046,13 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
             created_pipelines = out_pPipelines;
         }
 
-        result = GetDeviceTable(device)->CreateRayTracingPipelinesKHR(device,
-                                                                      in_deferredOperation,
-                                                                      overridePipelineCache,
-                                                                      createInfoCount,
-                                                                      modified_create_infos.data(),
-                                                                      in_pAllocator,
-                                                                      created_pipelines);
+        result = func(device,
+                      in_deferredOperation,
+                      overridePipelineCache,
+                      createInfoCount,
+                      modified_create_infos.data(),
+                      in_pAllocator,
+                      created_pipelines);
 
         if ((result == VK_SUCCESS) || (result == VK_OPERATION_NOT_DEFERRED_KHR) ||
             (result == VK_PIPELINE_COMPILE_REQUIRED_EXT))
@@ -10090,13 +10105,13 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
             created_pipelines = out_pPipelines;
         }
 
-        result = GetDeviceTable(device)->CreateRayTracingPipelinesKHR(device,
-                                                                      in_deferredOperation,
-                                                                      overridePipelineCache,
-                                                                      createInfoCount,
-                                                                      in_pCreateInfos,
-                                                                      in_pAllocator,
-                                                                      created_pipelines);
+        result = func(device,
+                      in_deferredOperation,
+                      overridePipelineCache,
+                      createInfoCount,
+                      in_pCreateInfos,
+                      in_pAllocator,
+                      created_pipelines);
 
         if ((result == VK_SUCCESS) || (result == VK_OPERATION_NOT_DEFERRED_KHR) ||
             (result == VK_PIPELINE_COMPILE_REQUIRED_EXT))
@@ -10152,8 +10167,11 @@ VulkanReplayConsumerBase::OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperati
     VkDevice               device             = device_info->handle;
     VkDeferredOperationKHR deferred_operation = deferred_operation_info->handle;
 
+    auto device_table = GetInjectedDeviceCalls(device);
+    auto injected     = device_table.Open();
+
     PFN_vkGetDeferredOperationMaxConcurrencyKHR vkGetDeferredOperationMaxConcurrencyKHR =
-        GetDeviceTable(device)->GetDeferredOperationMaxConcurrencyKHR;
+        injected->GetDeferredOperationMaxConcurrencyKHR;
 
     uint32_t max_threads  = std::thread::hardware_concurrency();
     uint32_t thread_count = std::min(vkGetDeferredOperationMaxConcurrencyKHR(device, deferred_operation), max_threads);
@@ -10780,26 +10798,23 @@ void VulkanReplayConsumerBase::MaybeInjectExecutionBarrier(const VulkanCommandBu
         return;
     }
 
-    util::BeginInjectedCommands();
-
     const VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
     GFXRECON_ASSERT(device_info != nullptr);
-    const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device_info->handle);
-    GFXRECON_ASSERT(device_table != nullptr);
+    const auto device_table = GetInjectedDeviceCalls(device_info->handle);
+    auto       injected     = device_table.Open();
 
     // Make sure graphics work before this barrier is completed before doing other graphics work.
-    device_table->CmdPipelineBarrier(command_buffer_info->handle,
-                                     VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-                                     VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-                                     0,
-                                     0,
-                                     nullptr,
-                                     0,
-                                     nullptr,
-                                     0,
-                                     nullptr);
-
-    util::EndInjectedCommands();
+    injected.InsertLabel(command_buffer_info->handle, "Serialize rendering");
+    injected->CmdPipelineBarrier(command_buffer_info->handle,
+                                 VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                                 VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                                 0,
+                                 0,
+                                 nullptr,
+                                 0,
+                                 nullptr,
+                                 0,
+                                 nullptr);
 }
 
 std::vector<format::HandleId> VulkanReplayConsumerBase::GetRenderPassAttachmentImageViewIds(
@@ -11291,12 +11306,8 @@ void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryA
 {
     GFXRECON_ASSERT(device_info != nullptr);
 
-    const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device_info->handle);
-
     if (screenshot_handler_ != nullptr && !options_.screenshot_ignore_frameBoundaryAndroid)
     {
-        util::BeginInjectedCommands();
-
         if (screenshot_handler_->IsScreenshotFrame() && image_info != nullptr)
         {
             const std::string filename_prefix =
@@ -11320,7 +11331,7 @@ void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryA
 
             screenshot_handler_->WriteImage(filename_prefix,
                                             device_info,
-                                            device_table,
+                                            GetInjectedDeviceCalls(device_info->handle),
                                             memory_properties,
                                             device_info->allocator.get(),
                                             image_info->handle,
@@ -11333,8 +11344,6 @@ void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryA
         }
 
         screenshot_handler_->EndFrame();
-
-        util::EndInjectedCommands();
     }
 
     if (options_.swapchain_option == util::SwapchainOption::kVirtual)
@@ -11350,16 +11359,14 @@ void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryA
 
         const graphics::VulkanInstanceTable* instance_table = GetInstanceTable(instance_info->handle);
 
-        util::BeginInjectedCommands();
         swapchain_->PresentImageAdHoc(device_info,
                                       semaphore_info,
                                       image_info,
                                       instance_info,
                                       instance_table,
-                                      device_table,
+                                      GetInjectedDeviceCalls(device_info->handle),
                                       application_.get(),
                                       {});
-        util::EndInjectedCommands();
     }
     else
     {
@@ -11821,7 +11828,11 @@ VkResult VulkanReplayConsumerBase::CreateSwapchainImage(const VulkanDeviceInfo* 
         VulkanResourceAllocator::MemoryData allocator_memory_data = 0;
         VkMemoryRequirements                memory_reqs;
 
-        GetDeviceTable(device_info->handle)->GetImageMemoryRequirements(device_info->handle, *image, &memory_reqs);
+        {
+            auto device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto injected     = device_table.Open();
+            injected->GetImageMemoryRequirements(device_info->handle, *image, &memory_reqs);
+        }
 
         // TODO - Move this and VulkanResourceInitializer::GetVkMemoryTypeIndex to common place
         // Can be any flag
@@ -12026,7 +12037,7 @@ VulkanAddressReplacer& VulkanReplayConsumerBase::GetDeviceAddressReplacer(const 
     auto [new_it, success] =
         device_address_replacers_.insert({ device_info,
                                            VulkanAddressReplacer(device_info,
-                                                                 GetDeviceTable(device_info->handle),
+                                                                 GetInjectedDeviceCalls(device_info->handle),
                                                                  GetInstanceTable(device_info->parent),
                                                                  *object_info_table_) });
     GFXRECON_ASSERT(success);
@@ -12040,13 +12051,14 @@ VulkanFrameWarmUp& VulkanReplayConsumerBase::GetDeviceFrameWarmUp(const VulkanDe
         return it->second;
     }
 
-    auto [new_it, success] = device_frame_warmups_.insert({ device_info,
-                                                            VulkanFrameWarmUp(device_info,
-                                                                              GetDeviceTable(device_info->handle),
-                                                                              GetInstanceTable(device_info->parent),
-                                                                              *object_info_table_,
-                                                                              options_.frame_warm_up_spirv_path,
-                                                                              options_.frame_warm_up_load) });
+    auto [new_it, success] =
+        device_frame_warmups_.insert({ device_info,
+                                       VulkanFrameWarmUp(device_info,
+                                                         GetInjectedDeviceCalls(device_info->handle),
+                                                         GetInstanceTable(device_info->parent),
+                                                         *object_info_table_,
+                                                         options_.frame_warm_up_spirv_path,
+                                                         options_.frame_warm_up_load) });
     GFXRECON_ASSERT(success);
     return new_it->second;
 }
@@ -12797,8 +12809,9 @@ void VulkanReplayConsumerBase::OverrideDestroyPipeline(
                 {
                     SavePipelineCache(id, itTracked->second);
                 }
-                auto device_table = GetDeviceTable(device_info->handle);
-                device_table->DestroyPipelineCache(
+                auto device_table = GetInjectedDeviceCalls(device_info->handle);
+                auto injected     = device_table.Open();
+                injected->DestroyPipelineCache(
                     itTracked->second.device_info->handle, itTracked->second.vk_cache, nullptr);
                 tracked_pipeline_caches_.erase(itTracked);
             }
@@ -13459,10 +13472,11 @@ void VulkanReplayConsumerBase::SavePipelineCache(format::HandleId id, const Trac
     GFXRECON_ASSERT(tracked_cache.device_info != nullptr);
     GFXRECON_ASSERT(tracked_cache.vk_cache != VK_NULL_HANDLE);
 
-    auto device_table = GetDeviceTable(tracked_cache.device_info->handle);
+    auto device_table = GetInjectedDeviceCalls(tracked_cache.device_info->handle);
+    auto injected     = device_table.Open();
 
     size_t cacheSize = 0;
-    device_table->GetPipelineCacheData(tracked_cache.device_info->handle, tracked_cache.vk_cache, &cacheSize, nullptr);
+    injected->GetPipelineCacheData(tracked_cache.device_info->handle, tracked_cache.vk_cache, &cacheSize, nullptr);
     if (cacheSize == 0)
     {
         GFXRECON_LOG_INFO("Attempted to save an empty pipeline cache.");
@@ -13471,7 +13485,7 @@ void VulkanReplayConsumerBase::SavePipelineCache(format::HandleId id, const Trac
     }
 
     std::vector<char> buffer(cacheSize);
-    device_table->GetPipelineCacheData(
+    injected->GetPipelineCacheData(
         tracked_cache.device_info->handle, tracked_cache.vk_cache, &cacheSize, buffer.data());
 
     uint64_t writtenCacheSize = static_cast<uint64_t>(cacheSize);
@@ -13519,11 +13533,12 @@ VkPipelineCache VulkanReplayConsumerBase::CreateNewPipelineCache(const VulkanDev
         }
     }
 
-    auto device_table = GetDeviceTable(device_info->handle);
+    auto device_table = GetInjectedDeviceCalls(device_info->handle);
+    auto injected     = device_table.Open();
 
     VkPipelineCache pipelineCache;
     VkResult        result =
-        device_table->CreatePipelineCache(device_info->handle, &pipelineCacheCreateInfo, nullptr, &pipelineCache);
+        injected->CreatePipelineCache(device_info->handle, &pipelineCacheCreateInfo, nullptr, &pipelineCache);
 
     if (result != VK_SUCCESS)
     {
@@ -14006,13 +14021,11 @@ void VulkanReplayConsumerBase::MaybeInjectComputeTransferBarrier(
         return;
     }
 
-    util::BeginInjectedCommands();
-
     GFXRECON_ASSERT(command_buffer_info != nullptr);
     const VulkanDeviceInfo* device_info = GetObjectInfoTable().GetVkDeviceInfo(command_buffer_info->parent_id);
     GFXRECON_ASSERT(device_info != nullptr);
-    const graphics::VulkanDeviceTable* device_table = GetDeviceTable(device_info->handle);
-    GFXRECON_ASSERT(device_table != nullptr);
+    const auto device_table = GetInjectedDeviceCalls(device_info->handle);
+    auto       injected     = device_table.Open();
 
     VkMemoryBarrier memory_barrier = { VK_STRUCTURE_TYPE_MEMORY_BARRIER };
     memory_barrier.srcAccessMask   = VK_ACCESS_MEMORY_WRITE_BIT;
@@ -14024,10 +14037,9 @@ void VulkanReplayConsumerBase::MaybeInjectComputeTransferBarrier(
 
     // Make sure compute and transfer write operations before this barrier are completed
     // before doing other compute and transfer read/write operations.
-    device_table->CmdPipelineBarrier(
+    injected.InsertLabel(command_buffer_info->handle, "Serialize compute");
+    injected->CmdPipelineBarrier(
         command_buffer_info->handle, stages, stages, 0, 1, &memory_barrier, 0, nullptr, 0, nullptr);
-
-    util::EndInjectedCommands();
 }
 
 void VulkanReplayConsumerBase::OverrideCmdDispatch(PFN_vkCmdDispatch              func,
@@ -14396,8 +14408,9 @@ VulkanReplayConsumerBase::OverrideCreateTensorARM(PFN_vkCreateTensorARM         
 
         // call directly (not via allocator) so capture_mem_reqs is not polluted with zeros;
         // the decoded vkGetTensorMemoryRequirementsARM replay sets them from the actual captured values.
-        GetDeviceTable(device_info->handle)
-            ->GetTensorMemoryRequirementsARM(device_info->handle, &tensor_mem_req, &replay_req_2);
+        auto device_table = GetInjectedDeviceCalls(device_info->handle);
+        auto injected     = device_table.Open();
+        injected->GetTensorMemoryRequirementsARM(device_info->handle, &tensor_mem_req, &replay_req_2);
         tensor_info->size = replay_req_2.memoryRequirements.size;
 
         if (replay_create_info->sharingMode == VK_SHARING_MODE_CONCURRENT &&

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -10470,14 +10470,18 @@ VulkanReplayConsumerBase::OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperati
     VkDevice               device             = device_info->handle;
     VkDeferredOperationKHR deferred_operation = deferred_operation_info->handle;
 
-    auto device_table = GetInjectedDeviceCalls(device);
-    auto injected     = device_table.Open();
+    uint32_t max_concurrency;
+    {
+        auto device_table = GetInjectedDeviceCalls(device);
+        auto injected     = device_table.Open();
 
-    PFN_vkGetDeferredOperationMaxConcurrencyKHR vkGetDeferredOperationMaxConcurrencyKHR =
-        injected->GetDeferredOperationMaxConcurrencyKHR;
+        PFN_vkGetDeferredOperationMaxConcurrencyKHR vkGetDeferredOperationMaxConcurrencyKHR =
+            injected->GetDeferredOperationMaxConcurrencyKHR;
+        max_concurrency = vkGetDeferredOperationMaxConcurrencyKHR(device, deferred_operation);
+    }
 
-    uint32_t max_threads  = std::thread::hardware_concurrency();
-    uint32_t thread_count = std::min(vkGetDeferredOperationMaxConcurrencyKHR(device, deferred_operation), max_threads);
+    uint32_t                       max_threads                  = std::thread::hardware_concurrency();
+    uint32_t                       thread_count                 = std::min(max_concurrency, max_threads);
     std::atomic_bool               deferred_operation_completed = false;
     std::vector<std::future<void>> deferred_operation_joins;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -240,6 +240,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     const graphics::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
 
     const graphics::VulkanDeviceTable* GetDeviceTable(const void* handle) const;
+
+    // Handle for the replay-injected device calls of `handle`'s device, built
+    // from the registered device table, which must exist.
+    graphics::VulkanInjectedDeviceCalls GetInjectedDeviceCalls(const void* handle) const;
+
     void AddImageHandle(format::HandleId parent_id, format::HandleId id, VkImage handle, VulkanImageInfo&& initial_info)
     {
         AddHandle<VulkanImageInfo>(

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -173,6 +173,7 @@ struct VulkanReplayOptions : public ReplayOptions
     util::SwapchainOption   swapchain_option{ util::SwapchainOption::kVirtual };
     util::PresentModeOption present_mode_option{ util::PresentModeOption::kCapture };
     bool                    virtual_swapchain_skip_blit{ false };
+    bool                    annotate_injected_commands{ false };
 
     // optionally override swapchain-images by providing an image debug-utils name
     std::string present_override_image_name;

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -43,18 +43,18 @@ VulkanResourceInitializer::VulkanResourceInitializer(const VulkanDeviceInfo*    
                                                      const VkPhysicalDeviceMemoryProperties& memory_properties,
                                                      bool                                    have_shader_stencil_write,
                                                      VulkanResourceAllocator*                resource_allocator,
-                                                     const graphics::VulkanDeviceTable*      device_table) :
+                                                     const graphics::VulkanInjectedDeviceCalls& injected_calls) :
     device_(device_info->handle),
     staging_memory_(VK_NULL_HANDLE), staging_memory_data_(0), staging_buffer_(VK_NULL_HANDLE), staging_buffer_data_(0),
     staging_buffer_mapped_ptr_(nullptr), staging_buffer_offset_(0), staging_buffer_size_(0),
     draw_sampler_(VK_NULL_HANDLE), draw_pool_(VK_NULL_HANDLE), draw_set_layout_(VK_NULL_HANDLE),
     draw_set_(VK_NULL_HANDLE), memory_properties_(memory_properties),
     have_shader_stencil_write_(have_shader_stencil_write), resource_allocator_(resource_allocator),
-    device_table_(device_table), device_info_(device_info)
+    injected_calls_(injected_calls), device_info_(device_info)
 {
     GFXRECON_ASSERT((device_info != nullptr) && (device_info->handle != VK_NULL_HANDLE) &&
                     (memory_properties.memoryTypeCount > 0) && (memory_properties.memoryHeapCount > 0) &&
-                    (resource_allocator != nullptr) && (device_table != nullptr));
+                    (resource_allocator != nullptr));
 
     // flushes of staging-buffer need to be aligned to nonCoherentAtomSize
     staging_buffer_alignment_ = physical_device_properties.limits.nonCoherentAtomSize;
@@ -79,38 +79,42 @@ VulkanResourceInitializer::VulkanResourceInitializer(const VulkanDeviceInfo*    
     constexpr VkFenceCreateInfo fence_ci = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
                                              nullptr,
                                              static_cast<VkFenceCreateFlags>(0) };
-    VkResult                    result   = device_table_->CreateFence(device_, &fence_ci, nullptr, &fence_);
+    auto                        injected = injected_calls_.Open();
+
+    VkResult result = injected->CreateFence(device_, &fence_ci, nullptr, &fence_);
     GFXRECON_ASSERT(result == VK_SUCCESS);
 }
 
 VulkanResourceInitializer::~VulkanResourceInitializer()
 {
+    auto injected = injected_calls_.Open();
+
     FlushRemainingResourcesInit();
     ReleaseStagingBuffer();
 
     for (const auto& entry : command_exec_objects_)
     {
-        device_table_->DestroyCommandPool(device_, entry.second.command_pool, nullptr);
+        injected->DestroyCommandPool(device_, entry.second.command_pool, nullptr);
     }
 
     if (draw_sampler_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroySampler(device_, draw_sampler_, nullptr);
+        injected->DestroySampler(device_, draw_sampler_, nullptr);
     }
 
     if (draw_pool_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyDescriptorPool(device_, draw_pool_, nullptr);
+        injected->DestroyDescriptorPool(device_, draw_pool_, nullptr);
     }
 
     if (draw_set_layout_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyDescriptorSetLayout(device_, draw_set_layout_, nullptr);
+        injected->DestroyDescriptorSetLayout(device_, draw_set_layout_, nullptr);
     }
 
     if (fence_ != VK_NULL_HANDLE)
     {
-        device_table_->DestroyFence(device_, fence_, nullptr);
+        injected->DestroyFence(device_, fence_, nullptr);
     }
 }
 
@@ -142,6 +146,8 @@ VkResult VulkanResourceInitializer::InitializeBuffer(VkDeviceSize        data_si
 {
     // TODO: handle usage cases without TRANSFER_DST.
     GFXRECON_UNREFERENCED_PARAMETER(usage);
+
+    auto injected = injected_calls_.Open();
 
     VkResult result = AcquireStagingBuffer(data_size);
     if (result == VK_SUCCESS)
@@ -176,7 +182,8 @@ VkResult VulkanResourceInitializer::InitializeBuffer(VkDeviceSize        data_si
                     offsetted_regions_copy_[i].srcOffset += staging_buffer_offset_;
                 }
 
-                device_table_->CmdCopyBuffer(
+                injected.InsertLabel(command_buffer, "Initialize buffer");
+                injected->CmdCopyBuffer(
                     command_buffer, staging_buffer_, buffer, region_count, offsetted_regions_copy_.data());
 
                 // Advance staging buffer offset
@@ -328,6 +335,8 @@ VkResult VulkanResourceInitializer::TransitionImage(uint32_t              queue_
                                                     uint32_t              layer_count,
                                                     uint32_t              level_count)
 {
+    auto injected = injected_calls_.Open();
+
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
     VkResult        result         = BeginCommandBuffer(queue_family_index, &command_buffer);
 
@@ -351,16 +360,17 @@ VkResult VulkanResourceInitializer::TransitionImage(uint32_t              queue_
         memory_barrier.subresourceRange.baseArrayLayer = 0;
         memory_barrier.subresourceRange.layerCount     = layer_count;
 
-        device_table_->CmdPipelineBarrier(command_buffer,
-                                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                          VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                          0,
-                                          0,
-                                          nullptr,
-                                          0,
-                                          nullptr,
-                                          1,
-                                          &memory_barrier);
+        injected.InsertLabel(command_buffer, "Transition image layout");
+        injected->CmdPipelineBarrier(command_buffer,
+                                     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                     VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                     0,
+                                     0,
+                                     nullptr,
+                                     0,
+                                     nullptr,
+                                     1,
+                                     &memory_barrier);
 
         // Check if there are pending commands from InitializeImage by checking the staging buffer's offset.
         // If there are then don't submit the command buffer as there is still room left to init more resources
@@ -376,6 +386,8 @@ VkResult VulkanResourceInitializer::TransitionImage(uint32_t              queue_
 VkResult VulkanResourceInitializer::GetCommandExecObjects(uint32_t queue_family_index, VkCommandBuffer* command_buffer)
 {
     assert(command_buffer != nullptr);
+
+    auto injected = injected_calls_.Open();
 
     VkResult result = VK_SUCCESS;
     auto     iter   = command_exec_objects_.find(queue_family_index);
@@ -393,7 +405,7 @@ VkResult VulkanResourceInitializer::GetCommandExecObjects(uint32_t queue_family_
         create_info.flags                   = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
         create_info.queueFamilyIndex        = queue_family_index;
 
-        result = device_table_->CreateCommandPool(device_, &create_info, nullptr, &command_pool);
+        result = injected->CreateCommandPool(device_, &create_info, nullptr, &command_pool);
 
         if (result == VK_SUCCESS)
         {
@@ -403,17 +415,17 @@ VkResult VulkanResourceInitializer::GetCommandExecObjects(uint32_t queue_family_
             alloc_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
             alloc_info.commandBufferCount          = 1;
 
-            result = device_table_->AllocateCommandBuffers(device_, &alloc_info, command_buffer);
+            result = injected->AllocateCommandBuffers(device_, &alloc_info, command_buffer);
 
             if (result == VK_SUCCESS)
             {
-                VkQueue queue = GetDeviceQueue(device_table_, device_info_, queue_family_index, 0);
+                VkQueue queue = GetDeviceQueue(injected.GetTable(), device_info_, queue_family_index, 0);
                 command_exec_objects_.emplace(queue_family_index,
                                               CommandExecObjects{ queue, command_pool, *command_buffer, false });
             }
             else
             {
-                device_table_->DestroyCommandPool(device_, command_pool, nullptr);
+                injected->DestroyCommandPool(device_, command_pool, nullptr);
             }
         }
     }
@@ -426,6 +438,8 @@ VkResult VulkanResourceInitializer::GetDrawDescriptorObjects(VkSampler*         
                                                              VkDescriptorSet*       set)
 {
     assert((sampler != nullptr) && (set_layout != nullptr) && (set != nullptr));
+
+    auto injected = injected_calls_.Open();
 
     VkResult result = VK_SUCCESS;
 
@@ -450,7 +464,7 @@ VkResult VulkanResourceInitializer::GetDrawDescriptorObjects(VkSampler*         
         sampler_info.borderColor             = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
         sampler_info.unnormalizedCoordinates = VK_FALSE;
 
-        result = device_table_->CreateSampler(device_, &sampler_info, nullptr, &draw_sampler_);
+        result = injected->CreateSampler(device_, &sampler_info, nullptr, &draw_sampler_);
 
         if (result == VK_SUCCESS)
         {
@@ -467,7 +481,7 @@ VkResult VulkanResourceInitializer::GetDrawDescriptorObjects(VkSampler*         
             pool_info.poolSizeCount              = 2;
             pool_info.pPoolSizes                 = pool_size;
 
-            result = device_table_->CreateDescriptorPool(device_, &pool_info, nullptr, &draw_pool_);
+            result = injected->CreateDescriptorPool(device_, &pool_info, nullptr, &draw_pool_);
         }
 
         if (result == VK_SUCCESS)
@@ -490,7 +504,7 @@ VkResult VulkanResourceInitializer::GetDrawDescriptorObjects(VkSampler*         
             set_layout_info.bindingCount                    = 2;
             set_layout_info.pBindings                       = set_binding;
 
-            result = device_table_->CreateDescriptorSetLayout(device_, &set_layout_info, nullptr, &draw_set_layout_);
+            result = injected->CreateDescriptorSetLayout(device_, &set_layout_info, nullptr, &draw_set_layout_);
         }
 
         if (result == VK_SUCCESS)
@@ -501,26 +515,26 @@ VkResult VulkanResourceInitializer::GetDrawDescriptorObjects(VkSampler*         
             set_info.descriptorSetCount          = 1;
             set_info.pSetLayouts                 = &draw_set_layout_;
 
-            result = device_table_->AllocateDescriptorSets(device_, &set_info, &draw_set_);
+            result = injected->AllocateDescriptorSets(device_, &set_info, &draw_set_);
         }
 
         if (result != VK_SUCCESS)
         {
             if (draw_sampler_ != VK_NULL_HANDLE)
             {
-                device_table_->DestroySampler(device_, draw_sampler_, nullptr);
+                injected->DestroySampler(device_, draw_sampler_, nullptr);
                 draw_sampler_ = VK_NULL_HANDLE;
             }
 
             if (draw_pool_ != VK_NULL_HANDLE)
             {
-                device_table_->DestroyDescriptorPool(device_, draw_pool_, nullptr);
+                injected->DestroyDescriptorPool(device_, draw_pool_, nullptr);
                 draw_pool_ = VK_NULL_HANDLE;
             }
 
             if (draw_set_layout_ != VK_NULL_HANDLE)
             {
-                device_table_->DestroyDescriptorSetLayout(device_, draw_set_layout_, nullptr);
+                injected->DestroyDescriptorSetLayout(device_, draw_set_layout_, nullptr);
                 draw_set_layout_ = VK_NULL_HANDLE;
             }
         }
@@ -552,6 +566,8 @@ VkResult VulkanResourceInitializer::CreateDrawObjects(VkFormat              form
 {
     assert((set_layout != VK_NULL_HANDLE) && (pass != nullptr) && (pipeline_layout != nullptr) &&
            (pipeline != nullptr));
+
+    auto injected = injected_calls_.Open();
 
     VkRenderPass     draw_pass            = VK_NULL_HANDLE;
     VkPipelineLayout draw_pipeline_layout = VK_NULL_HANDLE;
@@ -626,7 +642,7 @@ VkResult VulkanResourceInitializer::CreateDrawObjects(VkFormat              form
     render_pass_info.dependencyCount        = 0;
     render_pass_info.pDependencies          = nullptr;
 
-    VkResult result = device_table_->CreateRenderPass(device_, &render_pass_info, nullptr, &draw_pass);
+    VkResult result = injected->CreateRenderPass(device_, &render_pass_info, nullptr, &draw_pass);
 
     if (result == VK_SUCCESS)
     {
@@ -643,7 +659,7 @@ VkResult VulkanResourceInitializer::CreateDrawObjects(VkFormat              form
         vs_info.codeSize                 = code_size;
         vs_info.pCode                    = reinterpret_cast<const uint32_t*>(g_VSMain);
 
-        result = device_table_->CreateShaderModule(device_, &vs_info, nullptr, &vs_module);
+        result = injected->CreateShaderModule(device_, &vs_info, nullptr, &vs_module);
 
         if (result == VK_SUCCESS)
         {
@@ -677,7 +693,7 @@ VkResult VulkanResourceInitializer::CreateDrawObjects(VkFormat              form
             ps_info.codeSize                 = code_size;
             ps_info.pCode                    = ps_code;
 
-            result = device_table_->CreateShaderModule(device_, &ps_info, nullptr, &ps_module);
+            result = injected->CreateShaderModule(device_, &ps_info, nullptr, &ps_module);
         }
 
         if (result == VK_SUCCESS)
@@ -690,8 +706,7 @@ VkResult VulkanResourceInitializer::CreateDrawObjects(VkFormat              form
             pipeline_layout_info.pushConstantRangeCount     = 0;
             pipeline_layout_info.pPushConstantRanges        = nullptr;
 
-            result =
-                device_table_->CreatePipelineLayout(device_, &pipeline_layout_info, nullptr, &draw_pipeline_layout);
+            result = injected->CreatePipelineLayout(device_, &pipeline_layout_info, nullptr, &draw_pipeline_layout);
         }
 
         if (result == VK_SUCCESS)
@@ -845,12 +860,12 @@ VkResult VulkanResourceInitializer::CreateDrawObjects(VkFormat              form
             pipeline_info.basePipelineHandle           = VK_NULL_HANDLE;
             pipeline_info.basePipelineIndex            = -1;
 
-            result = device_table_->CreateGraphicsPipelines(
-                device_, VK_NULL_HANDLE, 1, &pipeline_info, nullptr, &draw_pipeline);
+            result =
+                injected->CreateGraphicsPipelines(device_, VK_NULL_HANDLE, 1, &pipeline_info, nullptr, &draw_pipeline);
         }
 
-        device_table_->DestroyShaderModule(device_, ps_module, nullptr);
-        device_table_->DestroyShaderModule(device_, vs_module, nullptr);
+        injected->DestroyShaderModule(device_, ps_module, nullptr);
+        injected->DestroyShaderModule(device_, vs_module, nullptr);
     }
 
     if (result == VK_SUCCESS)
@@ -871,9 +886,11 @@ void VulkanResourceInitializer::DestroyDrawObjects(VkRenderPass     pass,
                                                    VkPipelineLayout pipeline_layout,
                                                    VkPipeline       pipeline)
 {
-    device_table_->DestroyPipeline(device_, pipeline, nullptr);
-    device_table_->DestroyPipelineLayout(device_, pipeline_layout, nullptr);
-    device_table_->DestroyRenderPass(device_, pass, nullptr);
+    auto injected = injected_calls_.Open();
+
+    injected->DestroyPipeline(device_, pipeline, nullptr);
+    injected->DestroyPipelineLayout(device_, pipeline_layout, nullptr);
+    injected->DestroyRenderPass(device_, pass, nullptr);
 }
 
 VkResult VulkanResourceInitializer::CreateStagingImage(const VkImageCreateInfo*               image_create_info,
@@ -884,6 +901,8 @@ VkResult VulkanResourceInitializer::CreateStagingImage(const VkImageCreateInfo* 
 {
     assert((memory != nullptr) && (image != nullptr) && (allocator_memory_data != nullptr) &&
            (allocator_image_data != nullptr));
+
+    auto injected = injected_calls_.Open();
 
     VkImage                               staging_image      = VK_NULL_HANDLE;
     VulkanResourceAllocator::ResourceData staging_image_data = 0;
@@ -897,7 +916,7 @@ VkResult VulkanResourceInitializer::CreateStagingImage(const VkImageCreateInfo* 
         VulkanResourceAllocator::MemoryData staging_memory_data = 0;
         VkMemoryRequirements                memory_reqs;
 
-        device_table_->GetImageMemoryRequirements(device_, staging_image, &memory_reqs);
+        injected->GetImageMemoryRequirements(device_, staging_image, &memory_reqs);
 
         auto memory_type_index = GetMemoryTypeIndex(memory_reqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
@@ -958,8 +977,10 @@ VkResult VulkanResourceInitializer::CreateFramebufferResources(const VkImageView
 {
     assert((view != nullptr) && (framebuffer != nullptr));
 
+    auto injected = injected_calls_.Open();
+
     VkImageView image_view = VK_NULL_HANDLE;
-    VkResult    result     = device_table_->CreateImageView(device_, view_create_info, nullptr, &image_view);
+    VkResult    result     = injected->CreateImageView(device_, view_create_info, nullptr, &image_view);
 
     if (result == VK_SUCCESS)
     {
@@ -973,7 +994,7 @@ VkResult VulkanResourceInitializer::CreateFramebufferResources(const VkImageView
         framebuffer_info.height                  = height;
         framebuffer_info.layers                  = 1;
 
-        result = device_table_->CreateFramebuffer(device_, &framebuffer_info, nullptr, framebuffer);
+        result = injected->CreateFramebuffer(device_, &framebuffer_info, nullptr, framebuffer);
 
         if (result == VK_SUCCESS)
         {
@@ -981,7 +1002,7 @@ VkResult VulkanResourceInitializer::CreateFramebufferResources(const VkImageView
         }
         else
         {
-            device_table_->DestroyImageView(device_, image_view, nullptr);
+            injected->DestroyImageView(device_, image_view, nullptr);
         }
     }
 
@@ -990,12 +1011,16 @@ VkResult VulkanResourceInitializer::CreateFramebufferResources(const VkImageView
 
 void VulkanResourceInitializer::DestroyFramebufferResources(VkImageView view, VkFramebuffer framebuffer)
 {
-    device_table_->DestroyFramebuffer(device_, framebuffer, nullptr);
-    device_table_->DestroyImageView(device_, view, nullptr);
+    auto injected = injected_calls_.Open();
+
+    injected->DestroyFramebuffer(device_, framebuffer, nullptr);
+    injected->DestroyImageView(device_, view, nullptr);
 }
 
 VkResult VulkanResourceInitializer::AcquireStagingBuffer(VkDeviceSize size)
 {
+    auto injected = injected_calls_.Open();
+
     VkResult result = VK_SUCCESS;
 
     // increase size if necessary, but we expect this is not necessary
@@ -1025,7 +1050,7 @@ VkResult VulkanResourceInitializer::AcquireStagingBuffer(VkDeviceSize size)
         if (result == VK_SUCCESS)
         {
             VkMemoryRequirements memory_requirements;
-            device_table_->GetBufferMemoryRequirements(device_, staging_buffer_, &memory_requirements);
+            injected->GetBufferMemoryRequirements(device_, staging_buffer_, &memory_requirements);
 
             auto memory_type_index =
                 GetMemoryTypeIndex(memory_requirements.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
@@ -1123,11 +1148,14 @@ void VulkanResourceInitializer::UpdateDrawDescriptorSet(VkDescriptorSet set, VkI
     write_set[1].pBufferInfo      = nullptr;
     write_set[1].pTexelBufferView = nullptr;
 
-    device_table_->UpdateDescriptorSets(device_, 2, write_set, 0, nullptr);
+    auto injected = injected_calls_.Open();
+    injected->UpdateDescriptorSets(device_, 2, write_set, 0, nullptr);
 }
 
 VkResult VulkanResourceInitializer::BeginCommandBuffer(uint32_t queue_family_index, VkCommandBuffer* command_buffer_p)
 {
+    auto injected = injected_calls_.Open();
+
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
     VkResult        result         = GetCommandExecObjects(queue_family_index, &command_buffer);
     if (result != VK_SUCCESS)
@@ -1149,7 +1177,7 @@ VkResult VulkanResourceInitializer::BeginCommandBuffer(uint32_t queue_family_ind
         begin_info.flags                    = 0;
         begin_info.pInheritanceInfo         = nullptr;
 
-        result = device_table_->BeginCommandBuffer(iter->second.command_buffer, &begin_info);
+        result = injected.BeginCommandBuffer(iter->second.command_buffer, &begin_info);
         if (result == VK_SUCCESS)
         {
             iter->second.recording = true;
@@ -1161,6 +1189,8 @@ VkResult VulkanResourceInitializer::BeginCommandBuffer(uint32_t queue_family_ind
 
 VkResult VulkanResourceInitializer::ExecuteCommandBuffer(VkQueue queue, VkCommandBuffer command_buffer)
 {
+    auto injected = injected_calls_.Open();
+
     VkSubmitInfo submit_info         = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
     submit_info.pNext                = nullptr;
     submit_info.waitSemaphoreCount   = 0;
@@ -1171,7 +1201,7 @@ VkResult VulkanResourceInitializer::ExecuteCommandBuffer(VkQueue queue, VkComman
     submit_info.signalSemaphoreCount = 0;
     submit_info.pSignalSemaphores    = nullptr;
 
-    VkResult result = device_table_->QueueSubmit(queue, 1, &submit_info, fence_);
+    VkResult result = injected->QueueSubmit(queue, 1, &submit_info, fence_);
     if (result != VK_SUCCESS)
     {
         return result;
@@ -1182,14 +1212,14 @@ VkResult VulkanResourceInitializer::ExecuteCommandBuffer(VkQueue queue, VkComman
 
     // Wait a sensible amount of time (10 seconds) to avoid hanging in case a prior
     // operation caused the GPU to hang or crash.
-    result = device_table_->WaitForFences(device_, 1, &fence_, VK_TRUE, 10000000000);
+    result = injected->WaitForFences(device_, 1, &fence_, VK_TRUE, 10000000000);
     if (result != VK_SUCCESS)
     {
         return result;
     }
 
     // reset to unsignaled state
-    result = device_table_->ResetFences(device_, 1, &fence_);
+    result = injected->ResetFences(device_, 1, &fence_);
     return result;
 }
 
@@ -1248,6 +1278,8 @@ VkResult VulkanResourceInitializer::BufferToImageCopy(uint32_t                 q
                                                       uint32_t                 level_count,
                                                       const VkBufferImageCopy* level_copies)
 {
+    auto injected = injected_calls_.Open();
+
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
 
     VkResult result = GetCommandExecObjects(queue_family_index, &command_buffer);
@@ -1259,6 +1291,8 @@ VkResult VulkanResourceInitializer::BufferToImageCopy(uint32_t                 q
 
         if (result == VK_SUCCESS)
         {
+            auto copy_region = injected_calls_.Label(injected, command_buffer, "Copy buffer to image");
+
             VkImageMemoryBarrier memory_barrier            = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
             memory_barrier.sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
             memory_barrier.pNext                           = nullptr;
@@ -1275,18 +1309,18 @@ VkResult VulkanResourceInitializer::BufferToImageCopy(uint32_t                 q
             memory_barrier.subresourceRange.baseArrayLayer = 0;
             memory_barrier.subresourceRange.layerCount     = layer_count;
 
-            device_table_->CmdPipelineBarrier(command_buffer,
-                                              VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                              VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                              0,
-                                              0,
-                                              nullptr,
-                                              0,
-                                              nullptr,
-                                              1,
-                                              &memory_barrier);
+            injected->CmdPipelineBarrier(command_buffer,
+                                         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                         VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                         0,
+                                         0,
+                                         nullptr,
+                                         0,
+                                         nullptr,
+                                         1,
+                                         &memory_barrier);
 
-            device_table_->CmdCopyBufferToImage(
+            injected->CmdCopyBufferToImage(
                 command_buffer, source, destination, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, level_count, level_copies);
 
             if ((final_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) && (final_layout != VK_IMAGE_LAYOUT_UNDEFINED) &&
@@ -1297,16 +1331,16 @@ VkResult VulkanResourceInitializer::BufferToImageCopy(uint32_t                 q
                 memory_barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
                 memory_barrier.newLayout     = final_layout;
 
-                device_table_->CmdPipelineBarrier(command_buffer,
-                                                  VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                                  VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                                  0,
-                                                  0,
-                                                  nullptr,
-                                                  0,
-                                                  nullptr,
-                                                  1,
-                                                  &memory_barrier);
+                injected->CmdPipelineBarrier(command_buffer,
+                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                             0,
+                                             0,
+                                             nullptr,
+                                             0,
+                                             nullptr,
+                                             1,
+                                             &memory_barrier);
             }
         }
     }
@@ -1328,6 +1362,8 @@ VkResult VulkanResourceInitializer::PixelShaderImageCopy(uint32_t               
                                                          uint32_t                 level_count,
                                                          const VkBufferImageCopy* level_copies)
 {
+    auto injected = injected_calls_.Open();
+
     VkSampler             sampler    = VK_NULL_HANDLE;
     VkDescriptorSetLayout set_layout = VK_NULL_HANDLE;
     VkDescriptorSet       set        = VK_NULL_HANDLE;
@@ -1435,7 +1471,7 @@ VkResult VulkanResourceInitializer::PixelShaderImageCopy(uint32_t               
                             view_info.image                           = staging_image;
                             view_info.subresourceRange.baseArrayLayer = layer;
 
-                            result = device_table_->CreateImageView(device_, &view_info, nullptr, &staging_view);
+                            result = injected->CreateImageView(device_, &view_info, nullptr, &staging_view);
 
                             if (result == VK_SUCCESS)
                             {
@@ -1468,28 +1504,33 @@ VkResult VulkanResourceInitializer::PixelShaderImageCopy(uint32_t               
                                     begin_info.clearValueCount          = 0;
                                     begin_info.pClearValues             = nullptr;
 
-                                    device_table_->CmdBeginRenderPass(
-                                        command_buffer, &begin_info, VK_SUBPASS_CONTENTS_INLINE);
-                                    device_table_->CmdBindPipeline(
-                                        command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
-                                    device_table_->CmdBindDescriptorSets(command_buffer,
-                                                                         VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                                                         pipeline_layout,
-                                                                         0,
-                                                                         1,
-                                                                         &set,
-                                                                         0,
-                                                                         nullptr);
-                                    device_table_->CmdSetViewport(command_buffer, 0, 1, &viewport);
-                                    device_table_->CmdSetScissor(command_buffer, 0, 1, &scissor_rect);
-                                    device_table_->CmdDraw(command_buffer, 3, 1, 0, 0);
-                                    device_table_->CmdEndRenderPass(command_buffer);
+                                    {
+                                        auto draw_region =
+                                            injected_calls_.Label(injected, command_buffer, "Pixel-shader image copy");
+
+                                        injected->CmdBeginRenderPass(
+                                            command_buffer, &begin_info, VK_SUBPASS_CONTENTS_INLINE);
+                                        injected->CmdBindPipeline(
+                                            command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+                                        injected->CmdBindDescriptorSets(command_buffer,
+                                                                        VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                                                        pipeline_layout,
+                                                                        0,
+                                                                        1,
+                                                                        &set,
+                                                                        0,
+                                                                        nullptr);
+                                        injected->CmdSetViewport(command_buffer, 0, 1, &viewport);
+                                        injected->CmdSetScissor(command_buffer, 0, 1, &scissor_rect);
+                                        injected->CmdDraw(command_buffer, 3, 1, 0, 0);
+                                        injected->CmdEndRenderPass(command_buffer);
+                                    }
                                     result = FlushCommandBuffer(queue_family_index);
                                 }
                             }
 
                             DestroyFramebufferResources(destination_view, framebuffer);
-                            device_table_->DestroyImageView(device_, staging_view, nullptr);
+                            injected->DestroyImageView(device_, staging_view, nullptr);
 
                             if (result != VK_SUCCESS)
                             {
@@ -1517,7 +1558,8 @@ VkResult VulkanResourceInitializer::FlushCommandBuffer(uint32_t queue_family_ind
 
     if (iter != command_exec_objects_.end() && iter->second.recording)
     {
-        device_table_->EndCommandBuffer(iter->second.command_buffer);
+        auto injected = injected_calls_.Open();
+        injected->EndCommandBuffer(iter->second.command_buffer);
 
         result                 = ExecuteCommandBuffer(iter->second.queue, iter->second.command_buffer);
         iter->second.recording = false;

--- a/framework/decode/vulkan_resource_initializer.h
+++ b/framework/decode/vulkan_resource_initializer.h
@@ -25,6 +25,7 @@
 
 #include "decode/vulkan_resource_allocator.h"
 #include "generated/generated_vulkan_dispatch_table.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "util/defines.h"
 
 #include "vulkan/vulkan.h"
@@ -41,14 +42,14 @@ struct VulkanDeviceInfo;
 class VulkanResourceInitializer
 {
   public:
-    VulkanResourceInitializer(const VulkanDeviceInfo*                 device_info,
-                              VkDeviceSize                            total_copy_size,
-                              VkDeviceSize                            max_copy_size,
-                              const VkPhysicalDeviceProperties&       physical_device_properties,
-                              const VkPhysicalDeviceMemoryProperties& memory_properties,
-                              bool                                    have_shader_stencil_write,
-                              VulkanResourceAllocator*                resource_allocator,
-                              const graphics::VulkanDeviceTable*      device_table);
+    VulkanResourceInitializer(const VulkanDeviceInfo*                    device_info,
+                              VkDeviceSize                               total_copy_size,
+                              VkDeviceSize                               max_copy_size,
+                              const VkPhysicalDeviceProperties&          physical_device_properties,
+                              const VkPhysicalDeviceMemoryProperties&    memory_properties,
+                              bool                                       have_shader_stencil_write,
+                              VulkanResourceAllocator*                   resource_allocator,
+                              const graphics::VulkanInjectedDeviceCalls& injected_calls);
 
     ~VulkanResourceInitializer();
 
@@ -201,8 +202,10 @@ class VulkanResourceInitializer
     VkPhysicalDeviceMemoryProperties      memory_properties_{};
     bool                                  have_shader_stencil_write_;
     VulkanResourceAllocator*              resource_allocator_;
-    const graphics::VulkanDeviceTable*    device_table_;
-    const VulkanDeviceInfo*               device_info_;
+    // Every device call this class makes is replay-injected, i.e. has no
+    // corresponding block in the capture file.
+    graphics::VulkanInjectedDeviceCalls injected_calls_;
+    const VulkanDeviceInfo*             device_info_;
 
     // Copies of the copy information passed into the InitializeBuffer and InitializeImage respectively.
     // Vectors are kept and only grow in size in order to save the cost of reallocating them each time.

--- a/framework/decode/vulkan_submit_info_helper.h
+++ b/framework/decode/vulkan_submit_info_helper.h
@@ -24,6 +24,7 @@
 #define GFXRECON_VULKAN_SUBMIT_INFO_HELPER_H
 
 #include "graphics/vulkan_semaphore_util.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "decode/vulkan_object_info.h"
 #include "util/defines.h"
 
@@ -43,8 +44,8 @@ class VulkanInjectedSemaphore
   private:
     graphics::VulkanSemaphore semaphore_{ VK_NULL_HANDLE };
 
-    const VulkanDeviceInfo*            device_info_;
-    const graphics::VulkanDeviceTable* device_table_;
+    const VulkanDeviceInfo*             device_info_;
+    graphics::VulkanInjectedDeviceCalls device_table_;
 
   public:
     bool                      HasReachedTargetValue() const;
@@ -53,7 +54,7 @@ class VulkanInjectedSemaphore
     uint64_t                  GetTargetValue() const { return semaphore_.timeline_value; }
     void                      IncreaseTargetValue() { semaphore_.timeline_value++; }
 
-    VulkanInjectedSemaphore(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* table);
+    VulkanInjectedSemaphore(const VulkanDeviceInfo* device_info, const graphics::VulkanInjectedDeviceCalls& table);
     ~VulkanInjectedSemaphore();
 
     VulkanInjectedSemaphore(const VulkanInjectedSemaphore&)            = delete;
@@ -74,7 +75,7 @@ struct VulkanInjectedSemaphoreInfo
     VulkanInjectedSemaphore semaphore;
     VkSemaphoreSubmitInfo   info = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
 
-    VulkanInjectedSemaphoreInfo(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* table);
+    VulkanInjectedSemaphoreInfo(const VulkanDeviceInfo* device_info, const graphics::VulkanInjectedDeviceCalls& table);
 };
 
 /**

--- a/framework/decode/vulkan_submit_job.cpp
+++ b/framework/decode/vulkan_submit_job.cpp
@@ -21,6 +21,7 @@
 */
 
 #include "decode/vulkan_submit_job.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "graphics/vulkan_struct_get_pnext.h"
 #include "generated/generated_vulkan_enum_to_string.h"
 
@@ -55,13 +56,12 @@ bool VulkanSubmitJobPlan::HasJobsForIndex(uint32_t submit_index) const
     return jobs_for_index && !jobs_for_index->jobs.empty();
 }
 
-VulkanInjectedSemaphore::VulkanInjectedSemaphore(const VulkanDeviceInfo*            device_info,
-                                                 const graphics::VulkanDeviceTable* device_table) :
+VulkanInjectedSemaphore::VulkanInjectedSemaphore(const VulkanDeviceInfo*                    device_info,
+                                                 const graphics::VulkanInjectedDeviceCalls& device_table) :
     device_info_{ device_info },
     device_table_{ device_table }
 {
     GFXRECON_ASSERT(device_info_ != nullptr);
-    GFXRECON_ASSERT(device_table_ != nullptr);
 
     VkSemaphoreTypeCreateInfo timeline_create_info{ VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO };
     timeline_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
@@ -70,8 +70,9 @@ VulkanInjectedSemaphore::VulkanInjectedSemaphore(const VulkanDeviceInfo*        
     VkSemaphoreCreateInfo semaphore_create_info{ VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
     semaphore_create_info.pNext = &timeline_create_info;
 
+    auto     injected = device_table.Open();
     VkResult result =
-        device_table_->CreateSemaphore(device_info_->handle, &semaphore_create_info, nullptr, &semaphore_.semaphore);
+        injected->CreateSemaphore(device_info_->handle, &semaphore_create_info, nullptr, &semaphore_.semaphore);
     if (result != VK_SUCCESS) [[unlikely]]
     {
         GFXRECON_LOG_ERROR("Failed to create timeline semaphore for submit job execution: %s",
@@ -103,10 +104,11 @@ bool VulkanInjectedSemaphore::HasReachedTargetValue() const
         return false;
     }
 
-    GFXRECON_ASSERT(device_table_->GetSemaphoreCounterValue != nullptr);
+    auto injected = device_table_.Open();
+    GFXRECON_ASSERT(injected->GetSemaphoreCounterValue != nullptr);
 
     uint64_t read_value = 0;
-    VkResult result = device_table_->GetSemaphoreCounterValue(device_info_->handle, semaphore_.semaphore, &read_value);
+    VkResult result     = injected->GetSemaphoreCounterValue(device_info_->handle, semaphore_.semaphore, &read_value);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("Failed to get timeline semaphore value for submit job execution: %s",
@@ -123,12 +125,13 @@ VulkanInjectedSemaphore::~VulkanInjectedSemaphore()
         {
             GFXRECON_LOG_ERROR("Injected timeline semaphore has not reached its target value at destruction time.");
         }
-        device_table_->DestroySemaphore(device_info_->handle, semaphore_.semaphore, nullptr);
+        auto injected = device_table_.Open();
+        injected->DestroySemaphore(device_info_->handle, semaphore_.semaphore, nullptr);
     }
 }
 
-VulkanInjectedSemaphoreInfo::VulkanInjectedSemaphoreInfo(const VulkanDeviceInfo*            device_info,
-                                                         const graphics::VulkanDeviceTable* device_table) :
+VulkanInjectedSemaphoreInfo::VulkanInjectedSemaphoreInfo(const VulkanDeviceInfo*                    device_info,
+                                                         const graphics::VulkanInjectedDeviceCalls& device_table) :
     semaphore{ device_info, device_table }
 {
     GFXRECON_ASSERT(semaphore.GetHandle() != VK_NULL_HANDLE);
@@ -249,9 +252,9 @@ void VulkanSubmitJobExecution::InjectBefore(VulkanSubmitJobPlan plan, std::span<
         // Only execute jobs if there are functions to execute for this submit.
         if (plan.HasJobsForIndex(submit_index))
         {
-            VkSubmitInfo2& submit_info                   = submit_infos[submit_index];
-            auto&          original_wait_semaphores      = original_wait_semaphores_[&submit_info].semaphores;
-            auto&          submit_helper                 = GetSubmitInfo2Helper(submit_info);
+            VkSubmitInfo2& submit_info              = submit_infos[submit_index];
+            auto&          original_wait_semaphores = original_wait_semaphores_[&submit_info].semaphores;
+            auto&          submit_helper            = GetSubmitInfo2Helper(submit_info);
 
             // Execute each job function and gather injected wait-semaphores.
             for (const auto& job : jobs)
@@ -330,13 +333,12 @@ void VulkanSubmitJobExecution::SubmitStandalone(VulkanSubmitJobPlan plan) const
     }
 }
 
-VulkanSubmitJobExecutor::VulkanSubmitJobExecutor(const VulkanDeviceInfo*            device_info,
-                                                 const graphics::VulkanDeviceTable* device_table) :
+VulkanSubmitJobExecutor::VulkanSubmitJobExecutor(const VulkanDeviceInfo*                    device_info,
+                                                 const graphics::VulkanInjectedDeviceCalls& device_table) :
     device_info_(device_info),
     device_table_(device_table)
 {
     GFXRECON_ASSERT(device_info_ != nullptr);
-    GFXRECON_ASSERT(device_table_ != nullptr);
 }
 
 VulkanInjectedSemaphore* VulkanSubmitJobExecutor::CreateTimelineSemaphore()

--- a/framework/decode/vulkan_submit_job.h
+++ b/framework/decode/vulkan_submit_job.h
@@ -29,6 +29,7 @@
 #include <unordered_map>
 
 #include "decode/vulkan_object_info.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "graphics/vulkan_semaphore_util.h"
 #include "decode/common_object_info_table.h"
 #include "decode/vulkan_submit_info_helper.h"
@@ -211,7 +212,8 @@ class VulkanSubmitJobExecutor
      * @param device_info Pointer to VulkanDeviceInfo for the device this executor manages.
      * @param device_table Pointer to the Vulkan device dispatch table used to create/destroy resources.
      */
-    VulkanSubmitJobExecutor(const VulkanDeviceInfo* device_info, const graphics::VulkanDeviceTable* device_table);
+    VulkanSubmitJobExecutor(const VulkanDeviceInfo*                    device_info,
+                            const graphics::VulkanInjectedDeviceCalls& device_table);
 
     /**
      * @brief Create a short-lived execution object for a single queue-submit call.
@@ -254,8 +256,8 @@ class VulkanSubmitJobExecutor
     void PruneSignaledTimelineSemaphoreInfos();
 
   private:
-    const VulkanDeviceInfo*            device_info_  = nullptr;
-    const graphics::VulkanDeviceTable* device_table_ = nullptr;
+    const VulkanDeviceInfo*             device_info_ = nullptr;
+    graphics::VulkanInjectedDeviceCalls device_table_;
 
     std::vector<std::unique_ptr<VulkanInjectedSemaphore>>     injected_semaphores_;
     std::vector<std::unique_ptr<VulkanInjectedSemaphoreInfo>> injected_semaphore_infos_;

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -29,11 +29,13 @@
 #include "decode/window.h"
 #include "util/defines.h"
 #include "decode/vulkan_replay_options.h"
+#include "graphics/vulkan_injected_calls.h"
 
 #include "application/application.h"
 
 #include "vulkan/vulkan.h"
 
+#include <optional>
 #include <string>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -66,7 +68,7 @@ class VulkanSwapchain
 
     virtual void Clean();
 
-    virtual void CleanDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table) {}
+    virtual void CleanDeviceResources(VkDevice device, const graphics::VulkanInjectedDeviceCalls* device_table) {}
 
     VulkanSwapchainOptions GetOptions() { return swapchain_options_; }
     void                   SetOptions(const VulkanSwapchainOptions& options) { swapchain_options_ = options; }
@@ -86,13 +88,13 @@ class VulkanSwapchain
                                 const VulkanSurfaceKHRInfo*  surface_info,
                                 const VkAllocationCallbacks* allocator);
 
-    virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
-                                        PFN_vkCreateSwapchainKHR              func,
-                                        const VulkanDeviceInfo*               device_info,
-                                        const VkSwapchainCreateInfoKHR*       create_info,
-                                        const VkAllocationCallbacks*          allocator,
-                                        HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const graphics::VulkanDeviceTable*    device_table) = 0;
+    virtual VkResult CreateSwapchainKHR(VkResult                                   original_result,
+                                        PFN_vkCreateSwapchainKHR                   func,
+                                        const VulkanDeviceInfo*                    device_info,
+                                        const VkSwapchainCreateInfoKHR*            create_info,
+                                        const VkAllocationCallbacks*               allocator,
+                                        HandlePointerDecoder<VkSwapchainKHR>*      swapchain,
+                                        const graphics::VulkanInjectedDeviceCalls& injected_calls) = 0;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
                                      const VulkanDeviceInfo*       device_info,
@@ -177,7 +179,7 @@ class VulkanSwapchain
                                    const VulkanImageInfo*                     image_info,
                                    VulkanInstanceInfo*                        instance_info,
                                    const graphics::VulkanInstanceTable*       instance_table,
-                                   const graphics::VulkanDeviceTable*         device_table,
+                                   const graphics::VulkanInjectedDeviceCalls& injected_calls,
                                    application::Application*                  application,
                                    const std::optional<std::array<float, 2>>& scale) = 0;
 
@@ -192,7 +194,11 @@ class VulkanSwapchain
     typedef std::unordered_set<Window*> ActiveWindows;
 
     const graphics::VulkanInstanceTable* instance_table_{ nullptr };
-    const graphics::VulkanDeviceTable*   device_table_{ nullptr };
+
+    // Access point for the device calls the swapchain classes make on their
+    // own, i.e. calls with no corresponding block in the capture file. Set
+    // from the device table passed to CreateSwapchainKHR.
+    std::optional<graphics::VulkanInjectedDeviceCalls> injected_calls_;
 
     application::Application* application_{ nullptr };
     ActiveWindows             active_windows_;

--- a/framework/decode/vulkan_temporary_objects.cpp
+++ b/framework/decode/vulkan_temporary_objects.cpp
@@ -37,11 +37,12 @@ VkResult TemporaryCommandBuffer::CreateAndBegin(graphics::FindQueueFamilyIndex_f
 
 VkResult TemporaryCommandBuffer::CreateAndBegin(uint32_t queue_family_index)
 {
+    auto                          injected         = device_table.Open();
     const VkCommandPoolCreateInfo pool_create_info = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
                                                        nullptr,
                                                        VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
                                                        queue_family_index };
-    VkResult res = device_table.CreateCommandPool(device_info.handle, &pool_create_info, nullptr, &command_pool);
+    VkResult res = injected->CreateCommandPool(device_info.handle, &pool_create_info, nullptr, &command_pool);
     if (res != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("%s() CreateCommandPool failed (%s)", __func__, util::ToString(res).c_str());
@@ -51,22 +52,22 @@ VkResult TemporaryCommandBuffer::CreateAndBegin(uint32_t queue_family_index)
     const VkCommandBufferAllocateInfo alloc_info = {
         VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, nullptr, command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1
     };
-    res = device_table.AllocateCommandBuffers(device_info.handle, &alloc_info, &command_buffer);
+    res = injected->AllocateCommandBuffers(device_info.handle, &alloc_info, &command_buffer);
     if (res != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("%s() AllocateCommandBuffers failed (%s)", __func__, util::ToString(res).c_str());
         return res;
     }
 
-    queue = GetDeviceQueue(&device_table, &device_info, queue_family_index, 0);
+    queue = GetDeviceQueue(injected.GetTable(), &device_info, queue_family_index, 0);
 
-    device_table.ResetCommandBuffer(command_buffer, VkCommandBufferResetFlagBits(0));
+    injected->ResetCommandBuffer(command_buffer, VkCommandBufferResetFlagBits(0));
 
     const VkCommandBufferBeginInfo begin_info = {
         VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr, VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, nullptr
     };
 
-    res = device_table.BeginCommandBuffer(command_buffer, &begin_info);
+    res = injected.BeginCommandBuffer(command_buffer, &begin_info);
     if (res != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("%s() BeginCommandBuffer failed (%s)", __func__, util::ToString(res).c_str());
@@ -82,9 +83,10 @@ VkResult TemporaryCommandBuffer::SubmitAndDestroy()
     GFXRECON_ASSERT(queue != VK_NULL_HANDLE);
     GFXRECON_ASSERT(command_pool != VK_NULL_HANDLE);
 
+    auto           injected = device_table.Open();
     TemporaryFence fence(device_info.handle, device_table);
 
-    VkResult res = device_table.EndCommandBuffer(command_buffer);
+    VkResult res = injected->EndCommandBuffer(command_buffer);
     if (res != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("%s() EndCommandBuffer failed (%s)", __func__, util::ToString(res).c_str());
@@ -94,7 +96,7 @@ VkResult TemporaryCommandBuffer::SubmitAndDestroy()
     const VkSubmitInfo submit_info = {
         VK_STRUCTURE_TYPE_SUBMIT_INFO, nullptr, 0, nullptr, nullptr, 1, &command_buffer, 0, nullptr
     };
-    res = device_table.QueueSubmit(queue, 1, &submit_info, fence.handle);
+    res = injected->QueueSubmit(queue, 1, &submit_info, fence.handle);
     if (res != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("%s() QueueSubmit failed (%s)", __func__, util::ToString(res).c_str());
@@ -107,7 +109,7 @@ VkResult TemporaryCommandBuffer::SubmitAndDestroy()
         return res;
     }
 
-    device_table.DestroyCommandPool(device_info.handle, command_pool, nullptr);
+    injected->DestroyCommandPool(device_info.handle, command_pool, nullptr);
     command_pool = VK_NULL_HANDLE;
 
     return VK_SUCCESS;

--- a/framework/decode/vulkan_temporary_objects.h
+++ b/framework/decode/vulkan_temporary_objects.h
@@ -26,6 +26,7 @@
 #include "decode/vulkan_object_info.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "generated/generated_vulkan_enum_to_string.h"
+#include "graphics/vulkan_injected_calls.h"
 #include "graphics/vulkan_util.h"
 #include "util/defines.h"
 #include "util/logging.h"
@@ -36,13 +37,14 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 // Wrapper class for VkFence. Either holds an existing VkFence or creates and handles destruction of one
 struct TemporaryFence
 {
-    TemporaryFence(VkFence other, VkDevice device, const graphics::VulkanDeviceTable& dt) :
-        handle(other), parent_device(device), device_table(dt)
+    TemporaryFence(VkFence other, VkDevice device, const graphics::VulkanInjectedDeviceCalls& injected_calls) :
+        handle(other), parent_device(device), device_table(injected_calls)
     {
         if (other == VK_NULL_HANDLE)
         {
+            auto              injected = device_table.Open();
             VkFenceCreateInfo fence_ci = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, 0 };
-            const VkResult    res      = device_table.CreateFence(parent_device, &fence_ci, nullptr, &handle);
+            const VkResult    res      = injected->CreateFence(parent_device, &fence_ci, nullptr, &handle);
             needs_cleanup              = (res == VK_SUCCESS);
             if (res != VK_SUCCESS)
             {
@@ -56,6 +58,14 @@ struct TemporaryFence
         }
     }
 
+    TemporaryFence(VkFence other, VkDevice device, const graphics::VulkanDeviceTable& dt) :
+        TemporaryFence(other, device, graphics::VulkanInjectedDeviceCalls(&dt))
+    {}
+
+    TemporaryFence(VkDevice device, const graphics::VulkanInjectedDeviceCalls& injected_calls) :
+        TemporaryFence(VK_NULL_HANDLE, device, injected_calls)
+    {}
+
     TemporaryFence(VkDevice device, const graphics::VulkanDeviceTable& dt) : TemporaryFence(VK_NULL_HANDLE, device, dt)
     {}
 
@@ -65,7 +75,8 @@ struct TemporaryFence
         GFXRECON_ASSERT(handle != VK_NULL_HANDLE);
 
         // Wait a sensible amount of time (10 seconds) in case we did something that can cause the GPU to hang or crash.
-        VkResult res = device_table.WaitForFences(parent_device, 1, &handle, VK_TRUE, 10000000000);
+        auto     injected = device_table.Open();
+        VkResult res      = injected->WaitForFences(parent_device, 1, &handle, VK_TRUE, 10000000000);
         if (res != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR("WaitForFences failed with %s", util::ToString(res).c_str());
@@ -79,7 +90,8 @@ struct TemporaryFence
         GFXRECON_ASSERT(parent_device != VK_NULL_HANDLE);
         GFXRECON_ASSERT(handle != VK_NULL_HANDLE);
 
-        VkResult res = device_table.ResetFences(parent_device, 1, &handle);
+        auto     injected = device_table.Open();
+        VkResult res      = injected->ResetFences(parent_device, 1, &handle);
         if (res != VK_SUCCESS)
         {
             GFXRECON_LOG_ERROR("ResetFences failed with %s", util::ToString(res).c_str());
@@ -95,27 +107,35 @@ struct TemporaryFence
             GFXRECON_ASSERT(parent_device != VK_NULL_HANDLE);
             GFXRECON_ASSERT(handle != VK_NULL_HANDLE);
 
-            device_table.DestroyFence(parent_device, handle, nullptr);
+            auto injected = device_table.Open();
+            injected->DestroyFence(parent_device, handle, nullptr);
         }
     }
 
-    VkFence                            handle;
-    VkDevice                           parent_device;
-    const graphics::VulkanDeviceTable& device_table;
-    bool                               needs_cleanup;
+    VkFence                             handle;
+    VkDevice                            parent_device;
+    graphics::VulkanInjectedDeviceCalls device_table;
+    bool                                needs_cleanup;
 };
 
 struct TemporaryCommandBuffer
 {
+    TemporaryCommandBuffer(const VulkanDeviceInfo&                    dev_info,
+                           const graphics::VulkanInjectedDeviceCalls& injected_calls) :
+        device_info(dev_info),
+        device_table(injected_calls)
+    {}
+
     TemporaryCommandBuffer(const VulkanDeviceInfo& dev_info, const graphics::VulkanDeviceTable& dev_table) :
-        device_info(dev_info), device_table(dev_table)
+        TemporaryCommandBuffer(dev_info, graphics::VulkanInjectedDeviceCalls(&dev_table))
     {}
 
     ~TemporaryCommandBuffer()
     {
         if (command_pool != VK_NULL_HANDLE)
         {
-            device_table.DestroyCommandPool(device_info.handle, command_pool, nullptr);
+            auto injected = device_table.Open();
+            injected->DestroyCommandPool(device_info.handle, command_pool, nullptr);
         }
     };
 
@@ -125,11 +145,11 @@ struct TemporaryCommandBuffer
 
     VkResult SubmitAndDestroy();
 
-    const VulkanDeviceInfo&            device_info{ nullptr };
-    const graphics::VulkanDeviceTable& device_table{ nullptr };
-    VkCommandPool                      command_pool{ VK_NULL_HANDLE };
-    VkCommandBuffer                    command_buffer{ VK_NULL_HANDLE };
-    VkQueue                            queue{ VK_NULL_HANDLE };
+    VkCommandPool                       command_pool{ VK_NULL_HANDLE };
+    VkCommandBuffer                     command_buffer{ VK_NULL_HANDLE };
+    VkQueue                             queue{ VK_NULL_HANDLE };
+    const VulkanDeviceInfo&             device_info;
+    graphics::VulkanInjectedDeviceCalls device_table;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -1154,7 +1154,7 @@ void VulkanVirtualSwapchain::ProcessSetSwapchainImageStateCommand(
     // trim-state setup has already run, so mark as injected from here
     auto injected = injected_calls_->Open();
 
-    TemporaryCommandBuffer transition_command_buffer(*device_info, *injected.GetTable());
+    TemporaryCommandBuffer transition_command_buffer(*device_info, *injected_calls_);
 
     VkResult result = transition_command_buffer.CreateAndBegin(queue_family_index);
 

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -60,6 +60,7 @@ VulkanVirtualSwapchain::AdhocDeviceData::~AdhocDeviceData()
 
     // free swapchains before command-pool
     swapchains.clear();
+    copy_util.reset();
 
     if (command_pool != VK_NULL_HANDLE)
     {

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -24,7 +24,6 @@
 #include "Vulkan-Utility-Libraries/vk_format_utils.h"
 #include "decode/vulkan_resource_allocator.h"
 #include "decode/decoder_util.h"
-#include "util/callbacks.h"
 #include "graphics/vulkan_resources_util.h"
 #include "decode/vulkan_swapchain_format.h"
 #include "decode/vulkan_temporary_objects.h"
@@ -36,7 +35,8 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-void VulkanVirtualSwapchain::CleanDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table)
+void VulkanVirtualSwapchain::CleanDeviceResources(VkDevice                                   device,
+                                                  const graphics::VulkanInjectedDeviceCalls* device_table)
 {
     GFXRECON_UNREFERENCED_PARAMETER(device_table);
     GFXRECON_ASSERT(device != VK_NULL_HANDLE);
@@ -52,8 +52,9 @@ VulkanVirtualSwapchain::AdhocDeviceData::~AdhocDeviceData()
 
     if (command_pool != VK_NULL_HANDLE)
     {
-        GFXRECON_ASSERT(device != VK_NULL_HANDLE && device_table != nullptr);
-        device_table->DestroyCommandPool(device, command_pool, nullptr);
+        GFXRECON_ASSERT(device != VK_NULL_HANDLE && injected_calls.has_value());
+        auto injected = injected_calls->Open();
+        injected->DestroyCommandPool(device, command_pool, nullptr);
     }
 }
 
@@ -69,13 +70,13 @@ bool VulkanVirtualSwapchain::AddSwapchainResourceData(VkSwapchainKHR swapchain)
     return true;
 }
 
-VkResult VulkanVirtualSwapchain::CreateSwapchainKHR(VkResult                              original_result,
-                                                    PFN_vkCreateSwapchainKHR              func,
-                                                    const VulkanDeviceInfo*               device_info,
-                                                    const VkSwapchainCreateInfoKHR*       create_info,
-                                                    const VkAllocationCallbacks*          allocator,
-                                                    HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                                    const graphics::VulkanDeviceTable*    device_table)
+VkResult VulkanVirtualSwapchain::CreateSwapchainKHR(VkResult                                   original_result,
+                                                    PFN_vkCreateSwapchainKHR                   func,
+                                                    const VulkanDeviceInfo*                    device_info,
+                                                    const VkSwapchainCreateInfoKHR*            create_info,
+                                                    const VkAllocationCallbacks*               allocator,
+                                                    HandlePointerDecoder<VkSwapchainKHR>*      swapchain,
+                                                    const graphics::VulkanInjectedDeviceCalls& injected_calls)
 {
     VkDevice                 device          = VK_NULL_HANDLE;
     VkPhysicalDevice         physical_device = VK_NULL_HANDLE;
@@ -86,7 +87,7 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainKHR(VkResult                    
         device          = device_info->handle;
         physical_device = device_info->parent;
     }
-    device_table_ = device_table;
+    injected_calls_ = injected_calls;
 
     VkSwapchainCreateInfoKHR modified_create_info = *create_info;
 
@@ -135,6 +136,9 @@ void VulkanVirtualSwapchain::CleanSwapchainResourceData(const VulkanDeviceInfo* 
         auto allocator = device_info->allocator.get();
         assert(allocator != nullptr);
 
+        // The cleanup below makes Vulkan API calls that are not in the capture file.
+        auto injected = injected_calls_->Open();
+
         // Delete the virtual swapchain-specific swapchain resource data
         if (swapchain_resources_.find(swapchain) != swapchain_resources_.end())
         {
@@ -143,7 +147,7 @@ void VulkanVirtualSwapchain::CleanSwapchainResourceData(const VulkanDeviceInfo* 
             {
                 for (const auto& fence : copy_cmd_data.second.fences)
                 {
-                    device_table_->WaitForFences(device, 1, &fence, VK_TRUE, ~0UL);
+                    injected->WaitForFences(device, 1, &fence, VK_TRUE, ~0UL);
                 }
             }
 
@@ -157,20 +161,19 @@ void VulkanVirtualSwapchain::CleanSwapchainResourceData(const VulkanDeviceInfo* 
             {
                 if (copy_cmd_data.second.command_pool != VK_NULL_HANDLE)
                 {
-                    device_table_->FreeCommandBuffers(
-                        device,
-                        copy_cmd_data.second.command_pool,
-                        static_cast<uint32_t>(copy_cmd_data.second.command_buffers.size()),
-                        copy_cmd_data.second.command_buffers.data());
-                    device_table_->DestroyCommandPool(device, copy_cmd_data.second.command_pool, nullptr);
+                    injected->FreeCommandBuffers(device,
+                                                 copy_cmd_data.second.command_pool,
+                                                 static_cast<uint32_t>(copy_cmd_data.second.command_buffers.size()),
+                                                 copy_cmd_data.second.command_buffers.data());
+                    injected->DestroyCommandPool(device, copy_cmd_data.second.command_pool, nullptr);
                 }
                 for (const auto& semaphore : copy_cmd_data.second.semaphores)
                 {
-                    device_table_->DestroySemaphore(device, semaphore, nullptr);
+                    injected->DestroySemaphore(device, semaphore, nullptr);
                 }
                 for (const auto& fence : copy_cmd_data.second.fences)
                 {
-                    device_table_->DestroyFence(device, fence, nullptr);
+                    injected->DestroyFence(device, fence, nullptr);
                 }
             }
 
@@ -192,13 +195,7 @@ void VulkanVirtualSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     f
 {
     if ((device_info != nullptr) && (swapchain_info != nullptr))
     {
-        // CleanSwapchainResourceData() makes Vulkan API calls that are not in the capture file.
-        // Notify any layers by calling the provided pointer to their ReportReplayGeneratedVulkanCommands
-        util::BeginInjectedCommands();
-
         CleanSwapchainResourceData(device_info, swapchain_info);
-
-        util::EndInjectedCommands();
 
         VkDevice       device    = device_info->handle;
         VkSwapchainKHR swapchain = swapchain_info->handle;
@@ -289,7 +286,10 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceI
     }
     copy_queue_family_index_[device] = copy_queue_family_index;
 
-    VkQueue initial_copy_queue = GetDeviceQueue(device_table_, device_info, copy_queue_family_index, 0);
+    // The resource setup below makes Vulkan API calls that are not in the capture file.
+    auto injected = injected_calls_->Open();
+
+    VkQueue initial_copy_queue = GetDeviceQueue(injected.GetTable(), device_info, copy_queue_family_index, 0);
     if (initial_copy_queue == VK_NULL_HANDLE)
     {
         GFXRECON_LOG_ERROR("Virtual swapchain failed getting device queue %d to create initial virtual swapchain "
@@ -341,7 +341,7 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceI
                 };
 
                 CopyCmdData copy_cmd_data = {};
-                result                    = device_table_->CreateCommandPool(
+                result                    = injected->CreateCommandPool(
                     device, &command_pool_create_info, nullptr, &copy_cmd_data.command_pool);
                 if (result != VK_SUCCESS)
                 {
@@ -376,7 +376,7 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceI
                     new_count                                       // commandBufferCount
                 };
 
-                result = device_table_->AllocateCommandBuffers(
+                result = injected->AllocateCommandBuffers(
                     device, &allocate_info, &copy_cmd_data.command_buffers[command_buffer_count]);
                 if (result != VK_SUCCESS)
                 {
@@ -403,7 +403,7 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceI
                     };
 
                     VkSemaphore semaphore = 0;
-                    result = device_table_->CreateSemaphore(device, &semaphore_create_info, nullptr, &semaphore);
+                    result = injected->CreateSemaphore(device, &semaphore_create_info, nullptr, &semaphore);
                     if (result != VK_SUCCESS)
                     {
                         GFXRECON_LOG_ERROR("Virtual swapchain failed creating internal copy semaphore for "
@@ -428,7 +428,7 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceI
                     };
 
                     VkFence fence = VK_NULL_HANDLE;
-                    result        = device_table_->CreateFence(device, &fence_create_info, nullptr, &fence);
+                    result        = injected->CreateFence(device, &fence_create_info, nullptr, &fence);
                     if (result != VK_SUCCESS)
                     {
                         GFXRECON_LOG_ERROR("Virtual swapchain failed creating internal copy fence for "
@@ -519,6 +519,9 @@ VkResult VulkanVirtualSwapchain::TransitionSwapchainImage(VkDevice              
     GFXRECON_ASSERT(swapchain_info != nullptr);
     VkSwapchainKHR swapchain = swapchain_info->handle;
 
+    // The image transition below makes Vulkan API calls that are not in the capture file.
+    auto injected = injected_calls_->Open();
+
     VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
     begin_info.pNext                    = nullptr;
     begin_info.flags                    = 0;
@@ -528,19 +531,19 @@ VkResult VulkanVirtualSwapchain::TransitionSwapchainImage(VkDevice              
     auto  command_buffer = copy_cmd_data.command_buffers[image_index];
     auto  copy_fence     = copy_cmd_data.fences[image_index];
 
-    result = device_table_->WaitForFences(device, 1, &copy_fence, VK_TRUE, ~0UL);
+    result = injected->WaitForFences(device, 1, &copy_fence, VK_TRUE, ~0UL);
     if (result != VK_SUCCESS)
     {
         return result;
     }
 
-    result = device_table_->ResetFences(device, 1, &copy_fence);
+    result = injected->ResetFences(device, 1, &copy_fence);
     if (result != VK_SUCCESS)
     {
         return result;
     }
 
-    result = device_table_->ResetCommandBuffer(command_buffer, 0);
+    result = injected->ResetCommandBuffer(command_buffer, 0);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("TransitionSwapchainImage: Virtual swapchain failed resetting internal command buffer %d "
@@ -550,7 +553,7 @@ VkResult VulkanVirtualSwapchain::TransitionSwapchainImage(VkDevice              
         return result;
     }
 
-    result = device_table_->BeginCommandBuffer(command_buffer, &begin_info);
+    result = injected.BeginCommandBuffer(command_buffer, &begin_info);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("TransitionSwapchainImage: Virtual swapchain failed starting internal command buffer %d for "
@@ -582,19 +585,19 @@ VkResult VulkanVirtualSwapchain::TransitionSwapchainImage(VkDevice              
     for (uint32_t i = image_index; i < image_count + image_index; ++i)
     {
         barrier.image = swapchain_resources->replay_swapchain_images[i];
-        device_table_->CmdPipelineBarrier(command_buffer,
-                                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                          0,
-                                          0,
-                                          nullptr,
-                                          0,
-                                          nullptr,
-                                          1,
-                                          &barrier);
+        injected->CmdPipelineBarrier(command_buffer,
+                                     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                     0,
+                                     0,
+                                     nullptr,
+                                     0,
+                                     nullptr,
+                                     1,
+                                     &barrier);
     }
 
-    result = device_table_->EndCommandBuffer(command_buffer);
+    result = injected->EndCommandBuffer(command_buffer);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("TransitionSwapchainImage: Virtual swapchain failed ending internal command buffer %d for "
@@ -621,14 +624,14 @@ VkResult VulkanVirtualSwapchain::TransitionSwapchainImage(VkDevice              
     else if (acquire_fence != VK_NULL_HANDLE)
     {
         // wait, but do not reset: the application still owns and waits this fence
-        result = device_table_->WaitForFences(device, 1, &acquire_fence, VK_TRUE, ~0UL);
+        result = injected->WaitForFences(device, 1, &acquire_fence, VK_TRUE, ~0UL);
         if (result != VK_SUCCESS)
         {
             return result;
         }
     }
 
-    result = device_table_->QueueSubmit(initial_copy_queue_[device], 1, &submit_info, copy_fence);
+    result = injected->QueueSubmit(initial_copy_queue_[device], 1, &submit_info, copy_fence);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("TransitionSwapchainImage: Virtual swapchain failed submitting internal command buffer %d "
@@ -638,7 +641,7 @@ VkResult VulkanVirtualSwapchain::TransitionSwapchainImage(VkDevice              
         return result;
     }
 
-    result = device_table_->WaitForFences(device, 1, &copy_fence, VK_TRUE, UINT64_MAX);
+    result = injected->WaitForFences(device, 1, &copy_fence, VK_TRUE, UINT64_MAX);
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("TransitionSwapchainImage: Virtual swapchain failed waiting for internal command buffer %d "
@@ -725,14 +728,8 @@ VkResult VulkanVirtualSwapchain::GetSwapchainImagesKHR(VkResult                 
             return result;
         }
 
-        // CreateSwapchainResourceData() makes Vulkan API calls that are not in the capture file.
-        // Notify any layers by calling the provided pointer to their ReportReplayGeneratedVulkanCommands
-        util::BeginInjectedCommands();
-
         result =
             CreateSwapchainResourceData(device_info, swapchain_info, capture_image_count, replay_image_count, images);
-
-        util::EndInjectedCommands();
     }
 
     return result;
@@ -778,13 +775,8 @@ VkResult VulkanVirtualSwapchain::AcquireNextImageKHR(VkResult                  o
         GFXRECON_LOG_DEBUG("Virtual swapchain transitioning image index %u on first acquire during AcquireNextImageKHR",
                            *image_index);
 
-        // Notify any layers by calling the provided pointer to their ReportReplayGeneratedVulkanCommands
-        util::BeginInjectedCommands();
-
         VkResult transition_result = TransitionSwapchainImage(
             device, swapchain_info, swapchain_resources_[swapchain], *image_index, 1, semaphore, fence);
-
-        util::EndInjectedCommands();
 
         if (transition_result != VK_SUCCESS)
         {
@@ -833,9 +825,6 @@ VkResult VulkanVirtualSwapchain::AcquireNextImage2KHR(VkResult                  
             "Virtual swapchain transitioning image index %u on first acquire during AcquireNextImage2KHR",
             *image_index);
 
-        // Notify any layers by calling the provided pointer to their ReportReplayGeneratedVulkanCommands
-        util::BeginInjectedCommands();
-
         VkResult transition_result = TransitionSwapchainImage(device,
                                                               swapchain_info,
                                                               swapchain_resources_[swapchain],
@@ -843,8 +832,6 @@ VkResult VulkanVirtualSwapchain::AcquireNextImage2KHR(VkResult                  
                                                               1,
                                                               acquire_info->semaphore,
                                                               acquire_info->fence);
-
-        util::EndInjectedCommands();
 
         if (transition_result != VK_SUCCESS)
         {
@@ -874,10 +861,6 @@ VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                       
         // evaluation.
         return func(queue_info->handle, present_info);
     }
-
-    // Below Vulkan API calls are made that are not in the capture file.
-    // Notify any layers by calling the provided pointer to their ReportReplayGeneratedVulkanCommands
-    util::BeginInjectedCommands();
 
     VkDevice device             = queue_info->parent;
     VkQueue  queue              = queue_info->handle;
@@ -937,211 +920,215 @@ VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                       
     auto                     swapchainCount = present_info->swapchainCount;
     std::vector<VkSemaphore> present_wait_semaphores;
 
-    // TODO: There is a potential issue here where a vkQueuePresent comes in on a queue (let's call
-    // it QueueX) which does not support vkCmdCopyImage (i.e. a video-only queue).  In that case,
-    // we would need to insert an emtpy command buffer into the command stream of QueueX which
-    // triggers a semaphore (let's say SemA), then we would need to submit the vkCmdCopyImage in a
-    // command buffer on a queue that supports it (let's say QueueY) which will wait on SemA to
-    // start and signaling another semaphore (SemB) when it is done.  Then, we need to add the
-    // QueuePresent to QueueX, but waiting on SemB before it executes.  And that is assuming that
-    // the buffer image is even accessible on both Queues!
-
-    for (uint32_t i = 0; i < swapchainCount; ++i)
     {
-        const auto* swapchain_info      = swapchain_infos[i];
-        uint32_t    capture_image_index = capture_image_indices[i];
-        uint32_t    replay_image_index  = present_info->pImageIndices[i];
+        // The blit work below is made by replay and is not in the capture file. The scope closes
+        // before the call to the replayed vkQueuePresentKHR so that the present is not reported
+        // as injected.
+        auto injected = injected_calls_->Open();
 
-        auto aspect_mask                                          = graphics::GetFormatAspects(swapchain_info->format);
-        subresource.aspectMask                                    = aspect_mask;
-        initial_barrier_virtual_image.subresourceRange.aspectMask = aspect_mask;
-        final_barrier_virtual_image.subresourceRange.aspectMask   = aspect_mask;
-        initial_barrier_swapchain_image.subresourceRange.aspectMask = aspect_mask;
-        final_barrier_swapchain_image.subresourceRange.aspectMask   = aspect_mask;
+        // TODO: There is a potential issue here where a vkQueuePresent comes in on a queue (let's call
+        // it QueueX) which does not support vkCmdCopyImage (i.e. a video-only queue).  In that case,
+        // we would need to insert an emtpy command buffer into the command stream of QueueX which
+        // triggers a semaphore (let's say SemA), then we would need to submit the vkCmdCopyImage in a
+        // command buffer on a queue that supports it (let's say QueueY) which will wait on SemA to
+        // start and signaling another semaphore (SemB) when it is done.  Then, we need to add the
+        // QueuePresent to QueueX, but waiting on SemB before it executes.  And that is assuming that
+        // the buffer image is even accessible on both Queues!
 
-        // Get the per swapchain resource data so we have access to the virtual swapchain-specific information.
-        if (swapchain_resources_.find(swapchain_info->handle) == swapchain_resources_.end())
+        for (uint32_t i = 0; i < swapchainCount; ++i)
         {
-            GFXRECON_LOG_ERROR(
-                "Virtual swapchain vkQueuePresentKHR missing swapchain resource data for swapchain (ID = %" PRIu64 ")",
-                swapchain_info->capture_id);
-            continue;
-        }
+            const auto* swapchain_info      = swapchain_infos[i];
+            uint32_t    capture_image_index = capture_image_indices[i];
+            uint32_t    replay_image_index  = present_info->pImageIndices[i];
 
-        auto& swapchain_resources = swapchain_resources_[swapchain_info->handle];
-        assert(swapchain_resources != nullptr);
+            auto aspect_mask       = graphics::GetFormatAspects(swapchain_info->format);
+            subresource.aspectMask = aspect_mask;
+            initial_barrier_virtual_image.subresourceRange.aspectMask   = aspect_mask;
+            final_barrier_virtual_image.subresourceRange.aspectMask     = aspect_mask;
+            initial_barrier_swapchain_image.subresourceRange.aspectMask = aspect_mask;
+            final_barrier_swapchain_image.subresourceRange.aspectMask   = aspect_mask;
 
-        // Find the appropriate CommandCopyData struct for this queue family
-        if (swapchain_resources->copy_cmd_data.find(queue_family_index) == swapchain_resources->copy_cmd_data.end())
-        {
-            GFXRECON_LOG_ERROR("Virtual swapchain vkQueuePresentKHR missing swapchain resource copy command data for "
-                               "queue (Handle %" PRIu64 ") in swapchain (ID = %" PRIu64 ")",
-                               queue,
-                               swapchain_info->capture_id);
-            continue;
-        }
+            // Get the per swapchain resource data so we have access to the virtual swapchain-specific information.
+            if (swapchain_resources_.find(swapchain_info->handle) == swapchain_resources_.end())
+            {
+                GFXRECON_LOG_ERROR(
+                    "Virtual swapchain vkQueuePresentKHR missing swapchain resource data for swapchain (ID = %" PRIu64
+                    ")",
+                    swapchain_info->capture_id);
+                continue;
+            }
 
-        const auto& virtual_image = swapchain_resources->virtual_swapchain_images[capture_image_index];
-        const auto& replay_image  = swapchain_resources->replay_swapchain_images[replay_image_index];
+            auto& swapchain_resources = swapchain_resources_[swapchain_info->handle];
+            assert(swapchain_resources != nullptr);
 
-        // Use copy resources from the same queue index
-        auto& copy_cmd_data = swapchain_resources->copy_cmd_data[queue_family_index];
-        // Copy resources should be associated to the frames in flight, which is our real images
-        auto command_buffer = copy_cmd_data.command_buffers[replay_image_index];
-        auto copy_semaphore = copy_cmd_data.semaphores[replay_image_index];
-        auto copy_fence     = copy_cmd_data.fences[replay_image_index];
+            // Find the appropriate CommandCopyData struct for this queue family
+            if (swapchain_resources->copy_cmd_data.find(queue_family_index) == swapchain_resources->copy_cmd_data.end())
+            {
+                GFXRECON_LOG_ERROR(
+                    "Virtual swapchain vkQueuePresentKHR missing swapchain resource copy command data for "
+                    "queue (Handle %" PRIu64 ") in swapchain (ID = %" PRIu64 ")",
+                    queue,
+                    swapchain_info->capture_id);
+                continue;
+            }
 
-        std::vector<VkSemaphore> wait_semaphores;
-        std::vector<VkSemaphore> signal_semaphores;
+            const auto& virtual_image = swapchain_resources->virtual_swapchain_images[capture_image_index];
+            const auto& replay_image  = swapchain_resources->replay_swapchain_images[replay_image_index];
 
-        // Only wait for the present semaphore dependencies on the first copy command buffer.
-        // The others will automatically inherit that dependency because of their order in the
-        // command buffer.
-        if (i == 0 && present_info->waitSemaphoreCount > 0)
-        {
-            wait_semaphores.assign(present_info->pWaitSemaphores,
-                                   present_info->pWaitSemaphores + present_info->waitSemaphoreCount);
-        }
+            // Use copy resources from the same queue index
+            auto& copy_cmd_data = swapchain_resources->copy_cmd_data[queue_family_index];
+            // Copy resources should be associated to the frames in flight, which is our real images
+            auto command_buffer = copy_cmd_data.command_buffers[replay_image_index];
+            auto copy_semaphore = copy_cmd_data.semaphores[replay_image_index];
+            auto copy_fence     = copy_cmd_data.fences[replay_image_index];
 
-        // Only trigger a semaphore on the last copy
-        if (i == swapchainCount - 1)
-        {
-            signal_semaphores.push_back(copy_semaphore);
-            present_wait_semaphores.emplace_back(copy_semaphore);
-        }
+            std::vector<VkSemaphore> wait_semaphores;
+            std::vector<VkSemaphore> signal_semaphores;
 
-        result = device_table_->WaitForFences(device, 1, &copy_fence, VK_TRUE, ~0UL);
-        if (result != VK_SUCCESS)
-        {
-            util::EndInjectedCommands();
-            return result;
-        }
-        result = device_table_->ResetFences(device, 1, &copy_fence);
-        if (result != VK_SUCCESS)
-        {
-            util::EndInjectedCommands();
-            return result;
-        }
-        result = device_table_->ResetCommandBuffer(command_buffer, 0);
-        if (result != VK_SUCCESS)
-        {
-            util::EndInjectedCommands();
-            return result;
-        }
-        result = device_table_->BeginCommandBuffer(command_buffer, &begin_info);
-        if (result != VK_SUCCESS)
-        {
-            util::EndInjectedCommands();
-            return result;
-        }
+            // Only wait for the present semaphore dependencies on the first copy command buffer.
+            // The others will automatically inherit that dependency because of their order in the
+            // command buffer.
+            if (i == 0 && present_info->waitSemaphoreCount > 0)
+            {
+                wait_semaphores.assign(present_info->pWaitSemaphores,
+                                       present_info->pWaitSemaphores + present_info->waitSemaphoreCount);
+            }
 
-        initial_barrier_virtual_image.image                         = virtual_image.image;
-        initial_barrier_virtual_image.subresourceRange.layerCount   = swapchain_info->image_array_layers;
-        initial_barrier_swapchain_image.image                       = replay_image;
-        initial_barrier_swapchain_image.subresourceRange.layerCount = swapchain_info->image_array_layers;
+            // Only trigger a semaphore on the last copy
+            if (i == swapchainCount - 1)
+            {
+                signal_semaphores.push_back(copy_semaphore);
+                present_wait_semaphores.emplace_back(copy_semaphore);
+            }
 
-        device_table_->CmdPipelineBarrier(command_buffer,
-                                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                          VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                          0,
-                                          0,
-                                          nullptr,
-                                          0,
-                                          nullptr,
-                                          1,
-                                          &initial_barrier_virtual_image);
+            result = injected->WaitForFences(device, 1, &copy_fence, VK_TRUE, ~0UL);
+            if (result != VK_SUCCESS)
+            {
+                return result;
+            }
+            result = injected->ResetFences(device, 1, &copy_fence);
+            if (result != VK_SUCCESS)
+            {
+                return result;
+            }
+            result = injected->ResetCommandBuffer(command_buffer, 0);
+            if (result != VK_SUCCESS)
+            {
+                return result;
+            }
+            result = injected.BeginCommandBuffer(command_buffer, &begin_info);
+            if (result != VK_SUCCESS)
+            {
+                return result;
+            }
 
-        device_table_->CmdPipelineBarrier(command_buffer,
-                                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                          VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                          0,
-                                          0,
-                                          nullptr,
-                                          0,
-                                          nullptr,
-                                          1,
-                                          &initial_barrier_swapchain_image);
+            {
+                auto blit_region =
+                    injected_calls_->Label(injected, command_buffer, "Blit virtual image into swapchain image");
 
-        subresource.layerCount   = swapchain_info->image_array_layers;
-        VkExtent3D  image_extent = { std::min(swapchain_resources->actual_extent.width, swapchain_info->width),
-                                     std::min(swapchain_resources->actual_extent.height, swapchain_info->height),
-                                     1 };
-        VkImageCopy image_copy   = { subresource, offset, subresource, offset, image_extent };
+                initial_barrier_virtual_image.image                         = virtual_image.image;
+                initial_barrier_virtual_image.subresourceRange.layerCount   = swapchain_info->image_array_layers;
+                initial_barrier_swapchain_image.image                       = replay_image;
+                initial_barrier_swapchain_image.subresourceRange.layerCount = swapchain_info->image_array_layers;
 
-        // NOTE: vkCmdCopyImage works on Queues of types including Graphics, Compute
-        //       and Transfer.  So should work on any queues we get a vkQueuePresentKHR from.
-        device_table_->CmdCopyImage(command_buffer,
-                                    virtual_image.image,
-                                    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                    replay_image,
-                                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                    1,
-                                    &image_copy);
+                injected->CmdPipelineBarrier(command_buffer,
+                                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                             0,
+                                             0,
+                                             nullptr,
+                                             0,
+                                             nullptr,
+                                             1,
+                                             &initial_barrier_virtual_image);
 
-        final_barrier_virtual_image.image                         = virtual_image.image;
-        final_barrier_virtual_image.subresourceRange.layerCount   = swapchain_info->image_array_layers;
-        final_barrier_swapchain_image.image                       = replay_image;
-        final_barrier_swapchain_image.subresourceRange.layerCount = swapchain_info->image_array_layers;
+                injected->CmdPipelineBarrier(command_buffer,
+                                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                             0,
+                                             0,
+                                             nullptr,
+                                             0,
+                                             nullptr,
+                                             1,
+                                             &initial_barrier_swapchain_image);
 
-        device_table_->CmdPipelineBarrier(command_buffer,
-                                          VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                          VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                          0,
-                                          0,
-                                          nullptr,
-                                          0,
-                                          nullptr,
-                                          1,
-                                          &final_barrier_virtual_image);
+                subresource.layerCount   = swapchain_info->image_array_layers;
+                VkExtent3D  image_extent = { std::min(swapchain_resources->actual_extent.width, swapchain_info->width),
+                                             std::min(swapchain_resources->actual_extent.height, swapchain_info->height),
+                                             1 };
+                VkImageCopy image_copy   = { subresource, offset, subresource, offset, image_extent };
 
-        device_table_->CmdPipelineBarrier(command_buffer,
-                                          VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                          VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                          0,
-                                          0,
-                                          nullptr,
-                                          0,
-                                          nullptr,
-                                          1,
-                                          &final_barrier_swapchain_image);
+                // NOTE: vkCmdCopyImage works on Queues of types including Graphics, Compute
+                //       and Transfer.  So should work on any queues we get a vkQueuePresentKHR from.
+                injected->CmdCopyImage(command_buffer,
+                                       virtual_image.image,
+                                       VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                       replay_image,
+                                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                       1,
+                                       &image_copy);
 
-        result = device_table_->EndCommandBuffer(command_buffer);
-        if (result != VK_SUCCESS)
-        {
-            util::EndInjectedCommands();
+                final_barrier_virtual_image.image                         = virtual_image.image;
+                final_barrier_virtual_image.subresourceRange.layerCount   = swapchain_info->image_array_layers;
+                final_barrier_swapchain_image.image                       = replay_image;
+                final_barrier_swapchain_image.subresourceRange.layerCount = swapchain_info->image_array_layers;
 
-            return result;
-        }
+                injected->CmdPipelineBarrier(command_buffer,
+                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                             0,
+                                             0,
+                                             nullptr,
+                                             0,
+                                             nullptr,
+                                             1,
+                                             &final_barrier_virtual_image);
 
-        VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+                injected->CmdPipelineBarrier(command_buffer,
+                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                             0,
+                                             0,
+                                             nullptr,
+                                             0,
+                                             nullptr,
+                                             1,
+                                             &final_barrier_swapchain_image);
+            }
 
-        VkSubmitInfo submit_info       = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
-        submit_info.waitSemaphoreCount = static_cast<uint32_t>(wait_semaphores.size());
-        if (present_info->waitSemaphoreCount > 0)
-        {
-            submit_info.pWaitSemaphores = wait_semaphores.data();
-        }
-        else
-        {
-            submit_info.pWaitSemaphores = nullptr;
-        }
-        submit_info.pWaitDstStageMask    = &wait_stage;
-        submit_info.signalSemaphoreCount = static_cast<uint32_t>(signal_semaphores.size());
-        submit_info.pSignalSemaphores    = signal_semaphores.data();
-        submit_info.commandBufferCount   = 1;
-        submit_info.pCommandBuffers      = &command_buffer;
+            result = injected->EndCommandBuffer(command_buffer);
+            if (result != VK_SUCCESS)
+            {
+                return result;
+            }
 
-        result = device_table_->QueueSubmit(queue, 1, &submit_info, copy_fence);
+            VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_TRANSFER_BIT;
 
-        if (result != VK_SUCCESS)
-        {
-            util::EndInjectedCommands();
+            VkSubmitInfo submit_info       = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
+            submit_info.waitSemaphoreCount = static_cast<uint32_t>(wait_semaphores.size());
+            if (present_info->waitSemaphoreCount > 0)
+            {
+                submit_info.pWaitSemaphores = wait_semaphores.data();
+            }
+            else
+            {
+                submit_info.pWaitSemaphores = nullptr;
+            }
+            submit_info.pWaitDstStageMask    = &wait_stage;
+            submit_info.signalSemaphoreCount = static_cast<uint32_t>(signal_semaphores.size());
+            submit_info.pSignalSemaphores    = signal_semaphores.data();
+            submit_info.commandBufferCount   = 1;
+            submit_info.pCommandBuffers      = &command_buffer;
 
-            return result;
+            result = injected->QueueSubmit(queue, 1, &submit_info, copy_fence);
+
+            if (result != VK_SUCCESS)
+            {
+                return result;
+            }
         }
     }
-
-    util::EndInjectedCommands();
 
     VkPresentInfoKHR modified_present_info   = *present_info;
     modified_present_info.waitSemaphoreCount = static_cast<uint32_t>(present_wait_semaphores.size());
@@ -1160,14 +1147,14 @@ void VulkanVirtualSwapchain::ProcessSetSwapchainImageStateCommand(
     GFXRECON_UNREFERENCED_PARAMETER(last_presented_image);
     GFXRECON_UNREFERENCED_PARAMETER(swapchain_image_tracker);
 
-    GFXRECON_ASSERT(device_table_ != nullptr);
+    GFXRECON_ASSERT(injected_calls_.has_value());
 
     uint32_t queue_family_index = swapchain_info->queue_family_indices[0];
 
     // trim-state setup has already run, so mark as injected from here
-    util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+    auto injected = injected_calls_->Open();
 
-    TemporaryCommandBuffer transition_command_buffer(*device_info, *device_table_);
+    TemporaryCommandBuffer transition_command_buffer(*device_info, *injected.GetTable());
 
     VkResult result = transition_command_buffer.CreateAndBegin(queue_family_index);
 
@@ -1208,16 +1195,16 @@ void VulkanVirtualSwapchain::ProcessSetSwapchainImageStateCommand(
             image_barrier.image                       = image_info->handle;
             image_barrier.subresourceRange.aspectMask = graphics::GetFormatAspects(image_info->format);
 
-            device_table_->CmdPipelineBarrier(transition_command_buffer.command_buffer,
-                                              VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                              VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                              0,
-                                              0,
-                                              nullptr,
-                                              0,
-                                              nullptr,
-                                              1,
-                                              &image_barrier);
+            injected->CmdPipelineBarrier(transition_command_buffer.command_buffer,
+                                         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                         0,
+                                         0,
+                                         nullptr,
+                                         0,
+                                         nullptr,
+                                         1,
+                                         &image_barrier);
             ++barrier_count;
         }
 
@@ -1318,24 +1305,27 @@ void VulkanVirtualSwapchain::AdhocSwapChain::DestroySwapchain()
 {
     if (handle != VK_NULL_HANDLE)
     {
+        GFXRECON_ASSERT(injected_calls.has_value());
+        auto injected = injected_calls->Open();
+
         if (queue != VK_NULL_HANDLE)
         {
-            device_table->QueueWaitIdle(queue);
+            injected->QueueWaitIdle(queue);
         }
 
         for (auto& [cmd_buf, fence, acquire_semaphore] : frame_data)
         {
             if (cmd_buf != VK_NULL_HANDLE)
             {
-                device_table->FreeCommandBuffers(device, command_pool, 1, &cmd_buf);
+                injected->FreeCommandBuffers(device, command_pool, 1, &cmd_buf);
             }
             if (fence != VK_NULL_HANDLE)
             {
-                device_table->DestroyFence(device, fence, nullptr);
+                injected->DestroyFence(device, fence, nullptr);
             }
             if (acquire_semaphore != VK_NULL_HANDLE)
             {
-                device_table->DestroySemaphore(device, acquire_semaphore, nullptr);
+                injected->DestroySemaphore(device, acquire_semaphore, nullptr);
             }
         }
         frame_data.clear();
@@ -1344,12 +1334,12 @@ void VulkanVirtualSwapchain::AdhocSwapChain::DestroySwapchain()
         {
             if (img_data.semaphore != VK_NULL_HANDLE)
             {
-                device_table->DestroySemaphore(device, img_data.semaphore, nullptr);
+                injected->DestroySemaphore(device, img_data.semaphore, nullptr);
             }
         }
         image_data.clear();
 
-        device_table->DestroySwapchainKHR(device, handle, nullptr);
+        injected->DestroySwapchainKHR(device, handle, nullptr);
         handle = VK_NULL_HANDLE;
     }
 }
@@ -1372,12 +1362,12 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
                                                const VulkanImageInfo*                     image_info,
                                                VulkanInstanceInfo*                        instance_info,
                                                const graphics::VulkanInstanceTable*       instance_table,
-                                               const graphics::VulkanDeviceTable*         device_table,
+                                               const graphics::VulkanInjectedDeviceCalls& injected_calls,
                                                application::Application*                  application,
                                                const std::optional<std::array<float, 2>>& scale)
 {
     GFXRECON_ASSERT(instance_info != nullptr && instance_table != nullptr && device_info != nullptr &&
-                    device_table != nullptr && application != nullptr);
+                    application != nullptr);
 
     VkResult    result    = VK_SUCCESS;
     VkDevice    device    = device_info->handle;
@@ -1399,6 +1389,10 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
         return;
     }
 
+    // Everything below, including the ad-hoc present itself, is made by replay and is not in the
+    // capture file.
+    auto injected = injected_calls.Open();
+
     // retrieve device-context, create if necessary
     GFXRECON_ASSERT(device != VK_NULL_HANDLE);
     auto& ofb_data = adhoc_device_data_[device];
@@ -1406,11 +1400,11 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
     // init OFBData
     if (ofb_data.command_pool == VK_NULL_HANDLE)
     {
-        ofb_data.device       = device;
-        ofb_data.device_table = device_table;
+        ofb_data.device         = device;
+        ofb_data.injected_calls = injected_calls;
 
         // Retrieve the queue that will be used for presentation/image copy and create a command pool
-        device_table->GetDeviceQueue(device, 0, 0, &ofb_data.queue);
+        injected->GetDeviceQueue(device, 0, 0, &ofb_data.queue);
 
         VkCommandPoolCreateInfo command_pool_create_info;
         command_pool_create_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
@@ -1419,12 +1413,12 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
             VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
         command_pool_create_info.queueFamilyIndex = 0;
 
-        result = device_table->CreateCommandPool(device, &command_pool_create_info, nullptr, &ofb_data.command_pool);
+        result = injected->CreateCommandPool(device, &command_pool_create_info, nullptr, &ofb_data.command_pool);
         GFXRECON_ASSERT(result == VK_SUCCESS);
 
         // create a copy-util, used for image-transitions and blits (leave out memory-properties, no allocation needed)
         ofb_data.copy_util = std::make_unique<graphics::VulkanResourcesUtil>(
-            device, device_info->parent, *device_table, *instance_table, device_info->property_feature_info);
+            device, device_info->parent, *injected.GetTable(), *instance_table, device_info->property_feature_info);
     }
 
     // derive output-size and orientation from provided scale
@@ -1474,12 +1468,12 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
 
     if (swapchain.surface_info.handle == VK_NULL_HANDLE)
     {
-        swapchain.device        = device;
-        swapchain.device_table  = device_table;
-        swapchain.instance_info = instance_info;
-        swapchain.owner         = this;
-        swapchain.command_pool  = ofb_data.command_pool;
-        swapchain.queue         = ofb_data.queue;
+        swapchain.device         = device;
+        swapchain.injected_calls = injected_calls;
+        swapchain.instance_info  = instance_info;
+        swapchain.owner          = this;
+        swapchain.command_pool   = ofb_data.command_pool;
+        swapchain.queue          = ofb_data.queue;
 
         // Create a window and surface
         swapchain.surface_ptr.SetHandleLength(1);
@@ -1600,7 +1594,7 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
         }
 
         VkSwapchainKHR swapchain_handle;
-        result = device_table->CreateSwapchainKHR(device, &swapchain_create_info, nullptr, &swapchain_handle);
+        result = injected->CreateSwapchainKHR(device, &swapchain_create_info, nullptr, &swapchain_handle);
         GFXRECON_ASSERT(result == VK_SUCCESS);
 
         // Destroy old swapchain resources if necessary
@@ -1611,11 +1605,11 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
 
         // Get swapchain images and create swapchain resources
         uint32_t image_count = 0;
-        result               = device_table->GetSwapchainImagesKHR(device, swapchain.handle, &image_count, nullptr);
+        result               = injected->GetSwapchainImagesKHR(device, swapchain.handle, &image_count, nullptr);
         GFXRECON_ASSERT(result == VK_SUCCESS);
 
         std::vector<VkImage> swapchain_images(image_count, VK_NULL_HANDLE);
-        result = device_table->GetSwapchainImagesKHR(device, swapchain.handle, &image_count, swapchain_images.data());
+        result = injected->GetSwapchainImagesKHR(device, swapchain.handle, &image_count, swapchain_images.data());
         GFXRECON_ASSERT((result == VK_SUCCESS) && (swapchain_images.size() == image_count));
 
         swapchain.frame_data.resize(image_count);
@@ -1642,18 +1636,18 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
         {
             swapchain.image_data[i].image = swapchain_images[i];
 
-            result = device_table->CreateFence(device, &fence_create_info, nullptr, &swapchain.frame_data[i].fence);
+            result = injected->CreateFence(device, &fence_create_info, nullptr, &swapchain.frame_data[i].fence);
             GFXRECON_ASSERT(result == VK_SUCCESS);
 
-            result = device_table->CreateSemaphore(
+            result = injected->CreateSemaphore(
                 device, &semaphore_create_info, nullptr, &swapchain.frame_data[i].acquire_semaphore);
             GFXRECON_ASSERT(result == VK_SUCCESS);
 
-            result = device_table->CreateSemaphore(
-                device, &semaphore_create_info, nullptr, &swapchain.image_data[i].semaphore);
+            result =
+                injected->CreateSemaphore(device, &semaphore_create_info, nullptr, &swapchain.image_data[i].semaphore);
             GFXRECON_ASSERT(result == VK_SUCCESS);
 
-            result = device_table->AllocateCommandBuffers(
+            result = injected->AllocateCommandBuffers(
                 device, &command_buffer_alloc_info, &swapchain.frame_data[i].command_buffer);
             GFXRECON_ASSERT(result == VK_SUCCESS);
         }
@@ -1661,16 +1655,16 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
 
     // wait for previous frame
     const auto& frame_data = swapchain.frame_data[swapchain.acquire_index];
-    result = device_table->WaitForFences(device, 1, &frame_data.fence, true, std::numeric_limits<uint64_t>::max());
+    result = injected->WaitForFences(device, 1, &frame_data.fence, true, std::numeric_limits<uint64_t>::max());
     GFXRECON_ASSERT(result == VK_SUCCESS);
-    result = device_table->ResetFences(device, 1, &frame_data.fence);
+    result = injected->ResetFences(device, 1, &frame_data.fence);
     GFXRECON_ASSERT(result == VK_SUCCESS);
 
     // Acquire next image from the swapchain
     VkSemaphore acquire_semaphore     = frame_data.acquire_semaphore;
     uint32_t    swapchain_image_index = 0;
 
-    result = device_table->AcquireNextImageKHR(
+    result = injected->AcquireNextImageKHR(
         device, swapchain.handle, UINT64_MAX, acquire_semaphore, VK_NULL_HANDLE, &swapchain_image_index);
 
     auto& image_data = swapchain.image_data[swapchain_image_index];
@@ -1687,7 +1681,7 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
     if (!swapchain_options_.virtual_swapchain_skip_blit)
     {
         // Record command buffer for copy
-        result = device_table->ResetCommandBuffer(frame_data.command_buffer, 0);
+        result = injected->ResetCommandBuffer(frame_data.command_buffer, 0);
         GFXRECON_ASSERT(result == VK_SUCCESS);
 
         VkCommandBufferBeginInfo command_buffer_begin_info;
@@ -1696,7 +1690,7 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
         command_buffer_begin_info.flags            = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         command_buffer_begin_info.pInheritanceInfo = nullptr;
 
-        result = device_table->BeginCommandBuffer(frame_data.command_buffer, &command_buffer_begin_info);
+        result = injected.BeginCommandBuffer(frame_data.command_buffer, &command_buffer_begin_info);
         GFXRECON_ASSERT(result == VK_SUCCESS);
 
         constexpr VkImageAspectFlags aspect_color = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1729,8 +1723,36 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
             }
 
             // NOTE: VK_PIPELINE_STAGE_NONE is only legal as a srcStageMask when synchronization2 is enabled
-            device_table->CmdPipelineBarrier(frame_data.command_buffer,
-                                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+            injected->CmdPipelineBarrier(frame_data.command_buffer,
+                                         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                         0,
+                                         0,
+                                         nullptr,
+                                         0,
+                                         nullptr,
+                                         1,
+                                         &memory_barrier);
+
+            if (clear_unused_tiles)
+            {
+                // tiles not covered by a layer are never touched by a blit, so clearing them once is enough
+                constexpr VkClearColorValue clear_color = {};
+
+                injected->CmdClearColorImage(frame_data.command_buffer,
+                                             image_data.image,
+                                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                             &clear_color,
+                                             1,
+                                             &memory_barrier.subresourceRange);
+
+                memory_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                memory_barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+                memory_barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                memory_barrier.newLayout     = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+                injected->CmdPipelineBarrier(frame_data.command_buffer,
+                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
                                              VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                                              0,
                                              0,
@@ -1739,34 +1761,6 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
                                              nullptr,
                                              1,
                                              &memory_barrier);
-
-            if (clear_unused_tiles)
-            {
-                // tiles not covered by a layer are never touched by a blit, so clearing them once is enough
-                constexpr VkClearColorValue clear_color = {};
-
-                device_table->CmdClearColorImage(frame_data.command_buffer,
-                                                 image_data.image,
-                                                 VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                                 &clear_color,
-                                                 1,
-                                                 &memory_barrier.subresourceRange);
-
-                memory_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-                memory_barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-                memory_barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-                memory_barrier.newLayout     = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-
-                device_table->CmdPipelineBarrier(frame_data.command_buffer,
-                                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                                 VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 0,
-                                                 nullptr,
-                                                 1,
-                                                 &memory_barrier);
             }
         }
 
@@ -1806,7 +1800,7 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
             ofb_data.copy_util->BlitImage(frame_data.command_buffer, blit_params);
         }
 
-        result = device_table->EndCommandBuffer(frame_data.command_buffer);
+        result = injected->EndCommandBuffer(frame_data.command_buffer);
         GFXRECON_ASSERT(result == VK_SUCCESS);
 
         // Submit copy command buffer
@@ -1824,7 +1818,7 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
         submit_info.signalSemaphoreCount = 1;
         submit_info.pSignalSemaphores    = &image_data.semaphore;
 
-        result = device_table->QueueSubmit(ofb_data.queue, 1, &submit_info, frame_data.fence);
+        result = injected->QueueSubmit(ofb_data.queue, 1, &submit_info, frame_data.fence);
         GFXRECON_ASSERT(result == VK_SUCCESS);
     }
 
@@ -1848,7 +1842,7 @@ void VulkanVirtualSwapchain::PresentImageAdHoc(const VulkanDeviceInfo*          
         present_info.pWaitSemaphores    = &image_data.semaphore;
     }
 
-    result = device_table->QueuePresentKHR(ofb_data.queue, &present_info);
+    result = injected->QueuePresentKHR(ofb_data.queue, &present_info);
     GFXRECON_ASSERT(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR);
 }
 
@@ -1867,13 +1861,15 @@ VkResult VulkanVirtualSwapchain::CreateVirtualSwapchainImage(const VulkanDeviceI
 
     if (result == VK_SUCCESS)
     {
-        if ((instance_table_ == nullptr) || (device_table_ == nullptr))
+        if ((instance_table_ == nullptr) || !injected_calls_.has_value())
         {
             return VK_ERROR_FEATURE_NOT_PRESENT;
         }
 
+        auto injected = injected_calls_->Open();
+
         VkMemoryRequirements memory_reqs;
-        device_table_->GetImageMemoryRequirements(device_info->handle, image.image, &memory_reqs);
+        injected->GetImageMemoryRequirements(device_info->handle, image.image, &memory_reqs);
 
         VkMemoryPropertyFlags property_flags    = VK_QUEUE_FLAG_BITS_MAX_ENUM;
         uint32_t              memory_type_index = std::numeric_limits<uint32_t>::max();

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -47,13 +47,23 @@ void VulkanVirtualSwapchain::CleanDeviceResources(VkDevice                      
 
 VulkanVirtualSwapchain::AdhocDeviceData::~AdhocDeviceData()
 {
+    if (!injected_calls.has_value())
+    {
+        // Never populated; there is nothing to destroy.
+        GFXRECON_ASSERT(swapchains.empty() && (copy_util == nullptr) && (command_pool == VK_NULL_HANDLE));
+        return;
+    }
+
+    // Keep the injected-commands window open for all cleanup, including
+    // copy_util's destructor, which destroys its own staging resources.
+    auto injected = injected_calls->Open();
+
     // free swapchains before command-pool
     swapchains.clear();
 
     if (command_pool != VK_NULL_HANDLE)
     {
-        GFXRECON_ASSERT(device != VK_NULL_HANDLE && injected_calls.has_value());
-        auto injected = injected_calls->Open();
+        GFXRECON_ASSERT(device != VK_NULL_HANDLE);
         injected->DestroyCommandPool(device, command_pool, nullptr);
     }
 }
@@ -225,6 +235,10 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceI
         GFXRECON_ASSERT(swapchain != VK_NULL_HANDLE);
     }
 
+    // Everything below, including the queue-family queries used for copy-queue
+    // selection, is synthesized by replay and not in the capture file.
+    auto injected = injected_calls_->Open();
+
     // Determine what queue to use for the initial virtual image setup
     uint32_t                             property_count = 0;
     std::vector<VkQueueFamilyProperties> props;
@@ -285,9 +299,6 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const VulkanDeviceI
                           swapchain_info->capture_id);
     }
     copy_queue_family_index_[device] = copy_queue_family_index;
-
-    // The resource setup below makes Vulkan API calls that are not in the capture file.
-    auto injected = injected_calls_->Open();
 
     VkQueue initial_copy_queue = GetDeviceQueue(injected.GetTable(), device_info, copy_queue_family_index, 0);
     if (initial_copy_queue == VK_NULL_HANDLE)

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -34,7 +34,7 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
   public:
     ~VulkanVirtualSwapchain() override = default;
 
-    void CleanDeviceResources(VkDevice device, const graphics::VulkanDeviceTable* device_table) override;
+    void CleanDeviceResources(VkDevice device, const graphics::VulkanInjectedDeviceCalls* device_table) override;
 
     VkResult CreateSurface(VkResult                             original_result,
                            VulkanInstanceInfo*                  instance_info,
@@ -44,13 +44,13 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
                            const graphics::VulkanInstanceTable* instance_table,
                            application::Application*            application) override;
 
-    virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
-                                        PFN_vkCreateSwapchainKHR              func,
-                                        const VulkanDeviceInfo*               device_info,
-                                        const VkSwapchainCreateInfoKHR*       create_info,
-                                        const VkAllocationCallbacks*          allocator,
-                                        HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const graphics::VulkanDeviceTable*    device_table) override;
+    virtual VkResult CreateSwapchainKHR(VkResult                                   original_result,
+                                        PFN_vkCreateSwapchainKHR                   func,
+                                        const VulkanDeviceInfo*                    device_info,
+                                        const VkSwapchainCreateInfoKHR*            create_info,
+                                        const VkAllocationCallbacks*               allocator,
+                                        HandlePointerDecoder<VkSwapchainKHR>*      swapchain,
+                                        const graphics::VulkanInjectedDeviceCalls& injected_calls) override;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR     func,
                                      const VulkanDeviceInfo*       device_info,
@@ -125,7 +125,7 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
                            const VulkanImageInfo*                     image_info,
                            VulkanInstanceInfo*                        instance_info,
                            const graphics::VulkanInstanceTable*       instance_table,
-                           const graphics::VulkanDeviceTable*         device_table,
+                           const graphics::VulkanInjectedDeviceCalls& injected_calls,
                            application::Application*                  application,
                            const std::optional<std::array<float, 2>>& scale) override;
 
@@ -235,7 +235,7 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
         {
             using std::swap;
             swap(lhs.device, rhs.device);
-            swap(lhs.device_table, rhs.device_table);
+            swap(lhs.injected_calls, rhs.injected_calls);
             swap(lhs.instance_info, rhs.instance_info);
             swap(lhs.owner, rhs.owner);
             swap(lhs.command_pool, rhs.command_pool);
@@ -252,10 +252,10 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
         }
 
         // required for lifetime-management
-        VkDevice                           device{ VK_NULL_HANDLE };
-        const graphics::VulkanDeviceTable* device_table{ nullptr };
-        const VulkanInstanceInfo*          instance_info{ nullptr };
-        VulkanSwapchain*                   owner{ nullptr };
+        VkDevice                                           device{ VK_NULL_HANDLE };
+        std::optional<graphics::VulkanInjectedDeviceCalls> injected_calls;
+        const VulkanInstanceInfo*                          instance_info{ nullptr };
+        VulkanSwapchain*                                   owner{ nullptr };
 
         // non-owning handle
         VkCommandPool command_pool{ VK_NULL_HANDLE };
@@ -294,8 +294,8 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
         AdhocDeviceData& operator=(AdhocDeviceData&&) = delete;
 
         // required for lifetime-management
-        VkDevice                           device{ VK_NULL_HANDLE };
-        const graphics::VulkanDeviceTable* device_table{ nullptr };
+        VkDevice                                           device{ VK_NULL_HANDLE };
+        std::optional<graphics::VulkanInjectedDeviceCalls> injected_calls;
 
         // command-pool for all AdhocSwapChains
         VkCommandPool command_pool{ VK_NULL_HANDLE };

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -52,6 +52,8 @@ target_sources(gfxrecon_graphics
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_instance_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_injected_calls.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_injected_calls.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_semaphore_util.h

--- a/framework/graphics/vulkan_injected_calls.cpp
+++ b/framework/graphics/vulkan_injected_calls.cpp
@@ -1,0 +1,115 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "graphics/vulkan_injected_calls.h"
+
+#include "util/logging.h"
+
+#include <atomic>
+#include <string>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+static std::atomic<bool> annotate_injected_commands{ false };
+
+void SetAnnotateInjectedCommands(bool enabled)
+{
+    annotate_injected_commands = enabled;
+}
+
+bool GetAnnotateInjectedCommands()
+{
+    return annotate_injected_commands;
+}
+
+static VkDebugUtilsLabelEXT MakeLabel(const std::string& label_name)
+{
+    VkDebugUtilsLabelEXT label = {};
+    label.sType                = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+    label.pLabelName           = label_name.c_str();
+    return label;
+}
+
+VulkanInjectedDeviceCalls::VulkanInjectedDeviceCalls(const VulkanDeviceTable* table) : table_(table)
+{
+    GFXRECON_ASSERT(table_ != nullptr);
+}
+
+void VulkanInjectedDeviceCalls::Scope::InsertLabel(VkCommandBuffer command_buffer, const char* category) const
+{
+    if ((command_buffer != VK_NULL_HANDLE) && GetAnnotateInjectedCommands() &&
+        (table_->CmdInsertDebugUtilsLabelEXT != noop::vkCmdInsertDebugUtilsLabelEXT))
+    {
+        const std::string          label_name = std::string(kInjectedCommandLabelPrefix) + category;
+        const VkDebugUtilsLabelEXT label      = MakeLabel(label_name);
+        table_->CmdInsertDebugUtilsLabelEXT(command_buffer, &label);
+    }
+}
+
+VkResult VulkanInjectedDeviceCalls::Scope::BeginCommandBuffer(VkCommandBuffer                 command_buffer,
+                                                              const VkCommandBufferBeginInfo* begin_info) const
+{
+    VkResult result = table_->BeginCommandBuffer(command_buffer, begin_info);
+
+    if (result == VK_SUCCESS)
+    {
+        InsertLabel(command_buffer, "Synthesized command buffer");
+    }
+    return result;
+}
+
+VulkanInjectedDeviceCalls::LabelRegion::LabelRegion(const VulkanDeviceTable* table,
+                                                    VkCommandBuffer          command_buffer,
+                                                    const char*              category) :
+    table_(table),
+    command_buffer_(command_buffer)
+{
+    active_ = GetAnnotateInjectedCommands() && (command_buffer_ != VK_NULL_HANDLE) &&
+              (table_->CmdBeginDebugUtilsLabelEXT != noop::vkCmdBeginDebugUtilsLabelEXT) &&
+              (table_->CmdEndDebugUtilsLabelEXT != noop::vkCmdEndDebugUtilsLabelEXT);
+
+    if (active_)
+    {
+        const std::string          label_name = std::string(kInjectedCommandLabelPrefix) + category;
+        const VkDebugUtilsLabelEXT label      = MakeLabel(label_name);
+        table_->CmdBeginDebugUtilsLabelEXT(command_buffer_, &label);
+    }
+}
+
+VulkanInjectedDeviceCalls::LabelRegion::~LabelRegion()
+{
+    if (active_)
+    {
+        table_->CmdEndDebugUtilsLabelEXT(command_buffer_);
+    }
+}
+
+VulkanInjectedDeviceCalls::LabelRegion
+VulkanInjectedDeviceCalls::Label(const Scope& scope, VkCommandBuffer command_buffer, const char* category) const
+{
+    GFXRECON_UNREFERENCED_PARAMETER(scope);
+    return LabelRegion(table_, command_buffer, category);
+}
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/vulkan_injected_calls.h
+++ b/framework/graphics/vulkan_injected_calls.h
@@ -115,6 +115,8 @@ class VulkanInjectedDeviceCalls
 
     explicit VulkanInjectedDeviceCalls(const VulkanDeviceTable* table);
 
+    bool IsValid() const { return table_ != nullptr; }
+
     // Opens the injected-commands window for the calling thread and grants
     // access to the dispatch table for its duration.
     [[nodiscard]] Scope Open() const { return Scope(table_); }

--- a/framework/graphics/vulkan_injected_calls.h
+++ b/framework/graphics/vulkan_injected_calls.h
@@ -1,0 +1,134 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_GRAPHICS_VULKAN_INJECTED_CALLS_H
+#define GFXRECON_GRAPHICS_VULKAN_INJECTED_CALLS_H
+
+#include "generated/generated_vulkan_dispatch_table.h"
+#include "util/callbacks.h"
+#include "util/defines.h"
+
+#include "vulkan/vulkan_core.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+// Common prefix for every debug-utils label emitted around replay-injected commands.
+constexpr const char kInjectedCommandLabelPrefix[] = "GFXR Replay: ";
+
+// Process-wide switch for annotating injected commands with VK_EXT_debug_utils
+// labels. Set once from the replay options during consumer initialization. The
+// callback channel (util::SetInjectedCommandCallbacks) fires regardless of this switch.
+void SetAnnotateInjectedCommands(bool enabled);
+
+bool GetAnnotateInjectedCommands();
+
+// Access point for Vulkan calls injected by replay, i.e. calls that have no
+// corresponding block in the capture file (staging copies, swapchain blits,
+// dump-resources work, SBT patching, sync objects, cleanup, ...).
+//
+// The device dispatch table is intentionally not exposed: the only way to call
+// through it is to open a Scope, so "injected call made outside an
+// injected-commands scope" is a compile error rather than a runtime assert.
+class VulkanInjectedDeviceCalls
+{
+  public:
+    // RAII scope marking a run of replay-injected Vulkan calls on the calling
+    // thread. Construction/destruction of the outermost scope fires the
+    // injected-commands begin/end callbacks. Scopes may nest freely.
+    class Scope
+    {
+      public:
+        Scope(const Scope&)            = delete;
+        Scope& operator=(const Scope&) = delete;
+        Scope(Scope&&)                 = delete;
+        Scope& operator=(Scope&&)      = delete;
+
+        const VulkanDeviceTable* operator->() const { return table_; }
+
+        // Bridge for helpers that take the raw dispatch table as a parameter
+        // and have not been migrated to this class yet. Only call helpers with
+        // it while this scope is open; do not store the pointer.
+        const VulkanDeviceTable* GetTable() const { return table_; }
+
+        // Emits a single "GFXR Replay: <category>" label into command_buffer.
+        // No-op when annotation is disabled or debug utils is unavailable.
+        void InsertLabel(VkCommandBuffer command_buffer, const char* category) const;
+
+        // Begins command_buffer and, on success, tags it with an inserted
+        // "GFXR Replay: Synthesized command buffer" label so wholly
+        // replay-generated command buffers are identifiable in tools.
+        VkResult BeginCommandBuffer(VkCommandBuffer command_buffer, const VkCommandBufferBeginInfo* begin_info) const;
+
+      private:
+        friend class VulkanInjectedDeviceCalls;
+
+        explicit Scope(const VulkanDeviceTable* table) : table_(table) {}
+
+        util::MarkInjectedCommandsHelper mark_helper_;
+        const VulkanDeviceTable*         table_;
+    };
+
+    // RAII "GFXR Replay: <category>" debug-utils label region bracketing
+    // injected commands recorded into one command buffer. No-op when
+    // annotation is disabled or debug utils is unavailable.
+    class LabelRegion
+    {
+      public:
+        ~LabelRegion();
+
+        LabelRegion(const LabelRegion&)            = delete;
+        LabelRegion& operator=(const LabelRegion&) = delete;
+        LabelRegion(LabelRegion&&)                 = delete;
+        LabelRegion& operator=(LabelRegion&&)      = delete;
+
+      private:
+        friend class VulkanInjectedDeviceCalls;
+
+        LabelRegion(const VulkanDeviceTable* table, VkCommandBuffer command_buffer, const char* category);
+
+        const VulkanDeviceTable* table_;
+        VkCommandBuffer          command_buffer_;
+        bool                     active_;
+    };
+
+    VulkanInjectedDeviceCalls() = delete;
+
+    explicit VulkanInjectedDeviceCalls(const VulkanDeviceTable* table);
+
+    // Opens the injected-commands window for the calling thread and grants
+    // access to the dispatch table for its duration.
+    [[nodiscard]] Scope Open() const { return Scope(table_); }
+
+    // Brackets injected commands recorded into command_buffer with a
+    // Begin/EndDebugUtilsLabelEXT pair. Requires an open Scope; the parameter
+    // is the capability witness and is otherwise unused.
+    [[nodiscard]] LabelRegion Label(const Scope& scope, VkCommandBuffer command_buffer, const char* category) const;
+
+  private:
+    const VulkanDeviceTable* table_;
+};
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_GRAPHICS_VULKAN_INJECTED_CALLS_H

--- a/framework/util/callbacks.cpp
+++ b/framework/util/callbacks.cpp
@@ -92,7 +92,7 @@ class MarkInjectedCommands : public CallbackBase
     }
 };
 
-thread_local std::atomic<uint32_t> MarkInjectedCommandsHelper::semaphore = 0;
+thread_local uint32_t MarkInjectedCommandsHelper::semaphore = 0;
 
 MarkInjectedCommandsHelper::MarkInjectedCommandsHelper()
 {

--- a/framework/util/callbacks.h
+++ b/framework/util/callbacks.h
@@ -24,8 +24,6 @@
 #ifndef GFXRECON_UTIL_CALLBACKS_H
 #define GFXRECON_UTIL_CALLBACKS_H
 
-#include <atomic>
-
 #include "util/defines.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -43,7 +41,7 @@ void EndInjectedCommands();
 struct MarkInjectedCommandsHelper
 {
     // allow nested usage without hitting an assertion
-    static thread_local std::atomic<uint32_t> semaphore;
+    static thread_local uint32_t semaphore;
 
     MarkInjectedCommandsHelper();
     ~MarkInjectedCommandsHelper();

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -38,8 +38,7 @@ const char kOptions[] =
     "screenshot-ignore-FrameBoundaryANDROID,--screenshot-apply-prerotation,--deduplicate-device,--log-timestamps,--"
     "capture,--idle-before-submit,--"
     "serialize-render-passes,--serialize-queue-submissions,--async-processing,--isolate-render-passes,--serialize-"
-    "compute-"
-    "and-transfer";
+    "compute-and-transfer,--annotate-injected-commands";
 const char kArguments[] =
     "--log-level,--log-file,--cpu-mask,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--screenshot-interval,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -344,6 +343,10 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tForce wait on completion of queue operations for all queues");
     GFXRECON_WRITE_CONSOLE("          \t\tbefore calling Present. This is needed for accurate acquisition");
     GFXRECON_WRITE_CONSOLE("          \t\tof instrumentation data on some platforms.");
+    GFXRECON_WRITE_CONSOLE("  --annotate-injected-commands");
+    GFXRECON_WRITE_CONSOLE("          \t\tWrap commands injected by replay (not present in the capture,");
+    GFXRECON_WRITE_CONSOLE("          \t\te.g. virtual-swapchain copies and ray-tracing SBT fixups) in");
+    GFXRECON_WRITE_CONSOLE("          \t\tVK_EXT_debug_utils labels named \"GFXR Replay: <category>\".");
 #if !defined(_WIN32)
     GFXRECON_WRITE_CONSOLE("  --dump-resources <filename>.json");
     GFXRECON_WRITE_CONSOLE("          \t\tExtract dump resources block indices and options from the");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -139,6 +139,7 @@ const char kFrameRange[]                          = "--frame-range";
 const char kSkipGetFenceStatus[]                  = "--skip-get-fence-status";
 const char kSkipGetFenceRanges[]                  = "--skip-get-fence-ranges";
 const char kWaitBeforePresent[]                   = "--wait-before-present";
+const char kAnnotateInjectedCommands[]            = "--annotate-injected-commands";
 const char kPrintBlockInfoAllOption[]             = "--pbi-all";
 const char kPrintBlockInfosArgument[]             = "--pbis";
 const char kNumPipelineCreationJobs[]             = "--pipeline-creation-jobs";
@@ -1349,6 +1350,10 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     if (arg_parser.IsOptionSet(kWaitBeforePresent))
     {
         replay_options.wait_before_present = true;
+    }
+    if (arg_parser.IsOptionSet(kAnnotateInjectedCommands))
+    {
+        replay_options.annotate_injected_commands = true;
     }
     if (arg_parser.IsOptionSet(kPreloadMeasurementRangeOption))
     {


### PR DESCRIPTION
Adds graphics::VulkanInjectedDeviceCalls as a wrapper around the VulkanDeviceTable. The table's function pointer are reachable only by VulkanInjectedDeviceCalls::Open() which automates the calls to BeginInjectedCommands and EndInjectedCommands.
Also provides funcitonality to mark commands injected to existing command buffers or fully synthesized command buffers using the Vulkan DebutUtils functionality