### PR TITLE
Tools: Move command-line processing into features

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -822,16 +822,16 @@ options:
                         by <file>
   --version             Print version information and exit (forwarded to
                         replay tool)
-  --log-level LEVEL     Specify highest level message to log. Options are:
-                        debug, info, warning, error, and fatal. Default is
+  --log-level LEVEL     Specify lowest level message to log. Options are:
+                        fatal, error, warning, info, and debug. Default is
                         info. (forwarded to replay tool)
   --log-timestamps      Output a timestamp in front of each log message.
   --log-file DEVICE_FILE
                         Write log messages to a file at the specified path
                         instead of logcat (forwarded to replay tool)
   --debug-messenger-level LEVEL
-                        Specify highest debug messenger severity level.
-                        Options are: debug, info, warning, and error. Default
+                        Specify lowest debug messenger severity level.
+                        Options are: error, warning, info, and debug. Default
                         is warning. (forwarded to replay tool)
   --pause-frame N       Pause after replaying frame number N (forwarded to
                         replay tool)

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -652,15 +652,15 @@ Required arguments:
 Optional arguments:
   -h                    Print usage information and exit (same as --help).
   --version             Print version information and exit.
-  --log-level <level>   Specify highest level message to log. Options are:
-                        debug, info, warning, error, and fatal. Default is info.
+  --log-level <level>   Specify lowest level message to log. Options are:
+                        fatal, error, warning, info, and debug. Default is info.
   --log-timestamps      Output a timestamp in front of each log message.
   --log-file <file>     Write log messages to a file at the specified path.
                         Default is: Empty string (file logging disabled).
   --log-debugview       Log messages with OutputDebugStringA. Windows only.
   --debug-messenger-level <level>
-                        Specify highest debug messenger severity level. Options
-                        are: debug, info, warning, and error. Default is
+                        Specify lowest debug messenger severity level. Options
+                        are: error, warning, info, and debug. Default is
                         warning.
   --cpu-mask <binary-mask>
                         Set of CPU cores used by the replayer.

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -93,10 +93,10 @@ def CreateReplayParser():
     parser = argparse.ArgumentParser(prog=os.path.basename(sys.argv[0]) + ' replay', description='Launch the replay tool.')
     parser.add_argument('-p', '--push-file', metavar='LOCAL_FILE', help='Local file to push to the location on device specified by <file>')
     parser.add_argument('--version', action='store_true', default=False, help='Print version information and exit (forwarded to replay tool)')
-    parser.add_argument('--log-level', metavar='LEVEL', help='Specify highest level message to log. Options are: debug, info, warning, error, and fatal. Default is info. (forwarded to replay tool)')
+    parser.add_argument('--log-level', metavar='LEVEL', help='Specify lowest level message to log. Options are: fatal, error, warning, info, and debug. Default is info. (forwarded to replay tool)')
     parser.add_argument('--log-timestamps', action='store_true', help='Output a timestamp in front of each log message. (forwarded to replay tool)')
     parser.add_argument('--log-file', metavar='DEVICE_FILE', help='Write log messages to a file at the specified path instead of logcat (forwarded to replay tool)')
-    parser.add_argument('--debug-messenger-level', metavar='LEVEL', help='Specify highest debug messenger severity level. Options are: debug, info, warning, and error. Default is warning. (forwarded to replay tool)')
+    parser.add_argument('--debug-messenger-level', metavar='LEVEL', help='Specify lowest debug messenger severity level. Options are: error, warning, info, and debug. Default is warning. (forwarded to replay tool)')
     parser.add_argument('--pause-frame', metavar='N', help='Pause after replaying frame number N (forwarded to replay tool)')
     parser.add_argument('--paused', action='store_true', default=False, help='Pause after replaying the first frame (same as "--pause-frame 1"; forwarded to replay tool)')
 

--- a/android/tools/replay/CMakeLists.txt
+++ b/android/tools/replay/CMakeLists.txt
@@ -24,6 +24,7 @@ add_subdirectory(${GFXRECON_SOURCE_DIR}/framework/application application)
 add_library(gfxrecon-replay
             SHARED
                 ${GFXRECON_SOURCE_DIR}/tools/tool_settings.h
+                ${GFXRECON_SOURCE_DIR}/tools/tool_feature_options.h
                 ${GFXRECON_SOURCE_DIR}/tools/replay/parse_dump_resources_cli.h
                 ${GFXRECON_SOURCE_DIR}/tools/replay/parse_dump_resources_cli.cpp
                 ${GFXRECON_SOURCE_DIR}/tools/replay/replay_settings.h

--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -26,10 +26,14 @@
 #define GFXRECON_DECODE_REPLAY_OPTIONS_H
 
 #include "util/defines.h"
+#include "util/logging.h"
 #include "util/options.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
+
+// Default log level to use prior to loading settings.
+const util::LoggingSeverity kDefaultLogLevel = util::LoggingSeverity::kInfo;
 
 static constexpr char kDefaultScreenshotFilePrefix[] = "screenshot";
 

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -45,9 +45,6 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 typedef std::function<VulkanResourceAllocator*()> CreateResourceAllocator;
 
-// Default log level to use prior to loading settings.
-const util::LoggingSeverity kDefaultLogLevel = util::LoggingSeverity::kInfo;
-
 enum class SkipGetFenceStatus
 {
     NoSkip,

--- a/framework/util/feature_base.h
+++ b/framework/util/feature_base.h
@@ -26,9 +26,38 @@
 #include "util/defines.h"
 
 #include <string>
+#include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
+
+// One command-line entry that a Feature adds to the tool that contains it. A Feature returns
+// these entries from FeatureBase::GetOptionDescs(). The tool collects them before it builds its
+// ArgumentParser, so an entry is accepted only when its Feature is built into the tool.
+//
+// See tools/tool_feature_options.h for the functions that collect, validate, and print these
+// entries.
+struct FeatureOptionDesc
+{
+    // The name of the value that the entry takes, for the usage text. Example: "<backend>".
+    std::string name;
+
+    // The usage text for the entry. Each string is one line.
+    std::vector<std::string> description;
+
+    // True when the entry takes a value.
+    bool has_argument{ true };
+
+    // The names that trigger the entry, in ArgumentParser syntax. Put a pipe character between
+    // alternative names, as in "-o|--option-to-do-something". Do not use a comma.
+    std::string trigger_names;
+
+    // The full set of accepted values, when that set is closed. The tool adds the set to the
+    // usage text of the entry. A value that is not in the set gets a warning, and this Feature
+    // then uses the default value for the entry. The comparison ignores case. An empty vector
+    // accepts any value, and the Feature checks the value itself.
+    std::vector<std::string> accepted_values;
+};
 
 // Common interface required of every per-tool Feature base class (e.g. ReplayFeatureBase,
 // ConvertFeatureBase, ExtractFeatureBase, OptimizeFeature, InfoFeature) so that a Feature
@@ -47,6 +76,11 @@ class FeatureBase
     // suitable for printing as part of a tool's "--version" output. Returns an empty string
     // if this feature has no meaningful compiled-header version to report.
     virtual std::string CompiledHeaderVersionString() const = 0;
+
+    // The command-line entries that this Feature adds to its tool. The tool calls this function
+    // on each loaded Feature before it builds the ArgumentParser. The default is an empty list.
+    // A Feature that has no command-line entries of its own does not override this function.
+    virtual std::vector<FeatureOptionDesc> GetOptionDescs() const { return {}; }
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/tools/convert/convert_d3d12_feature.cpp
+++ b/tools/convert/convert_d3d12_feature.cpp
@@ -23,6 +23,9 @@
 
 #if defined(D3D12_SUPPORT)
 
+// This needs to be included before d3d12.h so that IIDs are defined and not just declared.
+#include <initguid.h>
+
 #include "convert_feature.h"
 
 #include "decode/dx12_detection_consumer.h"

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -25,6 +25,7 @@
 
 #include "optimize_feature.h"
 #include "tool_settings.h"
+#include "tool_feature_options.h"
 #include "tool_feature_version.h"
 
 #include "decode/decode_api_detection.h"
@@ -62,15 +63,13 @@ static void PrintUsage(const char* exe_name)
 {
     std::string app_name = std::filesystem::path(exe_name).stem().string();
 
-    // Build synopsis from feature fragments so it stays in sync automatically.
+    // Build synopsis from the feature entries so it stays in sync automatically.
     std::string synopsis = app_name + " [-h | --help] [--version]";
-    for (const auto& feature : g_optimize_features)
+
+    const std::string feature_synopsis = BuildFeatureSynopsis(g_optimize_features);
+    if (!feature_synopsis.empty())
     {
-        const std::string fragment = feature->GetSynopsisFragment();
-        if (!fragment.empty())
-        {
-            synopsis += " " + fragment;
-        }
+        synopsis += " " + feature_synopsis;
     }
     synopsis += " <input-file> <output-file>";
 
@@ -96,10 +95,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("        \t\t\tdisplayed when abort() is called (Windows debug only).");
 #endif
 
-    for (const auto& feature : g_optimize_features)
-    {
-        feature->PrintUsage();
-    }
+    PrintFeatureUsage(g_optimize_features);
     GFXRECON_WRITE_CONSOLE("");
     GFXRECON_WRITE_CONSOLE("Note: running without optional arguments will instruct the optimizer to detect the API "
                            "and run all available optimizations.");
@@ -130,33 +126,21 @@ int32_t main(int32_t argc, const char** argv)
         g_optimize_features.push_back(creator());
     }
 
-    // Aggregate option flags and argument keys from all features plus common flags.
-    std::string options   = "-h|--help,--version";
-    std::string arguments = "";
+    // Aggregate option flags and argument keys from all features plus common flags. The
+    // ArgumentParser keeps its own copy of the names, so the two lists go out of scope as soon
+    // as it is built.
+    gfxrecon::util::ArgumentParser arg_parser = [argc, argv]() {
+        std::string options   = "-h|--help,--version";
+        std::string arguments = "";
 
 #if defined(WIN32) && defined(_DEBUG)
-    options += ",--no-debug-popup";
+        options += ",--no-debug-popup";
 #endif
 
-    for (const auto& feature : g_optimize_features)
-    {
-        const std::string feature_opts = feature->GetOptions();
-        if (!feature_opts.empty())
-        {
-            options += "," + feature_opts;
-        }
-        const std::string feature_args = feature->GetArguments();
-        if (!feature_args.empty())
-        {
-            if (!arguments.empty())
-            {
-                arguments += ",";
-            }
-            arguments += feature_args;
-        }
-    }
+        AppendFeatureOptions(g_optimize_features, options, arguments);
 
-    gfxrecon::util::ArgumentParser arg_parser(argc, argv, options, arguments);
+        return gfxrecon::util::ArgumentParser(argc, argv, options, arguments);
+    }();
 
     if (CheckOptionPrintUsage(argv[0], arg_parser) ||
         CheckOptionPrintFeatureVersions<gfxrecon::optimize::OptimizeFeature>(argv[0], arg_parser))
@@ -170,6 +154,10 @@ int32_t main(int32_t argc, const char** argv)
     }
     else
     {
+        // An entry that received a value outside its accepted set gets a warning. The Feature
+        // that owns the entry then uses its default value.
+        CheckFeatureOptionValues(g_optimize_features, arg_parser);
+
 #if defined(_WIN32) && defined(_DEBUG)
         if (arg_parser.IsOptionSet(kNoDebugPopup))
         {

--- a/tools/optimize/optimize_dx12_feature.cpp
+++ b/tools/optimize/optimize_dx12_feature.cpp
@@ -23,6 +23,9 @@
 
 #if defined(D3D12_SUPPORT)
 
+// This needs to be included before d3d12.h so that IIDs are defined and not just declared.
+#include <initguid.h>
+
 #include "optimize_dx12_feature.h"
 
 #include "tool_settings.h"
@@ -72,36 +75,24 @@ bool OptimizeDx12Feature::ShouldRun(const util::ArgumentParser& args) const
     return manual_mode || WasDetected();
 }
 
-std::string OptimizeDx12Feature::GetOptions() const
+std::vector<util::FeatureOptionDesc> OptimizeDx12Feature::GetOptionDescs() const
 {
-    return "--d3d12-pso-removal,--d3d12-resource-removal,--dxr,--dxr-experimental";
-}
-
-std::string OptimizeDx12Feature::GetArguments() const
-{
-    return kOverrideGpuArgument;
-}
-
-std::string OptimizeDx12Feature::GetSynopsisFragment() const
-{
-    return "[--d3d12-pso-removal] [--d3d12-resource-removal] [--dxr] [--gpu <index>]";
-}
-
-void OptimizeDx12Feature::PrintUsage() const
-{
-    GFXRECON_WRITE_CONSOLE("");
-    GFXRECON_WRITE_CONSOLE(" // D3D12-only options:");
-    GFXRECON_WRITE_CONSOLE(" // -------------------");
-    GFXRECON_WRITE_CONSOLE("  --d3d12-pso-removal\t\tRemove creation of unreferenced PSOs.");
-    GFXRECON_WRITE_CONSOLE("  --d3d12-resource-removal\tRemove initialization of unreferenced resources "
-                           "(experimental, off by default).");
-    GFXRECON_WRITE_CONSOLE("  --dxr\t\t\t\tOptimize for DXR and ExecuteIndirect replay.");
-    GFXRECON_WRITE_CONSOLE("  --gpu <index>\t\t\tUse the specified device for the optimizer replay,");
-    GFXRECON_WRITE_CONSOLE("          \t\t\twhere index is the zero-based index to the array of adapters");
-    GFXRECON_WRITE_CONSOLE("          \t\t\treturned by IDXGIFactory1::EnumAdapters1.");
-    GFXRECON_WRITE_CONSOLE(
-        "          \t\t\tThe optimizer replay may fail if the specified device is not compatible with the");
-    GFXRECON_WRITE_CONSOLE("          \t\t\toriginal capture devices.");
+    return { { "", { "Remove creation of unreferenced PSOs." }, false, kD3d12PsoRemoval },
+             { "",
+               { "Remove initialization of unreferenced resources (experimental,", "off by default)." },
+               false,
+               kD3d12ResourceRemoval },
+             { "", { "Optimize for DXR and ExecuteIndirect replay." }, false, kDx12OptimizeDxr },
+             // The experimental form of --dxr has no description, so it stays out of the usage text.
+             { "", {}, false, kDx12OptimizeDxrExperimental },
+             { "<index>",
+               { "Use the specified device for the optimizer replay, where index is",
+                 "the zero-based index to the array of adapters that",
+                 "IDXGIFactory1::EnumAdapters1 returns. The optimizer replay can fail",
+                 "when the specified device is not compatible with the original",
+                 "capture devices." },
+               true,
+               kOverrideGpuArgument } };
 }
 
 decode::Dx12OptimizationOptions OptimizeDx12Feature::BuildOptions(const util::ArgumentParser& args) const

--- a/tools/optimize/optimize_dx12_feature.h
+++ b/tools/optimize/optimize_dx12_feature.h
@@ -33,6 +33,7 @@
 #include "generated/generated_dx12_decoder.h"
 
 #include <memory>
+#include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(optimize)
@@ -55,10 +56,7 @@ class OptimizeDx12Feature : public OptimizeFeature
 
     // Command-line options and arguments
     // -------------------------------------
-    std::string GetOptions() const override;
-    std::string GetArguments() const override;
-    std::string GetSynopsisFragment() const override;
-    void        PrintUsage() const override;
+    std::vector<util::FeatureOptionDesc> GetOptionDescs() const override;
 
   private:
     decode::Dx12OptimizationOptions BuildOptions(const util::ArgumentParser& args) const;

--- a/tools/optimize/optimize_feature.h
+++ b/tools/optimize/optimize_feature.h
@@ -60,20 +60,9 @@ class OptimizeFeature : public util::FeatureBase
                           const std::string&          output_filename,
                           const util::ArgumentParser& args) = 0;
 
-    // Command-line options and arguments
-    // -------------------------------------
-    // Returns feature-specific option flags for the ArgumentParser (comma-separated, | for aliases).
-    virtual std::string GetOptions() const { return ""; }
-
-    // Returns feature-specific argument keys for the ArgumentParser (comma-separated).
-    virtual std::string GetArguments() const { return ""; }
-
-    // Returns a synopsis fragment for the usage line, e.g. "[--my-flag] [--my-arg <val>]".
-    virtual std::string GetSynopsisFragment() const { return ""; }
-
-    // Prints feature-specific optional-argument help lines to the console.
-    // Called from main's PrintUsage(), which tool_settings.h invokes for --help.
-    virtual void PrintUsage() const {}
+    // Command-line options and arguments come from util::FeatureBase::GetOptionDescs(). The
+    // functions in tools/tool_feature_options.h collect them, validate the values, and print
+    // the synopsis fragments and the usage sections.
 };
 
 GFXRECON_END_NAMESPACE(optimize)

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(gfxrecon-replay
                PRIVATE
                     ${CMAKE_CURRENT_LIST_DIR}/../tool_settings.h
                     ${CMAKE_CURRENT_LIST_DIR}/../tool_command_line.h
+                    ${CMAKE_CURRENT_LIST_DIR}/../tool_feature_options.h
                     ${CMAKE_CURRENT_LIST_DIR}/replay_settings.h
                     ${CMAKE_CURRENT_LIST_DIR}/replay_feature.h
                     ${CMAKE_CURRENT_LIST_DIR}/replay_main_common.h

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -23,6 +23,7 @@
 
 #include "replay_settings.h"
 #include "replay_main_common.h"
+#include "tool_feature_options.h"
 
 #include "application/android_context.h"
 #include "application/android_window.h"
@@ -45,7 +46,6 @@
 
 const char kArgsExtentKey[]      = "args";
 const char kDefaultCaptureFile[] = "/sdcard/gfxrecon_capture" GFXRECON_FILE_EXTENSION;
-const char kLayerProperty[]      = "debug.vulkan.layers";
 
 const int32_t kSwipeDistance = 200;
 
@@ -80,16 +80,27 @@ void android_main(struct android_app* app)
 
     gfxrecon::replay::LoadFeatures(g_features);
 
-    std::string                    args = gfxrecon::util::GetIntentExtra(app, kArgsExtentKey);
-    gfxrecon::util::ArgumentParser arg_parser(false, args.c_str(), kOptions, kArguments);
+    // Each Feature adds its own command-line entries to the shared name lists, so an entry
+    // exists only when the build contains the Feature that reads it. The ArgumentParser keeps
+    // its own copy of the names, so the two lists go out of scope as soon as it is built.
+    const std::string              args       = gfxrecon::util::GetIntentExtra(app, kArgsExtentKey);
+    gfxrecon::util::ArgumentParser arg_parser = [&args]() {
+        std::string options   = kOptions;
+        std::string arguments = kArguments;
+        AppendFeatureOptions(g_features, options, arguments);
+        return gfxrecon::util::ArgumentParser(false, args.c_str(), options, arguments);
+    }();
 
     app->onAppCmd     = ProcessAppCmd;
     app->onInputEvent = ProcessInputEvent;
 
     bool run = true;
 
-    if (CheckOptionPrintUsage(kApplicationName, arg_parser) ||
-        CheckOptionPrintFeatureVersions<gfxrecon::replay::ReplayFeatureBase>(kApplicationName, arg_parser))
+    if (CheckOptionPrintUsage(kApplicationName, arg_parser))
+    {
+        run = false;
+    }
+    else if (CheckOptionPrintFeatureVersions<gfxrecon::replay::ReplayFeatureBase>(kApplicationName, arg_parser))
     {
         run = false;
     }
@@ -105,6 +116,11 @@ void android_main(struct android_app* app)
         GetLogSettings(arg_parser, log_settings);
         gfxrecon::util::Log::UpdateWithSettings(log_settings);
 
+        // An entry that received a value outside its accepted set gets a warning. The Feature that
+        // owns the entry then uses its default value. The log settings apply before this call, so
+        // --log-level controls the warning.
+        CheckFeatureOptionValues(g_features, arg_parser);
+
         std::string filename = kDefaultCaptureFile;
         if (arg_parser.GetPositionalArgumentsCount() == 1)
         {
@@ -118,8 +134,7 @@ void android_main(struct android_app* app)
                     kApplicationName, fp, VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, app);
             };
 
-            gfxrecon::replay::RunReplay(
-                g_file_processor, g_features, arg_parser, filename, kLayerProperty, make_application);
+            gfxrecon::replay::RunReplay(g_file_processor, g_features, arg_parser, filename, make_application);
         }
         catch (std::runtime_error& error)
         {

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -24,6 +24,7 @@
 
 #include "replay_settings.h"
 #include "replay_main_common.h"
+#include "tool_feature_options.h"
 
 #include "application/application.h"
 #include "decode/file_processor.h"
@@ -71,8 +72,6 @@ void WaitForExit()
 void WaitForExit() {}
 #endif
 
-const char kLayerEnvVar[] = "VK_INSTANCE_LAYERS";
-
 int main(int argc, const char** argv)
 {
     int return_code = 0;
@@ -84,10 +83,22 @@ int main(int argc, const char** argv)
     std::vector<std::unique_ptr<gfxrecon::replay::ReplayFeatureBase>> features;
     gfxrecon::replay::LoadFeatures(features);
 
-    gfxrecon::util::ArgumentParser arg_parser(argc, argv, kOptions, kArguments);
+    // Each Feature adds its own command-line entries to the shared name lists, so an entry
+    // exists only when the build contains the Feature that reads it. The ArgumentParser keeps
+    // its own copy of the names, so the two lists go out of scope as soon as it is built.
+    gfxrecon::util::ArgumentParser arg_parser = [&features, argc, argv]() {
+        std::string options   = kOptions;
+        std::string arguments = kArguments;
+        AppendFeatureOptions(features, options, arguments);
+        return gfxrecon::util::ArgumentParser(argc, argv, options, arguments);
+    }();
 
-    if (CheckOptionPrintFeatureVersions<gfxrecon::replay::ReplayFeatureBase>(argv[0], arg_parser) ||
-        CheckOptionPrintUsage(argv[0], arg_parser))
+    if (CheckOptionPrintFeatureVersions<gfxrecon::replay::ReplayFeatureBase>(argv[0], arg_parser))
+    {
+        gfxrecon::util::Log::Release();
+        exit(0);
+    }
+    else if (CheckOptionPrintUsage(argv[0], arg_parser))
     {
         gfxrecon::util::Log::Release();
         exit(0);
@@ -107,6 +118,11 @@ int main(int argc, const char** argv)
     GetLogSettings(arg_parser, log_settings);
     gfxrecon::util::Log::UpdateWithSettings(log_settings);
 
+    // An entry that received a value outside its accepted set gets a warning. The Feature that
+    // owns the entry then uses its default value. The log settings apply before this call, so
+    // --log-level controls the warning.
+    CheckFeatureOptionValues(features, arg_parser);
+
     try
     {
         const std::string filename = arg_parser.GetPositionalArguments()[0];
@@ -118,12 +134,7 @@ int main(int argc, const char** argv)
             return std::make_shared<gfxrecon::application::Application>(kApplicationName, fp, wsi_extension, nullptr);
         };
 
-        if (!gfxrecon::replay::RunReplay(file_processor,
-                                         features,
-                                         arg_parser,
-                                         filename,
-                                         gfxrecon::util::platform::GetEnv(kLayerEnvVar),
-                                         make_application))
+        if (!gfxrecon::replay::RunReplay(file_processor, features, arg_parser, filename, make_application))
         {
             return_code = -1;
         }

--- a/tools/replay/parse_dump_resources_cli.h
+++ b/tools/replay/parse_dump_resources_cli.h
@@ -26,6 +26,8 @@
 
 #include "replay_settings.h"
 
+#include "decode/vulkan_replay_options.h"
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(parse_dump_resources)
 

--- a/tools/replay/replay_d3d12_feature.cpp
+++ b/tools/replay/replay_d3d12_feature.cpp
@@ -23,12 +23,25 @@
 
 #if defined(D3D12_SUPPORT)
 
+// This needs to be included before d3d12.h so that IIDs are defined and not just declared.
+#include <initguid.h>
+
 #include "replay_d3d12_feature.h"
+
+#include "decode/dx_replay_options.h"
+#include "generated/generated_dx12_decoder.h"
+
+#include "tool_feature_options.h"
 #include "replay_settings.h"
 
 #include "util/api_version_info.h"
 #include "util/feature_module_registry.h"
 #include "util/logging.h"
+#include "util/options.h"
+#include "util/strings.h"
+
+#include <string>
+#include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(replay)
@@ -36,9 +49,175 @@ GFXRECON_BEGIN_NAMESPACE(replay)
 // Register this class as a feature in a module registry
 GFXR_UTIL_REGISTER_FEATURE_CREATOR(ReplayFeatureBase, ReplayD3d12Feature)
 
+// ----------------------------------------------------------------------------
+// D3D12-only command-line settings.
+//
+// The names, the values, and the code that reads them stay with this Feature, so that
+// tools/tool_settings.h and tools/replay/replay_settings.h keep only the settings that every
+// replay Feature shares.
+// ----------------------------------------------------------------------------
+
+const char kDiscardCachedPsosShortOption[]     = "--dcp";
+const char kDiscardCachedPsosLongOption[]      = "--discard-cached-psos";
+const char kUseCachedPsosOption[]              = "--use-cached-psos";
+const char kDeniedMessages[]                   = "--denied-messages";
+const char kAllowedMessages[]                  = "--allowed-messages";
+const char kDxTwoPassReplay[]                  = "--dx12-two-pass-replay";
+const char kDxOverrideObjectNames[]            = "--dx12-override-object-names";
+const char kDxAgsMarkRenderPasses[]            = "--dx12-ags-inject-markers";
+const char kBatchingMemoryUsageArgument[]      = "--batching-memory-usage";
+const char kDumpResourcesModifiableStateOnly[] = "--dump-resources-modifiable-state-only";
+const char kDumpResourcesBeforeDrawOption[]    = "--dump-resources-before-draw";
+
+// Only this Feature reads the two --dump-resources names above. The replay tool keeps them in
+// its shared option list, next to --dump-resources and --dump-resources-dir. Each platform
+// accepted the two names before the Features had their own command-line entries. An application
+// can depend on that behavior, so each platform must continue to accept them. A build without
+// this Feature parses the two names and then ignores them.
+
+static std::vector<int32_t> GetFilteredMsgs(const gfxrecon::util::ArgumentParser& arg_parser,
+                                            const char*                           filter_messages)
+{
+    const auto&          value = arg_parser.GetArgumentValue(filter_messages);
+    std::vector<int32_t> msgs;
+    if (!value.empty())
+    {
+        std::vector<std::string> values;
+        std::istringstream       value_input;
+        value_input.str(value);
+
+        for (std::string val; std::getline(value_input, val, ',');)
+        {
+            size_t count = std::count_if(val.begin(), val.end(), ::isdigit);
+            if (count == val.length())
+            {
+                msgs.push_back(std::stoi(val));
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING("Ignoring invalid filter messages\"%s\", which contains non-numeric values",
+                                     val.c_str());
+                break;
+            }
+        }
+    }
+    return msgs;
+}
+
+static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util::ArgumentParser& arg_parser,
+                                                            const std::string&                    filename)
+{
+    gfxrecon::decode::DxReplayOptions replay_options;
+    GetReplayOptions(replay_options, arg_parser, filename);
+
+    replay_options.DeniedDebugMessages  = GetFilteredMsgs(arg_parser, kDeniedMessages);
+    replay_options.AllowedDebugMessages = GetFilteredMsgs(arg_parser, kAllowedMessages);
+
+    if (arg_parser.IsOptionSet(kDxTwoPassReplay))
+    {
+        replay_options.enable_d3d12_two_pass_replay = true;
+    }
+
+    if (arg_parser.IsOptionSet(kDiscardCachedPsosLongOption) || arg_parser.IsOptionSet(kDiscardCachedPsosShortOption))
+    {
+        GFXRECON_LOG_WARNING("The parameters --dcp and --discard-cached-psos have been deprecated in favor for "
+                             "--use-cached-psos");
+    }
+
+    if (arg_parser.IsOptionSet(kUseCachedPsosOption))
+    {
+        replay_options.use_cached_psos = true;
+    }
+
+    if (arg_parser.IsOptionSet(kDxOverrideObjectNames))
+    {
+        replay_options.override_object_names = true;
+    }
+
+    if (arg_parser.IsOptionSet(kDxAgsMarkRenderPasses))
+    {
+#ifdef GFXRECON_AGS_SUPPORT
+        replay_options.ags_inject_markers = true;
+#else
+        GFXRECON_LOG_ERROR("Unsupported option --dx12-ags-inject-markers");
+#endif
+    }
+
+    const std::string& dump_resources = arg_parser.GetArgumentValue(kDumpResourcesArgument);
+    if (!dump_resources.empty() && dump_resources.find_first_not_of("0123456789,") == std::string::npos)
+    {
+        std::vector<std::string> values = gfxrecon::util::strings::SplitString(dump_resources, ',');
+        if (values.size() == 3)
+        {
+            replay_options.dump_resources_target.submit_index    = std::stoi(values[0]);
+            replay_options.dump_resources_target.command_index   = std::stoi(values[1]);
+            replay_options.dump_resources_target.draw_call_index = std::stoi(values[2]);
+            replay_options.enable_dump_resources                 = true;
+            replay_options.using_dump_resources_target           = true;
+        }
+    }
+
+    replay_options.dump_resources_output_dir            = GetDumpResourcesDir(arg_parser);
+    replay_options.dump_resources_before                = arg_parser.IsOptionSet(kDumpResourcesBeforeDrawOption);
+    replay_options.dump_resources_modifiable_state_only = arg_parser.IsOptionSet(kDumpResourcesModifiableStateOnly);
+
+    const std::string& memory_usage = arg_parser.GetArgumentValue(kBatchingMemoryUsageArgument);
+    if (!memory_usage.empty())
+    {
+        int memory_usage_int = std::stoi(memory_usage);
+        if (memory_usage_int >= 0 && memory_usage_int <= 100)
+        {
+            replay_options.memory_usage = static_cast<uint32_t>(memory_usage_int);
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING(
+                "The parameter to --batching-memory-usage is out of range [0, 100], will use 80 as default value.");
+        }
+    }
+    return replay_options;
+}
+
+// ----------------------------------------------------------------------------
+// End of the D3D12-only command-line settings.
+// ----------------------------------------------------------------------------
+
 std::string ReplayD3d12Feature::CompiledHeaderVersionString() const
 {
     return util::GetD3D12SdkVersionString();
+}
+
+std::vector<util::FeatureOptionDesc> ReplayD3d12Feature::GetOptionDescs() const
+{
+    return { { "",
+               { "Permit the use of cached PSOs when replay creates graphics or compute",
+                 "pipelines. A cached PSO can decrease the PSO creation time, but it can",
+                 "also cause replay errors." },
+               false,
+               kUseCachedPsosOption },
+             { "",
+               { "Generate a unique name for each ID3D12Object and assign that name to",
+                 "the object. This helps you to debug a replay." },
+               false,
+               kDxOverrideObjectNames },
+             { "",
+               { "Label each API call with the block index of the trace. Radeon GPU",
+                 "Detective can dump the label for debugging." },
+               false,
+               kDxAgsMarkRenderPasses },
+             { "<pct>",
+               { "The maximum memory consumption while replay loads a trimmed capture",
+                 "file. The accepted values are 0 to 100, and the default is 80. A value",
+                 "of 0 disables batching, and a value of 100 permits the use of all",
+                 "available system memory and GPU memory." },
+               true,
+               kBatchingMemoryUsageArgument },
+             // The entries below have no description, so they stay out of the usage text. They keep
+             // the same undocumented behavior that the shared option strings gave them.
+             { "", {}, false, AliasNames(kDiscardCachedPsosShortOption, kDiscardCachedPsosLongOption) },
+             { "", {}, false, kDxTwoPassReplay },
+             { "", {}, true, kDeniedMessages },
+             { "", {}, true, kAllowedMessages } };
 }
 
 void ReplayD3d12Feature::QueryOptions(gfxrecon::util::ArgumentParser& arg_parser, const std::string& capture_filename)

--- a/tools/replay/replay_d3d12_feature.h
+++ b/tools/replay/replay_d3d12_feature.h
@@ -53,6 +53,8 @@ class ReplayD3d12Feature : public ReplayPreProcessFeature<decode::Dx12ReplayCons
     std::string Label() const final { return "D3D12"; }
     std::string CompiledHeaderVersionString() const final;
 
+    std::vector<util::FeatureOptionDesc> GetOptionDescs() const final;
+
     void QueryOptions(util::ArgumentParser& arg_parser, const std::string& capture_filename) final;
     void QueryFpsInfoOptions(bool& quit_after_range,
                              bool& flush_range,

--- a/tools/replay/replay_feature.h
+++ b/tools/replay/replay_feature.h
@@ -52,6 +52,11 @@ class ReplayFeatureBase : public util::FeatureBase
     // Options queries
     virtual void QueryOptions(util::ArgumentParser& arg_parser, const std::string& capture_filename) {}
 
+    // Examines the environment of the process for conditions that make replay of this API
+    // unreliable, and writes a warning for each one. The replay tool calls this function for
+    // every Feature before it starts the replay. The default does nothing.
+    virtual void CheckEnvironment() {}
+
     // Composition methods (for an API like OpenXR which uses other graphics APIs to
     // compose final images). Called after CreateConsumer for all features so that
     // compositing features can obtain consumer pointers from graphics features.
@@ -109,7 +114,7 @@ class ReplayFeature : public ReplayFeatureBase
   public:
     void*     GetConsumer() override { return replay_consumer_.get(); }
     DecoderT* GetDecoder() { return decoder_.get(); }
-    void  Destroy() override
+    void      Destroy() override
     {
         if (replay_consumer_)
         {

--- a/tools/replay/replay_main_common.cpp
+++ b/tools/replay/replay_main_common.cpp
@@ -38,6 +38,10 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(replay)
 
+// The list that the last LoadFeatures() call filled. GetLoadedFeatures() gives it to the usage
+// function of the tool, which cannot receive the list as a parameter.
+static const std::vector<std::unique_ptr<ReplayFeatureBase>>* g_loaded_features = nullptr;
+
 void LoadFeatures(std::vector<std::unique_ptr<ReplayFeatureBase>>& features)
 {
     for (const auto& creator :
@@ -45,6 +49,15 @@ void LoadFeatures(std::vector<std::unique_ptr<ReplayFeatureBase>>& features)
     {
         features.push_back(creator());
     }
+
+    g_loaded_features = &features;
+}
+
+const std::vector<std::unique_ptr<ReplayFeatureBase>>& GetLoadedFeatures()
+{
+    static const std::vector<std::unique_ptr<ReplayFeatureBase>> empty;
+
+    return (g_loaded_features != nullptr) ? *g_loaded_features : empty;
 }
 
 void RunPreProcessConsumer(const std::string& filename, std::vector<std::unique_ptr<ReplayFeatureBase>>& features)
@@ -70,7 +83,6 @@ bool RunReplay(std::unique_ptr<decode::FileProcessor>&                          
                std::vector<std::unique_ptr<ReplayFeatureBase>>&                                 features,
                util::ArgumentParser&                                                            arg_parser,
                const std::string&                                                               filename,
-               const std::string&                                                               active_layers_value,
                std::function<std::shared_ptr<application::Application>(decode::FileProcessor*)> make_application)
 {
     uint32_t loop_frame        = 0;
@@ -191,7 +203,11 @@ bool RunReplay(std::unique_ptr<decode::FileProcessor>&                          
     }
 
     application->SetPauseFrame(GetPauseFrame(arg_parser));
-    CheckActiveLayers(active_layers_value);
+
+    for (auto& feature : features)
+    {
+        feature->CheckEnvironment();
+    }
 
 #if defined(__ANDROID__)
     // Start paused; replay begins once APP_CMD_GAINED_FOCUS fires.

--- a/tools/replay/replay_main_common.h
+++ b/tools/replay/replay_main_common.h
@@ -45,6 +45,12 @@ GFXRECON_BEGIN_NAMESPACE(replay)
 // Populate features from the module registry.
 void LoadFeatures(std::vector<std::unique_ptr<ReplayFeatureBase>>& features);
 
+// Gives the list that the last LoadFeatures() call filled. The usage function of the tool
+// cannot receive the list as a parameter, because tool_command_line.h declares that function
+// with a fixed signature. The usage function reads the list here to build the part of the
+// synopsis that the Features contribute. The list is empty before the first LoadFeatures() call.
+const std::vector<std::unique_ptr<ReplayFeatureBase>>& GetLoadedFeatures();
+
 // Run a pre-processing pass over filename using all features that opt in.
 void RunPreProcessConsumer(const std::string& filename, std::vector<std::unique_ptr<ReplayFeatureBase>>& features);
 
@@ -57,14 +63,12 @@ void RunPreProcessConsumer(const std::string& filename, std::vector<std::unique_
 //
 // file_processor_out  Receives the constructed FileProcessor; Android keeps a
 //                     global reference so the extern "C" query callbacks work.
-// active_layers_value String forwarded verbatim to CheckActiveLayers().
 // make_application    Platform factory called with the new FileProcessor
 //                     pointer; should return a fully constructed Application.
 bool RunReplay(std::unique_ptr<decode::FileProcessor>&                                          file_processor_out,
                std::vector<std::unique_ptr<ReplayFeatureBase>>&                                 features,
                util::ArgumentParser&                                                            arg_parser,
                const std::string&                                                               filename,
-               const std::string&                                                               active_layers_value,
                std::function<std::shared_ptr<application::Application>(decode::FileProcessor*)> make_application);
 
 GFXRECON_END_NAMESPACE(replay)

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -23,32 +23,74 @@
 
 #include "tool_settings.h"
 #include "tool_command_line.h"
+#include "tool_feature_options.h"
+
+#include "replay_main_common.h"
 
 #ifndef GFXRECON_REPLAY_SETTINGS_H
 #define GFXRECON_REPLAY_SETTINGS_H
 
 const char kOptions[] =
-    "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--opcd|--"
-    "omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
-    "screenshot-all,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-range,--fmr|--flush-"
-    "measurement-range,--flush-inside-measurement-range,--vssb|--virtual-swapchain-skip-blit,--use-captured-swapchain-"
-    "indices,--dcp,--discard-cached-psos,--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names,--"
-    "dx12-ags-inject-markers,--offscreen-swapchain-frame-boundary,--wait-before-present,--dump-resources-before-draw,"
-    "--dump-resources-modifiable-state-only,--pbi-all,--preload-measurement-range,--add-new-pipeline-caches,--"
-    "screenshot-ignore-FrameBoundaryANDROID,--screenshot-apply-prerotation,--deduplicate-device,--log-timestamps,--"
-    "capture,--idle-before-submit,--"
-    "serialize-render-passes,--serialize-queue-submissions,--async-processing,--isolate-render-passes,--serialize-"
-    "compute-and-transfer,--annotate-injected-commands";
+    "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--remove-unsupported,--validate,"
+    "--debug-device-lost,--create-dummy-allocations,--screenshot-all,--onhb|--omit-null-hardware-buffers,"
+    "--qamr|--quit-after-measurement-range,--fmr|--flush-measurement-range,--flush-inside-measurement-range,"
+    "--pbi-all,--preload-measurement-range,--log-timestamps,--async-processing,"
+    "--dump-resources-before-draw,--dump-resources-modifiable-state-only";
+
 const char kArguments[] =
-    "--log-level,--log-file,--cpu-mask,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
-    "--replace-shaders,--screenshots,--screenshot-interval,--denied-messages,--allowed-messages,--screenshot-format,--"
-    "screenshot-dir,--screenshot-prefix,--screenshot-size,--screenshot-scale,--mfr|--measurement-frame-range,--fw|--"
-    "force-windowed,--fwo|--force-windowed-origin,--batching-memory-usage,--measurement-file,--swapchain,--sgfs|--skip-"
-    "get-fence-status,--sgfr|--skip-get-fence-ranges,--dump-resources,--dump-resources-dir,--dump-resources-image-"
-    "format,--pbis,--pcj|--pipeline-creation-jobs,--save-pipeline-cache,--load-pipeline-cache,--quit-after-frame,--"
-    "present-mode,--wait-before-first-submit,--present-override,--frame-"
-    "warm-up-spirv,--frame-warm-up-load,--wait-before-frame,--loop-frame,--loop-count,--"
-    "replay-event-plugin-path,--replay-event-plugin-params";
+    "--log-level,--log-file,--cpu-mask,--gpu,--pause-frame,--wsi,--screenshots,--screenshot-interval,"
+    "--screenshot-format,--screenshot-dir,--screenshot-prefix,--screenshot-size,--screenshot-scale,"
+    "--mfr|--measurement-frame-range,--fw|--force-windowed,--fwo|--force-windowed-origin,--measurement-file,"
+    "--dump-resources,--dump-resources-dir,--dump-resources-image-format,--pbis,"
+    "--pcj|--pipeline-creation-jobs,--quit-after-frame,"
+    "--wait-before-first-submit,--frame-warm-up-spirv,--frame-warm-up-load,--wait-before-frame,--loop-frame,"
+    "--loop-count";
+
+// The three names below belong to the D3D12 Feature, but they stay in the shared lists above:
+//     --dump-resources-before-draw            The D3D12 Feature reads it.
+//     --dump-resources-modifiable-state-only  The D3D12 Feature reads it.
+//     --dump-resources-image-format           No code reads it yet.
+// Each platform accepted the three names before the Features had their own command-line entries.
+// An application can depend on that behavior, so each platform must continue to accept them. A
+// build without the D3D12 Feature parses the three names and then ignores them.
+
+// Prints the Feature part of the synopsis as lines that match the width of the lines that the
+// usage function writes before them. A line break comes only between two bracketed fragments.
+static void PrintFeatureSynopsisLines(const std::string& synopsis)
+{
+    const size_t kWrapColumn = 64;
+    std::string  line;
+    size_t       start = 0;
+
+    while (start < synopsis.size())
+    {
+        // A fragment ends at the bracket that closes it, and the next fragment starts two
+        // characters later, after the bracket and the space.
+        size_t end = synopsis.find("] [", start);
+        end        = (end == std::string::npos) ? synopsis.size() : (end + 1);
+
+        const std::string fragment = synopsis.substr(start, end - start);
+
+        if (!line.empty() && ((line.size() + fragment.size() + 1) > kWrapColumn))
+        {
+            GFXRECON_WRITE_CONSOLE("\t\t\t%s", line.c_str());
+            line.clear();
+        }
+
+        if (!line.empty())
+        {
+            line += " ";
+        }
+        line += fragment;
+
+        start = (end < synopsis.size()) ? (end + 1) : end;
+    }
+
+    if (!line.empty())
+    {
+        GFXRECON_WRITE_CONSOLE("\t\t\t%s", line.c_str());
+    }
+}
 
 static void PrintUsage(const char* exe_name)
 {
@@ -57,54 +99,43 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to replay GFXReconstruct capture files.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
     GFXRECON_WRITE_CONSOLE("  %s\t[-h | --help] [--version]", app_name.c_str());
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--cpu-mask <binary-mask>] [--gpu <index>] [--gpu-group <index>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--cpu-mask <binary-mask>] [--gpu <index>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--pause-frame <N>] [--paused] [--sync] [--screenshot-all]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshots <N1(-N2),...>] [--screenshot-format <format>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-size <width>x<height>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-scale <scale>] [--screenshot-interval <N>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--capture]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--sfa | --skip-failed-allocations] [--replace-shaders <dir>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data] [--wsi <platform>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--use-cached-psos] [--surface-index <N>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--wsi <platform>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--remove-unsupported] [--validate]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--onhb | --omit-null-hardware-buffers]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[-m <mode> | --memory-translation <mode>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--swapchain <mode>] [--present-mode <mode>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--vssb | --virtual-swapchain-skip-blit]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--use-captured-swapchain-indices]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--use-colorspace-fallback]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--offscreen-swapchain-frame-boundary]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--mfr|--measurement-frame-range <start-frame>-<end-frame>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--measurement-file <file>] [--quit-after-measurement-range]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--flush-measurement-range]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--fw <width,height> | --force-windowed <width,height>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--sgfs <status> | --skip-get-fence-status <status>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--sgfr <frame-ranges> | --skip-get-fence-ranges <frame-ranges>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--wait-before-first-submit <milliseconds>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--frame-warm-up-spirv <spirv-file>] [--frame-warm-up-load <load>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--idle-before-submit] [--pbi-all] [--pbis <index1,index2>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--serialize-render-passes] [--wait-before-frame <milliseconds>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--serialize-queue-submissions]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--replay-event-plugin-path <path>] [--replay-event-plugin-params <params>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--pbi-all] [--pbis <index1,index2>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--wait-before-frame <milliseconds>]");
 #if !defined(_WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources <filename>.json]");
 #endif
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-dir <dir>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--debug-messenger-level <level>]");
 #if defined(_WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources <submit-index,command-index,drawcall-index>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-modifiable-state-only]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-image-format <format>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-modifiable-state-only]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--fwo <x,y> | --force-windowed-origin <x,y>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--log-level <level>] [--log-file <file>] [--log-debugview]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--batching-memory-usage <pct>]");
 #if defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--no-debug-popup]");
 #endif
 #else
     GFXRECON_WRITE_CONSOLE("\t\t\t[--log-level <level>] [--log-file <file>]");
 #endif
+
+    // Each Feature contributes the entries that belong only to that Feature, so an entry is in
+    // the synopsis only when the build contains the Feature that reads it.
+    PrintFeatureSynopsisLines(BuildFeatureSynopsis(gfxrecon::replay::GetLoadedFeatures()));
+
     GFXRECON_WRITE_CONSOLE("\t\t\t<file>\n");
 
     GFXRECON_WRITE_CONSOLE("Required arguments:");
@@ -112,8 +143,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\nOptional arguments:");
     GFXRECON_WRITE_CONSOLE("  -h\t\t\tPrint usage information and exit (same as --help).");
     GFXRECON_WRITE_CONSOLE("  --version\t\tPrint version information and exit.");
-    GFXRECON_WRITE_CONSOLE("  --log-level <level>\tSpecify highest level message to log. Options are:");
-    GFXRECON_WRITE_CONSOLE("          \t\tdebug, info, warning, error, and fatal. Default is info.");
+    GFXRECON_WRITE_CONSOLE("  --log-level <level>\tSpecify lowest level message to log. Options are:");
+    GFXRECON_WRITE_CONSOLE("          \t\tfatal, error, warning, info, and debug. Default is info.");
     GFXRECON_WRITE_CONSOLE("  --log-timestamps\tOutput a timestamp in front of each log message.");
     GFXRECON_WRITE_CONSOLE("  --log-file <file>\tWrite log messages to a file at the specified path.")
     GFXRECON_WRITE_CONSOLE("          \t\tDefault is: Empty string (file logging disabled).");
@@ -121,8 +152,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --log-debugview\tLog messages with OutputDebugStringA.");
 #endif
     GFXRECON_WRITE_CONSOLE(
-        "  --debug-messenger-level <level>\tSpecify highest debug messenger severity level. Options are:")
-    GFXRECON_WRITE_CONSOLE("          \t\tdebug, info, warning, and error. Default is warning.");
+        "  --debug-messenger-level <level>\tSpecify lowest debug messenger severity level. Options are:")
+    GFXRECON_WRITE_CONSOLE("          \t\terror, warning, info, and debug. Default is warning.");
     GFXRECON_WRITE_CONSOLE("  --pause-frame <N>\tPause after replaying frame number N.");
     GFXRECON_WRITE_CONSOLE("  --paused\t\tPause after replaying the first frame (same");
     GFXRECON_WRITE_CONSOLE("          \t\tas --pause-frame 1).");
@@ -203,31 +234,18 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE(
         "  --fwo <x,y>\t\tForce windowed mode if not already, and allow setting of a custom window location.");
     GFXRECON_WRITE_CONSOLE("          \t\t(Same as --force-windowed-origin)");
+    GFXRECON_WRITE_CONSOLE("  --debug-device-lost\tEnable automatic injection of breadcrumbs into command buffers");
+    GFXRECON_WRITE_CONSOLE("            \t\tand page fault reporting.");
+    GFXRECON_WRITE_CONSOLE("            \t\tUsed to debug Direct3D 12 device removed problems.");
+    GFXRECON_WRITE_CONSOLE("  --fw <width,height>\tSetup windowed and override resolution.");
+    GFXRECON_WRITE_CONSOLE("                     \t(Same as --force-windowed)");
+    GFXRECON_WRITE_CONSOLE("  --create-dummy-allocations");
+    GFXRECON_WRITE_CONSOLE("          \t\tEnable creation of dummy heaps and resources for replay validation.");
 #if defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
     GFXRECON_WRITE_CONSOLE("       \t\t\tdisplayed when abort() is called (Windows debug only).");
 #endif
 #endif
-    GFXRECON_WRITE_CONSOLE("")
-    GFXRECON_WRITE_CONSOLE("Vulkan only:")
-    GFXRECON_WRITE_CONSOLE("  --capture\t\tCapture the replaying GFXR file. Capture uses the same log");
-    GFXRECON_WRITE_CONSOLE("       \t\t\toptions as replay. All other capture option behavior and");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tusage is the same as when capturing with the GFXR layer. The");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tcapture functionality is included in the `gfxrecon-replay`");
-    GFXRECON_WRITE_CONSOLE("       \t\t\texecutable--no GFXR capture layer is added to the Vulkan layer");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tchain.");
-    GFXRECON_WRITE_CONSOLE("  --sfa\t\t\tSkip vkAllocateMemory, vkAllocateCommandBuffers, and");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tvkAllocateDescriptorSets calls that failed during");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tcapture (same as --skip-failed-allocations).");
-    GFXRECON_WRITE_CONSOLE("  --replace-shaders <dir>");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tReplace the shader code in each CreateShaderModule");
-    GFXRECON_WRITE_CONSOLE("       \t\t\twith the contents of the file <dir>/sh<handle_id> if found, where");
-    GFXRECON_WRITE_CONSOLE("       \t\t\t<handle_id> is the handle id of the CreateShaderModule call.");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tSee gfxrecon-extract.");
-    GFXRECON_WRITE_CONSOLE("  --opcd\t\tOmit pipeline cache data from calls to");
-    GFXRECON_WRITE_CONSOLE("        \t\tvkCreatePipelineCache and skip calls to");
-    GFXRECON_WRITE_CONSOLE("        \t\tvkGetPipelineCacheData (same as");
-    GFXRECON_WRITE_CONSOLE("        \t\t--omit-pipeline-cache-data).");
     GFXRECON_WRITE_CONSOLE("  --wsi <platform>\tForce replay to use the specified wsi platform. If no surface");
     GFXRECON_WRITE_CONSOLE("                  \twas available at capture time the option is ignored and no");
     GFXRECON_WRITE_CONSOLE("                  \tsurface is chosen.");
@@ -235,68 +253,9 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("                  \tauto (default): Picks the same surface as at capture time if");
     GFXRECON_WRITE_CONSOLE("                  \t                possible, otherwise picks a surface available");
     GFXRECON_WRITE_CONSOLE("                  \t                on the replay device");
-    GFXRECON_WRITE_CONSOLE("  --surface-index <N>\tRestrict rendering to the Nth surface object created.");
-    GFXRECON_WRITE_CONSOLE("                  \tUsed with captures that include multiple surfaces.  Default");
-    GFXRECON_WRITE_CONSOLE("                  \tis -1 (render to all surfaces).");
     GFXRECON_WRITE_CONSOLE("  --sync\t\tSynchronize after each queue submission with vkQueueWaitIdle.");
     GFXRECON_WRITE_CONSOLE("  --remove-unsupported\tRemove unsupported extensions and features from instance");
     GFXRECON_WRITE_CONSOLE("                      \tand device creation parameters.");
-    GFXRECON_WRITE_CONSOLE("  -m <mode>\t\tEnable memory translation for replay on GPUs with memory");
-    GFXRECON_WRITE_CONSOLE("          \t\ttypes that are not compatible with the capture GPU's");
-    GFXRECON_WRITE_CONSOLE("          \t\tmemory types.  Available modes are:");
-    GFXRECON_WRITE_CONSOLE("          \t\t    %s\tNo memory translation is performed.  This", kMemoryTranslationNone);
-    GFXRECON_WRITE_CONSOLE("          \t\t         \tis the default behavior.");
-    GFXRECON_WRITE_CONSOLE("          \t\t    %s\tAttempt to map capture memory types to", kMemoryTranslationRemap);
-    GFXRECON_WRITE_CONSOLE("          \t\t         \tcompatible replay memory types, without");
-    GFXRECON_WRITE_CONSOLE("          \t\t         \taltering memory allocation behavior.");
-    GFXRECON_WRITE_CONSOLE("          \t\t    %s\tAdjust memory allocation sizes and", kMemoryTranslationRealign);
-    GFXRECON_WRITE_CONSOLE("          \t\t         \tresource binding offsets based on");
-    GFXRECON_WRITE_CONSOLE("          \t\t         \treplay memory properties.");
-    GFXRECON_WRITE_CONSOLE("          \t\t    %s\tChange memory allocation behavior based", kMemoryTranslationRebind);
-    GFXRECON_WRITE_CONSOLE("          \t\t         \ton resource usage and replay memory");
-    GFXRECON_WRITE_CONSOLE("          \t\t         \tproperties.  Resources may be bound");
-    GFXRECON_WRITE_CONSOLE("          \t\t         \tto different allocations with different");
-    GFXRECON_WRITE_CONSOLE("          \t\t         \toffsets.  Uses VMA to manage allocations");
-    GFXRECON_WRITE_CONSOLE("          \t\t         \tand suballocations.");
-    GFXRECON_WRITE_CONSOLE("  --swapchain <mode>\tChoose a swapchain mode to replay.");
-    GFXRECON_WRITE_CONSOLE("          \t\tAvailable modes are:");
-    GFXRECON_WRITE_CONSOLE("          \t\t    %s\tVirtual Swapchain of images which match", kSwapchainVirtual);
-    GFXRECON_WRITE_CONSOLE("          \t\t         \tthe swapchain in effect at capture time and");
-    GFXRECON_WRITE_CONSOLE("          \t\t         \twhich are copied to the underlying swapchain of the");
-    GFXRECON_WRITE_CONSOLE("          \t\t         \timplementation being replayed on. Also displays");
-    GFXRECON_WRITE_CONSOLE("          \t\t         \toffscreen frame boundaries to an additional window.");
-    GFXRECON_WRITE_CONSOLE("          \t\t         \tThis is only available and default for Vulkan.");
-    GFXRECON_WRITE_CONSOLE("          \t\t    %s\tUse the swapchain indices stored in the ", kSwapchainCaptured);
-    GFXRECON_WRITE_CONSOLE("          \t\t         \tcapture directly on the swapchain setup for replay.");
-    GFXRECON_WRITE_CONSOLE("          \t\t    %s\tDisable creating swapchains, surfaces", kSwapchainOffscreen);
-    GFXRECON_WRITE_CONSOLE("          \t\t         \tand windows. To see rendering, add the --screenshots option.");
-    GFXRECON_WRITE_CONSOLE("  --present-mode <mode>\tSet swapchain's VkPresentModeKHR.");
-    GFXRECON_WRITE_CONSOLE("          \t\tAvailable modes are:");
-    GFXRECON_WRITE_CONSOLE("          \t\t\t%s: Present mode used at capture time.", kPresentModeCapture);
-    GFXRECON_WRITE_CONSOLE("          \t\t\t%s: VK_PRESENT_MODE_IMMEDIATE_KHR", kPresentModeImmediate);
-    GFXRECON_WRITE_CONSOLE("          \t\t\t%s: VK_PRESENT_MODE_MAILBOX_KHR", kPresentModeMailbox);
-    GFXRECON_WRITE_CONSOLE("          \t\t\t%s: VK_PRESENT_MODE_FIFO_KHR", kPresentModeFifo);
-    GFXRECON_WRITE_CONSOLE("          \t\t\t%s: VK_PRESENT_MODE_FIFO_RELAXED_KHR", kPresentModeFifoRelaxed);
-    GFXRECON_WRITE_CONSOLE("  --present-override <debug-name>");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tAdditionally present an image identified by a substring match against its");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tVK_EXT_debug_utils object name (depth/stencil images are ignored). The");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tmatched image is presented in a dedicated swapchain on every present and");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tused for screenshot operations. Multi-layer images are presented tiled");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tinto a single window, one tile per array layer. If multiple images");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tmatch, the most recently named one is used.");
-    GFXRECON_WRITE_CONSOLE("  --vssb");
-    GFXRECON_WRITE_CONSOLE("          \t\tSkip blit to real swapchain to gain performance during replay.");
-    GFXRECON_WRITE_CONSOLE("  --use-captured-swapchain-indices");
-    GFXRECON_WRITE_CONSOLE("          \t\tSame as \"--swapchain captured\".");
-    GFXRECON_WRITE_CONSOLE("          \t\tIgnored if the \"--swapchain\" option is used.");
-    GFXRECON_WRITE_CONSOLE("  --offscreen-swapchain-frame-boundary");
-    GFXRECON_WRITE_CONSOLE("          \t\tShould only be used with offscreen swapchain.");
-    GFXRECON_WRITE_CONSOLE("          \t\tActivates the extension VK_EXT_frame_boundary (always supported if");
-    GFXRECON_WRITE_CONSOLE("          \t\ttrimming, checks for driver support otherwise) and inserts command");
-    GFXRECON_WRITE_CONSOLE("          \t\tbuffer submission with VkFrameBoundaryEXT where vkQueuePresentKHR");
-    GFXRECON_WRITE_CONSOLE("          \t\twas called in the original capture.");
-    GFXRECON_WRITE_CONSOLE("          \t\tThis allows preserving frames when capturing a replay that uses.");
-    GFXRECON_WRITE_CONSOLE("          \t\toffscreen swapchain.");
     GFXRECON_WRITE_CONSOLE("  --measurement-frame-range <start_frame>-<end_frame>");
     GFXRECON_WRITE_CONSOLE("          \t\tCustom framerange to measure FPS for.");
     GFXRECON_WRITE_CONSOLE("          \t\tThis range will include the start frame but not the end frame.");
@@ -304,10 +263,6 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tframe but can be configured for any range. If the end frame is past the");
     GFXRECON_WRITE_CONSOLE("          \t\tlast frame in the trace it will be clamped to the frame after the last");
     GFXRECON_WRITE_CONSOLE("          \t\t(so in that case the results would include the last frame).");
-    GFXRECON_WRITE_CONSOLE("  --use-colorspace-fallback");
-    GFXRECON_WRITE_CONSOLE("          \t\tSwap the swapchain color space if unsupported by replay device.");
-    GFXRECON_WRITE_CONSOLE("          \t\tCheck if color space is not supported by replay device and fallback to "
-                           "VK_COLOR_SPACE_SRGB_NONLINEAR_KHR.");
     GFXRECON_WRITE_CONSOLE("  --measurement-file <file>");
     GFXRECON_WRITE_CONSOLE("          \t\tWrite measurements to a file at the specified path.");
     GFXRECON_WRITE_CONSOLE("          \t\tDefault is: '/sdcard/gfxrecon-measurements.json' on android and");
@@ -324,67 +279,26 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tIf this is specified the replayer will flush")
     GFXRECON_WRITE_CONSOLE("          \t\tand wait for all current GPU work to finish at the");
     GFXRECON_WRITE_CONSOLE("          \t\tend of each frame inside the measurement range.");
-    GFXRECON_WRITE_CONSOLE("  --gpu-group <index>\tUse the specified device group for replay, where index");
-    GFXRECON_WRITE_CONSOLE("          \t\tis the zero-based index to the array of physical device group");
-    GFXRECON_WRITE_CONSOLE("          \t\treturned by vkEnumeratePhysicalDeviceGroups.  Replay may fail");
-    GFXRECON_WRITE_CONSOLE("          \t\tif the specified device group is not compatible with the");
-    GFXRECON_WRITE_CONSOLE("          \t\toriginal capture device group.");
-    GFXRECON_WRITE_CONSOLE("  --sgfs <status>");
-    GFXRECON_WRITE_CONSOLE("          \t\tSpecify behavior to skip calls to vkWaitForFences and vkGetFenceStatus:");
-    GFXRECON_WRITE_CONSOLE("          \t\t\tstatus=0 : Don't skip");
-    GFXRECON_WRITE_CONSOLE("          \t\t\tstatus=1 : Skip unsuccessful calls");
-    GFXRECON_WRITE_CONSOLE("          \t\t\tstatus=2 : Always skip");
-    GFXRECON_WRITE_CONSOLE("          \t\tIf no skip frame range is specified (--sgfr), the status applies to all");
-    GFXRECON_WRITE_CONSOLE("          \t\tframes.");
-    GFXRECON_WRITE_CONSOLE("  --sgfr <frame-ranges>");
-    GFXRECON_WRITE_CONSOLE("          \t\tFrame ranges where --sgfs applies. The format is:");
-    GFXRECON_WRITE_CONSOLE("          \t\t\t<frame-start-1>-<frame-end-1>[,<frame-start-1>-<frame-end-1>]*");
-    GFXRECON_WRITE_CONSOLE("  --wait-before-present");
-    GFXRECON_WRITE_CONSOLE("          \t\tForce wait on completion of queue operations for all queues");
-    GFXRECON_WRITE_CONSOLE("          \t\tbefore calling Present. This is needed for accurate acquisition");
-    GFXRECON_WRITE_CONSOLE("          \t\tof instrumentation data on some platforms.");
-    GFXRECON_WRITE_CONSOLE("  --annotate-injected-commands");
-    GFXRECON_WRITE_CONSOLE("          \t\tWrap commands injected by replay (not present in the capture,");
-    GFXRECON_WRITE_CONSOLE("          \t\te.g. virtual-swapchain copies and ray-tracing SBT fixups) in");
-    GFXRECON_WRITE_CONSOLE("          \t\tVK_EXT_debug_utils labels named \"GFXR Replay: <category>\".");
 #if !defined(_WIN32)
     GFXRECON_WRITE_CONSOLE("  --dump-resources <filename>.json");
     GFXRECON_WRITE_CONSOLE("          \t\tExtract dump resources block indices and options from the");
     GFXRECON_WRITE_CONSOLE("          \t\tspecified json file. The format for the json file is");
     GFXRECON_WRITE_CONSOLE("          \t\tdocumented in detail in vulkan_dump_resources.md.");
+#else
+    GFXRECON_WRITE_CONSOLE("  --dump-resources-image-format <format>");
+    GFXRECON_WRITE_CONSOLE("          \t\tImage file format to use when dumping image resources.");
+    GFXRECON_WRITE_CONSOLE("          \t\tAvailable formats are: bmp, png");
+    GFXRECON_WRITE_CONSOLE("  --dump-resources-modifiable-state-only");
+    GFXRECON_WRITE_CONSOLE("          \t\tDump only the resources that a D3D12 ResourceBarrier put into a");
+    GFXRECON_WRITE_CONSOLE("          \t\tmodifiable state.");
 #endif
     GFXRECON_WRITE_CONSOLE("  --pipeline-creation-jobs <num_jobs>");
     GFXRECON_WRITE_CONSOLE("          \t\tSpecify the number of asynchronous pipeline-creation jobs as integer.");
     GFXRECON_WRITE_CONSOLE("          \t\tIf <num_jobs> is negative it will be added to the number of cpu-cores");
     GFXRECON_WRITE_CONSOLE("          \t\tDefault: 0 (do not use asynchronous operations).");
     GFXRECON_WRITE_CONSOLE("          \t\tSame as --pcj <num_jobs>");
-    GFXRECON_WRITE_CONSOLE("  --save-pipeline-cache <cache-file>");
-    GFXRECON_WRITE_CONSOLE("          \t\tIf set, produces pipeline caches at replay time instead of using");
-    GFXRECON_WRITE_CONSOLE("          \t\tthe one saved at capture time and save those caches in <cache-file>.");
-    GFXRECON_WRITE_CONSOLE("  --load-pipeline-cache <cache-file>");
-    GFXRECON_WRITE_CONSOLE("          \t\tIf set, loads data created by the `--save-pipeline-cache`");
-    GFXRECON_WRITE_CONSOLE("          \t\toption in <cache-file> and uses it to create the pipelines instead");
-    GFXRECON_WRITE_CONSOLE("          \t\tof the pipeline caches saved at capture time.");
-    GFXRECON_WRITE_CONSOLE("  --add-new-pipeline-caches");
-    GFXRECON_WRITE_CONSOLE("          \t\tIf set, allows gfxreconstruct to create new vkPipelineCache objects");
-    GFXRECON_WRITE_CONSOLE("          \t\twhen it encounters a pipeline created without cache. This option can");
-    GFXRECON_WRITE_CONSOLE("          \t\tbe used in coordination with `--save-pipeline-cache` and");
-    GFXRECON_WRITE_CONSOLE("          \t\t`--load-pipeline-cache`.");
-    GFXRECON_WRITE_CONSOLE("  --screenshot-ignore-FrameBoundaryANDROID");
-    GFXRECON_WRITE_CONSOLE("          \t\tIf set, frames switced with vkFrameBoundANDROID will be ignored from");
-    GFXRECON_WRITE_CONSOLE("          \t\tthe screenshot handler.");
-    GFXRECON_WRITE_CONSOLE("  --screenshot-apply-prerotation");
-    GFXRECON_WRITE_CONSOLE("          \t\tIf set, screenshots will respect the preTransform of the swapchain.");
-    GFXRECON_WRITE_CONSOLE("  --deduplicate-device");
-    GFXRECON_WRITE_CONSOLE("          \t\tIf set, at most one VkDevice will be created for each VkPhysicalDevice for "
-                           "RenderDoc and DXVK case.");
     GFXRECON_WRITE_CONSOLE("  --wait-before-first-submit <milliseconds>");
     GFXRECON_WRITE_CONSOLE("          \t\tWait specified milliseconds before submitting the first command buffer.");
-    GFXRECON_WRITE_CONSOLE("  --idle-before-submit");
-    GFXRECON_WRITE_CONSOLE("          \t\tWait for the GPU to become idle before each submit.");
-    GFXRECON_WRITE_CONSOLE("  --serialize-render-passes");
-    GFXRECON_WRITE_CONSOLE("          \t\tSerialize render passes by injecting execution barriers before render pass");
-    GFXRECON_WRITE_CONSOLE("          \t\tbegin during replay.");
     GFXRECON_WRITE_CONSOLE("  --frame-warm-up-spirv <spirv-file>");
     GFXRECON_WRITE_CONSOLE("          \t\tSpecify a user-provided SPIR-V compute shader for the warm-up pass.");
     GFXRECON_WRITE_CONSOLE("          \t\tThe shader must use entry point `main` and set 0, binding 0 as a");
@@ -397,55 +311,9 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --wait-before-frame <milliseconds>");
     GFXRECON_WRITE_CONSOLE("          \t\tWait for the specified amount of milliseconds before starting to replay");
     GFXRECON_WRITE_CONSOLE("          \t\teach frame. Default is 0 (no wait).");
-    GFXRECON_WRITE_CONSOLE("  --serialize-queue-submissions");
-    GFXRECON_WRITE_CONSOLE("          \t\tSerialize submit entries within one vkQueueSubmit/vkQueueSubmit2");
-    GFXRECON_WRITE_CONSOLE("          \t\tcall by adding semaphores between consecutive submits.");
-    GFXRECON_WRITE_CONSOLE("  --replay-event-plugin-path <path>");
-    GFXRECON_WRITE_CONSOLE("          \t\tPath to a replay event plugin library. If specified, the");
-    GFXRECON_WRITE_CONSOLE("          \t\tplugin will be loaded and used to process replay events.");
-    GFXRECON_WRITE_CONSOLE("          \t\t(forwarded to replay tool)");
-    GFXRECON_WRITE_CONSOLE("  --replay-event-plugin-params <params>");
-    GFXRECON_WRITE_CONSOLE("          \t\tParameters to forward to the replay event plugin. The format");
-    GFXRECON_WRITE_CONSOLE("          \t\tof the parameters is determined by the plugin and is not");
-    GFXRECON_WRITE_CONSOLE("          \t\tinterpreted by the replay tool. (forwarded to replay tool)");
-    GFXRECON_WRITE_CONSOLE("  --isolate-render-passes");
-    GFXRECON_WRITE_CONSOLE(
-        "          \t\tIsolate render passes by splitting the command buffer into multiple submits.");
 
-#if defined(_WIN32)
-    GFXRECON_WRITE_CONSOLE("")
-    GFXRECON_WRITE_CONSOLE("D3D12 only:")
-    GFXRECON_WRITE_CONSOLE(
-        "  --use-cached-psos  \tPermit using cached PSOs when creating graphics or compute pipelines.");
-    GFXRECON_WRITE_CONSOLE(
-        "       \t\t\tUsing cached PSOs may reduce PSO creation time but may result in replay errors.");
-    GFXRECON_WRITE_CONSOLE("  --debug-device-lost\tEnable automatic injection of breadcrumbs into command buffers");
-    GFXRECON_WRITE_CONSOLE("            \t\tand page fault reporting.");
-    GFXRECON_WRITE_CONSOLE("            \t\tUsed to debug Direct3D 12 device removed problems.");
-    GFXRECON_WRITE_CONSOLE("  --fw <width,height>\tSetup windowed and override resolution.");
-    GFXRECON_WRITE_CONSOLE("                     \t(Same as --force-windowed)");
-    GFXRECON_WRITE_CONSOLE("  --create-dummy-allocations");
-    GFXRECON_WRITE_CONSOLE("          \t\tEnable creation of dummy heaps and resources for replay validation.");
-    GFXRECON_WRITE_CONSOLE("  --dx12-override-object-names");
-    GFXRECON_WRITE_CONSOLE("          \t\tGenerate unique names for all ID3D12Objects and");
-    GFXRECON_WRITE_CONSOLE("          \t\tassign each object the generated name.");
-    GFXRECON_WRITE_CONSOLE("          \t\tThis is intended to assist in replay debugging.");
-    GFXRECON_WRITE_CONSOLE("  --dx12-ags-inject-markers");
-    GFXRECON_WRITE_CONSOLE("          \t\tLabel each API calls as block index of the trace");
-    GFXRECON_WRITE_CONSOLE("          \t\tRadeon GPU Detective could dump the label for debugging.");
-    GFXRECON_WRITE_CONSOLE("  --batching-memory-usage <pct>");
-    GFXRECON_WRITE_CONSOLE("          \t\tMax amount of memory consumption while loading a trimmed capture file.");
-    GFXRECON_WRITE_CONSOLE("          \t\tAcceptable values range from 0 to 100 (default: 80)");
-    GFXRECON_WRITE_CONSOLE("          \t\t0 means no batching at all");
-    GFXRECON_WRITE_CONSOLE("          \t\t100 means use all available system and GPU memory");
-    GFXRECON_WRITE_CONSOLE("  --dump-resources-modifiable-state-only");
-    GFXRECON_WRITE_CONSOLE(
-        "          \t\tOnly dump resources that are in a modifiable state set by D3D12 ResourceBarrier")
-    GFXRECON_WRITE_CONSOLE("  --dump-resources-image-format <format>");
-    GFXRECON_WRITE_CONSOLE("          \t\tImage file format to use when dumping image resources.");
-    GFXRECON_WRITE_CONSOLE("          \t\tAvailable formats are: bmp, png");
-
-#endif
+    // The entries that belong to one Feature come last, in one section for each Feature.
+    PrintFeatureUsage(gfxrecon::replay::GetLoadedFeatures());
 }
 
 #endif // GFXRECON_REPLAY_SETTINGS_H

--- a/tools/replay/replay_vulkan_feature.cpp
+++ b/tools/replay/replay_vulkan_feature.cpp
@@ -23,6 +23,8 @@
 
 #include "replay_vulkan_feature.h"
 
+#include "tool_feature_options.h"
+
 #include "decode/vulkan_replay_frame_loop_consumer.h"
 #include "parse_dump_resources_cli.h"
 #if defined(GFXRECON_ENABLE_VULKAN)
@@ -35,11 +37,476 @@
 #include "util/feature_module_registry.h"
 #include "decode/vulkan_state_recording_decoder.h"
 
+// Headers for the Vulkan-only option parsing that this file owns.
+#include "decode/vulkan_default_allocator.h"
+#include "decode/vulkan_realign_allocator.h"
+#include "decode/vulkan_rebind_allocator.h"
+#include "decode/vulkan_remap_allocator.h"
+#include "decode/vulkan_resource_tracking_consumer.h"
+#include "generated/generated_vulkan_decoder.h"
+#include "util/platform.h"
+#include "util/strings.h"
+
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(replay)
 
 // Register this class as a feature in a module registry
 GFXR_UTIL_REGISTER_FEATURE_CREATOR(ReplayFeatureBase, ReplayVulkanFeature)
+
+// ----------------------------------------------------------------------------
+// Vulkan-only command-line settings.
+//
+// The names, the values, and the code that reads them stay with this Feature, so that
+// tools/tool_settings.h and tools/replay/replay_settings.h keep only the settings that every
+// replay Feature shares.
+// ----------------------------------------------------------------------------
+
+const char kCaptureLayer[] = "VK_LAYER_LUNARG_gfxreconstruct";
+
+// The environment variable, or on Android the system property, that lists the active layers.
+const char kLayerEnvVar[]   = "VK_INSTANCE_LAYERS";
+const char kLayerProperty[] = "debug.vulkan.layers";
+
+const char kDebugMessageSeverityArgument[]     = "--debug-messenger-level";
+const char kOverrideGpuGroupArgument[]         = "--gpu-group";
+const char kCaptureOption[]                    = "--capture";
+const char kSkipFailedAllocationShortOption[]  = "--sfa";
+const char kSkipFailedAllocationLongOption[]   = "--skip-failed-allocations";
+const char kOmitPipelineCacheDataShortOption[] = "--opcd";
+const char kOmitPipelineCacheDataLongOption[]  = "--omit-pipeline-cache-data";
+const char kSurfaceIndexArgument[]             = "--surface-index";
+const char kMemoryPortabilityShortOption[]     = "-m";
+const char kMemoryPortabilityLongOption[]      = "--memory-translation";
+const char kShaderReplaceArgument[]            = "--replace-shaders";
+const char kSwapchainOption[]                  = "--swapchain";
+const char kPresentModeOption[]                = "--present-mode";
+const char kPresentOverrideImageArgument[]     = "--present-override";
+const char kEnableUseCapturedSwapchainIndices[] =
+    "--use-captured-swapchain-indices"; // The same: util::SwapchainOption::kCaptured
+const char kVirtualSwapchainSkipBlitShortOption[] = "--vssb";
+const char kVirtualSwapchainSkipBlitLongOption[]  = "--virtual-swapchain-skip-blit";
+const char kColorspaceFallback[]                  = "--use-colorspace-fallback";
+const char kOffscreenSwapchainFrameBoundary[]     = "--offscreen-swapchain-frame-boundary";
+// The short forms of the two skip-get-fence entries.
+const char kSkipGetFenceStatusShortOption[]         = "--sgfs";
+const char kSkipGetFenceRangesShortOption[]         = "--sgfr";
+const char kSkipGetFenceStatus[]                    = "--skip-get-fence-status";
+const char kSkipGetFenceRanges[]                    = "--skip-get-fence-ranges";
+const char kWaitBeforePresent[]                     = "--wait-before-present";
+const char kAnnotateInjectedCommands[]              = "--annotate-injected-commands";
+const char kSavePipelineCacheArgument[]             = "--save-pipeline-cache";
+const char kLoadPipelineCacheArgument[]             = "--load-pipeline-cache";
+const char kCreateNewPipelineCacheOption[]          = "--add-new-pipeline-caches";
+const char kDeduplicateDevice[]                     = "--deduplicate-device";
+const char kIdleBeforeSubmit[]                      = "--idle-before-submit";
+const char kSerializeRenderPasses[]                 = "--serialize-render-passes";
+const char kScreenshotIgnoreFrameBoundaryArgument[] = "--screenshot-ignore-FrameBoundaryANDROID";
+const char kScreenshotApplyPrerotationArgument[]    = "--screenshot-apply-prerotation";
+const char kSerializeQueueSubmissions[]             = "--serialize-queue-submissions";
+const char kReplayEventPluginPath[]                 = "--replay-event-plugin-path";
+const char kReplayEventPluginParams[]               = "--replay-event-plugin-params";
+const char kIsolateRenderPasses[]                   = "--isolate-render-passes";
+const char kSerializeComputeAndTransfer[]           = "--serialize-compute-and-transfer";
+
+const char kMemoryTranslationNone[]    = "none";
+const char kMemoryTranslationRemap[]   = "remap";
+const char kMemoryTranslationRealign[] = "realign";
+const char kMemoryTranslationRebind[]  = "rebind";
+
+const char kSwapchainVirtual[]   = "virtual";
+const char kSwapchainCaptured[]  = "captured";
+const char kSwapchainOffscreen[] = "offscreen";
+
+const char kPresentModeCapture[]     = "capture";
+const char kPresentModeImmediate[]   = "immediate";
+const char kPresentModeMailbox[]     = "mailbox";
+const char kPresentModeFifo[]        = "fifo";
+const char kPresentModeFifoRelaxed[] = "fifo_relaxed";
+
+// The closed sets of accepted values, in the order that the usage text lists them.
+const std::vector<std::string> kMemoryTranslationValues = {
+    kMemoryTranslationNone, kMemoryTranslationRemap, kMemoryTranslationRealign, kMemoryTranslationRebind
+};
+const std::vector<std::string> kSwapchainValues   = { kSwapchainVirtual, kSwapchainCaptured, kSwapchainOffscreen };
+const std::vector<std::string> kPresentModeValues = {
+    kPresentModeCapture, kPresentModeImmediate, kPresentModeMailbox, kPresentModeFifo, kPresentModeFifoRelaxed
+};
+
+static void CheckActiveLayers(const std::string& list)
+{
+    if (!list.empty())
+    {
+        // Check for the presence of the layer name in the list of active layers.
+        size_t start = list.find(kCaptureLayer);
+
+        if (start != std::string::npos)
+        {
+            size_t end         = start + gfxrecon::util::platform::StringLength(kCaptureLayer);
+            bool   match_start = false;
+            bool   match_end   = false;
+
+            // For an exact match, the start of the layer name is either at the start of the list or comes after a path
+            // separator.
+            if ((start == 0) || ((list[start - 1] == ';') || (list[start - 1] == ':')))
+            {
+                match_start = true;
+            }
+
+            // For an exact match, the end of the layer name is either at the end of the list or comes before a path
+            // separator.
+            if ((list.length() == end) || ((list[end] == ';') || (list[end] == ':')))
+            {
+                match_end = true;
+            }
+
+            if (match_start && match_end)
+            {
+                GFXRECON_LOG_WARNING("Replay tool has detected that the capture layer is enabled");
+            }
+        }
+    }
+}
+
+static gfxrecon::decode::VulkanResourceAllocator* CreateDefaultAllocator()
+{
+    return new gfxrecon::decode::VulkanDefaultAllocator(
+        "Try replay with the '-m remap' or '-m rebind' options to enable memory translation.");
+}
+
+static gfxrecon::decode::VulkanResourceAllocator* CreateRemapAllocator()
+{
+    return new gfxrecon::decode::VulkanRemapAllocator(
+        "Try replay with the '-m rebind' option to enable advanced memory translation.");
+}
+
+static gfxrecon::decode::VulkanResourceAllocator* CreateRebindAllocator()
+{
+    return new gfxrecon::decode::VulkanRebindAllocator();
+}
+
+static gfxrecon::decode::CreateResourceAllocator
+InitRealignAllocatorCreateFunc(const std::string&                              filename,
+                               const gfxrecon::decode::VulkanReplayOptions&    replay_options,
+                               gfxrecon::decode::VulkanTrackedObjectInfoTable* tracked_object_info_table)
+{
+    // Enable first pass of replay to generate resource tracking information.
+    GFXRECON_WRITE_CONSOLE("First pass of replay resource tracking for realign memory portability mode. This may take "
+                           "some time. Please wait...");
+
+    gfxrecon::decode::FileProcessor file_processor_resource_tracking;
+    gfxrecon::decode::VulkanDecoder decoder;
+
+    auto resource_tracking_consumer =
+        new gfxrecon::decode::VulkanResourceTrackingConsumer(replay_options, tracked_object_info_table);
+
+    if (file_processor_resource_tracking.Initialize(filename))
+    {
+        decoder.AddConsumer(resource_tracking_consumer);
+        file_processor_resource_tracking.AddDecoder(&decoder);
+        file_processor_resource_tracking.InitializeFrameProcessing();
+        file_processor_resource_tracking.ProcessAllFrames();
+        file_processor_resource_tracking.RemoveDecoder(&decoder);
+        decoder.RemoveConsumer(resource_tracking_consumer);
+    }
+
+    // Sort the bound resources according to the binding offsets.
+    resource_tracking_consumer->SortMemoriesBoundResourcesByOffset();
+
+    // calculate the replay binding offset of the bound resources and replay memory allocation size
+    resource_tracking_consumer->CalculateReplayBindingOffsetAndMemoryAllocationSize();
+
+    GFXRECON_WRITE_CONSOLE("First pass of replay resource tracking done.");
+
+    return [tracked_object_info_table]() -> gfxrecon::decode::VulkanResourceAllocator* {
+        return new gfxrecon::decode::VulkanRealignAllocator(
+            tracked_object_info_table, "Try replay with the '-m rebind' option to enable advanced memory translation.");
+    };
+}
+
+static gfxrecon::decode::CreateResourceAllocator
+GetCreateResourceAllocatorFunc(const gfxrecon::util::ArgumentParser&           arg_parser,
+                               const std::string&                              filename,
+                               const gfxrecon::decode::VulkanReplayOptions&    replay_options,
+                               gfxrecon::decode::VulkanTrackedObjectInfoTable* tracked_object_info_table)
+{
+    gfxrecon::decode::CreateResourceAllocator func  = CreateDefaultAllocator;
+    const auto&                               value = arg_parser.GetArgumentValue(kMemoryPortabilityShortOption);
+
+    if (!value.empty())
+    {
+        if (gfxrecon::util::platform::StringCompareNoCase(kMemoryTranslationRebind, value.c_str()) == 0)
+        {
+            func = CreateRebindAllocator;
+        }
+        else if (gfxrecon::util::platform::StringCompareNoCase(kMemoryTranslationRemap, value.c_str()) == 0)
+        {
+            func = CreateRemapAllocator;
+        }
+        else if (gfxrecon::util::platform::StringCompareNoCase(kMemoryTranslationRealign, value.c_str()) == 0)
+        {
+            func = InitRealignAllocatorCreateFunc(filename, replay_options, tracked_object_info_table);
+        }
+    }
+
+    return func;
+}
+
+static gfxrecon::decode::VulkanReplayOptions
+GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parser,
+                       const std::string&                              filename,
+                       gfxrecon::decode::VulkanTrackedObjectInfoTable* tracked_object_info_table)
+{
+    gfxrecon::decode::VulkanReplayOptions replay_options;
+    GetReplayOptions(replay_options, arg_parser, filename);
+
+    if (arg_parser.IsOptionSet(kCaptureOption))
+    {
+        replay_options.capture = true;
+    }
+
+    const auto& override_gpu_group = arg_parser.GetArgumentValue(kOverrideGpuGroupArgument);
+    if (!override_gpu_group.empty())
+    {
+        replay_options.override_gpu_group_index = std::stoi(override_gpu_group);
+    }
+
+    if (arg_parser.IsOptionSet(kSkipFailedAllocationLongOption) ||
+        arg_parser.IsOptionSet(kSkipFailedAllocationShortOption))
+    {
+        replay_options.skip_failed_allocations = true;
+    }
+
+    if (arg_parser.IsOptionSet(kOmitPipelineCacheDataLongOption) ||
+        arg_parser.IsOptionSet(kOmitPipelineCacheDataShortOption))
+    {
+        replay_options.omit_pipeline_cache_data = true;
+    }
+
+    auto swapchain_option          = arg_parser.GetArgumentValue(kSwapchainOption);
+    auto enable_captured_swapchain = arg_parser.IsOptionSet(kEnableUseCapturedSwapchainIndices);
+    if (swapchain_option.empty())
+    {
+        if (enable_captured_swapchain)
+        {
+            replay_options.swapchain_option = gfxrecon::util::SwapchainOption::kCaptured;
+        }
+    }
+    else
+    {
+        if (enable_captured_swapchain)
+        {
+            GFXRECON_LOG_WARNING("Ignoring option: \"%s\" because option: \"%s\" is added",
+                                 kEnableUseCapturedSwapchainIndices,
+                                 kSwapchainOption);
+        }
+
+        if (gfxrecon::util::platform::StringCompareNoCase(kSwapchainCaptured, swapchain_option.c_str()) == 0)
+        {
+            replay_options.swapchain_option = gfxrecon::util::SwapchainOption::kCaptured;
+        }
+        else if (gfxrecon::util::platform::StringCompareNoCase(kSwapchainOffscreen, swapchain_option.c_str()) == 0)
+        {
+            replay_options.swapchain_option = gfxrecon::util::SwapchainOption::kOffscreen;
+        }
+    }
+
+    auto present_mode_option = arg_parser.GetArgumentValue(kPresentModeOption);
+    if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeCapture, present_mode_option.c_str()) == 0)
+    {
+        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kCapture;
+    }
+    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeImmediate, present_mode_option.c_str()) == 0)
+    {
+        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kImmediate;
+    }
+    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeMailbox, present_mode_option.c_str()) == 0)
+    {
+        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kMailbox;
+    }
+    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeFifo, present_mode_option.c_str()) == 0)
+    {
+        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kFifo;
+    }
+    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeFifoRelaxed, present_mode_option.c_str()) == 0)
+    {
+        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kFifoRelaxed;
+    }
+
+    if (arg_parser.IsOptionSet(kColorspaceFallback))
+    {
+        replay_options.use_colorspace_fallback = true;
+    }
+
+    if (arg_parser.IsOptionSet(kOffscreenSwapchainFrameBoundary))
+    {
+        replay_options.offscreen_swapchain_frame_boundary = true;
+    }
+
+    if (arg_parser.IsOptionSet(kVirtualSwapchainSkipBlitLongOption) ||
+        arg_parser.IsOptionSet(kVirtualSwapchainSkipBlitShortOption))
+    {
+        replay_options.virtual_swapchain_skip_blit = true;
+    }
+
+    const std::string debug_severity_string = arg_parser.GetArgumentValue(kDebugMessageSeverityArgument);
+    if (!debug_severity_string.empty())
+    {
+        if (gfxrecon::util::platform::StringCompareNoCase("debug", debug_severity_string.c_str()) == 0)
+        {
+            replay_options.debug_message_severity =
+                VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT |
+                VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+        }
+        else if (gfxrecon::util::platform::StringCompareNoCase("info", debug_severity_string.c_str()) == 0)
+        {
+            replay_options.debug_message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT |
+                                                    VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+                                                    VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+        }
+        else if (gfxrecon::util::platform::StringCompareNoCase("warning", debug_severity_string.c_str()) == 0)
+        {
+            replay_options.debug_message_severity =
+                VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+        }
+        else if (gfxrecon::util::platform::StringCompareNoCase("error", debug_severity_string.c_str()) == 0)
+        {
+            replay_options.debug_message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING("Ignoring unrecognized debug messenger severity option value \"%s\"",
+                                 debug_severity_string.c_str());
+        }
+    }
+
+    replay_options.replace_shader_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);
+    replay_options.create_resource_allocator =
+        GetCreateResourceAllocatorFunc(arg_parser, filename, replay_options, tracked_object_info_table);
+
+    GetScreenshotSize(arg_parser, replay_options.screenshot_width, replay_options.screenshot_height);
+    replay_options.screenshot_scale = GetScreenshotScale(arg_parser);
+
+    if (auto override_name = arg_parser.GetArgumentValue(kPresentOverrideImageArgument); !override_name.empty())
+    {
+        replay_options.present_override_image_name = override_name;
+    }
+
+    if (arg_parser.IsOptionSet(kScreenshotIgnoreFrameBoundaryArgument))
+    {
+        replay_options.screenshot_ignore_frameBoundaryAndroid = true;
+    }
+
+    if (arg_parser.IsOptionSet(kQuitAfterMeasurementRangeOption))
+    {
+        replay_options.quit_after_measurement_frame_range = true;
+    }
+
+    if (arg_parser.IsOptionSet(kFlushMeasurementRangeOption))
+    {
+        replay_options.flush_measurement_frame_range = true;
+    }
+
+    std::string surface_index = arg_parser.GetArgumentValue(kSurfaceIndexArgument);
+    if (!surface_index.empty())
+    {
+        replay_options.surface_index = std::stoi(surface_index);
+    }
+
+    const std::string& skip_get_fence_status = arg_parser.GetArgumentValue(kSkipGetFenceStatus);
+    if (!skip_get_fence_status.empty())
+    {
+        const int i_skip_get_fence_status = std::stoi(skip_get_fence_status);
+        if (i_skip_get_fence_status < static_cast<int>(gfxrecon::decode::SkipGetFenceStatus::COUNT))
+        {
+            replay_options.skip_get_fence_status =
+                static_cast<gfxrecon::decode::SkipGetFenceStatus>(i_skip_get_fence_status);
+        }
+        else
+        {
+            GFXRECON_LOG_FATAL("Unexpected value after '--skip-get-fence-status': '%s'", skip_get_fence_status.c_str());
+        }
+    }
+
+    const std::string& skip_get_fence_ranges = arg_parser.GetArgumentValue(kSkipGetFenceRanges);
+    if (skip_get_fence_ranges.empty())
+    {
+        gfxrecon::util::UintRange range;
+        range.first = 1;
+        range.last  = std::numeric_limits<uint32_t>::max();
+        replay_options.skip_get_fence_ranges.push_back(range);
+    }
+    else
+    {
+        replay_options.skip_get_fence_ranges =
+            gfxrecon::util::GetUintRanges(skip_get_fence_ranges.c_str(), "skip-get-fence-ranges");
+    }
+    if (arg_parser.IsOptionSet(kWaitBeforePresent))
+    {
+        replay_options.wait_before_present = true;
+    }
+    if (arg_parser.IsOptionSet(kAnnotateInjectedCommands))
+    {
+        replay_options.annotate_injected_commands = true;
+    }
+    if (arg_parser.IsOptionSet(kPreloadMeasurementRangeOption))
+    {
+        replay_options.preload_measurement_range = true;
+    }
+
+    const std::string& dump_resources = arg_parser.GetArgumentValue(kDumpResourcesArgument);
+    if (!dump_resources.empty())
+    {
+        replay_options.enable_dump_resources = true;
+        if (dump_resources.find_first_not_of("0123456789,") == std::string::npos)
+        {
+            std::vector<std::string> values = gfxrecon::util::strings::SplitString(dump_resources, ',');
+            if (values.size() == 3)
+            {
+                replay_options.dump_resources_target.submit_index    = std::stoi(values[0]);
+                replay_options.dump_resources_target.command_index   = std::stoi(values[1]);
+                replay_options.dump_resources_target.draw_call_index = std::stoi(values[2]);
+                replay_options.using_dump_resources_target           = true;
+            }
+        }
+        else
+        {
+            replay_options.dump_resources_block_indices = dump_resources;
+        }
+    }
+
+    replay_options.dump_resources_output_dir = GetDumpResourcesDir(arg_parser);
+
+    replay_options.save_pipeline_cache_filename = arg_parser.GetArgumentValue(kSavePipelineCacheArgument);
+    replay_options.load_pipeline_cache_filename = arg_parser.GetArgumentValue(kLoadPipelineCacheArgument);
+    replay_options.add_new_pipeline_caches      = arg_parser.IsOptionSet(kCreateNewPipelineCacheOption);
+    replay_options.do_device_deduplication      = arg_parser.IsOptionSet(kDeduplicateDevice);
+
+    GetWaitBeforeFirstSubmit(arg_parser, replay_options.wait_before_first_submit);
+    replay_options.idle_before_submit          = arg_parser.IsOptionSet(kIdleBeforeSubmit);
+    replay_options.serialize_render_passes     = arg_parser.IsOptionSet(kSerializeRenderPasses);
+    replay_options.serialize_queue_submissions = arg_parser.IsOptionSet(kSerializeQueueSubmissions);
+
+    GetFrameWarmUpOptions(arg_parser, replay_options.frame_warm_up_spirv_path, replay_options.frame_warm_up_load);
+    GetWaitBeforeFrame(arg_parser, replay_options.wait_before_frame);
+
+    replay_options.replay_event_plugin_path       = arg_parser.GetArgumentValue(kReplayEventPluginPath);
+    replay_options.replay_event_plugin_params     = arg_parser.GetArgumentValue(kReplayEventPluginParams);
+    replay_options.isolate_render_passes          = arg_parser.IsOptionSet(kIsolateRenderPasses);
+    replay_options.serialize_compute_and_transfer = arg_parser.IsOptionSet(kSerializeComputeAndTransfer);
+
+    replay_options.screenshot_apply_prerotation = arg_parser.IsOptionSet(kScreenshotApplyPrerotationArgument);
+
+    return replay_options;
+}
+
+// ----------------------------------------------------------------------------
+// End of the Vulkan-only command-line settings.
+// ----------------------------------------------------------------------------
 
 std::string ReplayVulkanFeature::CompiledHeaderVersionString() const
 {
@@ -48,6 +515,220 @@ std::string ReplayVulkanFeature::CompiledHeaderVersionString() const
 #else
     return "";
 #endif
+}
+
+std::vector<util::FeatureOptionDesc> ReplayVulkanFeature::GetOptionDescs() const
+{
+    return { { "",
+               { "Capture the replaying GFXR file. Capture uses the same log options as",
+                 "replay. All other capture option behavior and usage is the same as when",
+                 "capturing with the GFXR layer. The capture functionality is included in",
+                 "the `gfxrecon-replay` executable--no GFXR capture layer is added to the",
+                 "Vulkan layer chain." },
+               false,
+               kCaptureOption },
+             { "",
+               { "Skip vkAllocateMemory, vkAllocateCommandBuffers, and",
+                 "vkAllocateDescriptorSets calls that failed during capture." },
+               false,
+               AliasNames(kSkipFailedAllocationShortOption, kSkipFailedAllocationLongOption) },
+             { "<dir>",
+               { "Replace the shader code in each CreateShaderModule with the contents of",
+                 "the file <dir>/sh<handle_id> if found, where <handle_id> is the handle id",
+                 "of the CreateShaderModule call. See gfxrecon-extract." },
+               true,
+               kShaderReplaceArgument },
+             { "",
+               { "Omit pipeline cache data from calls to vkCreatePipelineCache and skip",
+                 "calls to vkGetPipelineCacheData." },
+               false,
+               AliasNames(kOmitPipelineCacheDataShortOption, kOmitPipelineCacheDataLongOption) },
+             { "<N>",
+               { "Restrict rendering to the Nth surface object created. Used with captures",
+                 "that include multiple surfaces. Default is -1 (render to all surfaces)." },
+               true,
+               kSurfaceIndexArgument },
+             { "<mode>",
+               { "Enable memory translation for replay on GPUs with memory types that are",
+                 "not compatible with the memory types of the capture GPU.",
+                 "    none     No memory translation. This is the default behavior.",
+                 "    remap    Map capture memory types to compatible replay memory",
+                 "             types, without a change to the allocation behavior.",
+                 "    realign  Adjust the allocation sizes and the resource binding",
+                 "             offsets to the replay memory properties.",
+                 "    rebind   Change the allocation behavior to the resource usage and",
+                 "             the replay memory properties. Resources can bind to",
+                 "             different allocations with different offsets. This mode",
+                 "             uses VMA to manage allocations and suballocations." },
+               true,
+               AliasNames(kMemoryPortabilityShortOption, kMemoryPortabilityLongOption),
+               kMemoryTranslationValues },
+             { "<mode>",
+               { "Choose a swapchain mode to replay.",
+                 "    virtual    A swapchain of images that match the swapchain in effect",
+                 "               at capture time. The images are copied to the swapchain",
+                 "               of the implementation that replays them. This mode also",
+                 "               shows offscreen frame boundaries in an additional window.",
+                 "               This is the default mode.",
+                 "    captured   Use the swapchain indices from the capture directly on",
+                 "               the swapchain that replay sets up.",
+                 "    offscreen  Do not create swapchains, surfaces, and windows. To see",
+                 "               the rendering, add the --screenshots option." },
+               true,
+               kSwapchainOption,
+               kSwapchainValues },
+             { "<mode>",
+               { "Set the VkPresentModeKHR of the swapchain.",
+                 "    capture       The present mode from capture time.",
+                 "    immediate     VK_PRESENT_MODE_IMMEDIATE_KHR",
+                 "    mailbox       VK_PRESENT_MODE_MAILBOX_KHR",
+                 "    fifo          VK_PRESENT_MODE_FIFO_KHR",
+                 "    fifo_relaxed  VK_PRESENT_MODE_FIFO_RELAXED_KHR" },
+               true,
+               kPresentModeOption,
+               kPresentModeValues },
+             { "<debug-name>",
+               { "Also present an image that a substring match against its",
+                 "VK_EXT_debug_utils object name identifies (depth and stencil images are",
+                 "ignored). The matched image is presented in a dedicated swapchain on",
+                 "every present, and is used for screenshot operations. A multi-layer",
+                 "image is presented tiled into a single window, one tile for each array",
+                 "layer. If more than one image matches, replay uses the most recently",
+                 "named one." },
+               true,
+               kPresentOverrideImageArgument },
+             { "",
+               { "Skip the blit to the real swapchain to increase replay performance." },
+               false,
+               AliasNames(kVirtualSwapchainSkipBlitShortOption, kVirtualSwapchainSkipBlitLongOption) },
+             { "",
+               { "The same as \"--swapchain captured\".",
+                 "Replay ignores this entry when the \"--swapchain\" entry is present." },
+               false,
+               kEnableUseCapturedSwapchainIndices },
+             { "",
+               { "Use this entry only with the offscreen swapchain. It activates the",
+                 "VK_EXT_frame_boundary extension (always supported for a trimmed",
+                 "capture, and checked against the driver otherwise) and it inserts a",
+                 "command buffer submission with VkFrameBoundaryEXT where the original",
+                 "capture called vkQueuePresentKHR. This keeps the frames when you",
+                 "capture a replay that uses the offscreen swapchain." },
+               false,
+               kOffscreenSwapchainFrameBoundary },
+             { "",
+               { "Swap the color space of the swapchain when the replay device does not",
+                 "support it. Replay falls back to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR." },
+               false,
+               kColorspaceFallback },
+             { "<index>",
+               { "Use the specified device group for replay, where index is the",
+                 "zero-based index to the array of physical device groups that",
+                 "vkEnumeratePhysicalDeviceGroups returns. Replay can fail when the",
+                 "specified device group is not compatible with the original capture",
+                 "device group." },
+               true,
+               kOverrideGpuGroupArgument },
+             { "<status>",
+               { "Specify the behavior that skips calls to vkWaitForFences and",
+                 "vkGetFenceStatus:",
+                 "    status=0  Do not skip.",
+                 "    status=1  Skip unsuccessful calls.",
+                 "    status=2  Always skip.",
+                 "The status applies to all frames when no skip frame range (--sgfr) is",
+                 "specified." },
+               true,
+               AliasNames(kSkipGetFenceStatusShortOption, kSkipGetFenceStatus) },
+             { "<frame-ranges>",
+               { "The frame ranges where --sgfs applies. The format is:",
+                 "    <frame-start-1>-<frame-end-1>[,<frame-start-2>-<frame-end-2>]*" },
+               true,
+               AliasNames(kSkipGetFenceRangesShortOption, kSkipGetFenceRanges) },
+             { "",
+               { "Force a wait on the completion of the queue operations for all queues",
+                 "before the call to Present. Some platforms need this to get accurate",
+                 "instrumentation data." },
+               false,
+               kWaitBeforePresent },
+             { "",
+               { "Put the commands that replay injects, which are not in the capture (for",
+                 "example, the virtual-swapchain copies and the ray-tracing SBT fixups), in",
+                 "VK_EXT_debug_utils labels with the name \"GFXR Replay: <category>\"." },
+               false,
+               kAnnotateInjectedCommands },
+             { "<cache-file>",
+               { "Produce pipeline caches at replay time instead of the use of the cache",
+                 "saved at capture time, and save those caches in <cache-file>." },
+               true,
+               kSavePipelineCacheArgument },
+             { "<cache-file>",
+               { "Load the data that the `--save-pipeline-cache` entry created in",
+                 "<cache-file>, and use it to create the pipelines instead of the",
+                 "pipeline caches saved at capture time." },
+               true,
+               kLoadPipelineCacheArgument },
+             { "",
+               { "Let gfxreconstruct create new vkPipelineCache objects when it finds a",
+                 "pipeline created without a cache. Use this entry together with",
+                 "`--save-pipeline-cache` and `--load-pipeline-cache`." },
+               false,
+               kCreateNewPipelineCacheOption },
+             { "",
+               { "Ignore the frames that vkFrameBoundaryANDROID switches in the", "screenshot handler." },
+               false,
+               kScreenshotIgnoreFrameBoundaryArgument },
+             { "",
+               { "Apply the preTransform of the swapchain to the screenshots." },
+               false,
+               kScreenshotApplyPrerotationArgument },
+             { "",
+               { "Create at most one VkDevice for each VkPhysicalDevice, for the RenderDoc", "and DXVK case." },
+               false,
+               kDeduplicateDevice },
+             { "", { "Wait for the GPU to become idle before each submit." }, false, kIdleBeforeSubmit },
+             { "",
+               { "Serialize the render passes. Replay injects execution barriers before",
+                 "the start of a render pass." },
+               false,
+               kSerializeRenderPasses },
+             { "",
+               { "Serialize the submit entries within one vkQueueSubmit or vkQueueSubmit2",
+                 "call. Replay adds semaphores between consecutive submits." },
+               false,
+               kSerializeQueueSubmissions },
+             { "<path>",
+               { "Path to a replay event plugin library. Replay loads the plugin and uses",
+                 "it to process the replay events." },
+               true,
+               kReplayEventPluginPath },
+             { "<params>",
+               { "Parameters to forward to the replay event plugin. The plugin determines",
+                 "the format of the parameters, and replay does not interpret them." },
+               true,
+               kReplayEventPluginParams },
+             { "",
+               { "Isolate the render passes. Replay splits the command buffer into more", "than one submit." },
+               false,
+               kIsolateRenderPasses },
+             { "<level>",
+               { "The highest debug messenger severity level to report. The levels are",
+                 "debug, info, warning, and error. The default is warning." },
+               true,
+               kDebugMessageSeverityArgument },
+             // This entry has no description, so it stays out of the usage text.
+             { "", {}, false, kSerializeComputeAndTransfer } };
+}
+
+void ReplayVulkanFeature::CheckEnvironment()
+{
+    // platform::GetEnv() reads an environment variable on the desktop platforms and a system
+    // property on Android.
+#if defined(__ANDROID__)
+    const std::string active_layers = gfxrecon::util::platform::GetEnv(kLayerProperty);
+#else
+    const std::string active_layers = gfxrecon::util::platform::GetEnv(kLayerEnvVar);
+#endif
+
+    CheckActiveLayers(active_layers);
 }
 
 void ReplayVulkanFeature::QueryOptions(util::ArgumentParser& arg_parser, const std::string& capture_filename)

--- a/tools/replay/replay_vulkan_feature.h
+++ b/tools/replay/replay_vulkan_feature.h
@@ -47,7 +47,10 @@ class ReplayVulkanFeature : public ReplayPreProcessFeature<decode::VulkanReplayC
     std::string Label() const final { return "Vulkan"; }
     std::string CompiledHeaderVersionString() const final;
 
+    std::vector<util::FeatureOptionDesc> GetOptionDescs() const final;
+
     void QueryOptions(util::ArgumentParser& arg_parser, const std::string& capture_filename) final;
+    void CheckEnvironment() final;
     void QueryFpsInfoOptions(bool& quit_after_range,
                              bool& flush_range,
                              bool& flush_inside_range,

--- a/tools/tool_feature_options.h
+++ b/tools/tool_feature_options.h
@@ -1,0 +1,309 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+// Shared command-line handling for the option entries that Feature modules contribute (see
+// util::FeatureOptionDesc in framework/util/feature_base.h). A tool keeps its own kOptions and
+// kArguments strings for the entries that all of its Features share. Each Feature returns the
+// entries that belong only to that Feature, and these functions put the two sets together.
+//
+// The steps in a tool main are:
+//
+//   1. AppendFeatureOptions()     -- before the tool builds the ArgumentParser
+//   2. CheckFeatureOptionValues() -- after the tool builds the ArgumentParser
+//   3. BuildFeatureSynopsis()     -- in the usage function of the tool, for the "Usage:" line
+//   4. PrintFeatureUsage()        -- after the usage function of the tool
+//
+// An entry exists only when its Feature is built into the tool, so a Feature that the build
+// removes also removes its entries from the parser and from the usage text. An entry with an
+// empty description is accepted but is not documented, which suits an experimental entry.
+
+#ifndef GFXRECON_TOOL_FEATURE_OPTIONS_H
+#define GFXRECON_TOOL_FEATURE_OPTIONS_H
+
+#include "util/argument_parser.h"
+#include "util/feature_base.h"
+#include "util/logging.h"
+#include "util/platform.h"
+
+#include <algorithm>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+// Splits an ArgumentParser name list into the individual names. The separators are the comma
+// between entries and the pipe between the alternative names of one entry.
+inline std::vector<std::string> SplitFeatureOptionNames(const std::string& name_list)
+{
+    std::vector<std::string> names;
+    size_t                   start = 0;
+
+    while (start <= name_list.size())
+    {
+        size_t end = name_list.find_first_of(",|", start);
+        if (end == std::string::npos)
+        {
+            end = name_list.size();
+        }
+
+        if (end > start)
+        {
+            names.push_back(name_list.substr(start, end - start));
+        }
+
+        start = end + 1;
+    }
+
+    return names;
+}
+
+// Joins two alternative names of one entry into the syntax that the ArgumentParser reads.
+inline std::string AliasNames(const char* first, const char* second)
+{
+    return std::string(first) + "|" + second;
+}
+
+// Joins the accepted values of one entry into the text that the usage output shows.
+inline std::string JoinFeatureOptionValues(const std::vector<std::string>& values)
+{
+    std::string joined;
+
+    for (const auto& value : values)
+    {
+        if (!joined.empty())
+        {
+            joined += ", ";
+        }
+        joined += value;
+    }
+
+    return joined;
+}
+
+// Adds the command-line entries of every Feature to the two name lists that the ArgumentParser
+// accepts. Call this function after the tool loads its Features and before it builds the parser.
+// An entry whose name is already in use is not added, and the tool writes a warning.
+template <typename FeatureBaseT>
+inline void AppendFeatureOptions(const std::vector<std::unique_ptr<FeatureBaseT>>& features,
+                                 std::string&                                      options,
+                                 std::string&                                      arguments)
+{
+    std::set<std::string> used_names;
+
+    for (const auto& name : SplitFeatureOptionNames(options))
+    {
+        used_names.insert(name);
+    }
+    for (const auto& name : SplitFeatureOptionNames(arguments))
+    {
+        used_names.insert(name);
+    }
+
+    for (const auto& feature : features)
+    {
+        for (const auto& desc : feature->GetOptionDescs())
+        {
+            const std::vector<std::string> desc_names = SplitFeatureOptionNames(desc.trigger_names);
+            bool                           in_use     = false;
+
+            for (const auto& name : desc_names)
+            {
+                if (used_names.find(name) != used_names.end())
+                {
+                    GFXRECON_LOG_WARNING("The %s feature declares the command-line name %s, which is already in use. "
+                                         "This tool ignores the entry.",
+                                         feature->Label().c_str(),
+                                         name.c_str());
+                    in_use = true;
+                }
+            }
+
+            if (in_use)
+            {
+                continue;
+            }
+
+            used_names.insert(desc_names.begin(), desc_names.end());
+
+            std::string& name_list = desc.has_argument ? arguments : options;
+
+            if (!name_list.empty())
+            {
+                name_list += ",";
+            }
+            name_list += desc.trigger_names;
+        }
+    }
+}
+
+// Makes sure that each Feature entry with a closed set of accepted values received one of those
+// values. The comparison ignores case, because the Feature functions that read these values use
+// util::platform::StringCompareNoCase. A value that is not in the set gets a warning, and the
+// Feature then uses the default value for that entry. The tool continues, because an unusable
+// value for one entry does not stop the replay of the capture file. An entry with an empty
+// accepted_values list accepts any value, and the Feature checks that value itself.
+template <typename FeatureBaseT>
+inline void CheckFeatureOptionValues(const std::vector<std::unique_ptr<FeatureBaseT>>& features,
+                                     const gfxrecon::util::ArgumentParser&             arg_parser)
+{
+    for (const auto& feature : features)
+    {
+        for (const auto& desc : feature->GetOptionDescs())
+        {
+            if (!desc.has_argument || desc.accepted_values.empty())
+            {
+                continue;
+            }
+
+            const std::vector<std::string> desc_names = SplitFeatureOptionNames(desc.trigger_names);
+            if (desc_names.empty() || !arg_parser.IsArgumentSet(desc_names.front()))
+            {
+                continue;
+            }
+
+            // All of the alternative names of one entry share a value, so the first name reads it.
+            const std::string& value = arg_parser.GetArgumentValue(desc_names.front());
+
+            const bool accepted = std::any_of(
+                desc.accepted_values.begin(), desc.accepted_values.end(), [&value](const std::string& accepted_value) {
+                    return gfxrecon::util::platform::StringCompareNoCase(accepted_value.c_str(), value.c_str()) == 0;
+                });
+
+            if (!accepted)
+            {
+                GFXRECON_LOG_WARNING("The value \"%s\" is not valid for %s. The accepted values are: %s. "
+                                     "This tool uses the default value instead.",
+                                     value.c_str(),
+                                     desc_names.front().c_str(),
+                                     JoinFeatureOptionValues(desc.accepted_values).c_str());
+            }
+        }
+    }
+}
+
+// Builds the part of the "Usage:" line that comes from the Features, as a set of bracketed
+// fragments such as "[--dxr] [--gpu <index>]". A tool puts this text between its own leading
+// options and its positional arguments. An entry with an empty description stays out of the
+// synopsis, the same as it stays out of the usage sections.
+template <typename FeatureBaseT>
+inline std::string BuildFeatureSynopsis(const std::vector<std::unique_ptr<FeatureBaseT>>& features)
+{
+    std::string synopsis;
+
+    for (const auto& feature : features)
+    {
+        for (const auto& desc : feature->GetOptionDescs())
+        {
+            if (desc.description.empty())
+            {
+                continue;
+            }
+
+            const std::vector<std::string> desc_names = SplitFeatureOptionNames(desc.trigger_names);
+            const std::string value = (desc.has_argument && !desc.name.empty()) ? (" " + desc.name) : std::string();
+            std::string       fragment;
+
+            for (const auto& name : desc_names)
+            {
+                if (!fragment.empty())
+                {
+                    fragment += " | ";
+                }
+                fragment += name + value;
+            }
+
+            if (fragment.empty())
+            {
+                continue;
+            }
+
+            if (!synopsis.empty())
+            {
+                synopsis += " ";
+            }
+            synopsis += "[" + fragment + "]";
+        }
+    }
+
+    return synopsis;
+}
+
+// Prints one usage section for each Feature that adds command-line entries. Call this function
+// directly after the usage function of the tool.
+template <typename FeatureBaseT>
+inline void PrintFeatureUsage(const std::vector<std::unique_ptr<FeatureBaseT>>& features)
+{
+    // The continuation prefix and the wrap column keep the sections aligned with the usage text
+    // that the tool prints before them.
+    const char*  kContinuation = "          \t\t";
+    const size_t kWrapColumn   = 56;
+
+    for (const auto& feature : features)
+    {
+        const std::vector<gfxrecon::util::FeatureOptionDesc> descs = feature->GetOptionDescs();
+
+        const bool has_documented_entry =
+            std::any_of(descs.begin(), descs.end(), [](const gfxrecon::util::FeatureOptionDesc& desc) {
+                return !desc.description.empty();
+            });
+        if (!has_documented_entry)
+        {
+            continue;
+        }
+
+        GFXRECON_WRITE_CONSOLE("");
+        GFXRECON_WRITE_CONSOLE("%s only:", feature->Label().c_str());
+        GFXRECON_WRITE_CONSOLE("**************");
+
+        for (const auto& desc : descs)
+        {
+            // An entry with no description stays out of the usage text.
+            if (desc.description.empty())
+            {
+                continue;
+            }
+
+            // The parser separates alternative names with a pipe. The usage text spaces it out.
+            std::string names = desc.trigger_names;
+            for (size_t pos = names.find('|'); pos != std::string::npos; pos = names.find('|', pos + 3))
+            {
+                names.replace(pos, 1, " | ");
+            }
+
+            if (desc.has_argument && !desc.name.empty())
+            {
+                GFXRECON_WRITE_CONSOLE("  %s %s", names.c_str(), desc.name.c_str());
+            }
+            else
+            {
+                GFXRECON_WRITE_CONSOLE("  %s", names.c_str());
+            }
+
+            for (const auto& line : desc.description)
+            {
+                GFXRECON_WRITE_CONSOLE("%s%s", kContinuation, line.c_str());
+            }
+        }
+    }
+}
+
+#endif // GFXRECON_TOOL_FEATURE_OPTIONS_H

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -23,26 +23,10 @@
 
 #include PROJECT_VERSION_HEADER_FILE
 
-#if defined(D3D12_SUPPORT)
-#include "decode/dx_replay_options.h"
-#include <initguid.h>
-#include "generated/generated_dx12_decoder.h"
-#endif
 #include "decode/file_processor.h"
 
-#include "decode/vulkan_default_allocator.h"
-#include "decode/vulkan_realign_allocator.h"
-#include "decode/vulkan_rebind_allocator.h"
-#include "decode/vulkan_remap_allocator.h"
-#include "decode/vulkan_replay_options.h"
-#include "decode/vulkan_resource_tracking_consumer.h"
-#include "decode/vulkan_tracked_object_info_table.h"
-#include "generated/generated_vulkan_decoder.h"
+#include "decode/replay_options.h"
 #include "format/format.h"
-
-#if ENABLE_OPENXR_SUPPORT
-#include "generated/generated_openxr_decoder.h"
-#endif
 
 #include "util/argument_parser.h"
 #include "util/logging.h"
@@ -50,10 +34,8 @@
 #include "util/options.h"
 #include "util/strings.h"
 
-#if ENABLE_OPENXR_SUPPORT
-#include "openxr/openxr.h"
-#endif
-
+// The window-system helpers below name the Vulkan surface extensions, because the WSI contexts
+// of application::Application use those names as their keys for every API that it replays.
 #include "vulkan/vulkan_core.h"
 
 #include <cstdlib>
@@ -66,33 +48,19 @@
 #define GFXRECON_PLATFORM_SETTINGS_H
 
 const char kApplicationName[] = "GFXReconstruct Replay";
-const char kCaptureLayer[]    = "VK_LAYER_LUNARG_gfxreconstruct";
 
 const char kLogLevelArgument[]                   = "--log-level";
 const char kLogTimestampsOption[]                = "--log-timestamps";
-const char kDebugMessageSeverityArgument[]       = "--debug-messenger-level";
 const char kLogFileArgument[]                    = "--log-file";
 const char kLogDebugView[]                       = "--log-debugview";
 const char kNoDebugPopup[]                       = "--no-debug-popup";
 const char kCpuMaskArgument[]                    = "--cpu-mask";
 const char kOverrideGpuArgument[]                = "--gpu";
-const char kOverrideGpuGroupArgument[]           = "--gpu-group";
 const char kPausedOption[]                       = "--paused";
 const char kPauseFrameArgument[]                 = "--pause-frame";
 const char kLoopFrameArgument[]                  = "--loop-frame";
 const char kLoopCountArgument[]                  = "--loop-count";
-const char kCaptureOption[]                      = "--capture";
-const char kSkipFailedAllocationShortOption[]    = "--sfa";
-const char kSkipFailedAllocationLongOption[]     = "--skip-failed-allocations";
-const char kDiscardCachedPsosShortOption[]       = "--dcp";
-const char kDiscardCachedPsosLongOption[]        = "--discard-cached-psos";
-const char kUseCachedPsosOption[]                = "--use-cached-psos";
-const char kOmitPipelineCacheDataShortOption[]   = "--opcd";
-const char kOmitPipelineCacheDataLongOption[]    = "--omit-pipeline-cache-data";
 const char kWsiArgument[]                        = "--wsi";
-const char kSurfaceIndexArgument[]               = "--surface-index";
-const char kMemoryPortabilityShortOption[]       = "-m";
-const char kMemoryPortabilityLongOption[]        = "--memory-translation";
 const char kSyncOption[]                         = "--sync";
 const char kRemoveUnsupportedOption[]            = "--remove-unsupported";
 const char kValidateOption[]                     = "--validate";
@@ -100,9 +68,6 @@ const char kDebugDeviceLostOption[]              = "--debug-device-lost";
 const char kCreateDummyAllocationsOption[]       = "--create-dummy-allocations";
 const char kOmitNullHardwareBuffersLongOption[]  = "--omit-null-hardware-buffers";
 const char kOmitNullHardwareBuffersShortOption[] = "--onhb";
-const char kDeniedMessages[]                     = "--denied-messages";
-const char kAllowedMessages[]                    = "--allowed-messages";
-const char kShaderReplaceArgument[]              = "--replace-shaders";
 const char kScreenshotAllOption[]                = "--screenshot-all";
 const char kScreenshotRangeArgument[]            = "--screenshots";
 const char kScreenshotIntervalArgument[]         = "--screenshot-interval";
@@ -122,59 +87,23 @@ const char kQuitAfterMeasurementRangeOption[]    = "--quit-after-measurement-ran
 const char kQuitAfterFrameArgument[]             = "--quit-after-frame";
 const char kFlushMeasurementRangeOption[]        = "--flush-measurement-range";
 const char kFlushInsideMeasurementRangeOption[]  = "--flush-inside-measurement-range";
-const char kSwapchainOption[]                    = "--swapchain";
-const char kPresentModeOption[]                  = "--present-mode";
-const char kPresentOverrideImageArgument[]       = "--present-override";
-const char kEnableUseCapturedSwapchainIndices[] =
-    "--use-captured-swapchain-indices"; // The same: util::SwapchainOption::kCaptured
-const char kVirtualSwapchainSkipBlitShortOption[] = "--vssb";
-const char kVirtualSwapchainSkipBlitLongOption[]  = "--virtual-swapchain-skip-blit";
-const char kColorspaceFallback[]                  = "--use-colorspace-fallback";
-const char kOffscreenSwapchainFrameBoundary[]     = "--offscreen-swapchain-frame-boundary";
-const char kFormatArgument[]                      = "--format";
-const char kIncludeBinariesOption[]               = "--include-binaries";
-const char kExpandFlagsOption[]                   = "--expand-flags";
-const char kFilePerFrameOption[]                  = "--file-per-frame";
-const char kFrameRange[]                          = "--frame-range";
-const char kSkipGetFenceStatus[]                  = "--skip-get-fence-status";
-const char kSkipGetFenceRanges[]                  = "--skip-get-fence-ranges";
-const char kWaitBeforePresent[]                   = "--wait-before-present";
-const char kAnnotateInjectedCommands[]            = "--annotate-injected-commands";
-const char kPrintBlockInfoAllOption[]             = "--pbi-all";
-const char kPrintBlockInfosArgument[]             = "--pbis";
-const char kNumPipelineCreationJobs[]             = "--pipeline-creation-jobs";
-const char kPreloadMeasurementRangeOption[]       = "--preload-measurement-range";
-const char kSavePipelineCacheArgument[]           = "--save-pipeline-cache";
-const char kLoadPipelineCacheArgument[]           = "--load-pipeline-cache";
-const char kCreateNewPipelineCacheOption[]        = "--add-new-pipeline-caches";
-const char kDeduplicateDevice[]                   = "--deduplicate-device";
-const char kWaitBeforeFirstSubmit[]               = "--wait-before-first-submit";
-const char kIdleBeforeSubmit[]                    = "--idle-before-submit";
-const char kSerializeRenderPasses[]               = "--serialize-render-passes";
-const char kWaitBeforeFrame[]                     = "--wait-before-frame";
-const char kAsyncProcessingOption[]               = "--async-processing";
-
-const char kScreenshotIgnoreFrameBoundaryArgument[] = "--screenshot-ignore-FrameBoundaryANDROID";
-const char kScreenshotApplyPrerotationArgument[]    = "--screenshot-apply-prerotation";
-
-#if defined(_WIN32)
-const char kDxTwoPassReplay[]                  = "--dx12-two-pass-replay";
-const char kDxOverrideObjectNames[]            = "--dx12-override-object-names";
-const char kDxAgsMarkRenderPasses[]            = "--dx12-ags-inject-markers";
-const char kBatchingMemoryUsageArgument[]      = "--batching-memory-usage";
-const char kDumpResourcesModifiableStateOnly[] = "--dump-resources-modifiable-state-only";
-const char kDumpResourcesBeforeDrawOption[]    = "--dump-resources-before-draw";
-#endif
-
-const char kDumpResourcesArgument[]       = "--dump-resources";
-const char kDumpResourcesDirArgument[]    = "--dump-resources-dir";
-const char kFrameWarmUpSpirv[]            = "--frame-warm-up-spirv";
-const char kFrameWarmUpLoad[]             = "--frame-warm-up-load";
-const char kSerializeQueueSubmissions[]   = "--serialize-queue-submissions";
-const char kReplayEventPluginPath[]       = "--replay-event-plugin-path";
-const char kReplayEventPluginParams[]     = "--replay-event-plugin-params";
-const char kIsolateRenderPasses[]         = "--isolate-render-passes";
-const char kSerializeComputeAndTransfer[] = "--serialize-compute-and-transfer";
+const char kFormatArgument[]                     = "--format";
+const char kIncludeBinariesOption[]              = "--include-binaries";
+const char kExpandFlagsOption[]                  = "--expand-flags";
+const char kFilePerFrameOption[]                 = "--file-per-frame";
+const char kFrameRange[]                         = "--frame-range";
+const char kPrintBlockInfoAllOption[]            = "--pbi-all";
+const char kPrintBlockInfosArgument[]            = "--pbis";
+const char kNumPipelineCreationJobs[]            = "--pipeline-creation-jobs";
+const char kPreloadMeasurementRangeOption[]      = "--preload-measurement-range";
+const char kWaitBeforeFirstSubmit[]              = "--wait-before-first-submit";
+const char kWaitBeforeFrame[]                    = "--wait-before-frame";
+const char kAsyncProcessingOption[]              = "--async-processing";
+const char kDumpResourcesArgument[]              = "--dump-resources";
+const char kDumpResourcesDirArgument[]           = "--dump-resources-dir";
+const char kDumpResourcesImageFormatArgument[]   = "--dump-resources-image-format";
+const char kFrameWarmUpSpirv[]                   = "--frame-warm-up-spirv";
+const char kFrameWarmUpLoad[]                    = "--frame-warm-up-load";
 
 enum class WsiPlatform
 {
@@ -197,21 +126,6 @@ const char kWsiPlatformMetal[]    = "metal";
 const char kWsiPlatformDisplay[]  = "display";
 const char kWsiPlatformHeadless[] = "headless";
 
-const char kMemoryTranslationNone[]    = "none";
-const char kMemoryTranslationRemap[]   = "remap";
-const char kMemoryTranslationRealign[] = "realign";
-const char kMemoryTranslationRebind[]  = "rebind";
-
-const char kSwapchainVirtual[]   = "virtual";
-const char kSwapchainCaptured[]  = "captured";
-const char kSwapchainOffscreen[] = "offscreen";
-
-const char kPresentModeCapture[]     = "capture";
-const char kPresentModeImmediate[]   = "immediate";
-const char kPresentModeMailbox[]     = "mailbox";
-const char kPresentModeFifo[]        = "fifo";
-const char kPresentModeFifoRelaxed[] = "fifo_relaxed";
-
 #if defined(__ANDROID__)
 const char kDefaultScreenshotDir[]    = "/sdcard";
 const char kDefaultDumpResourcesDir[] = "/sdcard";
@@ -229,97 +143,6 @@ static void ProcessDisableDebugPopup(const gfxrecon::util::ArgumentParser& arg_p
         _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
     }
 #endif
-}
-
-static void CheckActiveLayers(const std::string& list)
-{
-    if (!list.empty())
-    {
-        // Check for the presence of the layer name in the list of active layers.
-        size_t start = list.find(kCaptureLayer);
-
-        if (start != std::string::npos)
-        {
-            size_t end         = start + gfxrecon::util::platform::StringLength(kCaptureLayer);
-            bool   match_start = false;
-            bool   match_end   = false;
-
-            // For an exact match, the start of the layer name is either at the start of the list or comes after a path
-            // separator.
-            if ((start == 0) || ((list[start - 1] == ';') || (list[start - 1] == ':')))
-            {
-                match_start = true;
-            }
-
-            // For an exact match, the end of the layer name is either at the end of the list or comes before a path
-            // separator.
-            if ((list.length() == end) || ((list[end] == ';') || (list[end] == ':')))
-            {
-                match_end = true;
-            }
-
-            if (match_start && match_end)
-            {
-                GFXRECON_LOG_WARNING("Replay tool has detected that the capture layer is enabled");
-            }
-        }
-    }
-}
-
-static gfxrecon::decode::VulkanResourceAllocator* CreateDefaultAllocator()
-{
-    return new gfxrecon::decode::VulkanDefaultAllocator(
-        "Try replay with the '-m remap' or '-m rebind' options to enable memory translation.");
-}
-
-static gfxrecon::decode::VulkanResourceAllocator* CreateRemapAllocator()
-{
-    return new gfxrecon::decode::VulkanRemapAllocator(
-        "Try replay with the '-m rebind' option to enable advanced memory translation.");
-}
-
-static gfxrecon::decode::VulkanResourceAllocator* CreateRebindAllocator()
-{
-    return new gfxrecon::decode::VulkanRebindAllocator();
-}
-
-static gfxrecon::decode::CreateResourceAllocator
-InitRealignAllocatorCreateFunc(const std::string&                              filename,
-                               const gfxrecon::decode::VulkanReplayOptions&    replay_options,
-                               gfxrecon::decode::VulkanTrackedObjectInfoTable* tracked_object_info_table)
-{
-    // Enable first pass of replay to generate resource tracking information.
-    GFXRECON_WRITE_CONSOLE("First pass of replay resource tracking for realign memory portability mode. This may take "
-                           "some time. Please wait...");
-
-    gfxrecon::decode::FileProcessor file_processor_resource_tracking;
-    gfxrecon::decode::VulkanDecoder decoder;
-
-    auto resource_tracking_consumer =
-        new gfxrecon::decode::VulkanResourceTrackingConsumer(replay_options, tracked_object_info_table);
-
-    if (file_processor_resource_tracking.Initialize(filename))
-    {
-        decoder.AddConsumer(resource_tracking_consumer);
-        file_processor_resource_tracking.AddDecoder(&decoder);
-        file_processor_resource_tracking.InitializeFrameProcessing();
-        file_processor_resource_tracking.ProcessAllFrames();
-        file_processor_resource_tracking.RemoveDecoder(&decoder);
-        decoder.RemoveConsumer(resource_tracking_consumer);
-    }
-
-    // Sort the bound resources according to the binding offsets.
-    resource_tracking_consumer->SortMemoriesBoundResourcesByOffset();
-
-    // calculate the replay binding offset of the bound resources and replay memory allocation size
-    resource_tracking_consumer->CalculateReplayBindingOffsetAndMemoryAllocationSize();
-
-    GFXRECON_WRITE_CONSOLE("First pass of replay resource tracking done.");
-
-    return [tracked_object_info_table]() -> gfxrecon::decode::VulkanResourceAllocator* {
-        return new gfxrecon::decode::VulkanRealignAllocator(
-            tracked_object_info_table, "Try replay with the '-m rebind' option to enable advanced memory translation.");
-    };
 }
 
 static uint32_t GetPauseFrame(const gfxrecon::util::ArgumentParser& arg_parser)
@@ -845,37 +668,6 @@ GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser, uint3
 
     return true;
 }
-static gfxrecon::decode::CreateResourceAllocator
-GetCreateResourceAllocatorFunc(const gfxrecon::util::ArgumentParser&           arg_parser,
-                               const std::string&                              filename,
-                               const gfxrecon::decode::VulkanReplayOptions&    replay_options,
-                               gfxrecon::decode::VulkanTrackedObjectInfoTable* tracked_object_info_table)
-{
-    gfxrecon::decode::CreateResourceAllocator func  = CreateDefaultAllocator;
-    const auto&                               value = arg_parser.GetArgumentValue(kMemoryPortabilityShortOption);
-
-    if (!value.empty())
-    {
-        if (gfxrecon::util::platform::StringCompareNoCase(kMemoryTranslationRebind, value.c_str()) == 0)
-        {
-            func = CreateRebindAllocator;
-        }
-        else if (gfxrecon::util::platform::StringCompareNoCase(kMemoryTranslationRemap, value.c_str()) == 0)
-        {
-            func = CreateRemapAllocator;
-        }
-        else if (gfxrecon::util::platform::StringCompareNoCase(kMemoryTranslationRealign, value.c_str()) == 0)
-        {
-            func = InitRealignAllocatorCreateFunc(filename, replay_options, tracked_object_info_table);
-        }
-        else if (gfxrecon::util::platform::StringCompareNoCase(kMemoryTranslationNone, value.c_str()) != 0)
-        {
-            GFXRECON_LOG_WARNING("Ignoring unrecognized memory translation option \"%s\"", value.c_str());
-        }
-    }
-
-    return func;
-}
 
 static void IsForceWindowed(gfxrecon::decode::ReplayOptions& options, const gfxrecon::util::ArgumentParser& arg_parser)
 {
@@ -921,35 +713,6 @@ static void SetWindowOrigin(gfxrecon::decode::ReplayOptions& options, const gfxr
         std::getline(value_input, val, ',');
         options.window_topleft_y = std::stoi(val);
     }
-}
-
-static std::vector<int32_t> GetFilteredMsgs(const gfxrecon::util::ArgumentParser& arg_parser,
-                                            const char*                           filter_messages)
-{
-    const auto&          value = arg_parser.GetArgumentValue(filter_messages);
-    std::vector<int32_t> msgs;
-    if (!value.empty())
-    {
-        std::vector<std::string> values;
-        std::istringstream       value_input;
-        value_input.str(value);
-
-        for (std::string val; std::getline(value_input, val, ',');)
-        {
-            size_t count = std::count_if(val.begin(), val.end(), ::isdigit);
-            if (count == val.length())
-            {
-                msgs.push_back(std::stoi(val));
-            }
-            else
-            {
-                GFXRECON_LOG_WARNING("Ignoring invalid filter messages\"%s\", which contains non-numeric values",
-                                     val.c_str());
-                break;
-            }
-        }
-    }
-    return msgs;
 }
 
 static void GetWaitBeforeFirstSubmit(const gfxrecon::util::ArgumentParser& arg_parser,
@@ -1149,337 +912,5 @@ static void GetReplayOptions(gfxrecon::decode::ReplayOptions&      options,
     options.screenshot_dir         = GetScreenshotDir(arg_parser);
     options.screenshot_file_prefix = arg_parser.GetArgumentValue(kScreenshotFilePrefixArgument);
 }
-
-static gfxrecon::decode::VulkanReplayOptions
-GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parser,
-                       const std::string&                              filename,
-                       gfxrecon::decode::VulkanTrackedObjectInfoTable* tracked_object_info_table)
-{
-    gfxrecon::decode::VulkanReplayOptions replay_options;
-    GetReplayOptions(replay_options, arg_parser, filename);
-
-    if (arg_parser.IsOptionSet(kCaptureOption))
-    {
-        replay_options.capture = true;
-    }
-
-    const auto& override_gpu_group = arg_parser.GetArgumentValue(kOverrideGpuGroupArgument);
-    if (!override_gpu_group.empty())
-    {
-        replay_options.override_gpu_group_index = std::stoi(override_gpu_group);
-    }
-
-    if (arg_parser.IsOptionSet(kSkipFailedAllocationLongOption) ||
-        arg_parser.IsOptionSet(kSkipFailedAllocationShortOption))
-    {
-        replay_options.skip_failed_allocations = true;
-    }
-
-    if (arg_parser.IsOptionSet(kOmitPipelineCacheDataLongOption) ||
-        arg_parser.IsOptionSet(kOmitPipelineCacheDataShortOption))
-    {
-        replay_options.omit_pipeline_cache_data = true;
-    }
-
-    auto swapchain_option          = arg_parser.GetArgumentValue(kSwapchainOption);
-    auto enable_captured_swapchain = arg_parser.IsOptionSet(kEnableUseCapturedSwapchainIndices);
-    if (swapchain_option.empty())
-    {
-        if (enable_captured_swapchain)
-        {
-            replay_options.swapchain_option = gfxrecon::util::SwapchainOption::kCaptured;
-        }
-    }
-    else
-    {
-        if (enable_captured_swapchain)
-        {
-            GFXRECON_LOG_WARNING("Ignoring option: \"%s\" because option: \"%s\" is added",
-                                 kEnableUseCapturedSwapchainIndices,
-                                 kSwapchainOption);
-        }
-
-        if (gfxrecon::util::platform::StringCompareNoCase(kSwapchainCaptured, swapchain_option.c_str()) == 0)
-        {
-            replay_options.swapchain_option = gfxrecon::util::SwapchainOption::kCaptured;
-        }
-        else if (gfxrecon::util::platform::StringCompareNoCase(kSwapchainOffscreen, swapchain_option.c_str()) == 0)
-        {
-            replay_options.swapchain_option = gfxrecon::util::SwapchainOption::kOffscreen;
-        }
-        else if (gfxrecon::util::platform::StringCompareNoCase(kSwapchainVirtual, swapchain_option.c_str()) != 0)
-        {
-            GFXRECON_LOG_WARNING("Ignoring unrecognized \"--swapchain\" option: %s", swapchain_option.c_str());
-        }
-    }
-
-    auto present_mode_option = arg_parser.GetArgumentValue(kPresentModeOption);
-    if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeCapture, present_mode_option.c_str()) == 0)
-    {
-        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kCapture;
-    }
-    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeImmediate, present_mode_option.c_str()) == 0)
-    {
-        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kImmediate;
-    }
-    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeMailbox, present_mode_option.c_str()) == 0)
-    {
-        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kMailbox;
-    }
-    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeFifo, present_mode_option.c_str()) == 0)
-    {
-        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kFifo;
-    }
-    else if (gfxrecon::util::platform::StringCompareNoCase(kPresentModeFifoRelaxed, present_mode_option.c_str()) == 0)
-    {
-        replay_options.present_mode_option = gfxrecon::util::PresentModeOption::kFifoRelaxed;
-    }
-    else if (!present_mode_option.empty())
-    {
-        GFXRECON_LOG_WARNING("Ignoring unrecognized \"--present-mode\" option: %s", present_mode_option.c_str());
-    }
-
-    if (arg_parser.IsOptionSet(kColorspaceFallback))
-    {
-        replay_options.use_colorspace_fallback = true;
-    }
-
-    if (arg_parser.IsOptionSet(kOffscreenSwapchainFrameBoundary))
-    {
-        replay_options.offscreen_swapchain_frame_boundary = true;
-    }
-
-    if (arg_parser.IsOptionSet(kVirtualSwapchainSkipBlitLongOption) ||
-        arg_parser.IsOptionSet(kVirtualSwapchainSkipBlitShortOption))
-    {
-        replay_options.virtual_swapchain_skip_blit = true;
-    }
-
-    const std::string debug_severity_string = arg_parser.GetArgumentValue(kDebugMessageSeverityArgument);
-    if (!debug_severity_string.empty())
-    {
-        if (gfxrecon::util::platform::StringCompareNoCase("debug", debug_severity_string.c_str()))
-        {
-            replay_options.debug_message_severity =
-                VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT |
-                VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-        }
-        else if (gfxrecon::util::platform::StringCompareNoCase("info", debug_severity_string.c_str()))
-        {
-            replay_options.debug_message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT |
-                                                    VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
-                                                    VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-        }
-        else if (gfxrecon::util::platform::StringCompareNoCase("warning", debug_severity_string.c_str()))
-        {
-            replay_options.debug_message_severity =
-                VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-        }
-        else if (gfxrecon::util::platform::StringCompareNoCase("error", debug_severity_string.c_str()))
-        {
-            replay_options.debug_message_severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-        }
-        else
-        {
-            GFXRECON_LOG_WARNING("Ignoring unrecognized debug messenger severity option value \"%s\"",
-                                 debug_severity_string.c_str());
-        }
-    }
-
-    replay_options.replace_shader_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);
-    replay_options.create_resource_allocator =
-        GetCreateResourceAllocatorFunc(arg_parser, filename, replay_options, tracked_object_info_table);
-
-    GetScreenshotSize(arg_parser, replay_options.screenshot_width, replay_options.screenshot_height);
-    replay_options.screenshot_scale = GetScreenshotScale(arg_parser);
-
-    if (auto override_name = arg_parser.GetArgumentValue(kPresentOverrideImageArgument); !override_name.empty())
-    {
-        replay_options.present_override_image_name = override_name;
-    }
-
-    if (arg_parser.IsOptionSet(kScreenshotIgnoreFrameBoundaryArgument))
-    {
-        replay_options.screenshot_ignore_frameBoundaryAndroid = true;
-    }
-
-    if (arg_parser.IsOptionSet(kQuitAfterMeasurementRangeOption))
-    {
-        replay_options.quit_after_measurement_frame_range = true;
-    }
-
-    if (arg_parser.IsOptionSet(kFlushMeasurementRangeOption))
-    {
-        replay_options.flush_measurement_frame_range = true;
-    }
-
-    std::string surface_index = arg_parser.GetArgumentValue(kSurfaceIndexArgument);
-    if (!surface_index.empty())
-    {
-        replay_options.surface_index = std::stoi(surface_index);
-    }
-
-    const std::string& skip_get_fence_status = arg_parser.GetArgumentValue(kSkipGetFenceStatus);
-    if (!skip_get_fence_status.empty())
-    {
-        const int i_skip_get_fence_status = std::stoi(skip_get_fence_status);
-        if (i_skip_get_fence_status < static_cast<int>(gfxrecon::decode::SkipGetFenceStatus::COUNT))
-        {
-            replay_options.skip_get_fence_status =
-                static_cast<gfxrecon::decode::SkipGetFenceStatus>(i_skip_get_fence_status);
-        }
-        else
-        {
-            GFXRECON_LOG_FATAL("Unexpected value after '--skip-get-fence-status': '%s'", skip_get_fence_status.c_str());
-        }
-    }
-
-    const std::string& skip_get_fence_ranges = arg_parser.GetArgumentValue(kSkipGetFenceRanges);
-    if (skip_get_fence_ranges.empty())
-    {
-        gfxrecon::util::UintRange range;
-        range.first = 1;
-        range.last  = std::numeric_limits<uint32_t>::max();
-        replay_options.skip_get_fence_ranges.push_back(range);
-    }
-    else
-    {
-        replay_options.skip_get_fence_ranges =
-            gfxrecon::util::GetUintRanges(skip_get_fence_ranges.c_str(), "skip-get-fence-ranges");
-    }
-    if (arg_parser.IsOptionSet(kWaitBeforePresent))
-    {
-        replay_options.wait_before_present = true;
-    }
-    if (arg_parser.IsOptionSet(kAnnotateInjectedCommands))
-    {
-        replay_options.annotate_injected_commands = true;
-    }
-    if (arg_parser.IsOptionSet(kPreloadMeasurementRangeOption))
-    {
-        replay_options.preload_measurement_range = true;
-    }
-
-    const std::string& dump_resources = arg_parser.GetArgumentValue(kDumpResourcesArgument);
-    if (!dump_resources.empty())
-    {
-        replay_options.enable_dump_resources = true;
-        if (dump_resources.find_first_not_of("0123456789,") == std::string::npos)
-        {
-            std::vector<std::string> values = gfxrecon::util::strings::SplitString(dump_resources, ',');
-            if (values.size() == 3)
-            {
-                replay_options.dump_resources_target.submit_index    = std::stoi(values[0]);
-                replay_options.dump_resources_target.command_index   = std::stoi(values[1]);
-                replay_options.dump_resources_target.draw_call_index = std::stoi(values[2]);
-                replay_options.using_dump_resources_target           = true;
-            }
-        }
-        else
-        {
-            replay_options.dump_resources_block_indices = dump_resources;
-        }
-    }
-
-    replay_options.dump_resources_output_dir = GetDumpResourcesDir(arg_parser);
-
-    replay_options.save_pipeline_cache_filename = arg_parser.GetArgumentValue(kSavePipelineCacheArgument);
-    replay_options.load_pipeline_cache_filename = arg_parser.GetArgumentValue(kLoadPipelineCacheArgument);
-    replay_options.add_new_pipeline_caches      = arg_parser.IsOptionSet(kCreateNewPipelineCacheOption);
-    replay_options.do_device_deduplication      = arg_parser.IsOptionSet(kDeduplicateDevice);
-
-    GetWaitBeforeFirstSubmit(arg_parser, replay_options.wait_before_first_submit);
-    replay_options.idle_before_submit          = arg_parser.IsOptionSet(kIdleBeforeSubmit);
-    replay_options.serialize_render_passes     = arg_parser.IsOptionSet(kSerializeRenderPasses);
-    replay_options.serialize_queue_submissions = arg_parser.IsOptionSet(kSerializeQueueSubmissions);
-
-    GetFrameWarmUpOptions(arg_parser, replay_options.frame_warm_up_spirv_path, replay_options.frame_warm_up_load);
-    GetWaitBeforeFrame(arg_parser, replay_options.wait_before_frame);
-
-    replay_options.replay_event_plugin_path   = arg_parser.GetArgumentValue(kReplayEventPluginPath);
-    replay_options.replay_event_plugin_params = arg_parser.GetArgumentValue(kReplayEventPluginParams);
-    replay_options.isolate_render_passes      = arg_parser.IsOptionSet(kIsolateRenderPasses);
-    replay_options.serialize_compute_and_transfer = arg_parser.IsOptionSet(kSerializeComputeAndTransfer);
-
-    replay_options.screenshot_apply_prerotation = arg_parser.IsOptionSet(kScreenshotApplyPrerotationArgument);
-
-    return replay_options;
-}
-
-#if defined(D3D12_SUPPORT)
-static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util::ArgumentParser& arg_parser,
-                                                            const std::string&                    filename)
-{
-    gfxrecon::decode::DxReplayOptions replay_options;
-    GetReplayOptions(replay_options, arg_parser, filename);
-
-    replay_options.DeniedDebugMessages  = GetFilteredMsgs(arg_parser, kDeniedMessages);
-    replay_options.AllowedDebugMessages = GetFilteredMsgs(arg_parser, kAllowedMessages);
-
-    if (arg_parser.IsOptionSet(kDxTwoPassReplay))
-    {
-        replay_options.enable_d3d12_two_pass_replay = true;
-    }
-
-    if (arg_parser.IsOptionSet(kDiscardCachedPsosLongOption) || arg_parser.IsOptionSet(kDiscardCachedPsosShortOption))
-    {
-        GFXRECON_LOG_WARNING("The parameters --dcp and --discard-cached-psos have been deprecated in favor for "
-                             "--use-cached-psos");
-    }
-
-    if (arg_parser.IsOptionSet(kUseCachedPsosOption))
-    {
-        replay_options.use_cached_psos = true;
-    }
-
-    if (arg_parser.IsOptionSet(kDxOverrideObjectNames))
-    {
-        replay_options.override_object_names = true;
-    }
-
-    if (arg_parser.IsOptionSet(kDxAgsMarkRenderPasses))
-    {
-#ifdef GFXRECON_AGS_SUPPORT
-        replay_options.ags_inject_markers = true;
-#else
-        GFXRECON_LOG_ERROR("Unsupported option --dx12-ags-inject-markers");
-#endif
-    }
-
-    const std::string& dump_resources = arg_parser.GetArgumentValue(kDumpResourcesArgument);
-    if (!dump_resources.empty() && dump_resources.find_first_not_of("0123456789,") == std::string::npos)
-    {
-        std::vector<std::string> values = gfxrecon::util::strings::SplitString(dump_resources, ',');
-        if (values.size() == 3)
-        {
-            replay_options.dump_resources_target.submit_index    = std::stoi(values[0]);
-            replay_options.dump_resources_target.command_index   = std::stoi(values[1]);
-            replay_options.dump_resources_target.draw_call_index = std::stoi(values[2]);
-            replay_options.enable_dump_resources                 = true;
-            replay_options.using_dump_resources_target           = true;
-        }
-    }
-
-    replay_options.dump_resources_output_dir            = GetDumpResourcesDir(arg_parser);
-    replay_options.dump_resources_before                = arg_parser.IsOptionSet(kDumpResourcesBeforeDrawOption);
-    replay_options.dump_resources_modifiable_state_only = arg_parser.IsOptionSet(kDumpResourcesModifiableStateOnly);
-
-    const std::string& memory_usage = arg_parser.GetArgumentValue(kBatchingMemoryUsageArgument);
-    if (!memory_usage.empty())
-    {
-        int memory_usage_int = std::stoi(memory_usage);
-        if (memory_usage_int >= 0 && memory_usage_int <= 100)
-        {
-            replay_options.memory_usage = static_cast<uint32_t>(memory_usage_int);
-        }
-        else
-        {
-            GFXRECON_LOG_WARNING(
-                "The parameter to --batching-memory-usage is out of range [0, 100], will use 80 as default value.");
-        }
-    }
-    return replay_options;
-}
-#endif
 
 #endif // GFXRECON_PLATFORM_SETTINGS_H


### PR DESCRIPTION
Optimize was a first approach at supporting command-line arguments in the features, but I decided to tweak it and do it a different way and make it global.  Then I implemented it in the replay tool and replaced the original mechanism in optimize.   This will eventually be migrated to other tools.