### PR TITLE
Fix Wayland replay size when fractional scaling is enabled on a monitor

### DIFF
--- a/framework/application/wayland_context.cpp
+++ b/framework/application/wayland_context.cpp
@@ -37,7 +37,7 @@ struct wl_keyboard_listener WaylandContext::keyboard_listener_;
 struct wl_seat_listener     WaylandContext::seat_listener_;
 struct wl_registry_listener WaylandContext::registry_listener_;
 struct wl_output_listener   WaylandContext::output_listener_;
-struct xdg_wm_base_listener WaylandContext::xdg_wm_base_listener_;
+util::XdgWmBaseListener     WaylandContext::xdg_wm_base_listener_;
 
 WaylandContext::WaylandContext(Application* application) : WsiContext(application)
 {
@@ -143,6 +143,16 @@ WaylandContext::~WaylandContext()
         wl.xdg->xdg_wm_base_destroy(xdg_wm_base_);
     }
 
+    if (fractional_scale_manager_)
+    {
+        wl.frac_scale->wp_fractional_scale_manager_v1_destroy(fractional_scale_manager_);
+    }
+
+    if (viewporter_)
+    {
+        wl.viewporter->wp_viewporter_destroy(viewporter_);
+    }
+
     if (compositor_)
     {
         wl.compositor_destroy(compositor_);
@@ -220,8 +230,19 @@ void WaylandContext::HandleRegistryGlobal(
     else if (util::platform::StringCompare(interface, wl.xdg->xdg_wm_base_interface.name) == 0)
     {
         wayland_context->xdg_wm_base_ =
-            reinterpret_cast<xdg_wm_base*>(wl.registry_bind(registry, id, &wl.xdg->xdg_wm_base_interface, 1));
+            reinterpret_cast<util::XdgWmBase*>(wl.registry_bind(registry, id, &wl.xdg->xdg_wm_base_interface, 1));
         wl.xdg->xdg_wm_base_add_listener(wayland_context->xdg_wm_base_, &xdg_wm_base_listener_, wayland_context);
+    }
+    else if (util::platform::StringCompare(interface, wl.viewporter->wp_viewporter_interface.name) == 0)
+    {
+        wayland_context->viewporter_ = reinterpret_cast<util::WpViewporter*>(
+            wl.registry_bind(registry, id, &wl.viewporter->wp_viewporter_interface, 1));
+    }
+    else if (util::platform::StringCompare(interface, wl.frac_scale->wp_fractional_scale_manager_v1_interface.name) ==
+             0)
+    {
+        wayland_context->fractional_scale_manager_ = reinterpret_cast<util::WpFractionalScaleManagerV1*>(
+            wl.registry_bind(registry, id, &wl.frac_scale->wp_fractional_scale_manager_v1_interface, 1));
     }
     else if (util::platform::StringCompare(interface, wl.seat_interface->name) == 0)
     {
@@ -419,7 +440,7 @@ void WaylandContext::HandleOutputScale(void* data, struct wl_output* wl_output, 
     output_info.scale     = factor;
 }
 
-void WaylandContext::HandleXdgWmBasePing(void* data, struct xdg_wm_base* xdg_wm_base, uint32_t serial)
+void WaylandContext::HandleXdgWmBasePing(void* data, util::XdgWmBase* xdg_wm_base, uint32_t serial)
 {
     auto& wl = reinterpret_cast<WaylandContext*>(data)->GetWaylandFunctionTable();
     wl.xdg->xdg_wm_base_pong(xdg_wm_base, serial);

--- a/framework/application/wayland_context.h
+++ b/framework/application/wayland_context.h
@@ -59,9 +59,15 @@ class WaylandContext : public WsiContext
 
     struct wl_shell* GetShell() const { return shell_; }
 
-    struct xdg_wm_base* GetXdgWmBase() const { return xdg_wm_base_; }
+    util::XdgWmBase* GetXdgWmBase() const { return xdg_wm_base_; }
 
     struct wl_compositor* GetCompositor() const { return compositor_; }
+
+    // Both are optional: a compositor that does not advertise them leaves these null and the
+    // window falls back to integer wl_output scaling. See WaylandWindow::UpdateViewportDestination.
+    util::WpViewporter* GetViewporter() const { return viewporter_; }
+
+    util::WpFractionalScaleManagerV1* GetFractionalScaleManager() const { return fractional_scale_manager_; }
 
     const OutputInfo& GetOutputInfo(const struct wl_output* wl_output) { return output_info_map_[wl_output]; }
 
@@ -133,7 +139,7 @@ class WaylandContext : public WsiContext
     static void HandleOutputDone(void* data, struct wl_output* wl_output);
     static void HandleOutputScale(void* data, struct wl_output* wl_output, int32_t factor);
 
-    static void HandleXdgWmBasePing(void* data, struct xdg_wm_base* xdg_wm_base, uint32_t serial);
+    static void HandleXdgWmBasePing(void* data, util::XdgWmBase* xdg_wm_base, uint32_t serial);
 
     typedef std::unordered_map<struct wl_surface*, WaylandWindow*>  WaylandWindowMap;
     typedef std::unordered_map<const struct wl_output*, OutputInfo> OutputInfoMap;
@@ -143,11 +149,13 @@ class WaylandContext : public WsiContext
     static struct wl_seat_listener     seat_listener_;
     static struct wl_registry_listener registry_listener_;
     static struct wl_output_listener   output_listener_;
-    static struct xdg_wm_base_listener xdg_wm_base_listener_;
+    static util::XdgWmBaseListener     xdg_wm_base_listener_;
     struct wl_display*                 display_{};
     struct wl_shell*                   shell_{};
-    struct xdg_wm_base*                xdg_wm_base_{};
+    util::XdgWmBase*                   xdg_wm_base_{};
     struct wl_compositor*              compositor_{};
+    util::WpViewporter*                viewporter_{};
+    util::WpFractionalScaleManagerV1*  fractional_scale_manager_{};
     struct wl_registry*                registry_{};
     struct wl_seat*                    seat_{};
     struct wl_pointer*                 pointer_{};

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -32,14 +32,16 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-struct wl_surface_listener       WaylandWindow::surface_listener_;
-struct wl_shell_surface_listener WaylandWindow::shell_surface_listener_;
-struct xdg_surface_listener      WaylandWindow::xdg_surface_listener_;
-struct xdg_toplevel_listener     WaylandWindow::xdg_toplevel_listener_;
+struct wl_surface_listener        WaylandWindow::surface_listener_;
+struct wl_shell_surface_listener  WaylandWindow::shell_surface_listener_;
+util::XdgSurfaceListener          WaylandWindow::xdg_surface_listener_;
+util::XdgToplevelListener         WaylandWindow::xdg_toplevel_listener_;
+util::WpFractionalScaleV1Listener WaylandWindow::fractional_scale_listener_;
 
 WaylandWindow::WaylandWindow(WaylandContext* wayland_context) :
     wayland_context_(wayland_context), surface_(nullptr), shell_surface_(nullptr), xdg_surface_(nullptr),
-    xdg_toplevel_(nullptr), width_(0), height_(0), scale_(1), output_(nullptr), xdg_surface_configured_(false)
+    xdg_toplevel_(nullptr), viewport_(nullptr), fractional_scale_(nullptr), width_(0), height_(0),
+    scale_fixed_point_(kFractionalScaleDenominator), scale_(1), output_(nullptr), xdg_surface_configured_(false)
 {
     assert(wayland_context_ != nullptr);
 
@@ -55,6 +57,8 @@ WaylandWindow::WaylandWindow(WaylandContext* wayland_context) :
 
     xdg_toplevel_listener_.configure = HandleXdgToplevelConfigure;
     xdg_toplevel_listener_.close     = HandleXdgToplevelClose;
+
+    fractional_scale_listener_.preferred_scale = HandlePreferredScale;
 }
 
 WaylandWindow::~WaylandWindow()
@@ -62,6 +66,16 @@ WaylandWindow::~WaylandWindow()
     if (surface_ != nullptr)
     {
         auto& wl = wayland_context_->GetWaylandFunctionTable();
+
+        if (fractional_scale_ != nullptr)
+        {
+            wl.frac_scale->wp_fractional_scale_v1_destroy(fractional_scale_);
+        }
+
+        if (viewport_ != nullptr)
+        {
+            wl.viewporter->wp_viewport_destroy(viewport_);
+        }
 
         if (xdg_toplevel_ != nullptr)
         {
@@ -95,6 +109,34 @@ bool WaylandWindow::Create(const std::string& title,
     {
         GFXRECON_LOG_ERROR("Failed to create Wayland surface");
         return false;
+    }
+
+    // Prefer wp_viewporter over wl_surface::set_buffer_scale for sizing. The buffer stays at its
+    // native pixel size and the viewport declares the logical size it should cover, which is the
+    // only way to land on a fractionally scaled output correctly: set_buffer_scale takes an
+    // integer, and a compositor running at 125% or 150% reports a scale of 2 to clients that do
+    // not speak wp_fractional_scale_v1, which would shrink the window to half its intended size.
+
+    if (wayland_context_->GetViewporter() == nullptr)
+    {
+        GFXRECON_LOG_DEBUG("Compositor does not support wp_viewporter; falling back to integer wl_output scaling, "
+                           "which cannot represent a fractional display scale");
+    }
+    else
+    {
+        viewport_ = wl.viewporter->wp_viewporter_get_viewport(wayland_context_->GetViewporter(), surface_);
+
+        if ((viewport_ != nullptr) && (wayland_context_->GetFractionalScaleManager() != nullptr))
+        {
+            fractional_scale_ = wl.frac_scale->wp_fractional_scale_manager_v1_get_fractional_scale(
+                wayland_context_->GetFractionalScaleManager(), surface_);
+
+            if (fractional_scale_ != nullptr)
+            {
+                wl.frac_scale->wp_fractional_scale_v1_add_listener(
+                    fractional_scale_, &WaylandWindow::fractional_scale_listener_, this);
+            }
+        }
     }
 
     // If we have the choice between xdg_toplevel and wl_shell_surface, chose the xdg_toplevel
@@ -153,6 +195,7 @@ bool WaylandWindow::Create(const std::string& title,
 
     width_  = width;
     height_ = height;
+    UpdateViewportDestination();
     UpdateWindowSize();
 
     return true;
@@ -165,6 +208,18 @@ bool WaylandWindow::Destroy()
         wayland_context_->UnregisterWaylandWindow(this);
 
         auto& wl = wayland_context_->GetWaylandFunctionTable();
+
+        if (fractional_scale_ != nullptr)
+        {
+            wl.frac_scale->wp_fractional_scale_v1_destroy(fractional_scale_);
+            fractional_scale_ = nullptr;
+        }
+
+        if (viewport_ != nullptr)
+        {
+            wl.viewporter->wp_viewport_destroy(viewport_);
+            viewport_ = nullptr;
+        }
 
         if (xdg_toplevel_ != nullptr)
         {
@@ -210,12 +265,15 @@ void WaylandWindow::SetPosition(const int32_t x, const int32_t y)
     // TODO: May be possible with xdg-shell extension.
 }
 
+// 'width' and 'height' are buffer dimensions, in device pixels: they are the size of the images
+// the renderer presents, not a logical window size.
 void WaylandWindow::SetSize(const uint32_t width, const uint32_t height)
 {
     if (width != width_ || height != height_)
     {
         width_  = width;
         height_ = height;
+        UpdateViewportDestination();
         UpdateWindowSize();
     }
 }
@@ -293,7 +351,10 @@ void WaylandWindow::UpdateWindowSize()
     {
         auto& output_info = wayland_context_->GetOutputInfo(output_);
 
-        if (output_info.scale > 0 && output_info.scale != scale_)
+        // Only the fallback path drives the buffer scale. When a viewport is in use the buffer
+        // stays at scale 1 and UpdateViewportDestination owns the sizing, including the
+        // fractional case that wl_output::scale cannot express.
+        if (viewport_ == nullptr && output_info.scale > 0 && output_info.scale != scale_)
         {
             wl.surface_set_buffer_scale(surface_, output_info.scale);
             scale_ = output_info.scale;
@@ -321,6 +382,57 @@ void WaylandWindow::UpdateWindowSize()
     }
 }
 
+void WaylandWindow::UpdateViewportDestination()
+{
+    if ((viewport_ == nullptr) || (width_ == 0) || (height_ == 0) || (scale_fixed_point_ == 0))
+    {
+        return;
+    }
+
+    auto& wl = wayland_context_->GetWaylandFunctionTable();
+
+    // The destination is the logical size the buffer should cover. Dividing the pixel size by the
+    // preferred scale puts one buffer pixel on one physical pixel, so the window occupies the same
+    // area of the display that it did on the machine the capture came from. The scale is fixed
+    // point over kFractionalScaleDenominator (120 is 1.0, 150 is 1.25, 180 is 1.5), so the division
+    // is done in that fixed point; rounding to nearest keeps the error below half a logical pixel
+    // for scales that do not divide evenly.
+    const uint64_t denominator       = kFractionalScaleDenominator;
+    const int32_t  destination_width = static_cast<int32_t>(
+        ((static_cast<uint64_t>(width_) * denominator) + (scale_fixed_point_ / 2)) / scale_fixed_point_);
+    const int32_t destination_height = static_cast<int32_t>(
+        ((static_cast<uint64_t>(height_) * denominator) + (scale_fixed_point_ / 2)) / scale_fixed_point_);
+
+    // wp_viewport state is double buffered and applies on the next wl_surface::commit, which the
+    // renderer performs when it presents. Committing here would push a buffer-less commit into
+    // that sequence, so the new destination is deliberately left pending for the next frame.
+    wl.viewporter->wp_viewport_set_destination(viewport_, destination_width, destination_height);
+
+    GFXRECON_LOG_DEBUG("Wayland viewport destination set to %dx%d logical for a %ux%u pixel buffer (preferred "
+                       "scale %u/%u)",
+                       destination_width,
+                       destination_height,
+                       width_,
+                       height_,
+                       scale_fixed_point_,
+                       static_cast<uint32_t>(denominator));
+}
+
+void WaylandWindow::HandlePreferredScale(void*                      data,
+                                         util::WpFractionalScaleV1* fractional_scale,
+                                         uint32_t                   scale_fixed_point)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(fractional_scale);
+
+    auto window = reinterpret_cast<WaylandWindow*>(data);
+
+    if ((scale_fixed_point != 0) && (scale_fixed_point != window->scale_fixed_point_))
+    {
+        window->scale_fixed_point_ = scale_fixed_point;
+        window->UpdateViewportDestination();
+    }
+}
+
 void WaylandWindow::HandleSurfaceEnter(void* data, struct wl_surface* surface, struct wl_output* output)
 {
     auto window     = reinterpret_cast<WaylandWindow*>(data);
@@ -343,7 +455,7 @@ void WaylandWindow::HandleShellSurfaceConfigure(
 
 void WaylandWindow::HandleShellSurfacePopupDone(void* data, wl_shell_surface* shell_surface) {}
 
-void WaylandWindow::HandleXdgSurfaceConfigure(void* data, struct xdg_surface* xdg_surface, uint32_t serial)
+void WaylandWindow::HandleXdgSurfaceConfigure(void* data, util::XdgSurface* xdg_surface, uint32_t serial)
 {
     WaylandWindow* window = reinterpret_cast<WaylandWindow*>(data);
 
@@ -354,10 +466,10 @@ void WaylandWindow::HandleXdgSurfaceConfigure(void* data, struct xdg_surface* xd
 }
 
 void WaylandWindow::HandleXdgToplevelConfigure(
-    void* data, struct xdg_toplevel* xdg_toplevel, int32_t width, int32_t height, struct wl_array* states)
+    void* data, util::XdgToplevel* xdg_toplevel, int32_t width, int32_t height, struct wl_array* states)
 {}
 
-void WaylandWindow::HandleXdgToplevelClose(void* data, struct xdg_toplevel* xdg_toplevel) {}
+void WaylandWindow::HandleXdgToplevelClose(void* data, util::XdgToplevel* xdg_toplevel) {}
 
 WaylandWindowFactory::WaylandWindowFactory(WaylandContext* wayland_context) : wayland_context_(wayland_context)
 {

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -34,6 +34,10 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
+// Denominator of the fixed-point scale carried by wp_fractional_scale_v1::preferred_scale:
+// 120 is 1.0, 150 is 1.25, 180 is 1.5.
+constexpr uint32_t kFractionalScaleDenominator = 120;
+
 class WaylandWindow : public decode::Window
 {
   public:
@@ -45,7 +49,7 @@ class WaylandWindow : public decode::Window
 
     struct wl_shell_surface* GetShellSurface() const { return shell_surface_; }
 
-    struct xdg_toplevel* GetXdgToplevel() const { return xdg_toplevel_; }
+    util::XdgToplevel* GetXdgToplevel() const { return xdg_toplevel_; }
 
     virtual bool Create(const std::string& title,
                         const int32_t      x,
@@ -92,29 +96,45 @@ class WaylandWindow : public decode::Window
         void* data, wl_shell_surface* shell_surface, uint32_t edges, int32_t width, int32_t height);
     static void HandleShellSurfacePopupDone(void* data, wl_shell_surface* shell_surface);
 
-    static void HandleXdgSurfaceConfigure(void* data, struct xdg_surface* xdg_surface, uint32_t serial);
+    static void HandleXdgSurfaceConfigure(void* data, util::XdgSurface* xdg_surface, uint32_t serial);
 
     static void HandleXdgToplevelConfigure(
-        void* data, struct xdg_toplevel* xdg_toplevel, int32_t width, int32_t height, struct wl_array* states);
-    static void HandleXdgToplevelClose(void* data, struct xdg_toplevel* xdg_toplevel);
+        void* data, util::XdgToplevel* xdg_toplevel, int32_t width, int32_t height, struct wl_array* states);
+    static void HandleXdgToplevelClose(void* data, util::XdgToplevel* xdg_toplevel);
+
+    static void
+    HandlePreferredScale(void* data, util::WpFractionalScaleV1* fractional_scale, uint32_t scale_fixed_point);
 
     void UpdateWindowSize();
 
+    // Recomputes the wp_viewport destination from the current buffer size and preferred scale.
+    // A no-op when the compositor does not support wp_viewporter.
+    void UpdateViewportDestination();
+
   private:
-    static struct wl_surface_listener       surface_listener_;
-    static struct wl_shell_surface_listener shell_surface_listener_;
-    static struct xdg_surface_listener      xdg_surface_listener_;
-    static struct xdg_toplevel_listener     xdg_toplevel_listener_;
-    WaylandContext*                         wayland_context_;
-    struct wl_surface*                      surface_;
-    struct wl_shell_surface*                shell_surface_;
-    struct xdg_surface*                     xdg_surface_;
-    struct xdg_toplevel*                    xdg_toplevel_;
-    uint32_t                                width_;
-    uint32_t                                height_;
-    int32_t                                 scale_;
-    struct wl_output*                       output_;
-    bool                                    xdg_surface_configured_;
+    static struct wl_surface_listener        surface_listener_;
+    static struct wl_shell_surface_listener  shell_surface_listener_;
+    static util::XdgSurfaceListener          xdg_surface_listener_;
+    static util::XdgToplevelListener         xdg_toplevel_listener_;
+    static util::WpFractionalScaleV1Listener fractional_scale_listener_;
+    WaylandContext*                          wayland_context_;
+    struct wl_surface*                       surface_;
+    struct wl_shell_surface*                 shell_surface_;
+    util::XdgSurface*                        xdg_surface_;
+    util::XdgToplevel*                       xdg_toplevel_;
+    util::WpViewport*                        viewport_;
+    util::WpFractionalScaleV1*               fractional_scale_;
+    // width_ and height_ are buffer dimensions, in device pixels. The logical size the window
+    // occupies is derived from them and scale_fixed_point_, the compositor's preferred scale as
+    // reported by wp_fractional_scale_v1::preferred_scale: a fixed-point value over a denominator
+    // of kFractionalScaleDenominator, so 120 is 1.0, 150 is 1.25, and 180 is 1.5. It defaults to a
+    // 1.0 scale, which is what applies until the compositor reports otherwise.
+    uint32_t          width_;
+    uint32_t          height_;
+    uint32_t          scale_fixed_point_;
+    int32_t           scale_;
+    struct wl_output* output_;
+    bool              xdg_surface_configured_;
 };
 
 class WaylandWindowFactory : public decode::WindowFactory

--- a/framework/generated/generate_wayland.py
+++ b/framework/generated/generate_wayland.py
@@ -60,6 +60,54 @@ COPYRIGHT = '''/*
 '''
 
 
+# Indentation of a class member, of an access specifier and of a nesting level within a
+# member function body.  Generated sources use spaces only.
+MEMBER_INDENT = ' ' * 4
+ACCESS_INDENT = ' ' * 2
+BODY_INDENT = ' ' * 4
+
+
+# The types generated for the interfaces of the protocol currently being processed, keyed by
+# Wayland interface name.  Interfaces that libwayland already declares (the "wl_" ones) are
+# absent from this table and keep the names wayland-client.h gives them.
+protocol_interface_types = dict()
+
+
+def to_upper_camel_case(name: str) -> str:
+    return ''.join(word[:1].upper() + word[1:] for word in name.split('_'))
+
+
+def interface_to_cpp_type(interface_name: str) -> str:
+    """C++ type name for a Wayland interface, generated or from wayland-client.h."""
+    return protocol_interface_types.get(interface_name, interface_name)
+
+
+def generated_type_name(*parts: str) -> str:
+    """Name for a type generated for a Wayland interface.
+
+    Everything the generator writes goes into the gfxrecon::util namespace, which keeps these
+    names apart from the ones the real Wayland protocol headers declare at global scope.
+    """
+    return ''.join(to_upper_camel_case(part) for part in parts)
+
+
+def generated_enum_entry_name(entry_name: str) -> str:
+    """Name for one entry of a generated enum.
+
+    The enum classes scope their entries, so an entry keeps only the name the protocol gives
+    it.  A protocol can name an entry with a leading digit, which C++ does not accept in an
+    identifier, so reject that here instead of writing a source file that does not compile.
+    """
+    if entry_name[:1].isdigit():
+        raise Exception(f'Enum entry "{entry_name}" starts with a digit: Case not handled.')
+    return entry_name.upper()
+
+
+def protocol_table_type_name(protocol_name: str) -> str:
+    """Name of the table class generated for a protocol."""
+    return 'Wayland' + to_upper_camel_case(protocol_name) + 'Table'
+
+
 def wayland_arg_to_cpp_type(arg: ET.Element) -> str:
 
     arg_type = arg.attrib['type']
@@ -69,9 +117,9 @@ def wayland_arg_to_cpp_type(arg: ET.Element) -> str:
     elif arg_type == 'uint':
         return 'uint32_t'
     elif arg_type == 'fixed':
-        return 'wl_fixed'
+        return 'wl_fixed_t'
     elif arg_type == 'object' or arg_type == 'new_id':
-        return arg.attrib['interface'] + '*'
+        return interface_to_cpp_type(arg.attrib['interface']) + '*'
     elif arg_type == 'string':
         return 'const char*'
     elif arg_type == 'array':
@@ -83,34 +131,37 @@ def wayland_arg_to_cpp_type(arg: ET.Element) -> str:
 def generate_request(file: TextIOWrapper, interface_name: str, request: ET.Element, opcode: int) -> None:
 
     return_type = 'void'
+    return_interface = None
     args = list()
 
     for arg in request.findall('arg'):
         if arg.attrib['type'] == 'new_id':
-            if return_type != 'void':
+            if return_interface is not None:
                 raise Exception('Two objects created by the same request: Case not handled.')
+            return_interface = arg.attrib['interface']
             return_type = wayland_arg_to_cpp_type(arg)
         else:
             args.append((wayland_arg_to_cpp_type(arg), arg.attrib['name']))
 
     func_name = interface_name + '_' + request.attrib["name"]
+    self_type = interface_to_cpp_type(interface_name)
 
-    file.write(f'\t\t{return_type} {func_name}({interface_name}* self{", ".join([""] + [arg[0] + " " + arg[1] for arg in args])}) const\n')
-    file.write('\t\t{\n')
+    file.write(f'{MEMBER_INDENT}{return_type} {func_name}({self_type}* self{", ".join([""] + [arg[0] + " " + arg[1] for arg in args])}) const\n')
+    file.write(f'{MEMBER_INDENT}{{\n')
 
-    if return_type != 'void':
+    if return_interface is not None:
 
         params = [
             'reinterpret_cast<wl_proxy*>(self)',
             str(opcode),
-            f'&{return_type[:-1]}_interface',
+            f'&{return_interface}_interface',
             'NULL'
         ]
 
         params.extend(arg[1] for arg in args)
 
-        file.write(f'\t\t\treturn reinterpret_cast<{return_type}>(_wl->proxy_marshal_constructor({", ".join(params)}));\n')
-    
+        file.write(f'{MEMBER_INDENT}{BODY_INDENT}return reinterpret_cast<{return_type}>(_wl->proxy_marshal_constructor({", ".join(params)}));\n')
+
     else:
 
         params = [
@@ -120,13 +171,12 @@ def generate_request(file: TextIOWrapper, interface_name: str, request: ET.Eleme
 
         params.extend(arg[1] for arg in args)
 
-        file.write(f'\t\t\t_wl->proxy_marshal({", ".join(params)});\n')
+        file.write(f'{MEMBER_INDENT}{BODY_INDENT}_wl->proxy_marshal({", ".join(params)});\n')
 
         if request.attrib["name"] == 'destroy':
-            file.write('\t\t\t_wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));\n')
+            file.write(f'{MEMBER_INDENT}{BODY_INDENT}_wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));\n')
 
-
-    file.write('\t\t}\n')
+    file.write(f'{MEMBER_INDENT}}}\n')
     file.write('\n')
 
 
@@ -220,6 +270,12 @@ def generate(protocol_path: str) -> None:
     protocol_name = root.attrib['name']
     generated_filename = os.path.join(SCRIPT_DIR, f'generated_wayland_{protocol_name}.h')
 
+    global protocol_interface_types
+    protocol_interface_types = {
+        interface.attrib['name']: generated_type_name(interface.attrib['name'])
+        for interface in root.findall('interface')
+    }
+
     with open(generated_filename, 'w') as file:
         
         # Header of file
@@ -229,6 +285,7 @@ def generate(protocol_path: str) -> None:
         file.write(f'#ifndef GFXRECON_GENERATED_WAYLAND_{protocol_name.upper()}_H\n')
         file.write(f'#define GFXRECON_GENERATED_WAYLAND_{protocol_name.upper()}_H\n')
         file.write('\n')
+        file.write('#include <cstdint>\n')
         file.write('#include <vector>\n')
         file.write('\n')
         file.write('#include <wayland-client.h>\n')
@@ -236,17 +293,21 @@ def generate(protocol_path: str) -> None:
         file.write('#include "util/defines.h"\n')
         file.write('#include "util/wayland_loader.h"\n')
         file.write('\n')
+        file.write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)\n')
+        file.write('GFXRECON_BEGIN_NAMESPACE(util)\n')
+        file.write('\n')
 
         # Static declarations
 
         for interface in root.findall('interface'):
-            file.write(f'struct {interface.attrib["name"]};\n')
+            file.write(f'struct {interface_to_cpp_type(interface.attrib["name"])};\n')
 
         file.write('\n')
 
         for interface in root.findall('interface'):
 
             interface_name = interface.attrib['name']
+            interface_type = interface_to_cpp_type(interface_name)
 
             file.write(f'// {interface_name} static declarations\n')
             file.write('\n')
@@ -254,26 +315,27 @@ def generate(protocol_path: str) -> None:
             # Enums
 
             for enum in interface.findall('enum'):
-                file.write(f'enum {interface_name}_{enum.attrib["name"]}\n')
+                file.write(f'enum class {generated_type_name(interface_name, enum.attrib["name"])} : uint32_t\n')
                 file.write('{\n')
                 for entry in enum.findall('entry'):
-                    file.write(f'\t{interface_name}_{enum.attrib["name"]}_{entry.attrib["name"]} = {entry.attrib["value"]},\n'.upper())
+                    entry_name = generated_enum_entry_name(entry.attrib['name'])
+                    file.write(f'{MEMBER_INDENT}{entry_name} = {entry.attrib["value"]},\n')
                 file.write('};\n')
                 file.write('\n')
-        
+
             # Listeners
 
             if interface.find('event') is not None:
 
-                file.write(f'struct {interface_name}_listener\n')
+                file.write(f'struct {generated_type_name(interface_name, "listener")}\n')
                 file.write('{\n')
 
                 for event in interface.findall('event'):
-                    file.write(f'\tvoid (*{event.attrib["name"]})(void* data, {interface_name}* object')
+                    file.write(f'{MEMBER_INDENT}void (*{event.attrib["name"]})(void* data, {interface_type}* object')
 
                     for arg in event.findall('arg'):
                         file.write(f', {wayland_arg_to_cpp_type(arg)} {arg.attrib["name"]}')
-                    
+
                     file.write(');\n')
 
                 file.write('};\n')
@@ -281,20 +343,17 @@ def generate(protocol_path: str) -> None:
 
         # Protocol table
                 
-        file.write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)\n')
-        file.write('GFXRECON_BEGIN_NAMESPACE(util)\n')
-        file.write('\n')
         file.write(f'// Global to {protocol_name}\n')
         file.write('\n')
-        file.write(f'class wayland_{protocol_name}_table\n')
+        file.write(f'class {protocol_table_type_name(protocol_name)}\n')
         file.write('{\n')
-        file.write('\tprivate:\n')
+        file.write(f'{ACCESS_INDENT}private:\n')
         file.write('\n')
-        file.write('\t\tconst WaylandLoader::FunctionTable* _wl;\n')
-        file.write('\t\tstd::vector<wl_message> _messages;\n')
-        file.write('\t\tstd::vector<const wl_interface*> _messageArgs;\n')
+        file.write(f'{MEMBER_INDENT}const WaylandLoader::FunctionTable* _wl;\n')
+        file.write(f'{MEMBER_INDENT}std::vector<wl_message> _messages;\n')
+        file.write(f'{MEMBER_INDENT}std::vector<const wl_interface*> _messageArgs;\n')
         file.write('\n')
-        file.write('\tpublic:\n')
+        file.write(f'{ACCESS_INDENT}public:\n')
         file.write('\n')
 
         # Per-interface dynamic declarations
@@ -302,48 +361,51 @@ def generate(protocol_path: str) -> None:
         for interface in root.findall('interface'):
 
             interface_name = interface.attrib['name']
+            interface_type = interface_to_cpp_type(interface_name)
 
-            file.write(f'\t\t// {interface_name} dynamic declarations\n')
+            file.write(f'{MEMBER_INDENT}// {interface_name} dynamic declarations\n')
             file.write('\n')
 
             # Interfaces
-            
-            file.write(f'\t\twl_interface {interface.attrib["name"]}_interface;\n')
+
+            file.write(f'{MEMBER_INDENT}wl_interface {interface_name}_interface;\n')
             file.write('\n')
 
             # Listeners
 
             if interface.find('event') is not None:
-                
-                file.write(f'\t\tint {interface_name}_add_listener({interface_name}* self, {interface_name}_listener* listener, void* data) const\n')
-                file.write('\t\t{\n')
-                file.write('\t\t\treturn _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);\n')
-                file.write('\t\t}\n')
+
+                listener_type = generated_type_name(interface_name, 'listener')
+
+                file.write(f'{MEMBER_INDENT}int {interface_name}_add_listener({interface_type}* self, {listener_type}* listener, void* data) const\n')
+                file.write(f'{MEMBER_INDENT}{{\n')
+                file.write(f'{MEMBER_INDENT}{BODY_INDENT}return _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);\n')
+                file.write(f'{MEMBER_INDENT}}}\n')
                 file.write('\n')
 
             # Requests
-        
+
             destroy_found = False
             for opcode, request in enumerate(interface.findall('request')):
                 generate_request(file, interface_name, request, opcode)
                 if request.attrib['name'] == 'destroy':
                     destroy_found = True
-            
+
             if not destroy_found:
-                file.write(f'\t\tvoid {interface_name}_destroy({interface_name}* self) const\n')
-                file.write('\t\t{\n')
-                file.write('\t\t\t_wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));\n')
-                file.write('\t\t}\n')
+                file.write(f'{MEMBER_INDENT}void {interface_name}_destroy({interface_type}* self) const\n')
+                file.write(f'{MEMBER_INDENT}{{\n')
+                file.write(f'{MEMBER_INDENT}{BODY_INDENT}_wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));\n')
+                file.write(f'{MEMBER_INDENT}}}\n')
                 file.write('\n')
 
         # Initialize func
 
-        file.write('\t\t// Call this once libwayland-client is successfully loaded\n')
+        file.write(f'{MEMBER_INDENT}// Call this once libwayland-client is successfully loaded\n')
         file.write('\n')
-        file.write('\t\tvoid initialize(const WaylandLoader* waylandLoader)\n')
-        file.write('\t\t{\n')
+        file.write(f'{MEMBER_INDENT}void initialize(const WaylandLoader* waylandLoader)\n')
+        file.write(f'{MEMBER_INDENT}{{\n')
 
-        file.write('\t\t\t_wl = &waylandLoader->GetFunctionTable();\n')
+        file.write(f'{MEMBER_INDENT}{BODY_INDENT}_wl = &waylandLoader->GetFunctionTable();\n')
         file.write('\n')
 
         messages = dict()
@@ -356,18 +418,18 @@ def generate(protocol_path: str) -> None:
             for event in interface.findall('event'):
                 messages[interface_name][1].append(message_from_func(message_args, event))
 
-        file.write('\t\t\t_messageArgs = {\n')
+        file.write(f'{MEMBER_INDENT}{BODY_INDENT}_messageArgs = {{\n')
         for arg in message_args:
-            file.write(f'\t\t\t\t{arg},\n')
-        file.write('\t\t\t};\n')
+            file.write(f'{MEMBER_INDENT}{BODY_INDENT * 2}{arg},\n')
+        file.write(f'{MEMBER_INDENT}{BODY_INDENT}}};\n')
         file.write('\n')
 
-        file.write('\t\t\t_messages = {\n')
+        file.write(f'{MEMBER_INDENT}{BODY_INDENT}_messages = {{\n')
         for interface in root.findall('interface'):
             for message in itertools.chain(messages[interface.attrib['name']][0], messages[interface.attrib['name']][1]):
-                file.write(f'\t\t\t\t{{ "{message[0]}", "{message[1]}", _messageArgs.data() + {message[2]} }},\n')
+                file.write(f'{MEMBER_INDENT}{BODY_INDENT * 2}{{ "{message[0]}", "{message[1]}", _messageArgs.data() + {message[2]} }},\n')
 
-        file.write('\t\t\t};\n')
+        file.write(f'{MEMBER_INDENT}{BODY_INDENT}}};\n')
         file.write('\n')
 
         counter = 0
@@ -377,13 +439,13 @@ def generate(protocol_path: str) -> None:
             request_count = len(messages[interface_name][0])
             event_count = len(messages[interface_name][1])
 
-            file.write(f'\t\t\t{interface_name}_interface = {{ "{interface_name}", {interface.attrib["version"]},')
+            file.write(f'{MEMBER_INDENT}{BODY_INDENT}{interface_name}_interface = {{ "{interface_name}", {interface.attrib["version"]},')
             file.write(f' {request_count}, _messages.data() + {counter},')
             counter += request_count
             file.write(f' {event_count}, _messages.data() + {counter} }};\n')
             counter += event_count
 
-        file.write('\t\t}\n')
+        file.write(f'{MEMBER_INDENT}}}\n')
         file.write('};\n')
         file.write('\n')
 
@@ -408,6 +470,10 @@ def clone_wayland_protocols():
 def main():
     clone_wayland_protocols()
     generate(os.path.join(PROTOCOLS_DIR, 'stable', 'xdg-shell', 'xdg-shell.xml'))
+    # viewporter and fractional-scale together let a window size itself correctly on a
+    # fractionally scaled output, which wl_surface::set_buffer_scale cannot express.
+    generate(os.path.join(PROTOCOLS_DIR, 'stable', 'viewporter', 'viewporter.xml'))
+    generate(os.path.join(PROTOCOLS_DIR, 'staging', 'fractional-scale', 'fractional-scale-v1.xml'))
 
 
 if __name__ == '__main__':

--- a/framework/generated/generated_wayland_fractional_scale_v1.h
+++ b/framework/generated/generated_wayland_fractional_scale_v1.h
@@ -1,0 +1,124 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_GENERATED_WAYLAND_FRACTIONAL_SCALE_V1_H
+#define GFXRECON_GENERATED_WAYLAND_FRACTIONAL_SCALE_V1_H
+
+#include <cstdint>
+#include <vector>
+
+#include <wayland-client.h>
+
+#include "util/defines.h"
+#include "util/wayland_loader.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+struct WpFractionalScaleManagerV1;
+struct WpFractionalScaleV1;
+
+// wp_fractional_scale_manager_v1 static declarations
+
+enum class WpFractionalScaleManagerV1Error : uint32_t
+{
+    FRACTIONAL_SCALE_EXISTS = 0,
+};
+
+// wp_fractional_scale_v1 static declarations
+
+struct WpFractionalScaleV1Listener
+{
+    void (*preferred_scale)(void* data, WpFractionalScaleV1* object, uint32_t scale);
+};
+
+// Global to fractional_scale_v1
+
+class WaylandFractionalScaleV1Table
+{
+  private:
+
+    const WaylandLoader::FunctionTable* _wl;
+    std::vector<wl_message> _messages;
+    std::vector<const wl_interface*> _messageArgs;
+
+  public:
+
+    // wp_fractional_scale_manager_v1 dynamic declarations
+
+    wl_interface wp_fractional_scale_manager_v1_interface;
+
+    void wp_fractional_scale_manager_v1_destroy(WpFractionalScaleManagerV1* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
+        _wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
+    }
+
+    WpFractionalScaleV1* wp_fractional_scale_manager_v1_get_fractional_scale(WpFractionalScaleManagerV1* self, wl_surface* surface) const
+    {
+        return reinterpret_cast<WpFractionalScaleV1*>(_wl->proxy_marshal_constructor(reinterpret_cast<wl_proxy*>(self), 1, &wp_fractional_scale_v1_interface, NULL, surface));
+    }
+
+    // wp_fractional_scale_v1 dynamic declarations
+
+    wl_interface wp_fractional_scale_v1_interface;
+
+    int wp_fractional_scale_v1_add_listener(WpFractionalScaleV1* self, WpFractionalScaleV1Listener* listener, void* data) const
+    {
+        return _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);
+    }
+
+    void wp_fractional_scale_v1_destroy(WpFractionalScaleV1* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
+        _wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
+    }
+
+    // Call this once libwayland-client is successfully loaded
+
+    void initialize(const WaylandLoader* waylandLoader)
+    {
+        _wl = &waylandLoader->GetFunctionTable();
+
+        _messageArgs = {
+            &wp_fractional_scale_v1_interface,
+            _wl->surface_interface,
+            nullptr,
+        };
+
+        _messages = {
+            { "destroy", "", _messageArgs.data() + 0 },
+            { "get_fractional_scale", "no", _messageArgs.data() + 0 },
+            { "destroy", "", _messageArgs.data() + 0 },
+            { "preferred_scale", "u", _messageArgs.data() + 2 },
+        };
+
+        wp_fractional_scale_manager_v1_interface = { "wp_fractional_scale_manager_v1", 1, 2, _messages.data() + 0, 0, _messages.data() + 2 };
+        wp_fractional_scale_v1_interface = { "wp_fractional_scale_v1", 1, 1, _messages.data() + 2, 1, _messages.data() + 3 };
+    }
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_GENERATED_WAYLAND_FRACTIONAL_SCALE_V1_H

--- a/framework/generated/generated_wayland_viewporter.h
+++ b/framework/generated/generated_wayland_viewporter.h
@@ -1,0 +1,136 @@
+/*
+** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_GENERATED_WAYLAND_VIEWPORTER_H
+#define GFXRECON_GENERATED_WAYLAND_VIEWPORTER_H
+
+#include <cstdint>
+#include <vector>
+
+#include <wayland-client.h>
+
+#include "util/defines.h"
+#include "util/wayland_loader.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+struct WpViewporter;
+struct WpViewport;
+
+// wp_viewporter static declarations
+
+enum class WpViewporterError : uint32_t
+{
+    VIEWPORT_EXISTS = 0,
+};
+
+// wp_viewport static declarations
+
+enum class WpViewportError : uint32_t
+{
+    BAD_VALUE = 0,
+    BAD_SIZE = 1,
+    OUT_OF_BUFFER = 2,
+    NO_SURFACE = 3,
+};
+
+// Global to viewporter
+
+class WaylandViewporterTable
+{
+  private:
+
+    const WaylandLoader::FunctionTable* _wl;
+    std::vector<wl_message> _messages;
+    std::vector<const wl_interface*> _messageArgs;
+
+  public:
+
+    // wp_viewporter dynamic declarations
+
+    wl_interface wp_viewporter_interface;
+
+    void wp_viewporter_destroy(WpViewporter* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
+        _wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
+    }
+
+    WpViewport* wp_viewporter_get_viewport(WpViewporter* self, wl_surface* surface) const
+    {
+        return reinterpret_cast<WpViewport*>(_wl->proxy_marshal_constructor(reinterpret_cast<wl_proxy*>(self), 1, &wp_viewport_interface, NULL, surface));
+    }
+
+    // wp_viewport dynamic declarations
+
+    wl_interface wp_viewport_interface;
+
+    void wp_viewport_destroy(WpViewport* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
+        _wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
+    }
+
+    void wp_viewport_set_source(WpViewport* self, wl_fixed_t x, wl_fixed_t y, wl_fixed_t width, wl_fixed_t height) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 1, x, y, width, height);
+    }
+
+    void wp_viewport_set_destination(WpViewport* self, int32_t width, int32_t height) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 2, width, height);
+    }
+
+    // Call this once libwayland-client is successfully loaded
+
+    void initialize(const WaylandLoader* waylandLoader)
+    {
+        _wl = &waylandLoader->GetFunctionTable();
+
+        _messageArgs = {
+            &wp_viewport_interface,
+            _wl->surface_interface,
+            nullptr,
+            nullptr,
+            nullptr,
+            nullptr,
+        };
+
+        _messages = {
+            { "destroy", "", _messageArgs.data() + 0 },
+            { "get_viewport", "no", _messageArgs.data() + 0 },
+            { "destroy", "", _messageArgs.data() + 0 },
+            { "set_source", "ffff", _messageArgs.data() + 2 },
+            { "set_destination", "ii", _messageArgs.data() + 2 },
+        };
+
+        wp_viewporter_interface = { "wp_viewporter", 1, 2, _messages.data() + 0, 0, _messages.data() + 2 };
+        wp_viewport_interface = { "wp_viewport", 1, 3, _messages.data() + 2, 0, _messages.data() + 5 };
+    }
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_GENERATED_WAYLAND_VIEWPORTER_H

--- a/framework/generated/generated_wayland_xdg_shell.h
+++ b/framework/generated/generated_wayland_xdg_shell.h
@@ -24,6 +24,7 @@
 #ifndef GFXRECON_GENERATED_WAYLAND_XDG_SHELL_H
 #define GFXRECON_GENERATED_WAYLAND_XDG_SHELL_H
 
+#include <cstdint>
 #include <vector>
 
 #include <wayland-client.h>
@@ -31,477 +32,481 @@
 #include "util/defines.h"
 #include "util/wayland_loader.h"
 
-struct xdg_wm_base;
-struct xdg_positioner;
-struct xdg_surface;
-struct xdg_toplevel;
-struct xdg_popup;
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+struct XdgWmBase;
+struct XdgPositioner;
+struct XdgSurface;
+struct XdgToplevel;
+struct XdgPopup;
 
 // xdg_wm_base static declarations
 
-enum xdg_wm_base_error
+enum class XdgWmBaseError : uint32_t
 {
-	XDG_WM_BASE_ERROR_ROLE = 0,
-	XDG_WM_BASE_ERROR_DEFUNCT_SURFACES = 1,
-	XDG_WM_BASE_ERROR_NOT_THE_TOPMOST_POPUP = 2,
-	XDG_WM_BASE_ERROR_INVALID_POPUP_PARENT = 3,
-	XDG_WM_BASE_ERROR_INVALID_SURFACE_STATE = 4,
-	XDG_WM_BASE_ERROR_INVALID_POSITIONER = 5,
-	XDG_WM_BASE_ERROR_UNRESPONSIVE = 6,
+    ROLE = 0,
+    DEFUNCT_SURFACES = 1,
+    NOT_THE_TOPMOST_POPUP = 2,
+    INVALID_POPUP_PARENT = 3,
+    INVALID_SURFACE_STATE = 4,
+    INVALID_POSITIONER = 5,
+    UNRESPONSIVE = 6,
 };
 
-struct xdg_wm_base_listener
+struct XdgWmBaseListener
 {
-	void (*ping)(void* data, xdg_wm_base* object, uint32_t serial);
+    void (*ping)(void* data, XdgWmBase* object, uint32_t serial);
 };
 
 // xdg_positioner static declarations
 
-enum xdg_positioner_error
+enum class XdgPositionerError : uint32_t
 {
-	XDG_POSITIONER_ERROR_INVALID_INPUT = 0,
+    INVALID_INPUT = 0,
 };
 
-enum xdg_positioner_anchor
+enum class XdgPositionerAnchor : uint32_t
 {
-	XDG_POSITIONER_ANCHOR_NONE = 0,
-	XDG_POSITIONER_ANCHOR_TOP = 1,
-	XDG_POSITIONER_ANCHOR_BOTTOM = 2,
-	XDG_POSITIONER_ANCHOR_LEFT = 3,
-	XDG_POSITIONER_ANCHOR_RIGHT = 4,
-	XDG_POSITIONER_ANCHOR_TOP_LEFT = 5,
-	XDG_POSITIONER_ANCHOR_BOTTOM_LEFT = 6,
-	XDG_POSITIONER_ANCHOR_TOP_RIGHT = 7,
-	XDG_POSITIONER_ANCHOR_BOTTOM_RIGHT = 8,
+    NONE = 0,
+    TOP = 1,
+    BOTTOM = 2,
+    LEFT = 3,
+    RIGHT = 4,
+    TOP_LEFT = 5,
+    BOTTOM_LEFT = 6,
+    TOP_RIGHT = 7,
+    BOTTOM_RIGHT = 8,
 };
 
-enum xdg_positioner_gravity
+enum class XdgPositionerGravity : uint32_t
 {
-	XDG_POSITIONER_GRAVITY_NONE = 0,
-	XDG_POSITIONER_GRAVITY_TOP = 1,
-	XDG_POSITIONER_GRAVITY_BOTTOM = 2,
-	XDG_POSITIONER_GRAVITY_LEFT = 3,
-	XDG_POSITIONER_GRAVITY_RIGHT = 4,
-	XDG_POSITIONER_GRAVITY_TOP_LEFT = 5,
-	XDG_POSITIONER_GRAVITY_BOTTOM_LEFT = 6,
-	XDG_POSITIONER_GRAVITY_TOP_RIGHT = 7,
-	XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT = 8,
+    NONE = 0,
+    TOP = 1,
+    BOTTOM = 2,
+    LEFT = 3,
+    RIGHT = 4,
+    TOP_LEFT = 5,
+    BOTTOM_LEFT = 6,
+    TOP_RIGHT = 7,
+    BOTTOM_RIGHT = 8,
 };
 
-enum xdg_positioner_constraint_adjustment
+enum class XdgPositionerConstraintAdjustment : uint32_t
 {
-	XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_NONE = 0,
-	XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X = 1,
-	XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y = 2,
-	XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X = 4,
-	XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y = 8,
-	XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_RESIZE_X = 16,
-	XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_RESIZE_Y = 32,
+    NONE = 0,
+    SLIDE_X = 1,
+    SLIDE_Y = 2,
+    FLIP_X = 4,
+    FLIP_Y = 8,
+    RESIZE_X = 16,
+    RESIZE_Y = 32,
 };
 
 // xdg_surface static declarations
 
-enum xdg_surface_error
+enum class XdgSurfaceError : uint32_t
 {
-	XDG_SURFACE_ERROR_NOT_CONSTRUCTED = 1,
-	XDG_SURFACE_ERROR_ALREADY_CONSTRUCTED = 2,
-	XDG_SURFACE_ERROR_UNCONFIGURED_BUFFER = 3,
-	XDG_SURFACE_ERROR_INVALID_SERIAL = 4,
-	XDG_SURFACE_ERROR_INVALID_SIZE = 5,
-	XDG_SURFACE_ERROR_DEFUNCT_ROLE_OBJECT = 6,
+    NOT_CONSTRUCTED = 1,
+    ALREADY_CONSTRUCTED = 2,
+    UNCONFIGURED_BUFFER = 3,
+    INVALID_SERIAL = 4,
+    INVALID_SIZE = 5,
+    DEFUNCT_ROLE_OBJECT = 6,
 };
 
-struct xdg_surface_listener
+struct XdgSurfaceListener
 {
-	void (*configure)(void* data, xdg_surface* object, uint32_t serial);
+    void (*configure)(void* data, XdgSurface* object, uint32_t serial);
 };
 
 // xdg_toplevel static declarations
 
-enum xdg_toplevel_error
+enum class XdgToplevelError : uint32_t
 {
-	XDG_TOPLEVEL_ERROR_INVALID_RESIZE_EDGE = 0,
-	XDG_TOPLEVEL_ERROR_INVALID_PARENT = 1,
-	XDG_TOPLEVEL_ERROR_INVALID_SIZE = 2,
+    INVALID_RESIZE_EDGE = 0,
+    INVALID_PARENT = 1,
+    INVALID_SIZE = 2,
 };
 
-enum xdg_toplevel_resize_edge
+enum class XdgToplevelResizeEdge : uint32_t
 {
-	XDG_TOPLEVEL_RESIZE_EDGE_NONE = 0,
-	XDG_TOPLEVEL_RESIZE_EDGE_TOP = 1,
-	XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM = 2,
-	XDG_TOPLEVEL_RESIZE_EDGE_LEFT = 4,
-	XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT = 5,
-	XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT = 6,
-	XDG_TOPLEVEL_RESIZE_EDGE_RIGHT = 8,
-	XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT = 9,
-	XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT = 10,
+    NONE = 0,
+    TOP = 1,
+    BOTTOM = 2,
+    LEFT = 4,
+    TOP_LEFT = 5,
+    BOTTOM_LEFT = 6,
+    RIGHT = 8,
+    TOP_RIGHT = 9,
+    BOTTOM_RIGHT = 10,
 };
 
-enum xdg_toplevel_state
+enum class XdgToplevelState : uint32_t
 {
-	XDG_TOPLEVEL_STATE_MAXIMIZED = 1,
-	XDG_TOPLEVEL_STATE_FULLSCREEN = 2,
-	XDG_TOPLEVEL_STATE_RESIZING = 3,
-	XDG_TOPLEVEL_STATE_ACTIVATED = 4,
-	XDG_TOPLEVEL_STATE_TILED_LEFT = 5,
-	XDG_TOPLEVEL_STATE_TILED_RIGHT = 6,
-	XDG_TOPLEVEL_STATE_TILED_TOP = 7,
-	XDG_TOPLEVEL_STATE_TILED_BOTTOM = 8,
-	XDG_TOPLEVEL_STATE_SUSPENDED = 9,
+    MAXIMIZED = 1,
+    FULLSCREEN = 2,
+    RESIZING = 3,
+    ACTIVATED = 4,
+    TILED_LEFT = 5,
+    TILED_RIGHT = 6,
+    TILED_TOP = 7,
+    TILED_BOTTOM = 8,
+    SUSPENDED = 9,
+    CONSTRAINED_LEFT = 10,
+    CONSTRAINED_RIGHT = 11,
+    CONSTRAINED_TOP = 12,
+    CONSTRAINED_BOTTOM = 13,
 };
 
-enum xdg_toplevel_wm_capabilities
+enum class XdgToplevelWmCapabilities : uint32_t
 {
-	XDG_TOPLEVEL_WM_CAPABILITIES_WINDOW_MENU = 1,
-	XDG_TOPLEVEL_WM_CAPABILITIES_MAXIMIZE = 2,
-	XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN = 3,
-	XDG_TOPLEVEL_WM_CAPABILITIES_MINIMIZE = 4,
+    WINDOW_MENU = 1,
+    MAXIMIZE = 2,
+    FULLSCREEN = 3,
+    MINIMIZE = 4,
 };
 
-struct xdg_toplevel_listener
+struct XdgToplevelListener
 {
-	void (*configure)(void* data, xdg_toplevel* object, int32_t width, int32_t height, wl_array* states);
-	void (*close)(void* data, xdg_toplevel* object);
-	void (*configure_bounds)(void* data, xdg_toplevel* object, int32_t width, int32_t height);
-	void (*wm_capabilities)(void* data, xdg_toplevel* object, wl_array* capabilities);
+    void (*configure)(void* data, XdgToplevel* object, int32_t width, int32_t height, wl_array* states);
+    void (*close)(void* data, XdgToplevel* object);
+    void (*configure_bounds)(void* data, XdgToplevel* object, int32_t width, int32_t height);
+    void (*wm_capabilities)(void* data, XdgToplevel* object, wl_array* capabilities);
 };
 
 // xdg_popup static declarations
 
-enum xdg_popup_error
+enum class XdgPopupError : uint32_t
 {
-	XDG_POPUP_ERROR_INVALID_GRAB = 0,
+    INVALID_GRAB = 0,
 };
 
-struct xdg_popup_listener
+struct XdgPopupListener
 {
-	void (*configure)(void* data, xdg_popup* object, int32_t x, int32_t y, int32_t width, int32_t height);
-	void (*popup_done)(void* data, xdg_popup* object);
-	void (*repositioned)(void* data, xdg_popup* object, uint32_t token);
+    void (*configure)(void* data, XdgPopup* object, int32_t x, int32_t y, int32_t width, int32_t height);
+    void (*popup_done)(void* data, XdgPopup* object);
+    void (*repositioned)(void* data, XdgPopup* object, uint32_t token);
 };
-
-GFXRECON_BEGIN_NAMESPACE(gfxrecon)
-GFXRECON_BEGIN_NAMESPACE(util)
 
 // Global to xdg_shell
 
-class wayland_xdg_shell_table
+class WaylandXdgShellTable
 {
-	private:
+  private:
 
-		const WaylandLoader::FunctionTable* _wl;
-		std::vector<wl_message> _messages;
-		std::vector<const wl_interface*> _messageArgs;
+    const WaylandLoader::FunctionTable* _wl;
+    std::vector<wl_message> _messages;
+    std::vector<const wl_interface*> _messageArgs;
 
-	public:
+  public:
 
-		// xdg_wm_base dynamic declarations
+    // xdg_wm_base dynamic declarations
 
-		wl_interface xdg_wm_base_interface;
+    wl_interface xdg_wm_base_interface;
 
-		int xdg_wm_base_add_listener(xdg_wm_base* self, xdg_wm_base_listener* listener, void* data) const
-		{
-			return _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);
-		}
+    int xdg_wm_base_add_listener(XdgWmBase* self, XdgWmBaseListener* listener, void* data) const
+    {
+        return _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);
+    }
 
-		void xdg_wm_base_destroy(xdg_wm_base* self) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
-			_wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
-		}
+    void xdg_wm_base_destroy(XdgWmBase* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
+        _wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
+    }
 
-		xdg_positioner* xdg_wm_base_create_positioner(xdg_wm_base* self) const
-		{
-			return reinterpret_cast<xdg_positioner*>(_wl->proxy_marshal_constructor(reinterpret_cast<wl_proxy*>(self), 1, &xdg_positioner_interface, NULL));
-		}
+    XdgPositioner* xdg_wm_base_create_positioner(XdgWmBase* self) const
+    {
+        return reinterpret_cast<XdgPositioner*>(_wl->proxy_marshal_constructor(reinterpret_cast<wl_proxy*>(self), 1, &xdg_positioner_interface, NULL));
+    }
 
-		xdg_surface* xdg_wm_base_get_xdg_surface(xdg_wm_base* self, wl_surface* surface) const
-		{
-			return reinterpret_cast<xdg_surface*>(_wl->proxy_marshal_constructor(reinterpret_cast<wl_proxy*>(self), 2, &xdg_surface_interface, NULL, surface));
-		}
+    XdgSurface* xdg_wm_base_get_xdg_surface(XdgWmBase* self, wl_surface* surface) const
+    {
+        return reinterpret_cast<XdgSurface*>(_wl->proxy_marshal_constructor(reinterpret_cast<wl_proxy*>(self), 2, &xdg_surface_interface, NULL, surface));
+    }
 
-		void xdg_wm_base_pong(xdg_wm_base* self, uint32_t serial) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 3, serial);
-		}
+    void xdg_wm_base_pong(XdgWmBase* self, uint32_t serial) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 3, serial);
+    }
 
-		// xdg_positioner dynamic declarations
+    // xdg_positioner dynamic declarations
 
-		wl_interface xdg_positioner_interface;
+    wl_interface xdg_positioner_interface;
 
-		void xdg_positioner_destroy(xdg_positioner* self) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
-			_wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
-		}
+    void xdg_positioner_destroy(XdgPositioner* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
+        _wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
+    }
 
-		void xdg_positioner_set_size(xdg_positioner* self, int32_t width, int32_t height) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 1, width, height);
-		}
+    void xdg_positioner_set_size(XdgPositioner* self, int32_t width, int32_t height) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 1, width, height);
+    }
 
-		void xdg_positioner_set_anchor_rect(xdg_positioner* self, int32_t x, int32_t y, int32_t width, int32_t height) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 2, x, y, width, height);
-		}
+    void xdg_positioner_set_anchor_rect(XdgPositioner* self, int32_t x, int32_t y, int32_t width, int32_t height) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 2, x, y, width, height);
+    }
 
-		void xdg_positioner_set_anchor(xdg_positioner* self, uint32_t anchor) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 3, anchor);
-		}
+    void xdg_positioner_set_anchor(XdgPositioner* self, uint32_t anchor) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 3, anchor);
+    }
 
-		void xdg_positioner_set_gravity(xdg_positioner* self, uint32_t gravity) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 4, gravity);
-		}
+    void xdg_positioner_set_gravity(XdgPositioner* self, uint32_t gravity) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 4, gravity);
+    }
 
-		void xdg_positioner_set_constraint_adjustment(xdg_positioner* self, uint32_t constraint_adjustment) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 5, constraint_adjustment);
-		}
+    void xdg_positioner_set_constraint_adjustment(XdgPositioner* self, uint32_t constraint_adjustment) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 5, constraint_adjustment);
+    }
 
-		void xdg_positioner_set_offset(xdg_positioner* self, int32_t x, int32_t y) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 6, x, y);
-		}
+    void xdg_positioner_set_offset(XdgPositioner* self, int32_t x, int32_t y) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 6, x, y);
+    }
 
-		void xdg_positioner_set_reactive(xdg_positioner* self) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 7);
-		}
+    void xdg_positioner_set_reactive(XdgPositioner* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 7);
+    }
 
-		void xdg_positioner_set_parent_size(xdg_positioner* self, int32_t parent_width, int32_t parent_height) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 8, parent_width, parent_height);
-		}
+    void xdg_positioner_set_parent_size(XdgPositioner* self, int32_t parent_width, int32_t parent_height) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 8, parent_width, parent_height);
+    }
 
-		void xdg_positioner_set_parent_configure(xdg_positioner* self, uint32_t serial) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 9, serial);
-		}
+    void xdg_positioner_set_parent_configure(XdgPositioner* self, uint32_t serial) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 9, serial);
+    }
 
-		// xdg_surface dynamic declarations
+    // xdg_surface dynamic declarations
 
-		wl_interface xdg_surface_interface;
+    wl_interface xdg_surface_interface;
 
-		int xdg_surface_add_listener(xdg_surface* self, xdg_surface_listener* listener, void* data) const
-		{
-			return _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);
-		}
+    int xdg_surface_add_listener(XdgSurface* self, XdgSurfaceListener* listener, void* data) const
+    {
+        return _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);
+    }
 
-		void xdg_surface_destroy(xdg_surface* self) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
-			_wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
-		}
+    void xdg_surface_destroy(XdgSurface* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
+        _wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
+    }
 
-		xdg_toplevel* xdg_surface_get_toplevel(xdg_surface* self) const
-		{
-			return reinterpret_cast<xdg_toplevel*>(_wl->proxy_marshal_constructor(reinterpret_cast<wl_proxy*>(self), 1, &xdg_toplevel_interface, NULL));
-		}
+    XdgToplevel* xdg_surface_get_toplevel(XdgSurface* self) const
+    {
+        return reinterpret_cast<XdgToplevel*>(_wl->proxy_marshal_constructor(reinterpret_cast<wl_proxy*>(self), 1, &xdg_toplevel_interface, NULL));
+    }
 
-		xdg_popup* xdg_surface_get_popup(xdg_surface* self, xdg_surface* parent, xdg_positioner* positioner) const
-		{
-			return reinterpret_cast<xdg_popup*>(_wl->proxy_marshal_constructor(reinterpret_cast<wl_proxy*>(self), 2, &xdg_popup_interface, NULL, parent, positioner));
-		}
+    XdgPopup* xdg_surface_get_popup(XdgSurface* self, XdgSurface* parent, XdgPositioner* positioner) const
+    {
+        return reinterpret_cast<XdgPopup*>(_wl->proxy_marshal_constructor(reinterpret_cast<wl_proxy*>(self), 2, &xdg_popup_interface, NULL, parent, positioner));
+    }
 
-		void xdg_surface_set_window_geometry(xdg_surface* self, int32_t x, int32_t y, int32_t width, int32_t height) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 3, x, y, width, height);
-		}
+    void xdg_surface_set_window_geometry(XdgSurface* self, int32_t x, int32_t y, int32_t width, int32_t height) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 3, x, y, width, height);
+    }
 
-		void xdg_surface_ack_configure(xdg_surface* self, uint32_t serial) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 4, serial);
-		}
+    void xdg_surface_ack_configure(XdgSurface* self, uint32_t serial) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 4, serial);
+    }
 
-		// xdg_toplevel dynamic declarations
+    // xdg_toplevel dynamic declarations
 
-		wl_interface xdg_toplevel_interface;
+    wl_interface xdg_toplevel_interface;
 
-		int xdg_toplevel_add_listener(xdg_toplevel* self, xdg_toplevel_listener* listener, void* data) const
-		{
-			return _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);
-		}
+    int xdg_toplevel_add_listener(XdgToplevel* self, XdgToplevelListener* listener, void* data) const
+    {
+        return _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);
+    }
 
-		void xdg_toplevel_destroy(xdg_toplevel* self) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
-			_wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
-		}
+    void xdg_toplevel_destroy(XdgToplevel* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
+        _wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
+    }
 
-		void xdg_toplevel_set_parent(xdg_toplevel* self, xdg_toplevel* parent) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 1, parent);
-		}
+    void xdg_toplevel_set_parent(XdgToplevel* self, XdgToplevel* parent) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 1, parent);
+    }
 
-		void xdg_toplevel_set_title(xdg_toplevel* self, const char* title) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 2, title);
-		}
+    void xdg_toplevel_set_title(XdgToplevel* self, const char* title) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 2, title);
+    }
 
-		void xdg_toplevel_set_app_id(xdg_toplevel* self, const char* app_id) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 3, app_id);
-		}
+    void xdg_toplevel_set_app_id(XdgToplevel* self, const char* app_id) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 3, app_id);
+    }
 
-		void xdg_toplevel_show_window_menu(xdg_toplevel* self, wl_seat* seat, uint32_t serial, int32_t x, int32_t y) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 4, seat, serial, x, y);
-		}
+    void xdg_toplevel_show_window_menu(XdgToplevel* self, wl_seat* seat, uint32_t serial, int32_t x, int32_t y) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 4, seat, serial, x, y);
+    }
 
-		void xdg_toplevel_move(xdg_toplevel* self, wl_seat* seat, uint32_t serial) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 5, seat, serial);
-		}
+    void xdg_toplevel_move(XdgToplevel* self, wl_seat* seat, uint32_t serial) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 5, seat, serial);
+    }
 
-		void xdg_toplevel_resize(xdg_toplevel* self, wl_seat* seat, uint32_t serial, uint32_t edges) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 6, seat, serial, edges);
-		}
+    void xdg_toplevel_resize(XdgToplevel* self, wl_seat* seat, uint32_t serial, uint32_t edges) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 6, seat, serial, edges);
+    }
 
-		void xdg_toplevel_set_max_size(xdg_toplevel* self, int32_t width, int32_t height) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 7, width, height);
-		}
+    void xdg_toplevel_set_max_size(XdgToplevel* self, int32_t width, int32_t height) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 7, width, height);
+    }
 
-		void xdg_toplevel_set_min_size(xdg_toplevel* self, int32_t width, int32_t height) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 8, width, height);
-		}
+    void xdg_toplevel_set_min_size(XdgToplevel* self, int32_t width, int32_t height) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 8, width, height);
+    }
 
-		void xdg_toplevel_set_maximized(xdg_toplevel* self) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 9);
-		}
+    void xdg_toplevel_set_maximized(XdgToplevel* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 9);
+    }
 
-		void xdg_toplevel_unset_maximized(xdg_toplevel* self) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 10);
-		}
+    void xdg_toplevel_unset_maximized(XdgToplevel* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 10);
+    }
 
-		void xdg_toplevel_set_fullscreen(xdg_toplevel* self, wl_output* output) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 11, output);
-		}
+    void xdg_toplevel_set_fullscreen(XdgToplevel* self, wl_output* output) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 11, output);
+    }
 
-		void xdg_toplevel_unset_fullscreen(xdg_toplevel* self) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 12);
-		}
+    void xdg_toplevel_unset_fullscreen(XdgToplevel* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 12);
+    }
 
-		void xdg_toplevel_set_minimized(xdg_toplevel* self) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 13);
-		}
+    void xdg_toplevel_set_minimized(XdgToplevel* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 13);
+    }
 
-		// xdg_popup dynamic declarations
+    // xdg_popup dynamic declarations
 
-		wl_interface xdg_popup_interface;
+    wl_interface xdg_popup_interface;
 
-		int xdg_popup_add_listener(xdg_popup* self, xdg_popup_listener* listener, void* data) const
-		{
-			return _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);
-		}
+    int xdg_popup_add_listener(XdgPopup* self, XdgPopupListener* listener, void* data) const
+    {
+        return _wl->proxy_add_listener(reinterpret_cast<wl_proxy*>(self), reinterpret_cast<void (**)(void)>(listener), data);
+    }
 
-		void xdg_popup_destroy(xdg_popup* self) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
-			_wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
-		}
+    void xdg_popup_destroy(XdgPopup* self) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 0);
+        _wl->proxy_destroy(reinterpret_cast<wl_proxy*>(self));
+    }
 
-		void xdg_popup_grab(xdg_popup* self, wl_seat* seat, uint32_t serial) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 1, seat, serial);
-		}
+    void xdg_popup_grab(XdgPopup* self, wl_seat* seat, uint32_t serial) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 1, seat, serial);
+    }
 
-		void xdg_popup_reposition(xdg_popup* self, xdg_positioner* positioner, uint32_t token) const
-		{
-			_wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 2, positioner, token);
-		}
+    void xdg_popup_reposition(XdgPopup* self, XdgPositioner* positioner, uint32_t token) const
+    {
+        _wl->proxy_marshal(reinterpret_cast<wl_proxy*>(self), 2, positioner, token);
+    }
 
-		// Call this once libwayland-client is successfully loaded
+    // Call this once libwayland-client is successfully loaded
 
-		void initialize(const WaylandLoader* waylandLoader)
-		{
-			_wl = &waylandLoader->GetFunctionTable();
+    void initialize(const WaylandLoader* waylandLoader)
+    {
+        _wl = &waylandLoader->GetFunctionTable();
 
-			_messageArgs = {
-				&xdg_positioner_interface,
-				&xdg_surface_interface,
-				_wl->surface_interface,
-				nullptr,
-				nullptr,
-				nullptr,
-				nullptr,
-				&xdg_toplevel_interface,
-				&xdg_popup_interface,
-				&xdg_surface_interface,
-				&xdg_positioner_interface,
-				_wl->seat_interface,
-				nullptr,
-				nullptr,
-				nullptr,
-				_wl->output_interface,
-				&xdg_positioner_interface,
-				nullptr,
-			};
+        _messageArgs = {
+            &xdg_positioner_interface,
+            &xdg_surface_interface,
+            _wl->surface_interface,
+            nullptr,
+            nullptr,
+            nullptr,
+            nullptr,
+            &xdg_toplevel_interface,
+            &xdg_popup_interface,
+            &xdg_surface_interface,
+            &xdg_positioner_interface,
+            _wl->seat_interface,
+            nullptr,
+            nullptr,
+            nullptr,
+            _wl->output_interface,
+            &xdg_positioner_interface,
+            nullptr,
+        };
 
-			_messages = {
-				{ "destroy", "", _messageArgs.data() + 0 },
-				{ "create_positioner", "n", _messageArgs.data() + 0 },
-				{ "get_xdg_surface", "no", _messageArgs.data() + 1 },
-				{ "pong", "u", _messageArgs.data() + 3 },
-				{ "ping", "u", _messageArgs.data() + 3 },
-				{ "destroy", "", _messageArgs.data() + 0 },
-				{ "set_size", "ii", _messageArgs.data() + 3 },
-				{ "set_anchor_rect", "iiii", _messageArgs.data() + 3 },
-				{ "set_anchor", "u", _messageArgs.data() + 3 },
-				{ "set_gravity", "u", _messageArgs.data() + 3 },
-				{ "set_constraint_adjustment", "u", _messageArgs.data() + 3 },
-				{ "set_offset", "ii", _messageArgs.data() + 3 },
-				{ "set_reactive", "3", _messageArgs.data() + 0 },
-				{ "set_parent_size", "3ii", _messageArgs.data() + 3 },
-				{ "set_parent_configure", "3u", _messageArgs.data() + 3 },
-				{ "destroy", "", _messageArgs.data() + 0 },
-				{ "get_toplevel", "n", _messageArgs.data() + 7 },
-				{ "get_popup", "no?o", _messageArgs.data() + 8 },
-				{ "set_window_geometry", "iiii", _messageArgs.data() + 3 },
-				{ "ack_configure", "u", _messageArgs.data() + 3 },
-				{ "configure", "u", _messageArgs.data() + 3 },
-				{ "destroy", "", _messageArgs.data() + 0 },
-				{ "set_parent", "o?", _messageArgs.data() + 7 },
-				{ "set_title", "s", _messageArgs.data() + 3 },
-				{ "set_app_id", "s", _messageArgs.data() + 3 },
-				{ "show_window_menu", "ouii", _messageArgs.data() + 11 },
-				{ "move", "ou", _messageArgs.data() + 11 },
-				{ "resize", "ouu", _messageArgs.data() + 11 },
-				{ "set_max_size", "ii", _messageArgs.data() + 3 },
-				{ "set_min_size", "ii", _messageArgs.data() + 3 },
-				{ "set_maximized", "", _messageArgs.data() + 0 },
-				{ "unset_maximized", "", _messageArgs.data() + 0 },
-				{ "set_fullscreen", "o?", _messageArgs.data() + 15 },
-				{ "unset_fullscreen", "", _messageArgs.data() + 0 },
-				{ "set_minimized", "", _messageArgs.data() + 0 },
-				{ "configure", "iia", _messageArgs.data() + 3 },
-				{ "close", "", _messageArgs.data() + 0 },
-				{ "configure_bounds", "4ii", _messageArgs.data() + 3 },
-				{ "wm_capabilities", "5a", _messageArgs.data() + 3 },
-				{ "destroy", "", _messageArgs.data() + 0 },
-				{ "grab", "ou", _messageArgs.data() + 11 },
-				{ "reposition", "3ou", _messageArgs.data() + 16 },
-				{ "configure", "iiii", _messageArgs.data() + 3 },
-				{ "popup_done", "", _messageArgs.data() + 0 },
-				{ "repositioned", "3u", _messageArgs.data() + 3 },
-			};
+        _messages = {
+            { "destroy", "", _messageArgs.data() + 0 },
+            { "create_positioner", "n", _messageArgs.data() + 0 },
+            { "get_xdg_surface", "no", _messageArgs.data() + 1 },
+            { "pong", "u", _messageArgs.data() + 3 },
+            { "ping", "u", _messageArgs.data() + 3 },
+            { "destroy", "", _messageArgs.data() + 0 },
+            { "set_size", "ii", _messageArgs.data() + 3 },
+            { "set_anchor_rect", "iiii", _messageArgs.data() + 3 },
+            { "set_anchor", "u", _messageArgs.data() + 3 },
+            { "set_gravity", "u", _messageArgs.data() + 3 },
+            { "set_constraint_adjustment", "u", _messageArgs.data() + 3 },
+            { "set_offset", "ii", _messageArgs.data() + 3 },
+            { "set_reactive", "3", _messageArgs.data() + 0 },
+            { "set_parent_size", "3ii", _messageArgs.data() + 3 },
+            { "set_parent_configure", "3u", _messageArgs.data() + 3 },
+            { "destroy", "", _messageArgs.data() + 0 },
+            { "get_toplevel", "n", _messageArgs.data() + 7 },
+            { "get_popup", "no?o", _messageArgs.data() + 8 },
+            { "set_window_geometry", "iiii", _messageArgs.data() + 3 },
+            { "ack_configure", "u", _messageArgs.data() + 3 },
+            { "configure", "u", _messageArgs.data() + 3 },
+            { "destroy", "", _messageArgs.data() + 0 },
+            { "set_parent", "o?", _messageArgs.data() + 7 },
+            { "set_title", "s", _messageArgs.data() + 3 },
+            { "set_app_id", "s", _messageArgs.data() + 3 },
+            { "show_window_menu", "ouii", _messageArgs.data() + 11 },
+            { "move", "ou", _messageArgs.data() + 11 },
+            { "resize", "ouu", _messageArgs.data() + 11 },
+            { "set_max_size", "ii", _messageArgs.data() + 3 },
+            { "set_min_size", "ii", _messageArgs.data() + 3 },
+            { "set_maximized", "", _messageArgs.data() + 0 },
+            { "unset_maximized", "", _messageArgs.data() + 0 },
+            { "set_fullscreen", "o?", _messageArgs.data() + 15 },
+            { "unset_fullscreen", "", _messageArgs.data() + 0 },
+            { "set_minimized", "", _messageArgs.data() + 0 },
+            { "configure", "iia", _messageArgs.data() + 3 },
+            { "close", "", _messageArgs.data() + 0 },
+            { "configure_bounds", "4ii", _messageArgs.data() + 3 },
+            { "wm_capabilities", "5a", _messageArgs.data() + 3 },
+            { "destroy", "", _messageArgs.data() + 0 },
+            { "grab", "ou", _messageArgs.data() + 11 },
+            { "reposition", "3ou", _messageArgs.data() + 16 },
+            { "configure", "iiii", _messageArgs.data() + 3 },
+            { "popup_done", "", _messageArgs.data() + 0 },
+            { "repositioned", "3u", _messageArgs.data() + 3 },
+        };
 
-			xdg_wm_base_interface = { "xdg_wm_base", 6, 4, _messages.data() + 0, 1, _messages.data() + 4 };
-			xdg_positioner_interface = { "xdg_positioner", 6, 10, _messages.data() + 5, 0, _messages.data() + 15 };
-			xdg_surface_interface = { "xdg_surface", 6, 5, _messages.data() + 15, 1, _messages.data() + 20 };
-			xdg_toplevel_interface = { "xdg_toplevel", 6, 14, _messages.data() + 21, 4, _messages.data() + 35 };
-			xdg_popup_interface = { "xdg_popup", 6, 3, _messages.data() + 39, 3, _messages.data() + 42 };
-		}
+        xdg_wm_base_interface = { "xdg_wm_base", 7, 4, _messages.data() + 0, 1, _messages.data() + 4 };
+        xdg_positioner_interface = { "xdg_positioner", 7, 10, _messages.data() + 5, 0, _messages.data() + 15 };
+        xdg_surface_interface = { "xdg_surface", 7, 5, _messages.data() + 15, 1, _messages.data() + 20 };
+        xdg_toplevel_interface = { "xdg_toplevel", 7, 14, _messages.data() + 21, 4, _messages.data() + 35 };
+        xdg_popup_interface = { "xdg_popup", 7, 3, _messages.data() + 39, 3, _messages.data() + 42 };
+    }
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -149,6 +149,8 @@ target_sources(gfxrecon_util
                     $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_loader.h>
                     $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_loader.cpp>
                     $<$<BOOL:${WAYLAND_FOUND}>:${GFXRECON_SOURCE_DIR}/framework/generated/generated_wayland_xdg_shell.h>
+                    $<$<BOOL:${WAYLAND_FOUND}>:${GFXRECON_SOURCE_DIR}/framework/generated/generated_wayland_viewporter.h>
+                    $<$<BOOL:${WAYLAND_FOUND}>:${GFXRECON_SOURCE_DIR}/framework/generated/generated_wayland_fractional_scale_v1.h>
 )
 
 

--- a/framework/util/wayland_loader.cpp
+++ b/framework/util/wayland_loader.cpp
@@ -138,8 +138,12 @@ bool WaylandLoader::Initialize()
                 util::platform::GetProcAddress(libwayland_, "wl_shell_surface_interface"));
 
             // additional protocols
-            function_table_.xdg = std::make_unique<wayland_xdg_shell_table>();
+            function_table_.xdg = std::make_unique<WaylandXdgShellTable>();
             function_table_.xdg->initialize(this);
+            function_table_.viewporter = std::make_unique<WaylandViewporterTable>();
+            function_table_.viewporter->initialize(this);
+            function_table_.frac_scale = std::make_unique<WaylandFractionalScaleV1Table>();
+            function_table_.frac_scale->initialize(this);
         }
         else
         {

--- a/framework/util/wayland_loader.h
+++ b/framework/util/wayland_loader.h
@@ -33,7 +33,9 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
 
-class wayland_xdg_shell_table;
+class WaylandXdgShellTable;
+class WaylandViewporterTable;
+class WaylandFractionalScaleV1Table;
 
 class WaylandLoader
 {
@@ -73,7 +75,9 @@ class WaylandLoader
         decltype(wl_shell_surface_interface)* shell_surface_interface;
 
         // additional protocols
-        std::unique_ptr<wayland_xdg_shell_table> xdg;
+        std::unique_ptr<WaylandXdgShellTable>          xdg;
+        std::unique_ptr<WaylandViewporterTable>        viewporter;
+        std::unique_ptr<WaylandFractionalScaleV1Table> frac_scale;
 
         // inline functions, adapted from wayland-client-protocol.h
         struct wl_surface* compositor_create_surface(struct wl_compositor* wl_compositor) const
@@ -308,5 +312,7 @@ GFXRECON_END_NAMESPACE(util)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
 #include "generated/generated_wayland_xdg_shell.h"
+#include "generated/generated_wayland_viewporter.h"
+#include "generated/generated_wayland_fractional_scale_v1.h"
 
 #endif // GFXRECON_UTIL_WAYLAND_LOADER_H


### PR DESCRIPTION
The replay window used wl_surface::set_buffer_scale with the integer scale from wl_output. On a fractionally scaled desktop (125%, 150%) compositors report 2 to clients that do not speak wp_fractional_scale_v1, so the window claimed twice the logical size it needed and appeared at roughly half size.
    
Bind wp_viewporter and wp_fractional_scale_manager_v1, leave the buffer at scale 1, and set a viewport destination of pixels divided by the preferred scale. One buffer pixel then lands on one physical pixel. Compositors that advertise neither protocol keep the old integer-scale path unchanged.

To reproduce issue, boot into Gnome with Wayland enabled (my system was Fedora 44), under Settings, Display, select your monitor and set "Scale" to some value other than 100%.  I tested with 125%.  Before this fix, the replay swapchain was 1/2 the size= it should have been compared to the capture itself.
