### PR TITLE
ci: Use GitHub Releases URL for macOS zlib dependency download

### DIFF
--- a/.github/workflows/scripts/build-dependencies-macos.sh
+++ b/.github/workflows/scripts/build-dependencies-macos.sh
@@ -26,7 +26,7 @@ EOF
 curl -L \
 	-O "https://github.com/facebook/zstd/releases/download/v$ZSTD/zstd-$ZSTD.tar.gz" \
 	-O "https://github.com/lz4/lz4/releases/download/v$LZ4/lz4-$LZ4.tar.gz" \
-	-O "https://www.zlib.net/zlib-$ZLIB.tar.gz" \
+	-O "https://github.com/madler/zlib/releases/download/v$ZLIB/zlib-$ZLIB.tar.gz" \
 
 shasum -a 256 --check SHASUMS
 


### PR DESCRIPTION
Downloading from `www.zlib.net` frequently fails with connection timeouts on CI runners.

This change switches the download URL in `build-dependencies-macos.sh` to the official GitHub Releases repository (`https://github.com/madler/zlib/releases/download/v$ZLIB/zlib-$ZLIB.tar.gz`), matching how `zstd` and `lz4` are fetched.