### PR TITLE
Support VK_EXT_device_memory_report

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3485,6 +3485,17 @@ void VulkanReplayConsumerBase::ModifyCreateDeviceInfo(
         }
     }
 
+    // Remove VK_EXT_device_memory_report callback structures if set.
+    // The callbacks cannot be restored anyway, so the easiest is to remove them entirely
+    if (graphics::vulkan_struct_remove_pnext<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT>(&modified_create_info))
+    {
+        GFXRECON_LOG_WARNING("VkPhysicalDeviceDeviceMemoryReportFeaturesEXT was removed at device creation");
+    }
+    while (graphics::vulkan_struct_remove_pnext<VkDeviceDeviceMemoryReportCreateInfoEXT>(&modified_create_info))
+    {
+        GFXRECON_LOG_WARNING("VkDeviceDeviceMemoryReportCreateInfoEXT callback was removed at device creation");
+    }
+
     // Sanity checks depending on extension availability
     std::vector<VkExtensionProperties> available_extensions;
     if (graphics::feature_util::GetDeviceExtensions(

--- a/framework/graphics/vulkan_feature_util.cpp
+++ b/framework/graphics/vulkan_feature_util.cpp
@@ -45,7 +45,7 @@ GFXRECON_BEGIN_NAMESPACE(feature_util)
 std::set<std::string> kIgnorableExtensions = {
     VK_EXT_TOOLING_INFO_EXTENSION_NAME,   VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
     "VK_ANDROID_frame_boundary",          "VK_EXT_frame_boundary",
-    VK_EXT_LAYER_SETTINGS_EXTENSION_NAME,
+    VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME,
 };
 
 VkResult GetInstanceLayers(PFN_vkEnumerateInstanceLayerProperties instance_layer_proc,


### PR DESCRIPTION
The extension allows to set up a callback at device creation time. This commit propose to simply remove the callback at replay time, as it is not possible to restore the same callback, and a NULL callback is not allowed.

The current behavior is a SEGFAULT when the driver tries to call the NULL callback.
