### PR TITLE
Adds nullchecks in dx12_replay_consumer

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -456,7 +456,7 @@ void Dx12ReplayConsumerBase::ApplyBatchedResourceInitInfo(
         for (auto& resource_info : resource_infos)
         {
             auto object_info = GetObjectInfo(resource_info.second.resource_id);
-            if (object_info->extra_info != nullptr)
+            if (object_info != nullptr && object_info->extra_info != nullptr)
             {
                 auto extra_info = GetExtraInfo<D3D12ResourceInfo>(object_info);
                 if (extra_info->swap_chain_id != format::kNullHandleId)
@@ -467,6 +467,12 @@ void Dx12ReplayConsumerBase::ApplyBatchedResourceInitInfo(
                 {
                     others_resource_infos.insert(std::pair(resource_info.first, &resource_info.second));
                 }
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING("ApplyBatchedResourceInitInfo: skipping resource_id %" PRIu64
+                                     " with missing object/extra info; its init data will not be applied.",
+                                     resource_info.second.resource_id);
             }
         }
 
@@ -533,9 +539,23 @@ void Dx12ReplayConsumerBase::ApplyBatchedResourceInitInfo(
         {
             auto object_info          = GetObjectInfo(resource_info.second->resource_id);
             auto extra_info           = GetExtraInfo<D3D12ResourceInfo>(object_info);
+            if (extra_info == nullptr)
+            {
+                GFXRECON_LOG_WARNING("ApplyBatchedResourceInitInfo: skipping swapchain resource_id %" PRIu64
+                                     "; missing D3D12ResourceInfo extra info",
+                                     resource_info.second->resource_id);
+                continue;
+            }
             auto swapchain_info       = GetObjectInfo(extra_info->swap_chain_id);
             auto swapchain_extra_info = GetExtraInfo<DxgiSwapchainInfo>(swapchain_info);
-
+            if (swapchain_extra_info == nullptr)
+            {
+                GFXRECON_LOG_WARNING("ApplyBatchedResourceInitInfo: skipping swapchain resource_id %" PRIu64
+                                     " swap_chain_id %" PRIu64 "did not resovle to a valid swapchain",
+                                     resource_info.second->resource_id,
+                                     extra_info->swap_chain_id);
+                continue;
+            }
             resource_data_util_->ExecuteTransitionCommandList(resource_info.second->resource,
                                                               resource_info.second->before_states,
                                                               resource_info.second->after_states,


### PR DESCRIPTION
## Problem
There are several instances in dx12_replay_consumer.cpp where one of the get functions returns a pointer that may be null. Most of these are properly checked before use, however in several places, the object is assumed to be valid and members of the object are directly accessed or checked. 

For example on line 459:
``` 
    auto object_info = GetObjectInfo(resource_info.second.resource_id);
    if (object_info->extra_info != nullptr)
```
object_info can be null here since `GetObjectInfo` can return null.

Further down `GetExtraInfo<>` can do the same thing.



## Fix
Added several if-checks to catch potential null pointer dereferences. 
Added warnings to make sure that if these new checks catch null pointers, they do not fail silently. 