### PR TITLE
Skip DestroyDevice

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3890,9 +3890,8 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
         device_frame_warmups_.erase(device_info);
 
         device_info->allocator->Destroy();
+        func(device, GetAllocationCallbacks(pAllocator));
     }
-
-    func(device, GetAllocationCallbacks(pAllocator));
 }
 
 VkResult


### PR DESCRIPTION
When using `--deduplicate-device`, the duplicated device that isn't created shouldn't be destroyed. 