### PR TITLE
Reorder Swapchain Writer to perserve color space settings in trimmed captures

### DIFF
--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1494,6 +1494,14 @@ void Dx12StateWriter::WriteSwapChainState(const Dx12StateTable& state_table)
         // Write swapchain creation call.
         StandardCreateWrite(swapchain_wrapper);
 
+        // Write call to resize the swapchain buffers.
+        if (swapchain_info->resize_info.call_id != format::ApiCall_Unknown)
+        {
+            WriteMethodCall(swapchain_info->resize_info.call_id,
+                            swapchain_wrapper->GetCaptureId(),
+                            swapchain_info->resize_info.call_parameters.get());
+        }
+
         // Write swapchain set color space for HDR
         if (swapchain_info->set_color_space)
         {
@@ -1520,13 +1528,6 @@ void Dx12StateWriter::WriteSwapChainState(const Dx12StateTable& state_table)
             parameter_stream_.Clear();
         }
 
-        // Write call to resize the swapchain buffers.
-        if (swapchain_info->resize_info.call_id != format::ApiCall_Unknown)
-        {
-            WriteMethodCall(swapchain_info->resize_info.call_id,
-                            swapchain_wrapper->GetCaptureId(),
-                            swapchain_info->resize_info.call_parameters.get());
-        }
 
         // Write image state command.
         UINT                                  swapchain_buffer_index = 0;


### PR DESCRIPTION
## Problem

The encoding order for swap chain state  has `IDXGISwapChain::ResizeBuffers` after color space and hdr metadata. this creates a possible issue since `ResizeBuffers` sets the underlying format that `SetColorSpace` needs for HDR. If there is a mismatch, the application will not explicitly fail, however the replayed image will be incorrect. 

## Solution

Simply reordering the encoding calls so that `ResizeBuffer` (and setting the correct format), comes before `SetColorSpace` ensures that HDR behavior is maintained.