### PR TITLE
[Frame Looping] Basic timestamp query handling

### DIFF
--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -297,6 +297,18 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyFence(const ApiCallInfo& ca
     }
 }
 
+void VulkanReplayFrameLoopConsumer::Process_vkCmdWriteTimestamp(const ApiCallInfo&       call_info,
+                                                                args::CmdWriteTimestamp& args)
+{
+    if (frame_loop_info_.IsRepetition())
+    {
+        // Skip writing timestamps during repetition to avoid "query not reset" errors
+        // if the capture doesn't reset them in the frame.
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdWriteTimestamp(call_info, args);
+}
+
 void VulkanReplayFrameLoopConsumer::TrackFenceState(format::HandleId device, format::HandleId fence)
 {
     // If fence hasn't been seen yet, check and store the state it is in.

--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -452,6 +452,31 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroyDescriptorPool(const ApiCal
     }
 }
 
+void VulkanReplayFrameLoopConsumer::Process_vkBeginCommandBuffer(const ApiCallInfo&        call_info,
+                                                                 args::BeginCommandBuffer& args)
+{
+    VulkanReplayConsumer::Process_vkBeginCommandBuffer(call_info, args);
+
+    if (frame_loop_info_.IsLooping())
+    {
+        // Record query pool reset commands
+        VulkanCommandBufferInfo* cb_info       = GetObjectInfoTable().GetVkCommandBufferInfo(args.commandBuffer);
+        format::HandleId         device        = cb_info->parent_id;
+        VkDevice                 replay_device = GetObjectInfoTable().GetVkDeviceInfo(device)->handle;
+        GFXRECON_ASSERT(replay_device != 0);
+        GetObjectInfoTable().VisitVkQueryPoolInfo([this, replay_device, cb_info](const VulkanQueryPoolInfo* info) {
+            GFXRECON_ASSERT(query_pool_sizes_.contains(info->capture_id));
+            const graphics::VulkanDeviceTable* device_table = GetDeviceTable(replay_device);
+            GFXRECON_ASSERT(device_table != nullptr);
+            VkQueryPool pool_handle = info->handle;
+            uint32_t    pool_size   = query_pool_sizes_[info->capture_id];
+            GFXRECON_LOG_DEBUG(
+                "Resetting pool 0x%" PRIx64 " (replay time handle == 0x%" PRIx64 ")", info->handle, info->capture_id);
+            device_table->CmdResetQueryPool(cb_info->handle, pool_handle, 0, pool_size);
+        });
+    }
+}
+
 void VulkanReplayFrameLoopConsumer::RemovePoolDanglingCreateDescriptors(format::HandleId descriptorPool)
 {
     std::vector<format::HandleId> handles_to_delete;
@@ -786,6 +811,20 @@ void VulkanReplayFrameLoopConsumer::Process_vkDestroySemaphore(const ApiCallInfo
     }
 
     VulkanReplayFrameLoopConsumerBase::Process_vkDestroySemaphore(call_info, args);
+}
+
+void VulkanReplayFrameLoopConsumer::Process_vkCreateQueryPool(const ApiCallInfo& call_info, args::CreateQueryPool& args)
+{
+    VulkanReplayFrameLoopConsumerBase::Process_vkCreateQueryPool(call_info, args);
+
+    if (!frame_loop_info_.IsLooping() || (frame_loop_info_.IsLooping() && !frame_loop_info_.IsRepetition()))
+    {
+        // If this query pool was created outside the loop range or if it's the first iteration
+        // of the loop range, save query pool creation sizes
+        uint32_t               count  = args.pCreateInfo.GetPointer()->queryCount;
+        const format::HandleId handle = *args.pQueryPool.GetPointer();
+        query_pool_sizes_[handle]     = count;
+    }
 }
 
 void VulkanReplayFrameLoopConsumer::Process_vkMapMemory(const ApiCallInfo& call_info, args::MapMemory& args)

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -47,6 +47,8 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
 
     void Process_vkCreateCommandPool(const ApiCallInfo& call_info, args::CreateCommandPool& args) override;
 
+    void Process_vkBeginCommandBuffer(const ApiCallInfo& call_info, args::BeginCommandBuffer& args) override;
+
     void Process_vkDestroyDescriptorPool(const ApiCallInfo& call_info, args::DestroyDescriptorPool& args) override;
 
     void Process_vkResetDescriptorPool(const ApiCallInfo& call_info, args::ResetDescriptorPool& args) override;
@@ -67,6 +69,9 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
 
     void Process_vkQueueSubmit(const ApiCallInfo& call_info, args::QueueSubmit& args) override;
     void Process_vkQueueSubmit2KHR(const ApiCallInfo& call_info, args::QueueSubmit2KHR& args) override;
+
+    void Process_vkCreateQueryPool(const ApiCallInfo& call_info, args::CreateQueryPool& args) override;
+
     void Process_vkQueueSubmit2(const ApiCallInfo& call_info, args::QueueSubmit2& args) override;
 
     void Process_vkCreateSemaphore(const ApiCallInfo& call_info, args::CreateSemaphore& args) override;
@@ -171,8 +176,11 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
     std::unordered_set<format::HandleId> dangling_create_descriptor_sets_;
     std::unordered_set<format::HandleId> dangling_destroy_descriptor_sets_;
 
-    std::unordered_map<format::HandleId, FenceTracking>     per_device_fence_tracking_;
     std::unordered_map<format::HandleId, SemaphoreTracking> per_device_semaphore_tracking_;
+
+    std::unordered_map<format::HandleId, uint32_t> query_pool_sizes_;
+
+    std::unordered_map<format::HandleId, FenceTracking> per_device_fence_tracking_;
 
     std::unordered_set<format::HandleId>                host_visible_events_;
     std::unordered_map<format::HandleId, EventTracking> per_device_event_tracking_;

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -69,6 +69,8 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
 
     void Process_vkQueueSubmit2(const ApiCallInfo& call_info, args::QueueSubmit2& args) override;
 
+    void Process_vkCmdWriteTimestamp(const ApiCallInfo& call_info, args::CmdWriteTimestamp& args) override;
+
     void Process_vkQueuePresentKHR(const ApiCallInfo& call_info, args::QueuePresentKHR& args) override;
 
     void Process_vkMapMemory(const ApiCallInfo& call_info, args::MapMemory& args) override;


### PR DESCRIPTION
This PR allows frame looping to handle `vkCmdWriteTimestamp` by omitting calls to it during loop repetitions.