### PR TITLE
D3D12 trim-load staging buffers in a reusable UPLOAD heap

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021-2023 LunarG, Inc.
-** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2023-2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -577,6 +577,28 @@ void Dx12ReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId de
 
     resource_data_util_ = std::make_unique<graphics::Dx12ResourceDataUtil>(device, max_copy_size);
 
+    // Give the batch heap the same memory budget the per-resource staging path uses,
+    // so a large batch-heap allocation is only attempted when it fits; otherwise staging
+    // falls back to committed buffers.
+    auto device_info = GetObjectInfo(device_id);
+    if ((device_info != nullptr) && (device_info->extra_info != nullptr))
+    {
+        auto extra_device_info = GetExtraInfo<D3D12DeviceInfo>(device_info);
+        if (extra_device_info != nullptr)
+        {
+            resource_data_util_->SetBatchHeapMemoryLimits(extra_device_info->adapter3,
+                                                          static_cast<double>(options_.memory_usage) / 100.0,
+                                                          extra_device_info->is_uma);
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING("Device extra info unavailable for device %" PRIu64
+                                 "; batch-heap staging will not honor the "
+                                 "configured memory-usage budget.",
+                                 device_id);
+        }
+    }
+
     // Wait for any pending reserved resource tile mapping updates to complete.
     for (auto command_queue : trim_state_tile_update_queues_)
     {
@@ -641,18 +663,32 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
                                                  temp_subresource_layouts,
                                                  required_data_size);
 
-        const double max_mem_usage = static_cast<double>(options_.memory_usage) / 100.0;
-        if (!graphics::dx12::IsMemoryAvailable(
-                required_data_size, extra_device_info->adapter3, max_mem_usage, extra_device_info->is_uma))
+        resource_init_info.staging_resource = resource_data_util_->GetBatchStagingBuffer(required_data_size);
+        if (resource_init_info.staging_resource == nullptr)
         {
-            // If neither system memory or GPU memory are able to accommodate next resource,
-            // execute the Copy() calls and release temp buffer to free memory
+            // The batch heap couldn't provide a placed staging buffer (e.g., full, needs grow, or heap
+            // allocation/placement failed): flush the pending copies (this executes + waits and releases every placed
+            // staging buffer), reset the bump cursor, then retry.
             ApplyBatchedResourceInitInfo(resource_init_infos_);
-        }
+            resource_data_util_->ResetBatchHeap();
 
-        // Prepare Staging buffer for next resource
-        resource_init_info.staging_resource = resource_data_util_->CreateStagingBuffer(
-            graphics::Dx12ResourceDataUtil::CopyType::kCopyTypeWrite, required_data_size);
+            resource_init_info.staging_resource = resource_data_util_->GetBatchStagingBuffer(required_data_size);
+            if (resource_init_info.staging_resource == nullptr)
+            {
+                // Oversized single resource (> heap cap) or placement failure: use a dedicated committed buffer.
+                // The batch was just flushed above, but the reusable batch heap is still resident. If GPU/system
+                // memory can't accommodate this large committed allocation alongside it, release the batch heap
+                // first so the committed staging buffer has room.
+                const double max_mem_usage = static_cast<double>(options_.memory_usage) / 100.0;
+                if (!graphics::dx12::IsMemoryAvailable(
+                        required_data_size, extra_device_info->adapter3, max_mem_usage, extra_device_info->is_uma))
+                {
+                    resource_data_util_->ReleaseBatchHeap();
+                }
+                resource_init_info.staging_resource = resource_data_util_->CreateStagingBuffer(
+                    graphics::Dx12ResourceDataUtil::CopyType::kCopyTypeWrite, required_data_size);
+            }
+        }
         SetResourceInitInfoState(resource_init_info, command_header, data);
 
         // Only for buffer resources (which contain 1 subresource), map any resource values contained in the data.
@@ -3945,7 +3981,6 @@ IDXGIAdapter* Dx12ReplayConsumerBase::GetAdapter()
 
     return adapter_found;
 }
-
 
 // Helper to initialize the resource's D3D12ResourceInfo and set its is_reserved_resource = true.
 static void SetIsReservedResource(HandlePointerDecoder<void*>* resource)

--- a/framework/graphics/dx12_resource_data_util.cpp
+++ b/framework/graphics/dx12_resource_data_util.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -249,7 +249,8 @@ void Dx12ResourceDataUtil::GetResourceCopyInfo(ID3D12Resource*                  
 
 Dx12ResourceDataUtil::Dx12ResourceDataUtil(ID3D12Device* device, uint64_t min_buffer_size) :
     device_(device), staging_buffers_{ nullptr, nullptr }, staging_buffer_sizes_{ 0, 0 },
-    min_buffer_size_(min_buffer_size), fence_value_(0)
+    min_buffer_size_(min_buffer_size), fence_value_(0), batch_upload_heap_(nullptr), batch_heap_capacity_(0),
+    batch_heap_offset_(0), batch_heap_adapter_(nullptr), batch_heap_max_mem_usage_(0.0), batch_heap_is_uma_(false)
 {
     HRESULT result = E_FAIL;
 
@@ -892,6 +893,157 @@ Dx12ResourceDataUtil::ExecuteTransitionCommandList(ID3D12Resource*              
     }
 
     return result;
+}
+
+static constexpr uint64_t kBatchHeapDefaultCapacity = 256ull * 1024 * 1024;                       // 256 MiB
+static constexpr uint64_t kBatchHeapMaxCapacity     = 1024ull * 1024 * 1024;                      // 1 GiB
+static constexpr uint64_t kBatchPlacementAlign      = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT; // 64 KiB
+
+HRESULT Dx12ResourceDataUtil::EnsureBatchHeap(uint64_t min_capacity)
+{
+    // Reuse the existing heap if it already satisfies the request.
+    if ((batch_upload_heap_ != nullptr) && (batch_heap_capacity_ >= min_capacity))
+    {
+        return S_OK;
+    }
+
+    // Choose a bounded capacity: at least the default and the largest single resource seen (min_buffer_size_),
+    // at least the immediate request, capped at the max. Rounded up to placement alignment.
+    uint64_t capacity = std::max(kBatchHeapDefaultCapacity, min_buffer_size_);
+    capacity          = std::max(capacity, min_capacity);
+    capacity          = std::min(capacity, kBatchHeapMaxCapacity);
+    capacity          = util::platform::AlignValue<kBatchPlacementAlign>(capacity);
+
+    // Don't attempt a large heap allocation that the GPU/system memory budget can't accommodate. Check before
+    // touching any existing heap so a rejected grow leaves the current heap usable; the caller falls back to
+    // per-resource committed staging buffers. Skipped when no adapter was supplied (budget unknown).
+    if ((batch_heap_adapter_ != nullptr) &&
+        !dx12::IsMemoryAvailable(capacity, batch_heap_adapter_, batch_heap_max_mem_usage_, batch_heap_is_uma_))
+    {
+        GFXRECON_LOG_DEBUG("Insufficient memory budget for a %" PRIu64
+                           " MiB batched-staging UPLOAD heap; using committed staging buffers.",
+                           capacity / (1024 * 1024));
+        return E_OUTOFMEMORY;
+    }
+
+    // Growing/recreating is only safe when no placed buffer is live. GetBatchStagingBuffer enforces this by
+    // returning nullptr (forcing a flush + ResetBatchHeap) before it grows a heap with outstanding buffers, so
+    // by the time we destroy the old heap the bump cursor must be 0 and nothing aliases it.
+    GFXRECON_ASSERT(batch_heap_offset_ == 0);
+    batch_upload_heap_   = nullptr;
+    batch_heap_capacity_ = 0;
+    batch_heap_offset_   = 0;
+
+    D3D12_HEAP_PROPERTIES props = {};
+    props.Type                  = D3D12_HEAP_TYPE_UPLOAD;
+    props.CPUPageProperty       = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
+    props.MemoryPoolPreference  = D3D12_MEMORY_POOL_UNKNOWN;
+    props.CreationNodeMask      = 1;
+    props.VisibleNodeMask       = 1;
+
+    D3D12_HEAP_DESC heap_desc = {};
+    heap_desc.SizeInBytes     = capacity;
+    heap_desc.Properties      = props;
+    heap_desc.Alignment       = 0; // => 64 KiB default
+    heap_desc.Flags           = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
+
+    HRESULT result = device_->CreateHeap(&heap_desc, IID_PPV_ARGS(&batch_upload_heap_));
+    if (SUCCEEDED(result))
+    {
+        batch_heap_capacity_ = capacity;
+    }
+    else
+    {
+        GFXRECON_LOG_WARNING("Failed to create a %" PRIu64 " MiB batched-staging UPLOAD heap (0x%08lx); falling back "
+                             "to committed staging buffers.",
+                             capacity / (1024 * 1024),
+                             static_cast<unsigned long>(result));
+        batch_upload_heap_   = nullptr;
+        batch_heap_capacity_ = 0;
+    }
+    return result;
+}
+
+dx12::ID3D12ResourceComPtr Dx12ResourceDataUtil::GetBatchStagingBuffer(uint64_t required_buffer_size)
+{
+    if (required_buffer_size == 0)
+    {
+        return nullptr;
+    }
+
+    // A resource larger than any heap we will build must use a dedicated committed buffer.
+    if (required_buffer_size > kBatchHeapMaxCapacity)
+    {
+        return nullptr;
+    }
+
+    // If the request needs a larger heap than the current one, EnsureBatchHeap would destroy and recreate it.
+    // That is only safe when no placed buffer is live. When buffers from this batch are still outstanding
+    // (offset > 0), signal the caller to flush + ResetBatchHeap() first, then retry the placement on the grown
+    // heap. (In practice the heap is seeded to the capture's largest resource, so this rarely fires.)
+    const bool needs_grow = (batch_upload_heap_ == nullptr) || (batch_heap_capacity_ < required_buffer_size);
+    if (needs_grow && (batch_heap_offset_ > 0))
+    {
+        return nullptr;
+    }
+
+    if (FAILED(EnsureBatchHeap(required_buffer_size)))
+    {
+        return nullptr;
+    }
+
+    const uint64_t aligned_offset = util::platform::AlignValue<kBatchPlacementAlign>(batch_heap_offset_);
+    if (aligned_offset + required_buffer_size > batch_heap_capacity_)
+    {
+        // Heap is full for this batch. Signal the caller to flush + ResetBatchHeap() + retry.
+        return nullptr;
+    }
+
+    D3D12_RESOURCE_DESC desc = {};
+    desc.Dimension           = D3D12_RESOURCE_DIMENSION_BUFFER;
+    desc.Alignment           = 0;
+    desc.Width               = required_buffer_size;
+    desc.Height              = 1;
+    desc.DepthOrArraySize    = 1;
+    desc.MipLevels           = 1;
+    desc.Format              = DXGI_FORMAT_UNKNOWN;
+    desc.SampleDesc.Count    = 1;
+    desc.Layout              = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+    desc.Flags               = D3D12_RESOURCE_FLAG_NONE;
+
+    dx12::ID3D12ResourceComPtr placed;
+    HRESULT                    result = device_->CreatePlacedResource(
+        batch_upload_heap_, aligned_offset, &desc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, IID_PPV_ARGS(&placed));
+    if (FAILED(result))
+    {
+        // Treat as a fit failure; caller flushes/resets and falls back to a committed buffer if needed.
+        return nullptr;
+    }
+
+    batch_heap_offset_ = aligned_offset + required_buffer_size;
+    return placed;
+}
+
+void Dx12ResourceDataUtil::ResetBatchHeap()
+{
+    batch_heap_offset_ = 0;
+}
+
+void Dx12ResourceDataUtil::SetBatchHeapMemoryLimits(IDXGIAdapter3* adapter, double max_mem_usage, bool is_uma)
+{
+    batch_heap_adapter_       = dx12::IDXGIAdapter3ComPtr(adapter);
+    batch_heap_max_mem_usage_ = max_mem_usage;
+    batch_heap_is_uma_        = is_uma;
+}
+
+void Dx12ResourceDataUtil::ReleaseBatchHeap()
+{
+    // Fully free the reusable heap (not just the bump cursor). Only safe when no placed buffer is live, i.e.
+    // after the batch has been applied and its staging references released. EnsureBatchHeap lazily recreates
+    // the heap on the next batched allocation.
+    batch_upload_heap_   = nullptr;
+    batch_heap_capacity_ = 0;
+    batch_heap_offset_   = 0;
 }
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/framework/graphics/dx12_resource_data_util.cpp
+++ b/framework/graphics/dx12_resource_data_util.cpp
@@ -895,9 +895,7 @@ Dx12ResourceDataUtil::ExecuteTransitionCommandList(ID3D12Resource*              
     return result;
 }
 
-static constexpr uint64_t kBatchHeapDefaultCapacity = 256ull * 1024 * 1024;                       // 256 MiB
-static constexpr uint64_t kBatchHeapMaxCapacity     = 1024ull * 1024 * 1024;                      // 1 GiB
-static constexpr uint64_t kBatchPlacementAlign      = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT; // 64 KiB
+static constexpr uint64_t kBatchHeapMaxCapacity = 2048ull * 1024 * 1024; // 2 GiB
 
 HRESULT Dx12ResourceDataUtil::EnsureBatchHeap(uint64_t min_capacity)
 {
@@ -907,28 +905,19 @@ HRESULT Dx12ResourceDataUtil::EnsureBatchHeap(uint64_t min_capacity)
         return S_OK;
     }
 
-    // Choose a bounded capacity: at least the default and the largest single resource seen (min_buffer_size_),
-    // at least the immediate request, capped at the max. Rounded up to placement alignment.
-    uint64_t capacity = std::max(kBatchHeapDefaultCapacity, min_buffer_size_);
-    capacity          = std::max(capacity, min_capacity);
-    capacity          = std::min(capacity, kBatchHeapMaxCapacity);
-    capacity          = util::platform::AlignValue<kBatchPlacementAlign>(capacity);
-
     // Don't attempt a large heap allocation that the GPU/system memory budget can't accommodate. Check before
     // touching any existing heap so a rejected grow leaves the current heap usable; the caller falls back to
     // per-resource committed staging buffers. Skipped when no adapter was supplied (budget unknown).
     if ((batch_heap_adapter_ != nullptr) &&
-        !dx12::IsMemoryAvailable(capacity, batch_heap_adapter_, batch_heap_max_mem_usage_, batch_heap_is_uma_))
+        !dx12::IsMemoryAvailable(
+            kBatchHeapMaxCapacity, batch_heap_adapter_, batch_heap_max_mem_usage_, batch_heap_is_uma_))
     {
         GFXRECON_LOG_DEBUG("Insufficient memory budget for a %" PRIu64
                            " MiB batched-staging UPLOAD heap; using committed staging buffers.",
-                           capacity / (1024 * 1024));
+                           kBatchHeapMaxCapacity / (1024 * 1024));
         return E_OUTOFMEMORY;
     }
 
-    // Growing/recreating is only safe when no placed buffer is live. GetBatchStagingBuffer enforces this by
-    // returning nullptr (forcing a flush + ResetBatchHeap) before it grows a heap with outstanding buffers, so
-    // by the time we destroy the old heap the bump cursor must be 0 and nothing aliases it.
     GFXRECON_ASSERT(batch_heap_offset_ == 0);
     batch_upload_heap_   = nullptr;
     batch_heap_capacity_ = 0;
@@ -942,7 +931,7 @@ HRESULT Dx12ResourceDataUtil::EnsureBatchHeap(uint64_t min_capacity)
     props.VisibleNodeMask       = 1;
 
     D3D12_HEAP_DESC heap_desc = {};
-    heap_desc.SizeInBytes     = capacity;
+    heap_desc.SizeInBytes     = kBatchHeapMaxCapacity;
     heap_desc.Properties      = props;
     heap_desc.Alignment       = 0; // => 64 KiB default
     heap_desc.Flags           = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
@@ -950,13 +939,13 @@ HRESULT Dx12ResourceDataUtil::EnsureBatchHeap(uint64_t min_capacity)
     HRESULT result = device_->CreateHeap(&heap_desc, IID_PPV_ARGS(&batch_upload_heap_));
     if (SUCCEEDED(result))
     {
-        batch_heap_capacity_ = capacity;
+        batch_heap_capacity_ = kBatchHeapMaxCapacity;
     }
     else
     {
         GFXRECON_LOG_WARNING("Failed to create a %" PRIu64 " MiB batched-staging UPLOAD heap (0x%08lx); falling back "
                              "to committed staging buffers.",
-                             capacity / (1024 * 1024),
+                             kBatchHeapMaxCapacity / (1024 * 1024),
                              static_cast<unsigned long>(result));
         batch_upload_heap_   = nullptr;
         batch_heap_capacity_ = 0;
@@ -977,22 +966,13 @@ dx12::ID3D12ResourceComPtr Dx12ResourceDataUtil::GetBatchStagingBuffer(uint64_t 
         return nullptr;
     }
 
-    // If the request needs a larger heap than the current one, EnsureBatchHeap would destroy and recreate it.
-    // That is only safe when no placed buffer is live. When buffers from this batch are still outstanding
-    // (offset > 0), signal the caller to flush + ResetBatchHeap() first, then retry the placement on the grown
-    // heap. (In practice the heap is seeded to the capture's largest resource, so this rarely fires.)
-    const bool needs_grow = (batch_upload_heap_ == nullptr) || (batch_heap_capacity_ < required_buffer_size);
-    if (needs_grow && (batch_heap_offset_ > 0))
-    {
-        return nullptr;
-    }
-
     if (FAILED(EnsureBatchHeap(required_buffer_size)))
     {
         return nullptr;
     }
 
-    const uint64_t aligned_offset = util::platform::AlignValue<kBatchPlacementAlign>(batch_heap_offset_);
+    const uint64_t aligned_offset =
+        util::platform::AlignValue<D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT>(batch_heap_offset_);
     if (aligned_offset + required_buffer_size > batch_heap_capacity_)
     {
         // Heap is full for this batch. Signal the caller to flush + ResetBatchHeap() + retry.

--- a/framework/graphics/dx12_resource_data_util.h
+++ b/framework/graphics/dx12_resource_data_util.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -101,6 +101,11 @@ class Dx12ResourceDataUtil
     dx12::ID3D12ResourceComPtr GetStagingBuffer(CopyType type, uint64_t required_buffer_size);
     dx12::ID3D12ResourceComPtr CreateStagingBuffer(CopyType type, uint64_t required_buffer_size);
 
+    dx12::ID3D12ResourceComPtr GetBatchStagingBuffer(uint64_t required_buffer_size);
+    void                       ResetBatchHeap();
+    void                       ReleaseBatchHeap();
+    void                       SetBatchHeapMemoryLimits(IDXGIAdapter3* adapter, double max_mem_usage, bool is_uma);
+
     HRESULT ExecuteAndWaitForCommandList(ID3D12CommandQueue* queue = nullptr);
 
     // Build and execute a command list that copies data to or from the target_resource.
@@ -140,6 +145,8 @@ class Dx12ResourceDataUtil
                                      const std::vector<uint64_t>& subresource_offsets,
                                      const std::vector<uint64_t>& subresource_sizes);
 
+    HRESULT EnsureBatchHeap(uint64_t min_capacity);
+
     ID3D12Device*                          device_;
     dx12::ID3D12CommandQueueComPtr         command_queue_;
     dx12::ID3D12CommandAllocatorComPtr     command_allocator_;
@@ -149,6 +156,14 @@ class Dx12ResourceDataUtil
     uint64_t                               staging_buffer_sizes_[2];
     const uint64_t                         min_buffer_size_;
     uint64_t                               fence_value_;
+
+    dx12::ID3D12HeapComPtr batch_upload_heap_;
+    uint64_t               batch_heap_capacity_;
+    uint64_t               batch_heap_offset_;
+
+    dx12::IDXGIAdapter3ComPtr batch_heap_adapter_;
+    double                    batch_heap_max_mem_usage_;
+    bool                      batch_heap_is_uma_;
 
     // Temporary buffers.
     std::vector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT> temp_subresource_layouts_;

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -67,6 +67,7 @@ typedef _com_ptr_t<_com_IIID<IDXGIFactory, &__uuidof(IDXGIFactory)>>       IDXGI
 typedef _com_ptr_t<_com_IIID<IDXGIFactory1, &__uuidof(IDXGIFactory1)>>     IDXGIFactory1ComPtr;
 
 typedef _com_ptr_t<_com_IIID<ID3D12DescriptorHeap, &__uuidof(ID3D12DescriptorHeap)>>     ID3D12DescriptorHeapComPtr;
+typedef _com_ptr_t<_com_IIID<ID3D12Heap, &__uuidof(ID3D12Heap)>>                         ID3D12HeapComPtr;
 typedef _com_ptr_t<_com_IIID<ID3D12Device, &__uuidof(ID3D12Device)>>                     ID3D12DeviceComPtr;
 typedef _com_ptr_t<_com_IIID<ID3D12Device5, &__uuidof(ID3D12Device5)>>                   ID3D12Device5ComPtr;
 typedef _com_ptr_t<_com_IIID<ID3D12Fence, &__uuidof(ID3D12Fence)>>                       ID3D12FenceComPtr;


### PR DESCRIPTION
The GFXR create Committed Resource as stagging buffer when upload data from capture file over to resource (InitSubResource). But Committed Resource Create&Release will take some CPU&GPU time.

The solution is,
Create a big Heap when start InitSubResource, then create all batched stagging buffer as PlacedResource to the Heap. So that could save some time to allocate CPU&GPU memory.