### PR TITLE
optimize: Fix removing creation calls of referenced pipelines

### DIFF
--- a/framework/decode/referenced_resource_table.cpp
+++ b/framework/decode/referenced_resource_table.cpp
@@ -135,6 +135,13 @@ void ReferencedResourceTable::AddResourceToUser(format::HandleId user_id, format
                 {
                     user_info->resource_infos.emplace(child_resource_id, child_resource_info);
                 }
+
+                // A user that has already been submitted keeps all of its recorded blocks in the optimized file,
+                // even if the current recording is never submitted, so the resource must be treated as referenced.
+                if (user_info->used)
+                {
+                    MarkResourceUsed(resource_info.get());
+                }
             }
         }
     }
@@ -192,6 +199,13 @@ void ReferencedResourceTable::AddUserToUser(format::HandleId user_id, format::Ha
                         user_info->container_infos.insert(source_container_info);
                     }
                 }
+
+                // An already-submitted user keeps all of its recorded blocks, including this execute-commands
+                // block, so the child user's recording must be treated as submitted as well.
+                if (user_info->used)
+                {
+                    ProcessUserSubmission(child_user_id);
+                }
             }
         }
     }
@@ -246,7 +260,12 @@ void ReferencedResourceTable::RemoveUser(format::HandleId user_id)
             GFXRECON_ASSERT(user_info != nullptr);
 
             user_pool_handles_[user_info->pool_id].erase(user_id);
-            users_.erase(user_entry);
+
+            // NOTE: the user entry is intentionally kept in the table.  Handle ids are never reused within a capture,
+            // and the blocks recorded into a destroyed user remain in the capture file, so the user must still be
+            // classified by GetReferencedHandleIds: either as unreferenced (never submitted), so that its recorded
+            // blocks are removed together with the creation calls of resources only it references, or as referenced
+            // (submitted), so that the resources it references stay alive.
         }
     }
 }
@@ -326,13 +345,9 @@ void ReferencedResourceTable::ClearUsers(format::HandleId pool_id)
 {
     if (pool_id != format::kNullHandleId)
     {
-        auto& user_ids = user_pool_handles_[pool_id];
-        for (auto user_id : user_ids)
-        {
-            users_.erase(user_id);
-        }
-
-        user_ids.clear();
+        // NOTE: the user entries are intentionally kept in the table so they can still be classified by
+        // GetReferencedHandleIds; see RemoveUser.
+        user_pool_handles_[pool_id].clear();
     }
 }
 
@@ -366,7 +381,14 @@ void ReferencedResourceTable::CopyContainerEntry(format::HandleId source_contain
 
 void ReferencedResourceTable::ProcessUserSubmission(format::HandleId user_id)
 {
-    if (user_id != format::kNullHandleId)
+    std::unordered_set<format::HandleId> processed_users;
+    ProcessUserSubmission(user_id, processed_users);
+}
+
+void ReferencedResourceTable::ProcessUserSubmission(format::HandleId                      user_id,
+                                                    std::unordered_set<format::HandleId>& processed_users)
+{
+    if ((user_id != format::kNullHandleId) && processed_users.insert(user_id).second)
     {
         if (auto user_entry = users_.find(user_id); user_entry != users_.end())
         {
@@ -381,16 +403,7 @@ void ReferencedResourceTable::ProcessUserSubmission(format::HandleId user_id)
                 // attempt to lock a std::weak_ptr
                 if (auto resource_info_ptr = resource_info.second.lock())
                 {
-                    resource_info_ptr->used = true;
-
-                    for (auto& [child_id, child_info] : resource_info_ptr->child_infos)
-                    {
-                        // attempt to lock a std::weak_ptr
-                        if (auto child_info_ptr = child_info.lock())
-                        {
-                            child_info_ptr->used = true;
-                        }
-                    }
+                    MarkResourceUsed(resource_info_ptr.get());
                 }
             }
 
@@ -404,29 +417,34 @@ void ReferencedResourceTable::ProcessUserSubmission(format::HandleId user_id)
                         // attempt to lock a std::weak_ptr
                         if (auto resource_info_ptr = resource_info.second.lock())
                         {
-                            resource_info_ptr->used = true;
-
-                            for (auto& child_info_weak : resource_info_ptr->child_infos | std::views::values)
-                            {
-                                // attempt to lock a std::weak_ptr
-                                if (auto child_info_ptr = child_info_weak.lock())
-                                {
-                                    child_info_ptr->used = true;
-                                }
-                            }
+                            MarkResourceUsed(resource_info_ptr.get());
                         }
                     }
                 }
             }
 
-            for (auto& child_user_info : user_info->child_infos | std::views::values)
+            // Child users (secondary command buffers) are submitted along with this user, so process them
+            // recursively; this also marks resources that were recorded into a child but never copied here.
+            for (const auto& child_user_id : user_info->child_infos | std::views::keys)
             {
-                // attempt to lock a std::weak_ptr
-                if (auto child_user_ptr = child_user_info.lock())
-                {
-                    child_user_ptr->used = true;
-                }
+                ProcessUserSubmission(child_user_id, processed_users);
             }
+        }
+    }
+}
+
+void ReferencedResourceTable::MarkResourceUsed(ResourceInfo* resource_info)
+{
+    GFXRECON_ASSERT(resource_info != nullptr);
+
+    resource_info->used = true;
+
+    for (auto& child_info_weak : resource_info->child_infos | std::views::values)
+    {
+        // attempt to lock a std::weak_ptr
+        if (auto child_info_ptr = child_info_weak.lock())
+        {
+            child_info_ptr->used = true;
         }
     }
 }

--- a/framework/decode/referenced_resource_table.h
+++ b/framework/decode/referenced_resource_table.h
@@ -126,6 +126,10 @@ class ReferencedResourceTable
 
     bool IsUsed(const ResourceInfo* resource_info) const;
 
+    void ProcessUserSubmission(format::HandleId user_id, std::unordered_set<format::HandleId>& processed_users);
+
+    static void MarkResourceUsed(ResourceInfo* resource_info);
+
     std::unordered_map<format::HandleId, std::shared_ptr<ResourceInfo>>          resources_;
     std::unordered_map<format::HandleId, std::shared_ptr<ResourceContainerInfo>> containers_;
     std::unordered_map<format::HandleId, std::shared_ptr<ResourceUserInfo>>      users_;

--- a/framework/decode/test/main.cpp
+++ b/framework/decode/test/main.cpp
@@ -26,6 +26,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
+#include "decode/referenced_resource_table.h"
 #include "decode/screenshot_handler.h"
 #include "decode/vulkan_handle_mapping_util.h"
 #include "decode/vulkan_object_info.h"
@@ -312,5 +313,129 @@ TEST_CASE("Test a roundtrip between SubmitInfo2Translator and SubmitInfoTranslat
     for (uint32_t i = 0; i < submit_info.signalSemaphoreCount; ++i)
     {
         REQUIRE(r_device_group->pSignalSemaphoreDeviceIndices[i] == signal_device_indices[i]);
+    }
+}
+
+TEST_CASE("ReferencedResourceTable classifies destroyed command buffers", "[optimize]")
+{
+    using gfxrecon::decode::ReferencedResourceTable;
+    using gfxrecon::format::HandleId;
+
+    constexpr HandleId kPool     = 1;
+    constexpr HandleId kCmd      = 2;
+    constexpr HandleId kPipeline = 3;
+
+    ReferencedResourceTable table;
+    table.AddResource(kPipeline);
+    table.AddUser(kPool, kCmd);
+    table.AddResourceToUser(kCmd, kPipeline);
+
+    std::unordered_set<HandleId> unreferenced;
+
+    SECTION("recorded, never submitted, then freed: user and resource are both unreferenced")
+    {
+        // The recorded blocks of a destroyed command buffer stay in the capture file, so the user must still be
+        // classified as unreferenced for those blocks to be removed together with the pipeline creation call.
+        table.RemoveUser(kCmd); // vkFreeCommandBuffers
+
+        table.GetReferencedHandleIds(nullptr, &unreferenced);
+        REQUIRE(unreferenced.count(kCmd) == 1);
+        REQUIRE(unreferenced.count(kPipeline) == 1);
+    }
+
+    SECTION("recorded, never submitted, then pool destroyed: user and resource are both unreferenced")
+    {
+        table.ClearUsers(kPool); // vkDestroyCommandPool
+
+        table.GetReferencedHandleIds(nullptr, &unreferenced);
+        REQUIRE(unreferenced.count(kCmd) == 1);
+        REQUIRE(unreferenced.count(kPipeline) == 1);
+    }
+
+    SECTION("submitted and then freed: user and resource are both referenced")
+    {
+        table.ProcessUserSubmission(kCmd);
+        table.RemoveUser(kCmd);
+
+        table.GetReferencedHandleIds(nullptr, &unreferenced);
+        REQUIRE(unreferenced.count(kCmd) == 0);
+        REQUIRE(unreferenced.count(kPipeline) == 0);
+    }
+}
+
+TEST_CASE("ReferencedResourceTable marks resources recorded into a previously submitted user", "[optimize]")
+{
+    using gfxrecon::decode::ReferencedResourceTable;
+    using gfxrecon::format::HandleId;
+
+    constexpr HandleId kPool      = 1;
+    constexpr HandleId kCmd       = 2;
+    constexpr HandleId kPipeline1 = 3;
+    constexpr HandleId kPipeline2 = 4;
+
+    ReferencedResourceTable table;
+    table.AddUser(kPool, kCmd);
+    table.AddResource(kPipeline1);
+    table.AddResourceToUser(kCmd, kPipeline1);
+    table.ProcessUserSubmission(kCmd);
+
+    // Re-record the command buffer with a new pipeline, without a following submission (e.g. the capture ended
+    // between recording and submission).  All blocks of the submitted command buffer stay in the capture file,
+    // including the new recording, so the new pipeline must be classified as referenced.
+    table.ResetUser(kCmd); // vkBeginCommandBuffer
+    table.AddResource(kPipeline2);
+    table.AddResourceToUser(kCmd, kPipeline2);
+
+    std::unordered_set<HandleId> unreferenced;
+    table.GetReferencedHandleIds(nullptr, &unreferenced);
+    REQUIRE(unreferenced.count(kPipeline1) == 0);
+    REQUIRE(unreferenced.count(kPipeline2) == 0);
+}
+
+TEST_CASE("ReferencedResourceTable processes executed secondary command buffers", "[optimize]")
+{
+    using gfxrecon::decode::ReferencedResourceTable;
+    using gfxrecon::format::HandleId;
+
+    constexpr HandleId kPool      = 1;
+    constexpr HandleId kPrimary   = 2;
+    constexpr HandleId kSecondary = 3;
+    constexpr HandleId kNested    = 4;
+    constexpr HandleId kPipeline  = 5;
+
+    ReferencedResourceTable table;
+    table.AddUser(kPool, kPrimary);
+    table.AddUser(kPool, kSecondary);
+
+    std::unordered_set<HandleId> unreferenced;
+
+    SECTION("nested secondaries of a submitted primary are marked recursively")
+    {
+        table.AddUser(kPool, kNested);
+        table.AddResource(kPipeline);
+        table.AddResourceToUser(kNested, kPipeline);
+        table.AddUserToUser(kSecondary, kNested);  // vkCmdExecuteCommands in the secondary
+        table.AddUserToUser(kPrimary, kSecondary); // vkCmdExecuteCommands in the primary
+        table.ProcessUserSubmission(kPrimary);
+
+        table.GetReferencedHandleIds(nullptr, &unreferenced);
+        REQUIRE(unreferenced.count(kSecondary) == 0);
+        REQUIRE(unreferenced.count(kNested) == 0);
+        REQUIRE(unreferenced.count(kPipeline) == 0);
+    }
+
+    SECTION("execute-commands recorded into an already submitted primary marks the secondary")
+    {
+        table.ProcessUserSubmission(kPrimary);
+
+        // Trailing recording without a following submission: the primary's blocks all stay in the capture file,
+        // so the executed secondary and its resources must be classified as referenced.
+        table.AddResource(kPipeline);
+        table.AddResourceToUser(kSecondary, kPipeline);
+        table.AddUserToUser(kPrimary, kSecondary);
+
+        table.GetReferencedHandleIds(nullptr, &unreferenced);
+        REQUIRE(unreferenced.count(kSecondary) == 0);
+        REQUIRE(unreferenced.count(kPipeline) == 0);
     }
 }

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -273,6 +273,10 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
 
             const auto* meta_create_info = pCreateInfos->GetMetaStructPointer() + i;
 
+            // Track the base pipeline of a derivative pipeline as a child, so that creation of the base pipeline is
+            // preserved whenever the derivative pipeline is referenced (its create info names the base handle).
+            table_.AddResource(pipeline_id, meta_create_info->basePipelineHandle);
+
             if (auto* meta_pipeline_info =
                     GetPNextMetaStruct<Decoded_VkPipelineLibraryCreateInfoKHR>(meta_create_info->pNext))
             {


### PR DESCRIPTION
Command buffers (CB) that were never submitted but freed were retained in the capture file because their ids were removed from the live objects hence they were never been scanned for whethere they were referenced or not.

On the other hand pipeline objects that were referenced by such a CB were considered as unreferenced (the CB was never submitted) and their creation blocks were removed. This caused crashes as the vkCmdBindPipeline commands were replayed.

This PR fixes this issue. Note that this does not apply to other tracked objects (images, buffers, etc) as the optimizer removes their Init metacommands, not their creation blocks.