### PR TITLE
[Frame Looping] Suppress queries 

### DIFF
--- a/framework/generated/generated_vulkan_replay_frame_loop_consumer_base.cpp
+++ b/framework/generated/generated_vulkan_replay_frame_loop_consumer_base.cpp
@@ -412,6 +412,17 @@ void VulkanReplayFrameLoopConsumerBase::Process_vkDestroyQueryPool(
     }
 }
 
+void VulkanReplayFrameLoopConsumerBase::Process_vkGetQueryPoolResults(
+    const ApiCallInfo&                          call_info,
+    args::GetQueryPoolResults&                  args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkGetQueryPoolResults(call_info, args);
+}
+
 void VulkanReplayFrameLoopConsumerBase::Process_vkCreateBuffer(
     const ApiCallInfo&                          call_info,
     args::CreateBuffer&                         args)
@@ -637,6 +648,61 @@ void VulkanReplayFrameLoopConsumerBase::Process_vkFreeCommandBuffers(
         return;
     }
     VulkanReplayConsumer::Process_vkFreeCommandBuffers(call_info, args);
+}
+
+void VulkanReplayFrameLoopConsumerBase::Process_vkCmdBeginQuery(
+    const ApiCallInfo&                          call_info,
+    args::CmdBeginQuery&                        args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdBeginQuery(call_info, args);
+}
+
+void VulkanReplayFrameLoopConsumerBase::Process_vkCmdEndQuery(
+    const ApiCallInfo&                          call_info,
+    args::CmdEndQuery&                          args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdEndQuery(call_info, args);
+}
+
+void VulkanReplayFrameLoopConsumerBase::Process_vkCmdResetQueryPool(
+    const ApiCallInfo&                          call_info,
+    args::CmdResetQueryPool&                    args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdResetQueryPool(call_info, args);
+}
+
+void VulkanReplayFrameLoopConsumerBase::Process_vkCmdWriteTimestamp(
+    const ApiCallInfo&                          call_info,
+    args::CmdWriteTimestamp&                    args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdWriteTimestamp(call_info, args);
+}
+
+void VulkanReplayFrameLoopConsumerBase::Process_vkCmdCopyQueryPoolResults(
+    const ApiCallInfo&                          call_info,
+    args::CmdCopyQueryPoolResults&              args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdCopyQueryPoolResults(call_info, args);
 }
 
 void VulkanReplayFrameLoopConsumerBase::Process_vkCreateEvent(
@@ -1433,6 +1499,17 @@ void VulkanReplayFrameLoopConsumerBase::Process_vkDestroySamplerYcbcrConversion(
     }
 }
 
+void VulkanReplayFrameLoopConsumerBase::Process_vkResetQueryPool(
+    const ApiCallInfo&                          call_info,
+    args::ResetQueryPool&                       args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkResetQueryPool(call_info, args);
+}
+
 void VulkanReplayFrameLoopConsumerBase::Process_vkCreateRenderPass2(
     const ApiCallInfo&                          call_info,
     args::CreateRenderPass2&                    args)
@@ -1512,6 +1589,17 @@ void VulkanReplayFrameLoopConsumerBase::Process_vkDestroyPrivateDataSlot(
         // Since it might still be in use during the loop range, ONLY free it in the last iteration.
         VulkanReplayConsumer::Process_vkDestroyPrivateDataSlot(call_info, args);
     }
+}
+
+void VulkanReplayFrameLoopConsumerBase::Process_vkCmdWriteTimestamp2(
+    const ApiCallInfo&                          call_info,
+    args::CmdWriteTimestamp2&                   args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdWriteTimestamp2(call_info, args);
 }
 
 void VulkanReplayFrameLoopConsumerBase::Process_vkMapMemory2(
@@ -2236,6 +2324,28 @@ void VulkanReplayFrameLoopConsumerBase::Process_vkUnmapMemory2KHR(
     VulkanReplayConsumer::Process_vkUnmapMemory2KHR(call_info, args);
 }
 
+void VulkanReplayFrameLoopConsumerBase::Process_vkCmdWriteTimestamp2KHR(
+    const ApiCallInfo&                          call_info,
+    args::CmdWriteTimestamp2KHR&                args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdWriteTimestamp2KHR(call_info, args);
+}
+
+void VulkanReplayFrameLoopConsumerBase::Process_vkCmdCopyQueryPoolResultsToMemoryKHR(
+    const ApiCallInfo&                          call_info,
+    args::CmdCopyQueryPoolResultsToMemoryKHR&   args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdCopyQueryPoolResultsToMemoryKHR(call_info, args);
+}
+
 void VulkanReplayFrameLoopConsumerBase::Process_vkCreatePipelineBinariesKHR(
     const ApiCallInfo&                          call_info,
     args::CreatePipelineBinariesKHR&            args)
@@ -2358,6 +2468,28 @@ void VulkanReplayFrameLoopConsumerBase::Process_vkDestroyDebugReportCallbackEXT(
         // Since it might still be in use during the loop range, ONLY free it in the last iteration.
         VulkanReplayConsumer::Process_vkDestroyDebugReportCallbackEXT(call_info, args);
     }
+}
+
+void VulkanReplayFrameLoopConsumerBase::Process_vkCmdBeginQueryIndexedEXT(
+    const ApiCallInfo&                          call_info,
+    args::CmdBeginQueryIndexedEXT&              args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdBeginQueryIndexedEXT(call_info, args);
+}
+
+void VulkanReplayFrameLoopConsumerBase::Process_vkCmdEndQueryIndexedEXT(
+    const ApiCallInfo&                          call_info,
+    args::CmdEndQueryIndexedEXT&                args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkCmdEndQueryIndexedEXT(call_info, args);
 }
 
 void VulkanReplayFrameLoopConsumerBase::Process_vkCreateStreamDescriptorSurfaceGGP(
@@ -2781,6 +2913,17 @@ void VulkanReplayFrameLoopConsumerBase::Process_vkCreateHeadlessSurfaceEXT(
             allocatedLoopResources.insert(handle);
         }
     }
+}
+
+void VulkanReplayFrameLoopConsumerBase::Process_vkResetQueryPoolEXT(
+    const ApiCallInfo&                          call_info,
+    args::ResetQueryPoolEXT&                    args)
+{
+    if (getFrameLoopInfo().IsLooping())
+    {
+        return;
+    }
+    VulkanReplayConsumer::Process_vkResetQueryPoolEXT(call_info, args);
 }
 
 void VulkanReplayFrameLoopConsumerBase::Process_vkReleaseSwapchainImagesEXT(

--- a/framework/generated/generated_vulkan_replay_frame_loop_consumer_base.h
+++ b/framework/generated/generated_vulkan_replay_frame_loop_consumer_base.h
@@ -114,6 +114,10 @@ class VulkanReplayFrameLoopConsumerBase : public VulkanReplayConsumer
         const ApiCallInfo&                          call_info,
         args::DestroyQueryPool&                     args) override;
 
+    void Process_vkGetQueryPoolResults(
+        const ApiCallInfo&                          call_info,
+        args::GetQueryPoolResults&                  args) override;
+
     void Process_vkCreateBuffer(
         const ApiCallInfo&                          call_info,
         args::CreateBuffer&                         args) override;
@@ -149,6 +153,26 @@ class VulkanReplayFrameLoopConsumerBase : public VulkanReplayConsumer
     void Process_vkFreeCommandBuffers(
         const ApiCallInfo&                          call_info,
         args::FreeCommandBuffers&                   args) override;
+
+    void Process_vkCmdBeginQuery(
+        const ApiCallInfo&                          call_info,
+        args::CmdBeginQuery&                        args) override;
+
+    void Process_vkCmdEndQuery(
+        const ApiCallInfo&                          call_info,
+        args::CmdEndQuery&                          args) override;
+
+    void Process_vkCmdResetQueryPool(
+        const ApiCallInfo&                          call_info,
+        args::CmdResetQueryPool&                    args) override;
+
+    void Process_vkCmdWriteTimestamp(
+        const ApiCallInfo&                          call_info,
+        args::CmdWriteTimestamp&                    args) override;
+
+    void Process_vkCmdCopyQueryPoolResults(
+        const ApiCallInfo&                          call_info,
+        args::CmdCopyQueryPoolResults&              args) override;
 
     void Process_vkCreateEvent(
         const ApiCallInfo&                          call_info,
@@ -266,6 +290,10 @@ class VulkanReplayFrameLoopConsumerBase : public VulkanReplayConsumer
         const ApiCallInfo&                          call_info,
         args::DestroySamplerYcbcrConversion&        args) override;
 
+    void Process_vkResetQueryPool(
+        const ApiCallInfo&                          call_info,
+        args::ResetQueryPool&                       args) override;
+
     void Process_vkCreateRenderPass2(
         const ApiCallInfo&                          call_info,
         args::CreateRenderPass2&                    args) override;
@@ -277,6 +305,10 @@ class VulkanReplayFrameLoopConsumerBase : public VulkanReplayConsumer
     void Process_vkDestroyPrivateDataSlot(
         const ApiCallInfo&                          call_info,
         args::DestroyPrivateDataSlot&               args) override;
+
+    void Process_vkCmdWriteTimestamp2(
+        const ApiCallInfo&                          call_info,
+        args::CmdWriteTimestamp2&                   args) override;
 
     void Process_vkMapMemory2(
         const ApiCallInfo&                          call_info,
@@ -406,6 +438,14 @@ class VulkanReplayFrameLoopConsumerBase : public VulkanReplayConsumer
         const ApiCallInfo&                          call_info,
         args::UnmapMemory2KHR&                      args) override;
 
+    void Process_vkCmdWriteTimestamp2KHR(
+        const ApiCallInfo&                          call_info,
+        args::CmdWriteTimestamp2KHR&                args) override;
+
+    void Process_vkCmdCopyQueryPoolResultsToMemoryKHR(
+        const ApiCallInfo&                          call_info,
+        args::CmdCopyQueryPoolResultsToMemoryKHR&   args) override;
+
     void Process_vkCreatePipelineBinariesKHR(
         const ApiCallInfo&                          call_info,
         args::CreatePipelineBinariesKHR&            args) override;
@@ -429,6 +469,14 @@ class VulkanReplayFrameLoopConsumerBase : public VulkanReplayConsumer
     void Process_vkDestroyDebugReportCallbackEXT(
         const ApiCallInfo&                          call_info,
         args::DestroyDebugReportCallbackEXT&        args) override;
+
+    void Process_vkCmdBeginQueryIndexedEXT(
+        const ApiCallInfo&                          call_info,
+        args::CmdBeginQueryIndexedEXT&              args) override;
+
+    void Process_vkCmdEndQueryIndexedEXT(
+        const ApiCallInfo&                          call_info,
+        args::CmdEndQueryIndexedEXT&                args) override;
 
     void Process_vkCreateStreamDescriptorSurfaceGGP(
         const ApiCallInfo&                          call_info,
@@ -509,6 +557,10 @@ class VulkanReplayFrameLoopConsumerBase : public VulkanReplayConsumer
     void Process_vkCreateHeadlessSurfaceEXT(
         const ApiCallInfo&                          call_info,
         args::CreateHeadlessSurfaceEXT&             args) override;
+
+    void Process_vkResetQueryPoolEXT(
+        const ApiCallInfo&                          call_info,
+        args::ResetQueryPoolEXT&                    args) override;
 
     void Process_vkReleaseSwapchainImagesEXT(
         const ApiCallInfo&                          call_info,

--- a/framework/generated/khronos_generators/khronos_base_generator.py
+++ b/framework/generated/khronos_generators/khronos_base_generator.py
@@ -498,6 +498,7 @@ class KhronosBaseGenerator(OutputGenerator):
         self.REPLAY_FRAME_LOOP_RESOURCE_FREE_SINGLE_HANDLE_OVERRIDES = {}
         self.REPLAY_FRAME_LOOP_RESOURCE_ALLOCATE_NOT_FULLY_IMPLEMENTED = {}
         self.REPLAY_FRAME_LOOP_RESOURCE_FREE_NOT_FULLY_IMPLEMENTED = {}
+        self.REPLAY_FRAME_LOOP_SKIP_DURING_LOOPING = {}
         self.DUMP_RESOURCES_OVERRIDES = {}
         self.DUMP_RESOURCES_TRANSFER_API_CALLS = {}
         self.REPLAY_ASYNC_OVERRIDES = {}
@@ -731,6 +732,8 @@ class KhronosBaseGenerator(OutputGenerator):
                 'resourceAllocateNotFullyImplemented']
             self.REPLAY_FRAME_LOOP_RESOURCE_FREE_NOT_FULLY_IMPLEMENTED = frame_loop_overrides[
                 'resourceFreeNotFullyImplemented']
+            self.REPLAY_FRAME_LOOP_SKIP_DURING_LOOPING = frame_loop_overrides.get(
+                'skipDuringLooping', [])
         if dump_resources_overrides_filename is not None:
             dump_resources_overrides = json.loads(
                 open(dump_resources_overrides_filename, 'r').read()

--- a/framework/generated/khronos_generators/khronos_replay_frame_loop_consumer_base_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_replay_frame_loop_consumer_base_body_generator.py
@@ -32,7 +32,8 @@ class KhronosReplayFrameLoopConsumerBaseBodyGenerator():
                  self.REPLAY_FRAME_LOOP_RESOURCE_ALLOCATE_MULTIPLE_HANDLES_OVERRIDES +
                  self.REPLAY_FRAME_LOOP_RESOURCE_FREE_SINGLE_HANDLE_OVERRIDES +
                  self.REPLAY_FRAME_LOOP_RESOURCE_ALLOCATE_NOT_FULLY_IMPLEMENTED +
-                 self.REPLAY_FRAME_LOOP_RESOURCE_FREE_NOT_FULLY_IMPLEMENTED))
+                 self.REPLAY_FRAME_LOOP_RESOURCE_FREE_NOT_FULLY_IMPLEMENTED +
+                 self.REPLAY_FRAME_LOOP_SKIP_DURING_LOOPING))
 
     def genCallReplayConsumer(self, return_type, name, values):
         return f'{self.platform_type}ReplayConsumer::Process_{name}(call_info, args);\n'
@@ -137,6 +138,14 @@ class KhronosReplayFrameLoopConsumerBaseBodyGenerator():
         elif name in self.REPLAY_FRAME_LOOP_RESOURCE_FREE_NOT_FULLY_IMPLEMENTED:
 
             body += '    if (getFrameLoopInfo().IsLooping() && !getFrameLoopInfo().IsFinalIteration())\n'
+            body += '    {\n'
+            body += '        return;\n'
+            body += '    }\n'
+            body += '    ' + self.genCallReplayConsumer(return_type, name, values)
+
+        elif name in self.REPLAY_FRAME_LOOP_SKIP_DURING_LOOPING:
+
+            body += '    if (getFrameLoopInfo().IsLooping())\n'
             body += '    {\n'
             body += '        return;\n'
             body += '    }\n'

--- a/framework/generated/khronos_generators/khronos_replay_frame_loop_consumer_base_header_generator.py
+++ b/framework/generated/khronos_generators/khronos_replay_frame_loop_consumer_base_header_generator.py
@@ -35,7 +35,8 @@ class KhronosFrameLoopConsumerBaseHeaderGenerator():
                  self.REPLAY_FRAME_LOOP_RESOURCE_ALLOCATE_MULTIPLE_HANDLES_OVERRIDES +
                  self.REPLAY_FRAME_LOOP_RESOURCE_FREE_SINGLE_HANDLE_OVERRIDES +
                  self.REPLAY_FRAME_LOOP_RESOURCE_ALLOCATE_NOT_FULLY_IMPLEMENTED +
-                 self.REPLAY_FRAME_LOOP_RESOURCE_FREE_NOT_FULLY_IMPLEMENTED))
+                 self.REPLAY_FRAME_LOOP_RESOURCE_FREE_NOT_FULLY_IMPLEMENTED +
+                 self.REPLAY_FRAME_LOOP_SKIP_DURING_LOOPING))
 
     def write_class_setup(self, class_name, constructor_args):
         write(

--- a/framework/generated/khronos_generators/vulkan_generators/replay_frame_loop_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/replay_frame_loop_overrides.json
@@ -179,5 +179,24 @@
     "vkReleasePerformanceConfigurationINTEL",
     "vkReleaseSwapchainImagesEXT",
     "vkReleaseSwapchainImagesKHR"
+  ],
+
+  "comment" : "These entry points are unconditionally skipped during frame looping",
+  "comment" : "to avoid validation errors or CPU waits.",
+  "skipDuringLooping":
+  [
+    "vkCmdWriteTimestamp",
+    "vkCmdWriteTimestamp2",
+    "vkCmdWriteTimestamp2KHR",
+    "vkCmdBeginQuery",
+    "vkCmdBeginQueryIndexedEXT",
+    "vkCmdEndQuery",
+    "vkCmdEndQueryIndexedEXT",
+    "vkCmdResetQueryPool",
+    "vkGetQueryPoolResults",
+    "vkCmdCopyQueryPoolResults",
+    "vkCmdCopyQueryPoolResultsToMemoryKHR",
+    "vkResetQueryPool",
+    "vkResetQueryPoolEXT"
   ]
 }


### PR DESCRIPTION
Add Oleh's changes to suppress queries when frame looping as [described](https://github.com/olehkuznetsov/gfxreconstruct/blob/d64f4ab205604d2f55ed964a7521b7e62fb05425/frame_loop_queries.md) in https://github.com/LunarG/gfxreconstruct/pull/3047/changes/e069c04677ff38f4e67d2a809c25a76703ad0cec.

In Vulkan, queries must be reset before it can be written to or activated. However, query resets and writes can be in different frames. When looping, this can result in writes without resets and validation errors.

The changes opted for here is simply to suppress these query commands while frame looping by adding a frame looping check in the generated `Process_*` commands.

Perhaps it is possible to somehow keep functionality during frame looping by resetting specific queries before writing, but it is mentioned that this is a simpler solution than "custom complex manual reset trackers for every query pool index." Furthermore, accessing query results such as `vkGetQueryPoolResults` and `vkCmdCopyQueryPoolResults` might be take more effort to support.