### PR TITLE
android: Remove deprecated code

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -14,3 +14,10 @@ org.gradle.jvmargs=-Xmx1536m
 
 
 android.useAndroidX=true
+
+# Common Android/NDK versions shared by all modules in this build.
+# Update here instead of in each module's build.gradle.
+GFXR_COMPILE_SDK_VERSION=34
+GFXR_MIN_SDK_VERSION=26
+GFXR_TARGET_SDK_VERSION=33
+GFXR_NDK_VERSION=26.3.11579264

--- a/android/layer/build.gradle
+++ b/android/layer/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion GFXR_COMPILE_SDK_VERSION.toInteger()
     namespace = 'com.lunarg.gfxreconstruct.layer'
-    ndkVersion = '26.3.11579264'
+    ndkVersion = GFXR_NDK_VERSION
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion GFXR_MIN_SDK_VERSION.toInteger()
         ndk {
             if (providers.gradleProperty("armeabi-v7a").present) {
                 abiFilters 'armeabi-v7a'

--- a/android/test/test_apps/launcher/build.gradle
+++ b/android/test/test_apps/launcher/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion GFXR_COMPILE_SDK_VERSION.toInteger()
     namespace = 'com.lunarg.gfxreconstruct.test.test_apps.test_launcher'
-    ndkVersion = '26.3.11579264'
+    ndkVersion = GFXR_NDK_VERSION
     defaultConfig {
         applicationId "com.lunarg.gfxreconstruct.test.test_apps.test_launcher"
-        minSdkVersion 26
-        targetSdkVersion 33
+        minSdkVersion GFXR_MIN_SDK_VERSION.toInteger()
+        targetSdkVersion GFXR_TARGET_SDK_VERSION.toInteger()
         versionCode 1
         versionName "1.0"
         ndk {

--- a/android/tools/multi-win-replay/build.gradle
+++ b/android/tools/multi-win-replay/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion GFXR_COMPILE_SDK_VERSION.toInteger()
     namespace = 'com.lunarg.gfxreconstruct.replay'
-    ndkVersion = '26.3.11579264'
+    ndkVersion = GFXR_NDK_VERSION
     defaultConfig {
         applicationId "com.lunarg.gfxreconstruct.replay"
-        minSdkVersion 26
-        targetSdkVersion 33
+        minSdkVersion GFXR_MIN_SDK_VERSION.toInteger()
+        targetSdkVersion GFXR_TARGET_SDK_VERSION.toInteger()
         versionCode 1
         versionName "1.0"
         ndk {

--- a/android/tools/quest_replay/build.gradle
+++ b/android/tools/quest_replay/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion GFXR_COMPILE_SDK_VERSION.toInteger()
     namespace = 'com.lunarg.gfxreconstruct.replay'
-    ndkVersion = '26.3.11579264'
+    ndkVersion = GFXR_NDK_VERSION
     defaultConfig {
         applicationId "com.lunarg.gfxreconstruct.replay"
-        minSdkVersion 26
-        targetSdkVersion 33
+        minSdkVersion GFXR_MIN_SDK_VERSION.toInteger()
+        targetSdkVersion GFXR_TARGET_SDK_VERSION.toInteger()
         versionCode 1
         versionName "1.0"
         ndk {

--- a/android/tools/replay/build.gradle
+++ b/android/tools/replay/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion GFXR_COMPILE_SDK_VERSION.toInteger()
     namespace = 'com.lunarg.gfxreconstruct.replay'
-    ndkVersion = '26.3.11579264'
+    ndkVersion = GFXR_NDK_VERSION
     defaultConfig {
         applicationId "com.lunarg.gfxreconstruct.replay"
-        minSdkVersion 26
-        targetSdkVersion 33
+        minSdkVersion GFXR_MIN_SDK_VERSION.toInteger()
+        targetSdkVersion GFXR_TARGET_SDK_VERSION.toInteger()
         versionCode 1
         versionName "1.0"
         ndk {

--- a/framework/application/android_context.cpp
+++ b/framework/application/android_context.cpp
@@ -43,38 +43,40 @@ void AndroidContext::ProcessEvents(bool wait_for_input)
 {
     assert(application_);
     assert(android_app_);
-    // Process all pending events.
+
+    // Process all pending events. The first poll blocks when waiting for input; subsequent polls only drain events
+    // that are already pending.
     for (;;)
     {
-        int                         result = 0;
-        int                         events = 0;
-        struct android_poll_source* source = nullptr;
+        int                         events  = 0;
+        struct android_poll_source* source  = nullptr;
+        const int                   timeout = wait_for_input ? -1 : 0;
 
-        if (wait_for_input)
+        const int result = ALooper_pollOnce(timeout, nullptr, &events, reinterpret_cast<void**>(&source));
+        wait_for_input   = false;
+
+        // Unlike the deprecated ALooper_pollAll(), ALooper_pollOnce() returns to the caller after dispatching an event
+        // to a registered looper callback.
+        if (result == ALOOPER_POLL_CALLBACK)
         {
-            result         = ALooper_pollAll(-1, nullptr, &events, reinterpret_cast<void**>(&source));
-            wait_for_input = false;
-        }
-        else
-        {
-            result = ALooper_pollAll(0, nullptr, &events, reinterpret_cast<void**>(&source));
+            continue;
         }
 
-        if (result >= 0)
+        // ALOOPER_POLL_WAKE, ALOOPER_POLL_TIMEOUT, and ALOOPER_POLL_ERROR all indicate that there is no event for this
+        // thread to process.
+        if (result < 0)
         {
-            if (source)
-            {
-                source->process(android_app_, source);
-            }
-
-            if (android_app_->destroyRequested != 0)
-            {
-                application_->StopRunning();
-                break;
-            }
+            break;
         }
-        else
+
+        if (source != nullptr)
         {
+            source->process(android_app_, source);
+        }
+
+        if (android_app_->destroyRequested != 0)
+        {
+            application_->StopRunning();
             break;
         }
     }

--- a/framework/application/android_context.cpp
+++ b/framework/application/android_context.cpp
@@ -43,38 +43,43 @@ void AndroidContext::ProcessEvents(bool wait_for_input)
 {
     assert(application_);
     assert(android_app_);
-    // Process all pending events.
+
+    // Process all pending events. The first poll blocks when waiting for input; subsequent polls only drain events
+    // that are already pending.
     for (;;)
     {
-        int                         result = 0;
-        int                         events = 0;
-        struct android_poll_source* source = nullptr;
+        int                         events  = 0;
+        struct android_poll_source* source  = nullptr;
+        const int                   timeout = wait_for_input ? -1 : 0;
 
-        if (wait_for_input)
+        const int result = ALooper_pollOnce(timeout, nullptr, &events, reinterpret_cast<void**>(&source));
+
+        // Any ALooper_pollOnce() result may also indicate an ALooper_wake(), so never block a second time in this
+        // loop.  Re-blocking would swallow the wake.
+        wait_for_input = false;
+
+        // Unlike the deprecated ALooper_pollAll(), ALooper_pollOnce() returns to the caller after dispatching an event
+        // to a registered looper callback.
+        if (result == ALOOPER_POLL_CALLBACK)
         {
-            result         = ALooper_pollAll(-1, nullptr, &events, reinterpret_cast<void**>(&source));
-            wait_for_input = false;
-        }
-        else
-        {
-            result = ALooper_pollAll(0, nullptr, &events, reinterpret_cast<void**>(&source));
+            continue;
         }
 
-        if (result >= 0)
+        // ALOOPER_POLL_WAKE, ALOOPER_POLL_TIMEOUT, and ALOOPER_POLL_ERROR all indicate that there is no event for this
+        // thread to process.
+        if (result < 0)
         {
-            if (source)
-            {
-                source->process(android_app_, source);
-            }
-
-            if (android_app_->destroyRequested != 0)
-            {
-                application_->StopRunning();
-                break;
-            }
+            break;
         }
-        else
+
+        if (source != nullptr)
         {
+            source->process(android_app_, source);
+        }
+
+        if (android_app_->destroyRequested != 0)
+        {
+            application_->StopRunning();
             break;
         }
     }

--- a/framework/util/android/activity.cpp
+++ b/framework/util/android/activity.cpp
@@ -36,7 +36,14 @@ void DestroyActivity(struct android_app* app)
     {
         struct android_poll_source* source = nullptr;
         int                         events = 0;
-        int                         result = ALooper_pollAll(-1, nullptr, &events, reinterpret_cast<void**>(&source));
+        int                         result = ALooper_pollOnce(-1, nullptr, &events, reinterpret_cast<void**>(&source));
+
+        // Unlike the deprecated ALooper_pollAll(), ALooper_pollOnce() returns to the caller after dispatching an event
+        // to a registered looper callback.  APP_CMD_DESTROY has not been received yet, so keep polling.
+        if (result == ALOOPER_POLL_CALLBACK)
+        {
+            continue;
+        }
 
         if ((result >= 0) && (source))
         {

--- a/framework/util/android/activity.cpp
+++ b/framework/util/android/activity.cpp
@@ -22,27 +22,53 @@
 
 #include "util/android/activity.h"
 
+#include "util/logging.h"
+
 #include <android_native_app_glue.h>
+
+#include <chrono>
+#include <cinttypes>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
+
+// Maximum amount of time to wait for APP_CMD_DESTROY before giving up and continuing with shutdown.
+constexpr std::chrono::milliseconds kDestroyTimeout{ 5000 };
 
 void DestroyActivity(struct android_app* app)
 {
     ANativeActivity_finish(app->activity);
 
-    // Wait for APP_CMD_DESTROY
+    // Wait for APP_CMD_DESTROY. The wait is bounded because this runs during final shutdown: if the command never
+    // arrives, shutdown must continue instead of hanging the process.
+    const auto deadline = std::chrono::steady_clock::now() + kDestroyTimeout;
+
     while (app->destroyRequested == 0)
     {
+        // ALooper_pollOnce() takes a whole number of milliseconds, so the remainder of the wait is truncated to that
+        // resolution.  A sub-millisecond remainder truncates to zero and ends the wait, which is the intent.
+        const std::chrono::milliseconds remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
+
+        if (remaining <= std::chrono::milliseconds::zero())
+        {
+            GFXRECON_LOG_WARNING("Timed out after %" PRId64 " ms waiting for APP_CMD_DESTROY; continuing with shutdown",
+                                 static_cast<int64_t>(kDestroyTimeout.count()));
+            break;
+        }
+
         struct android_poll_source* source = nullptr;
         int                         events = 0;
-        const int                   result = ALooper_pollOnce(-1, nullptr, &events, reinterpret_cast<void**>(&source));
+        const int                   result =
+            ALooper_pollOnce(static_cast<int>(remaining.count()), nullptr, &events, reinterpret_cast<void**>(&source));
 
         // An event dispatched to a registered looper callback, an ALooper_wake(), or a file descriptor with no
-        // android_poll_source all mean APP_CMD_DESTROY has not been received yet, so keep polling.  Only
-        // ALOOPER_POLL_ERROR is unrecoverable.
+        // android_poll_source all mean APP_CMD_DESTROY has not been received yet, so keep polling until the deadline
+        // expires.  Only ALOOPER_POLL_ERROR is unrecoverable.
         if (result == ALOOPER_POLL_ERROR)
         {
+            GFXRECON_LOG_WARNING("ALooper_pollOnce() failed while waiting for APP_CMD_DESTROY; continuing with "
+                                 "shutdown");
             break;
         }
 

--- a/framework/util/android/activity.cpp
+++ b/framework/util/android/activity.cpp
@@ -36,15 +36,19 @@ void DestroyActivity(struct android_app* app)
     {
         struct android_poll_source* source = nullptr;
         int                         events = 0;
-        int                         result = ALooper_pollAll(-1, nullptr, &events, reinterpret_cast<void**>(&source));
+        const int                   result = ALooper_pollOnce(-1, nullptr, &events, reinterpret_cast<void**>(&source));
 
-        if ((result >= 0) && (source))
-        {
-            source->process(app, source);
-        }
-        else
+        // An event dispatched to a registered looper callback, an ALooper_wake(), or a file descriptor with no
+        // android_poll_source all mean APP_CMD_DESTROY has not been received yet, so keep polling.  Only
+        // ALOOPER_POLL_ERROR is unrecoverable.
+        if (result == ALOOPER_POLL_ERROR)
         {
             break;
+        }
+
+        if (source != nullptr)
+        {
+            source->process(app, source);
         }
     }
 }

--- a/test/test_apps/common/test_app_base.cpp
+++ b/test/test_apps/common/test_app_base.cpp
@@ -2841,7 +2841,7 @@ void device_initialization_phase_1(application::Application& app, InitInfo& init
         {
             int                         events = 0;
             struct android_poll_source* source = nullptr;
-            int result = ALooper_pollAll(-1, nullptr, &events, reinterpret_cast<void**>(&source));
+            int result = ALooper_pollOnce(-1, nullptr, &events, reinterpret_cast<void**>(&source));
             if (result >= 0 && source)
             {
                 source->process(init.android_app, source);

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -155,9 +155,9 @@ void android_main(struct android_app* app)
 
     GFXRECON_WRITE_CONSOLE("====== Exiting android_main");
 
-    gfxrecon::util::Log::Release();
-
     gfxrecon::util::DestroyActivity(app);
+
+    gfxrecon::util::Log::Release();
 
     raise(SIGTERM);
 }


### PR DESCRIPTION
Use `ALooper_pollOnce` instead of `ALooper_pollAll`.
`ALooper_pollAll` is removed in NDK versions >26.
Removing the deprecated code allows gfxreconstruct to be built with
newer compilers in newer NDKs.

This also contains a change from @MarkY-LunarG to consolidate which NDK version gfxreconstruct uses, rather than having the same NDK version copy/pasted for each gradle project.

This change was built locally with NDK 30.0.14904198, but not heavily tested.