### PR TITLE
vulkan: Fix queue retrieval and family selection for frame warm up

### DIFF
--- a/framework/decode/vulkan_frame_warm_up.cpp
+++ b/framework/decode/vulkan_frame_warm_up.cpp
@@ -23,9 +23,11 @@
 
 #include "vulkan_frame_warm_up.h"
 
+#include "decoder_util.h"
 #include "generated/generated_vulkan_enum_to_string.h"
 #include "graphics/vulkan_device_util.h"
 #include "graphics/vulkan_resources_util.h"
+#include "graphics/vulkan_util.h"
 #include "util/logging.h"
 #include "util/platform.h"
 
@@ -49,11 +51,24 @@ VulkanFrameWarmUp::VulkanFrameWarmUp(const VulkanDeviceInfo*                    
     device_ = device_info->handle;
     GFXRECON_ASSERT(device_ != VK_NULL_HANDLE);
 
-    injected->GetDeviceQueue(device_, 0, 0, &queue_);
+    uint32_t queue_family_index = graphics::FindComputeQueueFamilyIndex(device_info->enabled_queue_family_flags);
+    if (queue_family_index == VK_QUEUE_FAMILY_IGNORED)
+    {
+        if (!device_info->enabled_queue_family_flags.queue_family_queue_counts.empty())
+        {
+            queue_family_index = device_info->enabled_queue_family_flags.queue_family_queue_counts.begin()->first;
+        }
+        else
+        {
+            queue_family_index = 0;
+        }
+    }
+
+    queue_ = GetDeviceQueue(injected.GetTable(), device_info, queue_family_index, 0);
     GFXRECON_ASSERT(queue_ != VK_NULL_HANDLE);
 
     VkCommandPoolCreateInfo cmd_pool_info = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
-    cmd_pool_info.queueFamilyIndex        = 0;
+    cmd_pool_info.queueFamilyIndex        = queue_family_index;
     cmd_pool_info.flags                   = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
     VkResult result = injected->CreateCommandPool(device_, &cmd_pool_info, nullptr, &command_pool_);
 


### PR DESCRIPTION
When initializing `VulkanFrameWarmUp`, `vkGetDeviceQueue` was previously called directly with hardcoded family 0 and queue 0.

If the application created the device with queue flags (such as `VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT`) or non-zero family indices, calling `vkGetDeviceQueue` causes a crash in Vulkan drivers (such as on Android).

This change:
- Uses `FindComputeQueueFamilyIndex` to find the compute-capable queue family.
- Uses `GetDeviceQueue` helper from `decoder_util.h` to properly dispatch `vkGetDeviceQueue2` when queue creation flags are present.
- Sets `cmd_pool_info.queueFamilyIndex` to the resolved compute queue family.