### PR TITLE
Fix macOS build with SDK installed for SPIRV-Headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,19 +420,20 @@ if(MSVC)
 endif()
 
 add_library(vulkan_registry INTERFACE)
+add_library(spirv_registry INTERFACE)
 if (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang)
     # AppleClang implicitly adds /usr/local/include as a -I path, which takes precedence
     # over -isystem paths. Add external/Vulkan-Headers as a normal -I path for the correct
     # search order, then use --system-header-prefix to treat it as a system header for warnings
     target_include_directories(vulkan_registry INTERFACE ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include)
     target_compile_options(vulkan_registry INTERFACE --system-header-prefix vulkan/)
+    target_include_directories(spirv_registry INTERFACE ${PROJECT_SOURCE_DIR}/external/SPIRV-Headers/include)
 else ()
     target_include_directories(vulkan_registry SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include)
+    target_include_directories(spirv_registry SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/external/SPIRV-Headers/include)
 endif()
 target_compile_definitions(vulkan_registry INTERFACE VK_NO_PROTOTYPES VK_ENABLE_BETA_EXTENSIONS)
 
-add_library(spirv_registry INTERFACE)
-target_include_directories(spirv_registry SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/external/SPIRV-Headers/include)
 
 add_library(OpenXR INTERFACE)
 if (OPENXR_SUPPORT_ENABLED)


### PR DESCRIPTION
Extends the fix from #2878 to not set SPIRV-Headers as a SYSTEM include. Explanation: Due to a quirk in AppleClang, the header include order was incorrect and used SPIRV headers in /usr/local/include from the system global SDK install instead of the local copy in external/SPIRV-Headers/include.

Fixes #2296

Is an alternative solution for PR #3169 (I didn't see it when creating this PR).