### PR TITLE
Support VkImageFormatListCreateInfo for vkCreateSwapchainKHR

### DIFF
--- a/framework/decode/openxr_replay_consumer_base.cpp
+++ b/framework/decode/openxr_replay_consumer_base.cpp
@@ -1443,7 +1443,7 @@ void OpenXrReplayConsumerBase::UpdateState_xrEnumerateSwapchainImages(
     XrResult result = swapchain_data.ImportReplaySwapchain(images);
     if (XR_SUCCEEDED(result))
     {
-        result = swapchain_data.InitVirtualSwapchain(imageCountOutput, images);
+        result = swapchain_data.InitVirtualSwapchain(swapchain, imageCountOutput, images);
     }
 
     if (!XR_SUCCEEDED(result))

--- a/framework/decode/openxr_replay_swapchain_state.cpp
+++ b/framework/decode/openxr_replay_swapchain_state.cpp
@@ -86,7 +86,8 @@ XrResult SwapchainData::ImportReplaySwapchain(StructPointerDecoder<Decoded_XrSwa
     return result;
 }
 
-XrResult SwapchainData::InitVirtualSwapchain(PointerDecoder<uint32_t>*                                 imageCountOutput,
+XrResult SwapchainData::InitVirtualSwapchain(format::HandleId                                          swapchain_id,
+                                             PointerDecoder<uint32_t>*                                 imageCountOutput,
                                              StructPointerDecoder<Decoded_XrSwapchainImageBaseHeader>* capture_images)
 {
     // This call is invalid without a Session with a graphics binding specified
@@ -98,7 +99,7 @@ XrResult SwapchainData::InitVirtualSwapchain(PointerDecoder<uint32_t>*          
     {
         auto* vk_capture_images =
             reinterpret_cast<StructPointerDecoder<Decoded_XrSwapchainImageVulkanKHR>*>(capture_images);
-        result = InitVirtualSwapchain(imageCountOutput, vk_capture_images);
+        result = InitVirtualSwapchain(swapchain_id, imageCountOutput, vk_capture_images);
     }
     else
     {
@@ -110,7 +111,8 @@ XrResult SwapchainData::InitVirtualSwapchain(PointerDecoder<uint32_t>*          
     return result;
 }
 
-XrResult SwapchainData::InitVirtualSwapchain(PointerDecoder<uint32_t>*                                imageCountOutput,
+XrResult SwapchainData::InitVirtualSwapchain(format::HandleId                                         swapchain_id,
+                                             PointerDecoder<uint32_t>*                                imageCountOutput,
                                              StructPointerDecoder<Decoded_XrSwapchainImageVulkanKHR>* capture_images)
 {
 
@@ -235,9 +237,9 @@ XrResult SwapchainData::InitVirtualSwapchain(PointerDecoder<uint32_t>*          
 
         // Now tell the Vulkan Consumer to map the proxy image to the matching captured image id
         VulkanImageInfo handle_info;
-        handle_info.handle             = proxy.image;
-        handle_info.memory             = proxy.memory;
-        handle_info.is_swapchain_image = true;
+        handle_info.handle       = proxy.image;
+        handle_info.memory       = proxy.memory;
+        handle_info.swapchain_id = swapchain_id;
         vk_binding.vulkan_consumer->AddImageHandle(device_id, image_id, proxy.image, std::move(handle_info));
 
         vk_swap.proxy_images.emplace_back(proxy);

--- a/framework/decode/openxr_replay_swapchain_state.h
+++ b/framework/decode/openxr_replay_swapchain_state.h
@@ -47,9 +47,11 @@ class SwapchainData : public BaseReplayData<XrSwapchain>
     void
     InitSwapchainData(const GraphicsBinding& binding, const XrSwapchainCreateInfo& info, XrSwapchain replay_handle);
     XrResult ImportReplaySwapchain(StructPointerDecoder<Decoded_XrSwapchainImageBaseHeader>* images);
-    XrResult InitVirtualSwapchain(PointerDecoder<uint32_t>*                                 imageCountOutput,
+    XrResult InitVirtualSwapchain(format::HandleId                                          swapchain_id,
+                                  PointerDecoder<uint32_t>*                                 imageCountOutput,
                                   StructPointerDecoder<Decoded_XrSwapchainImageBaseHeader>* capture_images);
-    XrResult InitVirtualSwapchain(PointerDecoder<uint32_t>*                                imageCountOutput,
+    XrResult InitVirtualSwapchain(format::HandleId                                         swapchain_id,
+                                  PointerDecoder<uint32_t>*                                imageCountOutput,
                                   StructPointerDecoder<Decoded_XrSwapchainImageVulkanKHR>* vk_capture_images);
     XrResult AcquireSwapchainImage(uint32_t capture_index, uint32_t replay_index);
     XrResult ReleaseSwapchainImage(StructPointerDecoder<Decoded_XrSwapchainImageReleaseInfo>* releaseInfo);

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -52,7 +52,7 @@ void AddChildObject<VulkanImageInfo>(
 {
     assert(objects != nullptr);
 
-    if (!info->is_swapchain_image)
+    if (info->swapchain_id == format::kNullHandleId)
     {
         (*objects)[info->parent_id].insert(std::make_pair(info->handle, info));
     }

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -469,7 +469,7 @@ struct VulkanImageInfo : public VulkanObjectInfo<VkImage>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
 
-    bool is_swapchain_image{ false };
+    format::HandleId swapchain_id{ format::kNullHandleId };
 
     // The following values are only used for memory portability.
     VulkanResourceAllocator::ResourceData allocator_data{ 0 };
@@ -639,6 +639,7 @@ struct VulkanSwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
     uint32_t             width{ 0 };
     uint32_t             height{ 0 };
     VkFormat             format{ VK_FORMAT_UNDEFINED };
+    std::vector<VkFormat> supported_view_formats; // Based on VkImageFormatListCreateInfo
     std::vector<VkImage> images; // This image could be virtual or real according to if it uses VirtualSwapchain.
     std::unordered_map<uint32_t, size_t> array_counts;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -8688,6 +8688,13 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
     swapchain_info->height             = modified_create_info.imageExtent.height;
     swapchain_info->format             = modified_create_info.imageFormat;
 
+    if (const auto* format_list = graphics::vulkan_struct_get_pnext<VkImageFormatListCreateInfo>(replay_create_info);
+        format_list != nullptr && format_list->viewFormatCount > 0)
+    {
+        swapchain_info->supported_view_formats.assign(format_list->pViewFormats,
+                                                      format_list->pViewFormats + format_list->viewFormatCount);
+    }
+
     // Track the application's original intended pre-transform instead of modified_create_info.preTransform.
     // When replaying Android traces on Desktop, the WSI layer may override the transform to IDENTITY since Desktop
     // surfaces often don't support rotation. However, the captured drawing commands remain rotated, so we must
@@ -8831,16 +8838,16 @@ VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapch
                     break;
                 }
 
-                image_info->format             = swapchain_info->format;
-                image_info->extent             = { swapchain_info->width, swapchain_info->height, 1 };
-                image_info->layer_count        = swapchain_info->image_array_layers;
-                image_info->level_count        = 1;
-                image_info->tiling             = VK_IMAGE_TILING_OPTIMAL;
-                image_info->usage              = swapchain_info->image_usage;
-                image_info->sample_count       = VK_SAMPLE_COUNT_1_BIT;
-                image_info->type               = VK_IMAGE_TYPE_2D;
-                image_info->current_layout     = VK_IMAGE_LAYOUT_UNDEFINED;
-                image_info->is_swapchain_image = true;
+                image_info->format         = swapchain_info->format;
+                image_info->extent         = { swapchain_info->width, swapchain_info->height, 1 };
+                image_info->layer_count    = swapchain_info->image_array_layers;
+                image_info->level_count    = 1;
+                image_info->tiling         = VK_IMAGE_TILING_OPTIMAL;
+                image_info->usage          = swapchain_info->image_usage;
+                image_info->sample_count   = VK_SAMPLE_COUNT_1_BIT;
+                image_info->type           = VK_IMAGE_TYPE_2D;
+                image_info->current_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+                image_info->swapchain_id   = swapchain_info->capture_id;
 
                 // Create a copy of the image info to use for image cleanup when the swapchain is destroyed.
                 swapchain_info->image_infos.push_back(*image_info);
@@ -8873,16 +8880,16 @@ VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapch
                 auto* image_info = static_cast<VulkanImageInfo*>(pSwapchainImages->GetConsumerData(i));
                 GFXRECON_ASSERT(image_info != nullptr);
 
-                image_info->format             = swapchain_info->format;
-                image_info->extent             = { swapchain_info->width, swapchain_info->height, 1 };
-                image_info->layer_count        = swapchain_info->image_array_layers;
-                image_info->level_count        = 1;
-                image_info->tiling             = VK_IMAGE_TILING_OPTIMAL;
-                image_info->usage              = swapchain_info->image_usage;
-                image_info->sample_count       = VK_SAMPLE_COUNT_1_BIT;
-                image_info->type               = VK_IMAGE_TYPE_2D;
-                image_info->current_layout     = VK_IMAGE_LAYOUT_UNDEFINED;
-                image_info->is_swapchain_image = true;
+                image_info->format         = swapchain_info->format;
+                image_info->extent         = { swapchain_info->width, swapchain_info->height, 1 };
+                image_info->layer_count    = swapchain_info->image_array_layers;
+                image_info->level_count    = 1;
+                image_info->tiling         = VK_IMAGE_TILING_OPTIMAL;
+                image_info->usage          = swapchain_info->image_usage;
+                image_info->sample_count   = VK_SAMPLE_COUNT_1_BIT;
+                image_info->type           = VK_IMAGE_TYPE_2D;
+                image_info->current_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+                image_info->swapchain_id   = swapchain_info->capture_id;
             }
 
             // Store image handles for screenshot generation.
@@ -11456,19 +11463,37 @@ VkResult VulkanReplayConsumerBase::OverrideCreateImageView(
             modified_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
         }
     }
-    else if (img_info->is_swapchain_image && img_info->format != modified_create_info.format)
+    else if (img_info->swapchain_id != format::kNullHandleId)
     {
-        // for swapchain-images set image-view to a fallback format, avoid issues with distorted HDR/SRGB colors.
-        // when the swapchain fell back to a BGRA8 format we preserve the captured view's sRGB-ness; for any other
-        // fallback format we match the swapchain image format exactly to keep the view format-compatible.
-        if (img_info->format == VK_FORMAT_B8G8R8A8_UNORM || img_info->format == VK_FORMAT_B8G8R8A8_SRGB)
+        auto* swapchain_info = GetObjectInfoTable().GetVkSwapchainKHRInfo(img_info->swapchain_id);
+        GFXRECON_ASSERT(swapchain_info != nullptr);
+
+        // If the CreateSwapchainKHR has VkImageFormatListCreateInfo, the swapchain could support multiple view formats.
+        // The view format doesn't have to be the same as the swapchain image format.
+        if (!swapchain_info->supported_view_formats.empty())
         {
-            modified_create_info.format =
-                vkuFormatIsSRGB(modified_create_info.format) ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8A8_UNORM;
+            const auto found = std::find(swapchain_info->supported_view_formats.begin(),
+                                         swapchain_info->supported_view_formats.end(),
+                                         modified_create_info.format);
+            if (found == swapchain_info->supported_view_formats.end())
+            {
+                modified_create_info.format = swapchain_info->supported_view_formats[0];
+            }
         }
         else
         {
-            modified_create_info.format = img_info->format;
+            // for swapchain-images set image-view to a fallback format, avoid issues with distorted HDR/SRGB colors.
+            // when the swapchain fell back to a BGRA8 format we preserve the captured view's sRGB-ness; for any other
+            // fallback format we match the swapchain image format exactly to keep the view format-compatible.
+            if (img_info->format == VK_FORMAT_B8G8R8A8_UNORM || img_info->format == VK_FORMAT_B8G8R8A8_SRGB)
+            {
+                modified_create_info.format =
+                    vkuFormatIsSRGB(modified_create_info.format) ? VK_FORMAT_B8G8R8A8_SRGB : VK_FORMAT_B8G8R8A8_UNORM;
+            }
+            else
+            {
+                modified_create_info.format = img_info->format;
+            }
         }
     }
 


### PR DESCRIPTION
If the `CreateSwapchainKHR` has `VkImageFormatListCreateInfo`, the swapchain could support multiple view formats. The view format doesn't have to be the same as the swapchain image format.