### PR TITLE
Tensor/datagraph fixes for trim and rebind

### DIFF
--- a/framework/decode/vulkan_handle_mapping_util.cpp
+++ b/framework/decode/vulkan_handle_mapping_util.cpp
@@ -150,6 +150,15 @@ uint64_t MapHandle(uint64_t object, VkObjectType object_type, const CommonObject
         case VK_OBJECT_TYPE_MICROMAP_EXT:
             return format::ToHandleId(MapHandle<VulkanMicromapEXTInfo>(
                 object, object_info_table, &CommonObjectInfoTable::GetVkMicromapEXTInfo));
+        case VK_OBJECT_TYPE_TENSOR_ARM:
+            return format::ToHandleId(
+                MapHandle<VulkanTensorARMInfo>(object, object_info_table, &CommonObjectInfoTable::GetVkTensorARMInfo));
+        case VK_OBJECT_TYPE_TENSOR_VIEW_ARM:
+            return format::ToHandleId(MapHandle<VulkanTensorViewARMInfo>(
+                object, object_info_table, &CommonObjectInfoTable::GetVkTensorViewARMInfo));
+        case VK_OBJECT_TYPE_DATA_GRAPH_PIPELINE_SESSION_ARM:
+            return format::ToHandleId(MapHandle<VulkanDataGraphPipelineSessionARMInfo>(
+                object, object_info_table, &CommonObjectInfoTable::GetVkDataGraphPipelineSessionARMInfo));
         case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
             return format::ToHandleId(MapHandle<VulkanPrivateDataSlotEXTInfo>(
                 object, object_info_table, &CommonObjectInfoTable::GetVkPrivateDataSlotInfo));

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -3646,9 +3646,23 @@ VulkanRebindAllocator::CreateDataGraphPipelineSession(const VkDataGraphPipelineS
     ResourceAllocInfo* resource_alloc_info = new ResourceAllocInfo();
     resource_alloc_info->object_type       = VK_OBJECT_TYPE_DATA_GRAPH_PIPELINE_SESSION_ARM;
     resource_alloc_info->uses_extensions   = (create_info->pNext != nullptr);
-    resource_alloc_info->usage             = 0;
+    resource_alloc_info->usage             = create_info->flags;
 
-    *allocator_data = static_cast<ResourceData>(reinterpret_cast<uintptr_t>(resource_alloc_info));
+    ResourceData session_allocator_data = reinterpret_cast<ResourceData>(resource_alloc_info);
+
+    // Replay may require session memory even when capture required none and therefore emitted no bind command.
+    // Initialize directly from replay requirements as part of creating the replay session.
+    result = InitializeDataGraphPipelineSessionMemory(*data_graph_pipeline_session, resource_alloc_info);
+    if (result != VK_SUCCESS)
+    {
+        functions_.destroy_data_graph_pipeline_session(
+            device_, *data_graph_pipeline_session, allocator_->GetAllocationCallbacks());
+        delete resource_alloc_info;
+        *data_graph_pipeline_session = VK_NULL_HANDLE;
+        return result;
+    }
+
+    *allocator_data = session_allocator_data;
     return VK_SUCCESS;
 }
 
@@ -3782,263 +3796,206 @@ VulkanRebindAllocator::BindDataGraphPipelineSessionMemory(uint32_t bind_info_cou
                                                           const MemoryData*      allocator_memory_datas,
                                                           VkMemoryPropertyFlags* bind_memory_properties)
 {
-    struct DataGraphBindPointRequirementInfo
+    // Data graph session memory is created entirely from replay-device requirements when the replay session is
+    // created. Captured bind commands describe capture-device requirements, so consuming them must have no effect.
+    GFXRECON_UNREFERENCED_PARAMETER(bind_info_count);
+    GFXRECON_UNREFERENCED_PARAMETER(bind_infos);
+    GFXRECON_UNREFERENCED_PARAMETER(allocator_session_datas);
+    GFXRECON_UNREFERENCED_PARAMETER(allocator_memory_datas);
+    GFXRECON_UNREFERENCED_PARAMETER(bind_memory_properties);
+    return VK_SUCCESS;
+}
+
+VkResult VulkanRebindAllocator::InitializeDataGraphPipelineSessionMemory(VkDataGraphPipelineSessionARM session,
+                                                                         ResourceAllocInfo* resource_alloc_info)
+{
+    struct PendingBinding
     {
-        VkDataGraphPipelineSessionBindPointTypeARM bind_point_type = {};
-        uint32_t                                   num_objects     = 0;
+        VmaAllocator                     allocator = VK_NULL_HANDLE;
+        std::unique_ptr<MemoryAllocInfo> memory_alloc_info;
+        VmaMemoryInfo                    memory_info{};
+
+        ~PendingBinding()
+        {
+            if ((allocator != VK_NULL_HANDLE) && (memory_info.allocation != VK_NULL_HANDLE))
+            {
+                vmaFreeMemory(allocator, memory_info.allocation);
+            }
+        }
     };
 
-    struct DataGraphSessionBindRequirements
-    {
-        uint32_t                                                        bind_point_requirement_count = 0;
-        std::unordered_map<uint32_t, DataGraphBindPointRequirementInfo> requirements;
-    };
-
-    if (!bind_infos || !allocator_session_datas || !allocator_memory_datas || !bind_memory_properties)
+    if ((session == VK_NULL_HANDLE) || (resource_alloc_info == nullptr) ||
+        (resource_alloc_info->object_type != VK_OBJECT_TYPE_DATA_GRAPH_PIPELINE_SESSION_ARM))
     {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
-    if (bind_info_count == 0)
+    VkDataGraphPipelineSessionBindPointRequirementsInfoARM requirements_info{
+        VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENTS_INFO_ARM
+    };
+    requirements_info.session = session;
+
+    uint32_t requirement_count = 0;
+    VkResult result            = functions_.get_data_graph_pipeline_session_bind_point_requirements(
+        device_, &requirements_info, &requirement_count, nullptr);
+    if (result != VK_SUCCESS)
     {
-        GFXRECON_LOG_DEBUG("BindDataGraphPipelineSessionMemory: bind_info_count==0 (no-op).");
-        return VK_SUCCESS;
+        GFXRECON_LOG_ERROR("vkGetDataGraphPipelineSessionBindPointRequirementsARM failed for session 0x%llx: %d",
+                           static_cast<unsigned long long>(VK_HANDLE_TO_UINT64(session)),
+                           result);
+        return result;
     }
 
-    std::unordered_map<uint64_t, DataGraphSessionBindRequirements> session_bind_requirements_cache;
-    for (uint32_t i = 0; i < bind_info_count; ++i)
+    std::vector<VkDataGraphPipelineSessionBindPointRequirementARM> requirements(
+        requirement_count,
+        VkDataGraphPipelineSessionBindPointRequirementARM{
+            VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM, nullptr });
+
+    if (requirement_count != 0)
     {
-        const auto&                         in            = bind_infos[i];
-        const VkDataGraphPipelineSessionARM session       = in.session;
-        const auto                          bind_point    = in.bindPoint;
-        const uint32_t                      object_idx    = in.objectIndex;
-        const VkDeviceSize                  memory_offset = in.memoryOffset;
-        if (session == VK_NULL_HANDLE)
+        result = functions_.get_data_graph_pipeline_session_bind_point_requirements(
+            device_, &requirements_info, &requirement_count, requirements.data());
+        if (result != VK_SUCCESS)
         {
-            GFXRECON_LOG_ERROR("BindDataGraphPipelineSessionMemory[%u]: session handle is VK_NULL_HANDLE.", i);
-            return VK_ERROR_INITIALIZATION_FAILED;
+            GFXRECON_LOG_ERROR("vkGetDataGraphPipelineSessionBindPointRequirementsARM failed while enumerating session "
+                               "0x%llx: %d",
+                               static_cast<unsigned long long>(VK_HANDLE_TO_UINT64(session)),
+                               result);
+            return result;
+        }
+        requirements.resize(requirement_count);
+    }
+
+    const bool protected_session =
+        (resource_alloc_info->usage & VK_DATA_GRAPH_PIPELINE_SESSION_CREATE_PROTECTED_BIT_ARM) != 0;
+
+    std::vector<VkBindDataGraphPipelineSessionMemoryInfoARM> replay_bind_infos;
+    std::vector<std::unique_ptr<PendingBinding>>             pending_bindings;
+
+    for (const auto& requirement : requirements)
+    {
+        if (requirement.bindPointType != VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TYPE_MEMORY_ARM)
+        {
+            continue;
         }
 
-        const uint64_t session_id = VK_HANDLE_TO_UINT64(session);
-        auto           session_it = session_bind_requirements_cache.find(session_id);
-        if (session_it == session_bind_requirements_cache.end())
+        for (uint32_t object_index = 0; object_index < requirement.numObjects; ++object_index)
         {
-            DataGraphSessionBindRequirements                       session_requirements = {};
-            VkDataGraphPipelineSessionBindPointRequirementsInfoARM bind_info_req{};
-            bind_info_req.sType   = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENTS_INFO_ARM;
-            bind_info_req.session = session;
+            VkDataGraphPipelineSessionMemoryRequirementsInfoARM memory_requirements_info{
+                VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_MEMORY_REQUIREMENTS_INFO_ARM
+            };
+            memory_requirements_info.session     = session;
+            memory_requirements_info.bindPoint   = requirement.bindPoint;
+            memory_requirements_info.objectIndex = object_index;
 
-            functions_.get_data_graph_pipeline_session_bind_point_requirements(
-                device_, &bind_info_req, &session_requirements.bind_point_requirement_count, nullptr);
+            VkMemoryRequirements2 memory_requirements{ VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2 };
+            functions_.get_data_graph_pipeline_session_memory_requirements(
+                device_, &memory_requirements_info, &memory_requirements);
 
-            if (session_requirements.bind_point_requirement_count > 0)
+            uint32_t compatible_memory_type_bits = memory_requirements.memoryRequirements.memoryTypeBits;
+            for (uint32_t memory_type_index = 0; memory_type_index < replay_memory_properties_.memoryTypeCount;
+                 ++memory_type_index)
             {
-                std::vector<VkDataGraphPipelineSessionBindPointRequirementARM> bind_point_requirements(
-                    session_requirements.bind_point_requirement_count,
-                    VkDataGraphPipelineSessionBindPointRequirementARM{
-                        VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM, nullptr });
-
-                functions_.get_data_graph_pipeline_session_bind_point_requirements(
-                    device_,
-                    &bind_info_req,
-                    &session_requirements.bind_point_requirement_count,
-                    bind_point_requirements.data());
-
-                for (const auto& requirement : bind_point_requirements)
+                const bool protected_memory = (replay_memory_properties_.memoryTypes[memory_type_index].propertyFlags &
+                                               VK_MEMORY_PROPERTY_PROTECTED_BIT) != 0;
+                if (protected_memory != protected_session)
                 {
-                    session_requirements.requirements[static_cast<uint32_t>(requirement.bindPoint)] = {
-                        requirement.bindPointType, requirement.numObjects
-                    };
+                    compatible_memory_type_bits &= ~(1u << memory_type_index);
                 }
             }
 
-            session_it = session_bind_requirements_cache.emplace(session_id, std::move(session_requirements)).first;
-        }
-
-        const auto requirement_it = session_it->second.requirements.find(static_cast<uint32_t>(bind_point));
-        if (requirement_it == session_it->second.requirements.end())
-        {
-            GFXRECON_LOG_ERROR("BindDataGraphPipelineSessionMemory[%u]: session=0x%llx bindPoint=%u was captured "
-                               "with memory binding, but replay reports no matching bind point requirement "
-                               "(requirementCount=%u).",
-                               i,
-                               static_cast<unsigned long long>(session_id),
-                               static_cast<unsigned>(bind_point),
-                               session_it->second.bind_point_requirement_count);
-            return VK_ERROR_INITIALIZATION_FAILED;
-        }
-
-        const auto& bind_point_requirement = requirement_it->second;
-        if (bind_point_requirement.bind_point_type != VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TYPE_MEMORY_ARM)
-        {
-            GFXRECON_LOG_ERROR("BindDataGraphPipelineSessionMemory[%u]: session=0x%llx bindPoint=%u has replay "
-                               "bind point type %u instead of MEMORY_ARM.",
-                               i,
-                               static_cast<unsigned long long>(session_id),
-                               static_cast<unsigned>(bind_point),
-                               static_cast<unsigned>(bind_point_requirement.bind_point_type));
-            return VK_ERROR_INITIALIZATION_FAILED;
-        }
-
-        if (object_idx >= bind_point_requirement.num_objects)
-        {
-            GFXRECON_LOG_ERROR("BindDataGraphPipelineSessionMemory[%u]: session=0x%llx bindPoint=%u objectIndex=%u "
-                               "is outside replay range [0, %u).",
-                               i,
-                               static_cast<unsigned long long>(session_id),
-                               static_cast<unsigned>(bind_point),
-                               object_idx,
-                               bind_point_requirement.num_objects);
-            return VK_ERROR_INITIALIZATION_FAILED;
-        }
-
-        GFXRECON_LOG_INFO(
-            "BindDataGraphPipelineSessionMemory[%u]: session=0x%llx bindPoint=%u obj=%u memOffset=%" PRIu64
-            " numObjects=%u",
-            i,
-            static_cast<unsigned long long>(session_id),
-            static_cast<unsigned>(bind_point),
-            object_idx,
-            static_cast<unsigned long long>(memory_offset),
-            bind_point_requirement.num_objects);
-
-        const uintptr_t session_ud = allocator_session_datas[i];
-        const uintptr_t memory_ud  = allocator_memory_datas[i];
-
-        auto* resource_alloc_info = (session_ud != 0) ? reinterpret_cast<ResourceAllocInfo*>(session_ud) : nullptr;
-        auto* memory_alloc_info   = (memory_ud != 0) ? reinterpret_cast<MemoryAllocInfo*>(memory_ud) : nullptr;
-
-        const VkMemoryPropertyFlags want_props = bind_memory_properties[i];
-
-        VkDataGraphPipelineSessionMemoryRequirementsInfoARM mem_req_info{
-            VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_MEMORY_REQUIREMENTS_INFO_ARM
-        };
-        mem_req_info.session     = session;
-        mem_req_info.bindPoint   = bind_point;
-        mem_req_info.objectIndex = object_idx;
-
-        VkMemoryRequirements2 replay_mem_req_2{ VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2 };
-        replay_mem_req_2.pNext = nullptr;
-
-        functions_.get_data_graph_pipeline_session_memory_requirements(device_, &mem_req_info, &replay_mem_req_2);
-
-        const VkMemoryRequirements& replay_mem_req = replay_mem_req_2.memoryRequirements;
-
-        GFXRECON_LOG_DEBUG("BindDataGraphPipelineSessionMemory[%u]: session=0x%llx bindPoint=%u obj=%u size=%" PRIu64
-                           " align=%" PRIu64 " typeBits=0x%08X wantProps=0x%08X",
-                           i,
-                           static_cast<unsigned long long>(VK_HANDLE_TO_UINT64(session)),
-                           static_cast<unsigned>(bind_point),
-                           object_idx,
-                           static_cast<unsigned long long>(replay_mem_req.size),
-                           static_cast<unsigned long long>(replay_mem_req.alignment),
-                           replay_mem_req.memoryTypeBits,
-                           want_props);
-
-        VmaAllocation     allocation = VK_NULL_HANDLE;
-        VmaAllocationInfo alloc_info{};
-        VkResult          result = VK_ERROR_UNKNOWN;
-
-        VmaAllocationCreateInfo aci{};
-        aci.flags          = 0;
-        aci.memoryTypeBits = replay_mem_req.memoryTypeBits;
-        aci.requiredFlags  = want_props;
-        aci.preferredFlags = 0;
-
-        if (resource_alloc_info && memory_alloc_info)
-        {
-            aci.usage = GetTensorMemoryUsage(
-                resource_alloc_info->usage,
-                capture_memory_properties_.memoryTypes[memory_alloc_info->original_index].propertyFlags,
-                replay_mem_req);
-        }
-        else
-        {
-            aci.usage = VMA_MEMORY_USAGE_UNKNOWN;
-        }
-
-        VkMemoryRequirements capture_mem_req = {};
-        if (resource_alloc_info && resource_alloc_info->capture_mem_reqs.size() > 0)
-        {
-            capture_mem_req = resource_alloc_info->capture_mem_reqs[0];
-        }
-
-        VmaMemoryInfo mem_info                      = {};
-        mem_info.memory_info                        = memory_alloc_info;
-        mem_info.capture_mem_req                    = capture_mem_req;
-        mem_info.replay_mem_req                     = replay_mem_req;
-        mem_info.requires_dedicated_allocation      = false;
-        mem_info.prefers_dedicated_allocation       = false;
-        mem_info.alc_create_info                    = aci;
-        mem_info.offset_from_original_device_memory = memory_offset;
-
-        result = vmaAllocateMemory(allocator_, &replay_mem_req, &aci, &allocation, &alloc_info);
-        if (result != VK_SUCCESS)
-        {
-            GFXRECON_LOG_ERROR("BindDataGraphPipelineSessionMemory[%u]: vmaAllocateMemory failed: %d "
-                               "(size=%" PRIu64 ", align=%" PRIu64 ", typeBits=0x%08X)",
-                               i,
-                               result,
-                               static_cast<unsigned long long>(replay_mem_req.size),
-                               static_cast<unsigned long long>(replay_mem_req.alignment),
-                               replay_mem_req.memoryTypeBits);
-            return result;
-        }
-
-        VkBindDataGraphPipelineSessionMemoryInfoARM bind_session_memory_info{
-            VK_STRUCTURE_TYPE_BIND_DATA_GRAPH_PIPELINE_SESSION_MEMORY_INFO_ARM
-        };
-        bind_session_memory_info.session      = session;
-        bind_session_memory_info.bindPoint    = bind_point;
-        bind_session_memory_info.objectIndex  = object_idx;
-        bind_session_memory_info.memory       = alloc_info.deviceMemory;
-        bind_session_memory_info.memoryOffset = alloc_info.offset;
-
-        result = functions_.bind_data_graph_pipeline_session_memory(device_, 1, &bind_session_memory_info);
-        if (result != VK_SUCCESS)
-        {
-            GFXRECON_LOG_ERROR("BindDataGraphPipelineSessionMemory[%u]: vkBindDataGraphPipelineSessionMemoryARM "
-                               "failed: %d (mem=0x%llx, offset=%" PRIu64 ")",
-                               i,
-                               result,
-                               static_cast<unsigned long long>(VK_HANDLE_TO_UINT64(alloc_info.deviceMemory)),
-                               static_cast<unsigned long long>(alloc_info.offset));
-
-            if (allocation != VK_NULL_HANDLE)
+            if (compatible_memory_type_bits == 0)
             {
-                vmaFreeMemory(allocator_, allocation);
+                GFXRECON_LOG_ERROR(
+                    "No compatible %s memory type for data graph session 0x%llx bindPoint=%u objectIndex=%u.",
+                    protected_session ? "protected" : "unprotected",
+                    static_cast<unsigned long long>(VK_HANDLE_TO_UINT64(session)),
+                    static_cast<unsigned>(requirement.bindPoint),
+                    object_index);
+                return VK_ERROR_FEATURE_NOT_PRESENT;
             }
+
+            VmaAllocationCreateInfo allocation_create_info{};
+            allocation_create_info.usage          = VMA_MEMORY_USAGE_UNKNOWN;
+            allocation_create_info.memoryTypeBits = compatible_memory_type_bits;
+            allocation_create_info.requiredFlags  = protected_session ? VK_MEMORY_PROPERTY_PROTECTED_BIT : 0;
+
+            auto pending_binding                                = std::make_unique<PendingBinding>();
+            pending_binding->allocator                          = allocator_;
+            pending_binding->memory_alloc_info                  = std::make_unique<MemoryAllocInfo>();
+            pending_binding->memory_alloc_info->allocation_size = memory_requirements.memoryRequirements.size;
+            pending_binding->memory_alloc_info->is_free         = true;
+
+            auto& memory_info                              = pending_binding->memory_info;
+            memory_info.memory_info                        = pending_binding->memory_alloc_info.get();
+            memory_info.replay_mem_req                     = memory_requirements.memoryRequirements;
+            memory_info.alc_create_info                    = allocation_create_info;
+            memory_info.offset_from_original_device_memory = 0;
+
+            result = vmaAllocateMemory(allocator_,
+                                       &memory_requirements.memoryRequirements,
+                                       &allocation_create_info,
+                                       &memory_info.allocation,
+                                       &memory_info.allocation_info);
+            if (result != VK_SUCCESS)
+            {
+                GFXRECON_LOG_ERROR(
+                    "vmaAllocateMemory failed for data graph session 0x%llx bindPoint=%u objectIndex=%u: %d",
+                    static_cast<unsigned long long>(VK_HANDLE_TO_UINT64(session)),
+                    static_cast<unsigned>(requirement.bindPoint),
+                    object_index,
+                    result);
+                return result;
+            }
+
+            VkBindDataGraphPipelineSessionMemoryInfoARM replay_bind_info{
+                VK_STRUCTURE_TYPE_BIND_DATA_GRAPH_PIPELINE_SESSION_MEMORY_INFO_ARM
+            };
+            replay_bind_info.session      = session;
+            replay_bind_info.bindPoint    = requirement.bindPoint;
+            replay_bind_info.objectIndex  = object_index;
+            replay_bind_info.memory       = memory_info.allocation_info.deviceMemory;
+            replay_bind_info.memoryOffset = memory_info.allocation_info.offset;
+
+            replay_bind_infos.push_back(replay_bind_info);
+            pending_bindings.emplace_back(std::move(pending_binding));
+        }
+    }
+
+    if (!replay_bind_infos.empty())
+    {
+        GFXRECON_CHECK_CONVERSION_DATA_LOSS(uint32_t, replay_bind_infos.size());
+        result = functions_.bind_data_graph_pipeline_session_memory(
+            device_, static_cast<uint32_t>(replay_bind_infos.size()), replay_bind_infos.data());
+        if (result != VK_SUCCESS)
+        {
+            GFXRECON_LOG_ERROR(
+                "vkBindDataGraphPipelineSessionMemoryARM failed for replay-generated batch of %zu bindings: %d",
+                replay_bind_infos.size(),
+                result);
             return result;
         }
+    }
 
-        if (resource_alloc_info != nullptr && memory_alloc_info != nullptr)
-        {
-            mem_info.allocation      = allocation;
-            mem_info.allocation_info = alloc_info;
-            memory_alloc_info->vma_mem_infos.emplace_back(std::make_unique<VmaMemoryInfo>(mem_info));
+    for (auto& pending_binding_ptr : pending_bindings)
+    {
+        auto& pending_binding       = *pending_binding_ptr;
+        auto  memory_alloc_info     = std::move(pending_binding.memory_alloc_info);
+        auto* memory_alloc_info_ptr = memory_alloc_info.get();
+        memory_alloc_info_ptr->vma_mem_infos.emplace_back(std::make_unique<VmaMemoryInfo>(pending_binding.memory_info));
 
-            UpdateAllocInfo(*resource_alloc_info,
-                            VK_HANDLE_TO_UINT64(session),
-                            MemoryInfoType::kDataGraphSession,
-                            *memory_alloc_info,
-                            *memory_alloc_info->vma_mem_infos.back(),
-                            bind_memory_properties[i]);
-        }
-        else
-        {
-            GFXRECON_LOG_WARNING("BindDataGraphPipelineSessionMemory[%u]: allocator data missing for session "
-                                 "or memory — VMA allocation cannot be tracked and will be freed.",
-                                 i);
-            vmaFreeMemory(allocator_, allocation);
-        }
+        auto* committed_memory_info            = memory_alloc_info_ptr->vma_mem_infos.back().get();
+        pending_binding.memory_info.allocation = VK_NULL_HANDLE;
 
-        GFXRECON_LOG_DEBUG("BindDataGraphPipelineSessionMemory[%u]: SUCCESS session=0x%llx mem=0x%llx offset=%" PRIu64
-                           " size=%" PRIu64,
-                           i,
-                           static_cast<unsigned long long>(VK_HANDLE_TO_UINT64(session)),
-                           static_cast<unsigned long long>(VK_HANDLE_TO_UINT64(alloc_info.deviceMemory)),
-                           static_cast<unsigned long long>(alloc_info.offset),
-                           static_cast<unsigned long long>(replay_mem_req.size));
+        VkMemoryPropertyFlags unused_memory_properties = 0;
+        UpdateAllocInfo(*resource_alloc_info,
+                        VK_HANDLE_TO_UINT64(session),
+                        MemoryInfoType::kDataGraphSession,
+                        *memory_alloc_info_ptr,
+                        *committed_memory_info,
+                        unused_memory_properties);
+
+        memory_alloc_info.release();
     }
 
     return VK_SUCCESS;

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -3916,7 +3916,9 @@ VkResult VulkanRebindAllocator::InitializeDataGraphPipelineSessionMemory(VkDataG
             }
 
             VmaAllocationCreateInfo allocation_create_info{};
-            allocation_create_info.usage          = VMA_MEMORY_USAGE_UNKNOWN;
+            // Session memory is device-side working memory that is never mapped. Without a preference VMA
+            // takes the lowest compatible memory type index, which is not device-local everywhere.
+            allocation_create_info.usage          = VMA_MEMORY_USAGE_GPU_ONLY;
             allocation_create_info.memoryTypeBits = compatible_memory_type_bits;
             allocation_create_info.requiredFlags  = protected_session ? VK_MEMORY_PROPERTY_PROTECTED_BIT : 0;
 

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -734,6 +734,9 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                      MemoryAllocInfo&                        memory_alloc_info,
                                      VmaMemoryInfo**                         vma_mem_info);
 
+    VkResult InitializeDataGraphPipelineSessionMemory(VkDataGraphPipelineSessionARM session,
+                                                      ResourceAllocInfo*            resource_alloc_info);
+
     // Aliasing detection: if the resource's captured range [memory_offset, memory_offset+footprint)
     // overlaps a resource already bound to this memory, the two alias. Returns that existing resource's
     // VmaMemoryInfo so the newcomer binds into the same allocation at its captured relative offset;

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -359,6 +359,24 @@ void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSets(const 
                     }
                     break;
                 }
+                case VK_DESCRIPTOR_TYPE_TENSOR_ARM:
+                {
+                    const auto* tensor_writes =
+                        GetPNextMetaStruct<Decoded_VkWriteDescriptorSetTensorARM>(meta_writes[i].pNext);
+                    if (tensor_writes != nullptr)
+                    {
+                        const auto& tensor_views = tensor_writes->pTensorViews;
+                        if (!tensor_views.IsNull() && tensor_views.HasData())
+                        {
+                            AddResourcesToContainer(meta_writes[i].dstSet,
+                                                    writes[i].dstBinding,
+                                                    writes[i].dstArrayElement,
+                                                    writes[i].descriptorCount,
+                                                    tensor_views.GetPointer());
+                        }
+                    }
+                    break;
+                }
 
                 default:
                     GFXRECON_LOG_WARNING("Ignoring unrecognized descriptor type %d", writes[i].descriptorType);

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -157,6 +157,25 @@ void VulkanReferencedResourceConsumerBase::Process_vkCreateAccelerationStructure
     }
 }
 
+void VulkanReferencedResourceConsumerBase::Process_vkCreateTensorARM(const ApiCallInfo&     call_info,
+                                                                     args::CreateTensorARM& args)
+{
+    if (!args.pTensor.IsNull() && args.pTensor.HasData())
+    {
+        table_.AddResource(*args.pTensor.GetPointer());
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkCreateTensorViewARM(const ApiCallInfo&         call_info,
+                                                                         args::CreateTensorViewARM& args)
+{
+    if (!args.pCreateInfo.IsNull() && args.pCreateInfo.HasData() && !args.pView.IsNull() && args.pView.HasData())
+    {
+        const auto create_info = args.pCreateInfo.GetMetaStructPointer();
+        table_.AddResource(create_info->tensor, *args.pView.GetPointer());
+    }
+}
+
 void VulkanReferencedResourceConsumerBase::ProcessSetOpaqueAddressCommand(format::HandleId device_id,
                                                                           format::HandleId object_id,
                                                                           uint64_t         address)

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -86,6 +86,10 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
     void Process_vkCreateAccelerationStructureKHR(const ApiCallInfo&                    call_info,
                                                   args::CreateAccelerationStructureKHR& args) override;
 
+    void Process_vkCreateTensorARM(const ApiCallInfo& call_info, args::CreateTensorARM& args) override;
+
+    void Process_vkCreateTensorViewARM(const ApiCallInfo& call_info, args::CreateTensorViewARM& args) override;
+
     void Process_vkDestroyDescriptorPool(const ApiCallInfo& call_info, args::DestroyDescriptorPool& args) override;
 
     void Process_vkResetDescriptorPool(const ApiCallInfo& call_info, args::ResetDescriptorPool& args) override;

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -984,6 +984,7 @@ VkResult VulkanCaptureManager::OverrideCreateTensorARM(VkDevice                 
                                                        const VkAllocationCallbacks* pAllocator,
                                                        VkTensorARM*                 pTensor)
 {
+    auto* device_wrapper       = vulkan_wrappers::GetWrapper<vulkan_wrappers::DeviceWrapper>(device);
     auto* device_table         = vulkan_wrappers::GetDeviceTable(device);
     auto  handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
 
@@ -993,7 +994,13 @@ VkResult VulkanCaptureManager::OverrideCreateTensorARM(VkDevice                 
     VkTensorCreateInfoARM modified_create_info = *pCreateInfo_unwrapped;
 
     VkTensorDescriptionARM modified_desc;
-    if (IsTrimEnabled() && pCreateInfo_unwrapped->pDescription != nullptr)
+    if (IsTrimEnabled() && (device_wrapper != nullptr) && (device_wrapper->physical_device != nullptr) &&
+        (pCreateInfo_unwrapped->pDescription != nullptr) &&
+        graphics::TensorFormatSupportsFeatures(device_wrapper->physical_device->layer_table_ref,
+                                               device_wrapper->physical_device->handle,
+                                               pCreateInfo_unwrapped->pDescription,
+                                               VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT |
+                                                   VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT))
     {
         modified_desc = *pCreateInfo_unwrapped->pDescription;
         modified_desc.usage |= VK_TENSOR_USAGE_TRANSFER_SRC_BIT_ARM;
@@ -1002,7 +1009,7 @@ VkResult VulkanCaptureManager::OverrideCreateTensorARM(VkDevice                 
 
     VkResult result = device_table->CreateTensorARM(device, &modified_create_info, pAllocator, pTensor);
 
-    if (result >= 0 && pTensor != nullptr)
+    if ((result >= 0) && (pTensor != nullptr))
     {
         vulkan_wrappers::CreateWrappedHandle<vulkan_wrappers::DeviceWrapper,
                                              vulkan_wrappers::NoParentWrapper,

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -5051,6 +5051,11 @@ void VulkanStateWriter::WriteDataGraphPipelineSessionMemoryState(const VulkanSta
                                                  wrapper->pipeline_dependency.create_parameters.get()));
         }
 
+        // All objects for a session are emitted together. Splitting them into separate calls can make the second call
+        // an invalid attempt to bind a bind point that was already bound by the first call.
+        std::vector<VkBindDataGraphPipelineSessionMemoryInfoARM> bind_infos;
+        bind_infos.reserve(wrapper->memory_bindings.size());
+
         for (const auto& binding : wrapper->memory_bindings)
         {
             const auto* memory_wrapper = state_table.GetVulkanDeviceMemoryWrapper(binding.bind_memory_id);
@@ -5059,7 +5064,7 @@ void VulkanStateWriter::WriteDataGraphPipelineSessionMemoryState(const VulkanSta
                 continue;
             }
 
-            VkBindDataGraphPipelineSessionMemoryInfoARM info{};
+            auto& info        = bind_infos.emplace_back();
             info.sType        = VK_STRUCTURE_TYPE_BIND_DATA_GRAPH_PIPELINE_SESSION_MEMORY_INFO_ARM;
             info.pNext        = nullptr;
             info.session      = wrapper->handle;
@@ -5067,10 +5072,16 @@ void VulkanStateWriter::WriteDataGraphPipelineSessionMemoryState(const VulkanSta
             info.memoryOffset = binding.bind_offset;
             info.bindPoint    = binding.bind_point;
             info.objectIndex  = binding.object_index;
+        }
+
+        if (!bind_infos.empty())
+        {
+            GFXRECON_CHECK_CONVERSION_DATA_LOSS(uint32_t, bind_infos.size());
+            const uint32_t bind_info_count = static_cast<uint32_t>(bind_infos.size());
 
             encoder_.EncodeHandleIdValue(wrapper->bind_device->handle_id);
-            encoder_.EncodeUInt32Value(1);
-            EncodeStructArray(&encoder_, &info, 1);
+            encoder_.EncodeUInt32Value(bind_info_count);
+            EncodeStructArray(&encoder_, bind_infos.data(), bind_info_count);
             encoder_.EncodeEnumValue(VK_SUCCESS);
             WriteFunctionCall(format::ApiCallId::ApiCall_vkBindDataGraphPipelineSessionMemoryARM, &parameter_stream_);
             parameter_stream_.Clear();

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -5112,6 +5112,11 @@ void VulkanStateWriter::WriteDataGraphPipelineSessionMemoryState(const VulkanSta
                                                  wrapper->pipeline_dependency.create_parameters.get()));
         }
 
+        // All objects for a session are emitted together. Splitting them into separate calls can make the second call
+        // an invalid attempt to bind a bind point that was already bound by the first call.
+        std::vector<VkBindDataGraphPipelineSessionMemoryInfoARM> bind_infos;
+        bind_infos.reserve(wrapper->memory_bindings.size());
+
         for (const auto& binding : wrapper->memory_bindings)
         {
             const auto* memory_wrapper = state_table.GetVulkanDeviceMemoryWrapper(binding.bind_memory_id);
@@ -5120,7 +5125,7 @@ void VulkanStateWriter::WriteDataGraphPipelineSessionMemoryState(const VulkanSta
                 continue;
             }
 
-            VkBindDataGraphPipelineSessionMemoryInfoARM info{};
+            auto& info        = bind_infos.emplace_back();
             info.sType        = VK_STRUCTURE_TYPE_BIND_DATA_GRAPH_PIPELINE_SESSION_MEMORY_INFO_ARM;
             info.pNext        = nullptr;
             info.session      = wrapper->handle;
@@ -5128,10 +5133,16 @@ void VulkanStateWriter::WriteDataGraphPipelineSessionMemoryState(const VulkanSta
             info.memoryOffset = binding.bind_offset;
             info.bindPoint    = binding.bind_point;
             info.objectIndex  = binding.object_index;
+        }
+
+        if (!bind_infos.empty())
+        {
+            GFXRECON_CHECK_CONVERSION_DATA_LOSS(uint32_t, bind_infos.size());
+            const uint32_t bind_info_count = static_cast<uint32_t>(bind_infos.size());
 
             encoder_.EncodeHandleIdValue(wrapper->bind_device->handle_id);
-            encoder_.EncodeUInt32Value(1);
-            EncodeStructArray(&encoder_, &info, 1);
+            encoder_.EncodeUInt32Value(bind_info_count);
+            EncodeStructArray(&encoder_, bind_infos.data(), bind_info_count);
             encoder_.EncodeEnumValue(VK_SUCCESS);
             WriteFunctionCall(format::ApiCallId::ApiCall_vkBindDataGraphPipelineSessionMemoryARM, &parameter_stream_);
             parameter_stream_.Clear();

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
@@ -335,6 +335,29 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPipelineBarrier2(
     if (!args.pDependencyInfo.IsNull() && (args.pDependencyInfo.HasData()))
     {
         auto pDependencyInfo_ptr = args.pDependencyInfo.GetMetaStructPointer();
+        {
+            const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorDependencyInfoARM>(pDependencyInfo_ptr->pNext);
+            if (ext_struct_info != nullptr)
+            {
+                if (!ext_struct_info->pTensorMemoryBarriers->IsNull() && (ext_struct_info->pTensorMemoryBarriers->HasData()))
+                {
+                    auto pTensorMemoryBarriers_ptr = ext_struct_info->pTensorMemoryBarriers->GetMetaStructPointer();
+                    size_t pTensorMemoryBarriers_count = ext_struct_info->pTensorMemoryBarriers->GetLength();
+                    for (size_t pTensorMemoryBarriers_index = 0; pTensorMemoryBarriers_index < pTensorMemoryBarriers_count; ++pTensorMemoryBarriers_index)
+                    {
+                        GetTable().AddResourceToUser(args.commandBuffer, pTensorMemoryBarriers_ptr[pTensorMemoryBarriers_index].tensor);
+                    }
+                }
+            }
+        }
+        {
+            const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorMemoryBarrierARM>(pDependencyInfo_ptr->pNext);
+            if (ext_struct_info != nullptr)
+            {
+                GetTable().AddResourceToUser(args.commandBuffer, ext_struct_info->tensor);
+            }
+        }
+
         if (!pDependencyInfo_ptr->pBufferMemoryBarriers->IsNull() && (pDependencyInfo_ptr->pBufferMemoryBarriers->HasData()))
         {
             auto pBufferMemoryBarriers_ptr = pDependencyInfo_ptr->pBufferMemoryBarriers->GetMetaStructPointer();
@@ -412,6 +435,29 @@ void VulkanReferencedResourceConsumer::Process_vkCmdSetEvent2(
     if (!args.pDependencyInfo.IsNull() && (args.pDependencyInfo.HasData()))
     {
         auto pDependencyInfo_ptr = args.pDependencyInfo.GetMetaStructPointer();
+        {
+            const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorDependencyInfoARM>(pDependencyInfo_ptr->pNext);
+            if (ext_struct_info != nullptr)
+            {
+                if (!ext_struct_info->pTensorMemoryBarriers->IsNull() && (ext_struct_info->pTensorMemoryBarriers->HasData()))
+                {
+                    auto pTensorMemoryBarriers_ptr = ext_struct_info->pTensorMemoryBarriers->GetMetaStructPointer();
+                    size_t pTensorMemoryBarriers_count = ext_struct_info->pTensorMemoryBarriers->GetLength();
+                    for (size_t pTensorMemoryBarriers_index = 0; pTensorMemoryBarriers_index < pTensorMemoryBarriers_count; ++pTensorMemoryBarriers_index)
+                    {
+                        GetTable().AddResourceToUser(args.commandBuffer, pTensorMemoryBarriers_ptr[pTensorMemoryBarriers_index].tensor);
+                    }
+                }
+            }
+        }
+        {
+            const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorMemoryBarrierARM>(pDependencyInfo_ptr->pNext);
+            if (ext_struct_info != nullptr)
+            {
+                GetTable().AddResourceToUser(args.commandBuffer, ext_struct_info->tensor);
+            }
+        }
+
         if (!pDependencyInfo_ptr->pBufferMemoryBarriers->IsNull() && (pDependencyInfo_ptr->pBufferMemoryBarriers->HasData()))
         {
             auto pBufferMemoryBarriers_ptr = pDependencyInfo_ptr->pBufferMemoryBarriers->GetMetaStructPointer();
@@ -444,6 +490,29 @@ void VulkanReferencedResourceConsumer::Process_vkCmdWaitEvents2(
         size_t pDependencyInfos_count = args.pDependencyInfos.GetLength();
         for (size_t pDependencyInfos_index = 0; pDependencyInfos_index < pDependencyInfos_count; ++pDependencyInfos_index)
         {
+            {
+                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorDependencyInfoARM>(pDependencyInfos_ptr[pDependencyInfos_index].pNext);
+                if (ext_struct_info != nullptr)
+                {
+                    if (!ext_struct_info->pTensorMemoryBarriers->IsNull() && (ext_struct_info->pTensorMemoryBarriers->HasData()))
+                    {
+                        auto pTensorMemoryBarriers_ptr = ext_struct_info->pTensorMemoryBarriers->GetMetaStructPointer();
+                        size_t pTensorMemoryBarriers_count = ext_struct_info->pTensorMemoryBarriers->GetLength();
+                        for (size_t pTensorMemoryBarriers_index = 0; pTensorMemoryBarriers_index < pTensorMemoryBarriers_count; ++pTensorMemoryBarriers_index)
+                        {
+                            GetTable().AddResourceToUser(args.commandBuffer, pTensorMemoryBarriers_ptr[pTensorMemoryBarriers_index].tensor);
+                        }
+                    }
+                }
+            }
+            {
+                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorMemoryBarrierARM>(pDependencyInfos_ptr[pDependencyInfos_index].pNext);
+                if (ext_struct_info != nullptr)
+                {
+                    GetTable().AddResourceToUser(args.commandBuffer, ext_struct_info->tensor);
+                }
+            }
+
             if (!pDependencyInfos_ptr[pDependencyInfos_index].pBufferMemoryBarriers->IsNull() && (pDependencyInfos_ptr[pDependencyInfos_index].pBufferMemoryBarriers->HasData()))
             {
                 auto pBufferMemoryBarriers_ptr = pDependencyInfos_ptr[pDependencyInfos_index].pBufferMemoryBarriers->GetMetaStructPointer();
@@ -566,7 +635,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSet(
         for (size_t pDescriptorWrites_index = 0; pDescriptorWrites_index < pDescriptorWrites_count; ++pDescriptorWrites_index)
         {
             {
-                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites_ptr->pNext);
+                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites_ptr[pDescriptorWrites_index].pNext);
                 if (ext_struct_info != nullptr)
                 {
                     if (!ext_struct_info->pAccelerationStructures.IsNull() && (ext_struct_info->pAccelerationStructures.HasData()))
@@ -576,6 +645,21 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSet(
                         for (size_t pAccelerationStructures_index = 0; pAccelerationStructures_index < pAccelerationStructures_count; ++pAccelerationStructures_index)
                         {
                             GetTable().AddResourceToUser(args.commandBuffer, pAccelerationStructures_ptr[pAccelerationStructures_index]);
+                        }
+                    }
+                }
+            }
+            {
+                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetTensorARM>(pDescriptorWrites_ptr[pDescriptorWrites_index].pNext);
+                if (ext_struct_info != nullptr)
+                {
+                    if (!ext_struct_info->pTensorViews.IsNull() && (ext_struct_info->pTensorViews.HasData()))
+                    {
+                        auto pTensorViews_ptr = ext_struct_info->pTensorViews.GetPointer();
+                        size_t pTensorViews_count = ext_struct_info->pTensorViews.GetLength();
+                        for (size_t pTensorViews_index = 0; pTensorViews_index < pTensorViews_count; ++pTensorViews_index)
+                        {
+                            GetTable().AddResourceToUser(args.commandBuffer, pTensorViews_ptr[pTensorViews_index]);
                         }
                     }
                 }
@@ -648,7 +732,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSet2(
             for (size_t pDescriptorWrites_index = 0; pDescriptorWrites_index < pDescriptorWrites_count; ++pDescriptorWrites_index)
             {
                 {
-                    const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites_ptr->pNext);
+                    const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites_ptr[pDescriptorWrites_index].pNext);
                     if (ext_struct_info != nullptr)
                     {
                         if (!ext_struct_info->pAccelerationStructures.IsNull() && (ext_struct_info->pAccelerationStructures.HasData()))
@@ -658,6 +742,21 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSet2(
                             for (size_t pAccelerationStructures_index = 0; pAccelerationStructures_index < pAccelerationStructures_count; ++pAccelerationStructures_index)
                             {
                                 GetTable().AddResourceToUser(args.commandBuffer, pAccelerationStructures_ptr[pAccelerationStructures_index]);
+                            }
+                        }
+                    }
+                }
+                {
+                    const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetTensorARM>(pDescriptorWrites_ptr[pDescriptorWrites_index].pNext);
+                    if (ext_struct_info != nullptr)
+                    {
+                        if (!ext_struct_info->pTensorViews.IsNull() && (ext_struct_info->pTensorViews.HasData()))
+                        {
+                            auto pTensorViews_ptr = ext_struct_info->pTensorViews.GetPointer();
+                            size_t pTensorViews_count = ext_struct_info->pTensorViews.GetLength();
+                            for (size_t pTensorViews_index = 0; pTensorViews_index < pTensorViews_count; ++pTensorViews_index)
+                            {
+                                GetTable().AddResourceToUser(args.commandBuffer, pTensorViews_ptr[pTensorViews_index]);
                             }
                         }
                     }
@@ -824,7 +923,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSetKHR(
         for (size_t pDescriptorWrites_index = 0; pDescriptorWrites_index < pDescriptorWrites_count; ++pDescriptorWrites_index)
         {
             {
-                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites_ptr->pNext);
+                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites_ptr[pDescriptorWrites_index].pNext);
                 if (ext_struct_info != nullptr)
                 {
                     if (!ext_struct_info->pAccelerationStructures.IsNull() && (ext_struct_info->pAccelerationStructures.HasData()))
@@ -834,6 +933,21 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSetKHR(
                         for (size_t pAccelerationStructures_index = 0; pAccelerationStructures_index < pAccelerationStructures_count; ++pAccelerationStructures_index)
                         {
                             GetTable().AddResourceToUser(args.commandBuffer, pAccelerationStructures_ptr[pAccelerationStructures_index]);
+                        }
+                    }
+                }
+            }
+            {
+                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetTensorARM>(pDescriptorWrites_ptr[pDescriptorWrites_index].pNext);
+                if (ext_struct_info != nullptr)
+                {
+                    if (!ext_struct_info->pTensorViews.IsNull() && (ext_struct_info->pTensorViews.HasData()))
+                    {
+                        auto pTensorViews_ptr = ext_struct_info->pTensorViews.GetPointer();
+                        size_t pTensorViews_count = ext_struct_info->pTensorViews.GetLength();
+                        for (size_t pTensorViews_index = 0; pTensorViews_index < pTensorViews_count; ++pTensorViews_index)
+                        {
+                            GetTable().AddResourceToUser(args.commandBuffer, pTensorViews_ptr[pTensorViews_index]);
                         }
                     }
                 }
@@ -965,6 +1079,29 @@ void VulkanReferencedResourceConsumer::Process_vkCmdSetEvent2KHR(
     if (!args.pDependencyInfo.IsNull() && (args.pDependencyInfo.HasData()))
     {
         auto pDependencyInfo_ptr = args.pDependencyInfo.GetMetaStructPointer();
+        {
+            const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorDependencyInfoARM>(pDependencyInfo_ptr->pNext);
+            if (ext_struct_info != nullptr)
+            {
+                if (!ext_struct_info->pTensorMemoryBarriers->IsNull() && (ext_struct_info->pTensorMemoryBarriers->HasData()))
+                {
+                    auto pTensorMemoryBarriers_ptr = ext_struct_info->pTensorMemoryBarriers->GetMetaStructPointer();
+                    size_t pTensorMemoryBarriers_count = ext_struct_info->pTensorMemoryBarriers->GetLength();
+                    for (size_t pTensorMemoryBarriers_index = 0; pTensorMemoryBarriers_index < pTensorMemoryBarriers_count; ++pTensorMemoryBarriers_index)
+                    {
+                        GetTable().AddResourceToUser(args.commandBuffer, pTensorMemoryBarriers_ptr[pTensorMemoryBarriers_index].tensor);
+                    }
+                }
+            }
+        }
+        {
+            const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorMemoryBarrierARM>(pDependencyInfo_ptr->pNext);
+            if (ext_struct_info != nullptr)
+            {
+                GetTable().AddResourceToUser(args.commandBuffer, ext_struct_info->tensor);
+            }
+        }
+
         if (!pDependencyInfo_ptr->pBufferMemoryBarriers->IsNull() && (pDependencyInfo_ptr->pBufferMemoryBarriers->HasData()))
         {
             auto pBufferMemoryBarriers_ptr = pDependencyInfo_ptr->pBufferMemoryBarriers->GetMetaStructPointer();
@@ -997,6 +1134,29 @@ void VulkanReferencedResourceConsumer::Process_vkCmdWaitEvents2KHR(
         size_t pDependencyInfos_count = args.pDependencyInfos.GetLength();
         for (size_t pDependencyInfos_index = 0; pDependencyInfos_index < pDependencyInfos_count; ++pDependencyInfos_index)
         {
+            {
+                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorDependencyInfoARM>(pDependencyInfos_ptr[pDependencyInfos_index].pNext);
+                if (ext_struct_info != nullptr)
+                {
+                    if (!ext_struct_info->pTensorMemoryBarriers->IsNull() && (ext_struct_info->pTensorMemoryBarriers->HasData()))
+                    {
+                        auto pTensorMemoryBarriers_ptr = ext_struct_info->pTensorMemoryBarriers->GetMetaStructPointer();
+                        size_t pTensorMemoryBarriers_count = ext_struct_info->pTensorMemoryBarriers->GetLength();
+                        for (size_t pTensorMemoryBarriers_index = 0; pTensorMemoryBarriers_index < pTensorMemoryBarriers_count; ++pTensorMemoryBarriers_index)
+                        {
+                            GetTable().AddResourceToUser(args.commandBuffer, pTensorMemoryBarriers_ptr[pTensorMemoryBarriers_index].tensor);
+                        }
+                    }
+                }
+            }
+            {
+                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorMemoryBarrierARM>(pDependencyInfos_ptr[pDependencyInfos_index].pNext);
+                if (ext_struct_info != nullptr)
+                {
+                    GetTable().AddResourceToUser(args.commandBuffer, ext_struct_info->tensor);
+                }
+            }
+
             if (!pDependencyInfos_ptr[pDependencyInfos_index].pBufferMemoryBarriers->IsNull() && (pDependencyInfos_ptr[pDependencyInfos_index].pBufferMemoryBarriers->HasData()))
             {
                 auto pBufferMemoryBarriers_ptr = pDependencyInfos_ptr[pDependencyInfos_index].pBufferMemoryBarriers->GetMetaStructPointer();
@@ -1027,6 +1187,29 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPipelineBarrier2KHR(
     if (!args.pDependencyInfo.IsNull() && (args.pDependencyInfo.HasData()))
     {
         auto pDependencyInfo_ptr = args.pDependencyInfo.GetMetaStructPointer();
+        {
+            const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorDependencyInfoARM>(pDependencyInfo_ptr->pNext);
+            if (ext_struct_info != nullptr)
+            {
+                if (!ext_struct_info->pTensorMemoryBarriers->IsNull() && (ext_struct_info->pTensorMemoryBarriers->HasData()))
+                {
+                    auto pTensorMemoryBarriers_ptr = ext_struct_info->pTensorMemoryBarriers->GetMetaStructPointer();
+                    size_t pTensorMemoryBarriers_count = ext_struct_info->pTensorMemoryBarriers->GetLength();
+                    for (size_t pTensorMemoryBarriers_index = 0; pTensorMemoryBarriers_index < pTensorMemoryBarriers_count; ++pTensorMemoryBarriers_index)
+                    {
+                        GetTable().AddResourceToUser(args.commandBuffer, pTensorMemoryBarriers_ptr[pTensorMemoryBarriers_index].tensor);
+                    }
+                }
+            }
+        }
+        {
+            const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkTensorMemoryBarrierARM>(pDependencyInfo_ptr->pNext);
+            if (ext_struct_info != nullptr)
+            {
+                GetTable().AddResourceToUser(args.commandBuffer, ext_struct_info->tensor);
+            }
+        }
+
         if (!pDependencyInfo_ptr->pBufferMemoryBarriers->IsNull() && (pDependencyInfo_ptr->pBufferMemoryBarriers->HasData()))
         {
             auto pBufferMemoryBarriers_ptr = pDependencyInfo_ptr->pBufferMemoryBarriers->GetMetaStructPointer();
@@ -1183,7 +1366,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSet2KHR(
             for (size_t pDescriptorWrites_index = 0; pDescriptorWrites_index < pDescriptorWrites_count; ++pDescriptorWrites_index)
             {
                 {
-                    const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites_ptr->pNext);
+                    const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites_ptr[pDescriptorWrites_index].pNext);
                     if (ext_struct_info != nullptr)
                     {
                         if (!ext_struct_info->pAccelerationStructures.IsNull() && (ext_struct_info->pAccelerationStructures.HasData()))
@@ -1193,6 +1376,21 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSet2KHR(
                             for (size_t pAccelerationStructures_index = 0; pAccelerationStructures_index < pAccelerationStructures_count; ++pAccelerationStructures_index)
                             {
                                 GetTable().AddResourceToUser(args.commandBuffer, pAccelerationStructures_ptr[pAccelerationStructures_index]);
+                            }
+                        }
+                    }
+                }
+                {
+                    const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkWriteDescriptorSetTensorARM>(pDescriptorWrites_ptr[pDescriptorWrites_index].pNext);
+                    if (ext_struct_info != nullptr)
+                    {
+                        if (!ext_struct_info->pTensorViews.IsNull() && (ext_struct_info->pTensorViews.HasData()))
+                        {
+                            auto pTensorViews_ptr = ext_struct_info->pTensorViews.GetPointer();
+                            size_t pTensorViews_count = ext_struct_info->pTensorViews.GetLength();
+                            for (size_t pTensorViews_index = 0; pTensorViews_index < pTensorViews_count; ++pTensorViews_index)
+                            {
+                                GetTable().AddResourceToUser(args.commandBuffer, pTensorViews_ptr[pTensorViews_index]);
                             }
                         }
                     }
@@ -1474,7 +1672,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBindDescriptorBuffersEXT(
         for (size_t pBindingInfos_index = 0; pBindingInfos_index < pBindingInfos_count; ++pBindingInfos_index)
         {
             {
-                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkDescriptorBufferBindingPushDescriptorBufferHandleEXT>(pBindingInfos_ptr->pNext);
+                const auto* ext_struct_info = GetPNextMetaStruct<Decoded_VkDescriptorBufferBindingPushDescriptorBufferHandleEXT>(pBindingInfos_ptr[pBindingInfos_index].pNext);
                 if (ext_struct_info != nullptr)
                 {
                     GetTable().AddResourceToUser(args.commandBuffer, ext_struct_info->buffer);
@@ -1503,6 +1701,18 @@ void VulkanReferencedResourceConsumer::Process_vkCmdUpdatePipelineIndirectBuffer
     args::CmdUpdatePipelineIndirectBufferNV&    args)
 {
     GetTable().AddResourceToUser(args.commandBuffer, args.pipeline);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyTensorARM(
+    const ApiCallInfo&                          call_info,
+    args::CmdCopyTensorARM&                     args)
+{
+    if (!args.pCopyTensorInfo.IsNull() && (args.pCopyTensorInfo.HasData()))
+    {
+        auto pCopyTensorInfo_ptr = args.pCopyTensorInfo.GetMetaStructPointer();
+        GetTable().AddResourceToUser(args.commandBuffer, pCopyTensorInfo_ptr->srcTensor);
+        GetTable().AddResourceToUser(args.commandBuffer, pCopyTensorInfo_ptr->dstTensor);
+    }
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdPreprocessGeneratedCommandsEXT(

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.h
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.h
@@ -396,6 +396,10 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         const ApiCallInfo&                          call_info,
         args::CmdUpdatePipelineIndirectBufferNV&    args) override;
 
+    void Process_vkCmdCopyTensorARM(
+        const ApiCallInfo&                          call_info,
+        args::CmdCopyTensorARM&                     args) override;
+
     void Process_vkCmdPreprocessGeneratedCommandsEXT(
         const ApiCallInfo&                          call_info,
         args::CmdPreprocessGeneratedCommandsEXT&    args) override;

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_referenced_resource_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_referenced_resource_consumer_body_generator.py
@@ -65,7 +65,8 @@ class VulkanReferencedResourceBodyGenerator(VulkanBaseGenerator):
     # All resource and resource associated handle types to be processed.
     RESOURCE_HANDLE_TYPES = [
         'VkBuffer', 'VkImage', 'VkBufferView', 'VkImageView', 'VkFramebuffer',
-        'VkDescriptorSet', 'VkCommandBuffer', 'VkAccelerationStructureKHR', 'VkPipeline'
+        'VkDescriptorSet', 'VkCommandBuffer', 'VkAccelerationStructureKHR', 'VkPipeline',
+        'VkTensorARM', 'VkTensorViewARM'
     ]
 
     # Handle types that contain resource and child resource handle types.
@@ -247,8 +248,8 @@ class VulkanReferencedResourceBodyGenerator(VulkanBaseGenerator):
                         for ext_struct in ext_structs_with_handles:
                             body += indent + '{\n'
                             indent += ' ' * self.INDENT_SIZE
-                            body += indent + 'const auto* ext_struct_info = GetPNextMetaStruct<Decoded_{}>({}->pNext);\n'.format(
-                                 ext_struct, value_name
+                            body += indent + 'const auto* ext_struct_info = GetPNextMetaStruct<Decoded_{}>({}{}pNext);\n'.format(
+                                 ext_struct, value_name, access_operator
                              )
 
                             body += indent + 'if (ext_struct_info != nullptr)\n'

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
@@ -67,7 +67,8 @@ class VulkanReferencedResourceHeaderGenerator(VulkanBaseGenerator):
     # All resource and resource associated handle types to be processed.
     RESOURCE_HANDLE_TYPES = [
         'VkBuffer', 'VkImage', 'VkBufferView', 'VkImageView', 'VkFramebuffer',
-        'VkDescriptorSet', 'VkCommandBuffer', 'VkAccelerationStructureKHR', 'VkPipeline'
+        'VkDescriptorSet', 'VkCommandBuffer', 'VkAccelerationStructureKHR', 'VkPipeline',
+        'VkTensorARM', 'VkTensorViewARM'
     ]
 
     def __init__(

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -382,6 +382,59 @@ bool FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properti
     return found;
 }
 
+bool FindTensorStagingMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properties,
+                                      uint32_t                                memory_type_bits,
+                                      uint32_t*                               found_index,
+                                      VkMemoryPropertyFlags*                  found_flags)
+{
+    constexpr VkMemoryPropertyFlags kHostVisibleCached =
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+    constexpr VkMemoryPropertyFlags kHostVisibleCoherent =
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+
+    return FindMemoryTypeIndex(memory_properties, memory_type_bits, kHostVisibleCached, found_index, found_flags) ||
+           FindMemoryTypeIndex(memory_properties, memory_type_bits, kHostVisibleCoherent, found_index, found_flags) ||
+           FindMemoryTypeIndex(
+               memory_properties, memory_type_bits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, found_index, found_flags);
+}
+
+bool TensorFormatHasFeatures(const VkTensorFormatPropertiesARM& tensor_properties,
+                             VkTensorTilingARM                  tiling,
+                             VkFormatFeatureFlags2              required_features)
+{
+    VkFormatFeatureFlags2 available_features = 0;
+    switch (tiling)
+    {
+        case VK_TENSOR_TILING_OPTIMAL_ARM:
+            available_features = tensor_properties.optimalTilingTensorFeatures;
+            break;
+        case VK_TENSOR_TILING_LINEAR_ARM:
+            available_features = tensor_properties.linearTilingTensorFeatures;
+            break;
+        default:
+            return false;
+    }
+
+    return (required_features != 0) && ((available_features & required_features) == required_features);
+}
+
+bool TensorFormatSupportsFeatures(const VulkanInstanceTable*    instance_table,
+                                  VkPhysicalDevice              physical_device,
+                                  const VkTensorDescriptionARM* description,
+                                  VkFormatFeatureFlags2         required_features)
+{
+    if ((instance_table == nullptr) || (physical_device == VK_NULL_HANDLE) || (description == nullptr))
+    {
+        return false;
+    }
+
+    VkTensorFormatPropertiesARM tensor_properties = { VK_STRUCTURE_TYPE_TENSOR_FORMAT_PROPERTIES_ARM };
+    VkFormatProperties2         format_properties = { VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, &tensor_properties };
+    instance_table->GetPhysicalDeviceFormatProperties2(physical_device, description->format, &format_properties);
+
+    return TensorFormatHasFeatures(tensor_properties, description->tiling, required_features);
+}
+
 // Get the info on target image format. The function returns true if the target format
 // is supported, and returns texel size and other info to the corresponding pointer if the
 // pointer is not nullptr and the image format is supported.
@@ -881,6 +934,7 @@ VulkanResourcesUtil::~VulkanResourcesUtil()
 {
     DestroyStagingBuffer();
     DestroyStagingTensor();
+    DestroyStagingTensorMemory();
 
     for (const auto& [queue_family_index, command_asset] : command_asset_map_)
     {
@@ -1074,7 +1128,8 @@ VkResult VulkanResourcesUtil::AllocateStagingMemory(const VkMemoryRequirements& 
     alloc_info.allocationSize       = requirements.size;
     alloc_info.memoryTypeIndex      = memory_type_index;
 
-    VkResult result = device_table_.AllocateMemory(device_, &alloc_info, nullptr, &ctx.memory);
+    VkResult result       = device_table_.AllocateMemory(device_, &alloc_info, nullptr, &ctx.memory);
+    ctx.memory_type_index = memory_type_index;
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("Failed to allocate staging memory for resource memory snapshot");
@@ -1215,26 +1270,56 @@ VkResult VulkanResourcesUtil::CreateStagingTensor(const VkTensorDescriptionARM* 
     VkMemoryRequirements2 mem_req2                 = { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2 };
     device_table_.GetTensorMemoryRequirementsARM(device_, &mem_req_info, &mem_req2);
 
-    result = AllocateStagingMemory(mem_req2.memoryRequirements, staging_tensor_.mem);
-    if (result != VK_SUCCESS)
+    const bool memory_type_is_compatible =
+        (staging_tensor_.mem.memory_type_index < VK_MAX_MEMORY_TYPES) &&
+        ((mem_req2.memoryRequirements.memoryTypeBits & (1U << staging_tensor_.mem.memory_type_index)) != 0);
+
+    if ((mem_req2.memoryRequirements.size > staging_tensor_.mem.size) || !memory_type_is_compatible)
     {
-        DestroyStagingTensor();
-        return result;
+        DestroyStagingTensorMemory();
+
+        uint32_t memory_type_index = std::numeric_limits<uint32_t>::max();
+        bool     found             = FindTensorStagingMemoryTypeIndex(*memory_properties_,
+                                                      mem_req2.memoryRequirements.memoryTypeBits,
+                                                      &memory_type_index,
+                                                      &staging_tensor_.mem.memory_property_flags);
+        if (!found)
+        {
+            GFXRECON_LOG_ERROR("Failed to find host-visible memory for staging tensor");
+            DestroyStagingTensor();
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+
+        VkMemoryAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
+        alloc_info.pNext                = nullptr;
+        alloc_info.allocationSize       = mem_req2.memoryRequirements.size;
+        alloc_info.memoryTypeIndex      = memory_type_index;
+
+        result = device_table_.AllocateMemory(device_, &alloc_info, nullptr, &staging_tensor_.mem.memory);
+        if (result == VK_SUCCESS)
+        {
+            staging_tensor_.mem.size              = mem_req2.memoryRequirements.size;
+            staging_tensor_.mem.memory_type_index = memory_type_index;
+        }
     }
 
-    VkBindTensorMemoryInfoARM bind_info = { VK_STRUCTURE_TYPE_BIND_TENSOR_MEMORY_INFO_ARM };
-    bind_info.tensor                    = staging_tensor_.tensor;
-    bind_info.memory                    = staging_tensor_.mem.memory;
-    bind_info.memoryOffset              = 0;
-    result                              = device_table_.BindTensorMemoryARM(device_, 1, &bind_info);
-    if (result != VK_SUCCESS)
+    if (result == VK_SUCCESS)
     {
-        DestroyStagingTensor();
-        return result;
+        VkBindTensorMemoryInfoARM bind_info = { VK_STRUCTURE_TYPE_BIND_TENSOR_MEMORY_INFO_ARM };
+        bind_info.tensor                    = staging_tensor_.tensor;
+        bind_info.memory                    = staging_tensor_.mem.memory;
+        bind_info.memoryOffset              = 0;
+        result                              = device_table_.BindTensorMemoryARM(device_, 1, &bind_info);
     }
 
-    staging_tensor_.mem.size = mem_req2.memoryRequirements.size;
-    return VK_SUCCESS;
+    if (result != VK_SUCCESS)
+    {
+        GFXRECON_LOG_ERROR("Failed to allocate or bind staging tensor memory for resource memory snapshot");
+        DestroyStagingTensor();
+        DestroyStagingTensorMemory();
+    }
+
+    return result;
 }
 
 void VulkanResourcesUtil::DestroyStagingTensor()
@@ -1246,13 +1331,19 @@ void VulkanResourcesUtil::DestroyStagingTensor()
         device_table_.DestroyTensorARM(device_, staging_tensor_.tensor, nullptr);
         staging_tensor_.tensor = VK_NULL_HANDLE;
     }
+}
 
+void VulkanResourcesUtil::DestroyStagingTensorMemory()
+{
     if (staging_tensor_.mem.memory != VK_NULL_HANDLE)
     {
         device_table_.FreeMemory(device_, staging_tensor_.mem.memory, nullptr);
+        staging_tensor_.mem.memory = VK_NULL_HANDLE;
     }
 
-    staging_tensor_.mem = StagingMemoryContext{};
+    staging_tensor_.mem.memory_property_flags = VkMemoryPropertyFlags(0);
+    staging_tensor_.mem.memory_type_index     = std::numeric_limits<uint32_t>::max();
+    staging_tensor_.mem.size                  = 0;
 }
 
 VkCommandBuffer VulkanResourcesUtil::CreateCommandBufferAndBegin(uint32_t queue_family_index)
@@ -2758,6 +2849,22 @@ VkResult VulkanResourcesUtil::ReadFromTensorResource(VkTensorARM                
                                                      std::vector<uint8_t>&         data)
 {
     GFXRECON_ASSERT(tensor != VK_NULL_HANDLE);
+    GFXRECON_ASSERT(desc != nullptr);
+
+    if (desc == nullptr)
+    {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    constexpr VkFormatFeatureFlags2 required_features =
+        VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT;
+    if (!TensorFormatSupportsFeatures(&instance_table_, physical_device_, desc, required_features))
+    {
+        GFXRECON_LOG_WARNING(
+            "Skipping tensor resource snapshot: format does not support tensor transfer source and destination "
+            "operations for the requested tiling");
+        return VK_ERROR_FEATURE_NOT_PRESENT;
+    }
 
     const VkQueue queue = GetQueue(queue_family_index, 0);
     if (queue == VK_NULL_HANDLE)
@@ -2765,7 +2872,6 @@ VkResult VulkanResourcesUtil::ReadFromTensorResource(VkTensorARM                
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
-    // Create a host-visible staging tensor with the same shape but TRANSFER_DST usage.
     VkTensorDescriptionARM staging_desc = *desc;
     staging_desc.usage                  = VK_TENSOR_USAGE_TRANSFER_DST_BIT_ARM;
 
@@ -2776,6 +2882,7 @@ VkResult VulkanResourcesUtil::ReadFromTensorResource(VkTensorARM                
     }
 
     VkCommandBuffer command_buffer = CreateCommandBufferAndBegin(queue_family_index);
+    GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
     if (command_buffer == VK_NULL_HANDLE)
     {
         return VK_ERROR_UNKNOWN;

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -382,6 +382,59 @@ bool FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properti
     return found;
 }
 
+bool FindTensorStagingMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properties,
+                                      uint32_t                                memory_type_bits,
+                                      uint32_t*                               found_index,
+                                      VkMemoryPropertyFlags*                  found_flags)
+{
+    constexpr VkMemoryPropertyFlags kHostVisibleCached =
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+    constexpr VkMemoryPropertyFlags kHostVisibleCoherent =
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+
+    return FindMemoryTypeIndex(memory_properties, memory_type_bits, kHostVisibleCached, found_index, found_flags) ||
+           FindMemoryTypeIndex(memory_properties, memory_type_bits, kHostVisibleCoherent, found_index, found_flags) ||
+           FindMemoryTypeIndex(
+               memory_properties, memory_type_bits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, found_index, found_flags);
+}
+
+bool TensorFormatHasFeatures(const VkTensorFormatPropertiesARM& tensor_properties,
+                             VkTensorTilingARM                  tiling,
+                             VkFormatFeatureFlags2              required_features)
+{
+    VkFormatFeatureFlags2 available_features = 0;
+    switch (tiling)
+    {
+        case VK_TENSOR_TILING_OPTIMAL_ARM:
+            available_features = tensor_properties.optimalTilingTensorFeatures;
+            break;
+        case VK_TENSOR_TILING_LINEAR_ARM:
+            available_features = tensor_properties.linearTilingTensorFeatures;
+            break;
+        default:
+            return false;
+    }
+
+    return (required_features != 0) && ((available_features & required_features) == required_features);
+}
+
+bool TensorFormatSupportsFeatures(const VulkanInstanceTable*    instance_table,
+                                  VkPhysicalDevice              physical_device,
+                                  const VkTensorDescriptionARM* description,
+                                  VkFormatFeatureFlags2         required_features)
+{
+    if ((instance_table == nullptr) || (physical_device == VK_NULL_HANDLE) || (description == nullptr))
+    {
+        return false;
+    }
+
+    VkTensorFormatPropertiesARM tensor_properties = { VK_STRUCTURE_TYPE_TENSOR_FORMAT_PROPERTIES_ARM };
+    VkFormatProperties2         format_properties = { VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, &tensor_properties };
+    instance_table->GetPhysicalDeviceFormatProperties2(physical_device, description->format, &format_properties);
+
+    return TensorFormatHasFeatures(tensor_properties, description->tiling, required_features);
+}
+
 // Get the info on target image format. The function returns true if the target format
 // is supported, and returns texel size and other info to the corresponding pointer if the
 // pointer is not nullptr and the image format is supported.
@@ -881,6 +934,7 @@ VulkanResourcesUtil::~VulkanResourcesUtil()
 {
     DestroyStagingBuffer();
     DestroyStagingTensor();
+    DestroyStagingTensorMemory();
 
     for (const auto& [queue_family_index, command_asset] : command_asset_map_)
     {
@@ -1074,7 +1128,8 @@ VkResult VulkanResourcesUtil::AllocateStagingMemory(const VkMemoryRequirements& 
     alloc_info.allocationSize       = requirements.size;
     alloc_info.memoryTypeIndex      = memory_type_index;
 
-    VkResult result = device_table_.AllocateMemory(device_, &alloc_info, nullptr, &ctx.memory);
+    VkResult result       = device_table_.AllocateMemory(device_, &alloc_info, nullptr, &ctx.memory);
+    ctx.memory_type_index = memory_type_index;
     if (result != VK_SUCCESS)
     {
         GFXRECON_LOG_ERROR("Failed to allocate staging memory for resource memory snapshot");
@@ -1215,26 +1270,56 @@ VkResult VulkanResourcesUtil::CreateStagingTensor(const VkTensorDescriptionARM* 
     VkMemoryRequirements2 mem_req2                 = { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2 };
     device_table_.GetTensorMemoryRequirementsARM(device_, &mem_req_info, &mem_req2);
 
-    result = AllocateStagingMemory(mem_req2.memoryRequirements, staging_tensor_.mem);
-    if (result != VK_SUCCESS)
+    const bool memory_type_is_compatible =
+        (staging_tensor_.mem.memory_type_index < VK_MAX_MEMORY_TYPES) &&
+        ((mem_req2.memoryRequirements.memoryTypeBits & (1U << staging_tensor_.mem.memory_type_index)) != 0);
+
+    if ((mem_req2.memoryRequirements.size > staging_tensor_.mem.size) || !memory_type_is_compatible)
     {
-        DestroyStagingTensor();
-        return result;
+        DestroyStagingTensorMemory();
+
+        uint32_t memory_type_index = std::numeric_limits<uint32_t>::max();
+        bool     found             = FindTensorStagingMemoryTypeIndex(*memory_properties_,
+                                                      mem_req2.memoryRequirements.memoryTypeBits,
+                                                      &memory_type_index,
+                                                      &staging_tensor_.mem.memory_property_flags);
+        if (!found)
+        {
+            GFXRECON_LOG_ERROR("Failed to find host-visible memory for staging tensor");
+            DestroyStagingTensor();
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+
+        VkMemoryAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
+        alloc_info.pNext                = nullptr;
+        alloc_info.allocationSize       = mem_req2.memoryRequirements.size;
+        alloc_info.memoryTypeIndex      = memory_type_index;
+
+        result = device_table_.AllocateMemory(device_, &alloc_info, nullptr, &staging_tensor_.mem.memory);
+        if (result == VK_SUCCESS)
+        {
+            staging_tensor_.mem.size              = mem_req2.memoryRequirements.size;
+            staging_tensor_.mem.memory_type_index = memory_type_index;
+        }
     }
 
-    VkBindTensorMemoryInfoARM bind_info = { VK_STRUCTURE_TYPE_BIND_TENSOR_MEMORY_INFO_ARM };
-    bind_info.tensor                    = staging_tensor_.tensor;
-    bind_info.memory                    = staging_tensor_.mem.memory;
-    bind_info.memoryOffset              = 0;
-    result                              = device_table_.BindTensorMemoryARM(device_, 1, &bind_info);
-    if (result != VK_SUCCESS)
+    if (result == VK_SUCCESS)
     {
-        DestroyStagingTensor();
-        return result;
+        VkBindTensorMemoryInfoARM bind_info = { VK_STRUCTURE_TYPE_BIND_TENSOR_MEMORY_INFO_ARM };
+        bind_info.tensor                    = staging_tensor_.tensor;
+        bind_info.memory                    = staging_tensor_.mem.memory;
+        bind_info.memoryOffset              = 0;
+        result                              = device_table_.BindTensorMemoryARM(device_, 1, &bind_info);
     }
 
-    staging_tensor_.mem.size = mem_req2.memoryRequirements.size;
-    return VK_SUCCESS;
+    if (result != VK_SUCCESS)
+    {
+        GFXRECON_LOG_ERROR("Failed to allocate or bind staging tensor memory for resource memory snapshot");
+        DestroyStagingTensor();
+        DestroyStagingTensorMemory();
+    }
+
+    return result;
 }
 
 void VulkanResourcesUtil::DestroyStagingTensor()
@@ -1246,13 +1331,19 @@ void VulkanResourcesUtil::DestroyStagingTensor()
         device_table_.DestroyTensorARM(device_, staging_tensor_.tensor, nullptr);
         staging_tensor_.tensor = VK_NULL_HANDLE;
     }
+}
 
+void VulkanResourcesUtil::DestroyStagingTensorMemory()
+{
     if (staging_tensor_.mem.memory != VK_NULL_HANDLE)
     {
         device_table_.FreeMemory(device_, staging_tensor_.mem.memory, nullptr);
+        staging_tensor_.mem.memory = VK_NULL_HANDLE;
     }
 
-    staging_tensor_.mem = StagingMemoryContext{};
+    staging_tensor_.mem.memory_property_flags = VkMemoryPropertyFlags(0);
+    staging_tensor_.mem.memory_type_index     = std::numeric_limits<uint32_t>::max();
+    staging_tensor_.mem.size                  = 0;
 }
 
 VkCommandBuffer VulkanResourcesUtil::CreateCommandBufferAndBegin(uint32_t queue_family_index)
@@ -2698,6 +2789,22 @@ VkResult VulkanResourcesUtil::ReadFromTensorResource(VkTensorARM                
                                                      std::vector<uint8_t>&         data)
 {
     GFXRECON_ASSERT(tensor != VK_NULL_HANDLE);
+    GFXRECON_ASSERT(desc != nullptr);
+
+    if (desc == nullptr)
+    {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    constexpr VkFormatFeatureFlags2 required_features =
+        VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT;
+    if (!TensorFormatSupportsFeatures(&instance_table_, physical_device_, desc, required_features))
+    {
+        GFXRECON_LOG_WARNING(
+            "Skipping tensor resource snapshot: format does not support tensor transfer source and destination "
+            "operations for the requested tiling");
+        return VK_ERROR_FEATURE_NOT_PRESENT;
+    }
 
     const VkQueue queue = GetQueue(queue_family_index, 0);
     if (queue == VK_NULL_HANDLE)
@@ -2705,7 +2812,6 @@ VkResult VulkanResourcesUtil::ReadFromTensorResource(VkTensorARM                
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
-    // Create a host-visible staging tensor with the same shape but TRANSFER_DST usage.
     VkTensorDescriptionARM staging_desc = *desc;
     staging_desc.usage                  = VK_TENSOR_USAGE_TRANSFER_DST_BIT_ARM;
 
@@ -2716,6 +2822,7 @@ VkResult VulkanResourcesUtil::ReadFromTensorResource(VkTensorARM                
     }
 
     VkCommandBuffer command_buffer = CreateCommandBufferAndBegin(queue_family_index);
+    GFXRECON_ASSERT(command_buffer != VK_NULL_HANDLE);
     if (command_buffer == VK_NULL_HANDLE)
     {
         return VK_ERROR_UNKNOWN;

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <functional>
+#include <limits>
 #include <map>
 #include <optional>
 #include <vulkan/vulkan_core.h>
@@ -258,6 +259,7 @@ class VulkanResourcesUtil
     {
         VkDeviceMemory        memory                = VK_NULL_HANDLE;
         VkDeviceSize          size                  = 0;
+        uint32_t              memory_type_index     = std::numeric_limits<uint32_t>::max();
         VkMemoryPropertyFlags memory_property_flags = VkMemoryPropertyFlags(0);
         void*                 mapped_ptr            = nullptr;
     };
@@ -277,6 +279,7 @@ class VulkanResourcesUtil
 
     VkResult CreateStagingTensor(const VkTensorDescriptionARM* desc);
     void     DestroyStagingTensor();
+    void     DestroyStagingTensorMemory();
 
     void TransitionImageToTransferOptimal(VkCommandBuffer    command_buffer,
                                           VkImage            image,
@@ -411,6 +414,20 @@ bool FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properti
                          VkMemoryPropertyFlags                   desired_flags,
                          uint32_t*                               found_index,
                          VkMemoryPropertyFlags*                  found_flags);
+
+bool FindTensorStagingMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properties,
+                                      uint32_t                                memory_type_bits,
+                                      uint32_t*                               found_index,
+                                      VkMemoryPropertyFlags*                  found_flags);
+
+bool TensorFormatHasFeatures(const VkTensorFormatPropertiesARM& tensor_properties,
+                             VkTensorTilingARM                  tiling,
+                             VkFormatFeatureFlags2              required_features);
+
+bool TensorFormatSupportsFeatures(const VulkanInstanceTable*    instance_table,
+                                  VkPhysicalDevice              physical_device,
+                                  const VkTensorDescriptionARM* description,
+                                  VkFormatFeatureFlags2         required_features);
 
 struct VkOffset3DComparator
 {

--- a/tools/compress/compression_converter.cpp
+++ b/tools/compress/compression_converter.cpp
@@ -477,6 +477,41 @@ decode::FileTransformer::VisitResult CompressionConverter::WriteMetaData(const d
     return kSuccess;
 }
 
+decode::FileTransformer::VisitResult CompressionConverter::WriteMetaData(const decode::InitTensorArgs& args)
+{
+    GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitTensorCommand);
+
+    format::InitTensorCommandHeader init_cmd;
+
+    init_cmd.thread_id = args.thread_id;
+    init_cmd.device_id = args.device_id;
+    init_cmd.tensor_id = args.tensor_id;
+    init_cmd.data_size = args.data_size;
+
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, init_cmd.data_size);
+    size_t         data_size    = static_cast<size_t>(init_cmd.data_size);
+    const uint8_t* data_address = args.data;
+
+    PrepMetadataBlock(init_cmd.meta_header, args.meta_data_id, data_address, data_size);
+
+    // Calculate size of packet with compressed or uncompressed data size.
+    init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + data_size;
+
+    if (!WriteBytes(&init_cmd, sizeof(init_cmd)))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockHeader, "Failed to write init tensor meta-data block header");
+        return kError;
+    }
+
+    if (!WriteBytes(data_address, data_size))
+    {
+        HandleBlockWriteError(decode::kErrorWritingBlockData, "Failed to write init tensor meta-data block");
+        return kError;
+    }
+
+    return kSuccess;
+}
+
 decode::FileTransformer::VisitResult CompressionConverter::WriteMetaData(const decode::InitSubresourceArgs& args)
 {
     GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitSubresourceCommand);

--- a/tools/compress/compression_converter.h
+++ b/tools/compress/compression_converter.h
@@ -67,6 +67,7 @@ class CompressionConverter : public decode::FileTransformer
     VisitResult WriteMetaData(const decode::FillMemoryArgs& args);
     VisitResult WriteMetaData(const decode::InitBufferArgs& args);
     VisitResult WriteMetaData(const decode::InitImageArgs& args);
+    VisitResult WriteMetaData(const decode::InitTensorArgs& args);
     VisitResult WriteMetaData(const decode::InitSubresourceArgs& args);
     VisitResult WriteMetaData(const decode::InitDx12AccelerationStructureArgs& args);
     VisitResult WriteMetaData(const decode::FillMemoryResourceValueArgs& args);

--- a/tools/optimize/file_optimizer.cpp
+++ b/tools/optimize/file_optimizer.cpp
@@ -124,6 +124,24 @@ decode::FileTransformer::VisitResult FileOptimizer::FilterMetaData(const decode:
     return kNeedsPassthrough;
 }
 
+decode::FileTransformer::VisitResult FileOptimizer::FilterMetaData(const decode::InitTensorArgs& args)
+{
+    GFXRECON_ASSERT(format::GetMetaDataType(args.meta_data_id) == format::MetaDataType::kInitTensorCommand);
+
+    // If the tensor is in the unused list, omit its initialization data from the file.
+    if (unreferenced_ids_.find(args.tensor_id) != unreferenced_ids_.end())
+    {
+        // In its place insert a dummy annotation meta command. This should keep the block index when
+        // replaying an optimized trimmed capture in in alignment with the block index calculated
+        // at capture time
+        return WriteAnnotation(format::kAnnotationLabelRemovedResource,
+                               "Removed subresource from tensor " + std::to_string(args.tensor_id))
+                   ? kSuccess
+                   : kError;
+    }
+    return kNeedsPassthrough;
+}
+
 // Returns whether to filter this MethodCall block or not
 bool FileOptimizer::FilterMethodCall(const decode::MethodCallArgs& args) const
 {

--- a/tools/optimize/file_optimizer.h
+++ b/tools/optimize/file_optimizer.h
@@ -47,6 +47,7 @@ class FileOptimizer : public decode::FileTransformer
   private:
     VisitResult FilterMetaData(const decode::InitBufferArgs& args);
     VisitResult FilterMetaData(const decode::InitImageArgs& args);
+    VisitResult FilterMetaData(const decode::InitTensorArgs& args);
 
     template <typename Args>
     VisitResult FilterMetaData(const Args& args)


### PR DESCRIPTION
Change fills gaps in tensor and datagraph support across the codebase
* Support for staging snapshots for tensor trimming
* Better support for multi-bind datagraph pipeline sessions in trim and rebind replay
* Add tensor support for convert and optimize tools
