### PR TITLE
Add `FrameBoundaryEndOfFrame` to `Process_vkQueueSubmit2KHR`

### DIFF
--- a/framework/decode/vulkan_replay_frame_loop_consumer.cpp
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.cpp
@@ -542,6 +542,19 @@ void VulkanReplayFrameLoopConsumer::Process_vkQueueSubmit2(const ApiCallInfo& ca
     }
 }
 
+void VulkanReplayFrameLoopConsumer::Process_vkQueueSubmit2KHR(const ApiCallInfo& call_info, args::QueueSubmit2KHR& args)
+{
+    VulkanReplayConsumer::Process_vkQueueSubmit2KHR(call_info, args);
+
+    if (frame_loop_info_.IsLooping())
+    {
+        for (Decoded_VkSubmitInfo2 submit : args.pSubmits.GetMetaStructSpan())
+        {
+            FrameBoundaryEndOfFrame(args.queue, submit.pNext);
+        }
+    }
+}
+
 void VulkanReplayFrameLoopConsumer::Process_vkQueuePresentKHR(const ApiCallInfo& call_info, args::QueuePresentKHR& args)
 {
     VulkanReplayConsumer::Process_vkQueuePresentKHR(call_info, args);

--- a/framework/decode/vulkan_replay_frame_loop_consumer.h
+++ b/framework/decode/vulkan_replay_frame_loop_consumer.h
@@ -69,6 +69,8 @@ class VulkanReplayFrameLoopConsumer : public VulkanReplayFrameLoopConsumerBase
 
     void Process_vkQueueSubmit2(const ApiCallInfo& call_info, args::QueueSubmit2& args) override;
 
+    void Process_vkQueueSubmit2KHR(const ApiCallInfo& call_info, args::QueueSubmit2KHR& args) override;
+
     void Process_vkQueuePresentKHR(const ApiCallInfo& call_info, args::QueuePresentKHR& args) override;
 
     void Process_vkMapMemory(const ApiCallInfo& call_info, args::MapMemory& args) override;


### PR DESCRIPTION
It seems we are missing handling frame boundaries for `vkQueueSubmit2KHR` during frame looping. 

Currently it handles `vkQueueSubmit` and `vkQueueSubmit2`.

Add `vkQueueSubmit2KHR` for completeness.