### PR TITLE
Add option to present when trace lacks presentation but has frame boundaries

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2730,8 +2730,7 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
 }
 
 void VulkanReplayConsumerBase::WriteFrameBoundaryImage(const VulkanImageInfo* image_info,
-                                                       const std::string&     filename_prefix,
-                                                       uint32_t               layer)
+                                                       const std::string&     filename_prefix)
 {
     GFXRECON_ASSERT(image_info != nullptr);
 
@@ -2756,19 +2755,23 @@ void VulkanReplayConsumerBase::WriteFrameBoundaryImage(const VulkanImageInfo* im
         };
     }
 
-    screenshot_handler_->WriteImage(filename_prefix,
-                                    device_info,
-                                    GetInjectedDeviceCalls(device_info->handle),
-                                    memory_properties,
-                                    device_info->allocator.get(),
-                                    image_info->handle,
-                                    image_info->format,
-                                    image_info->extent.width,
-                                    image_info->extent.height,
-                                    layer,
-                                    screenshot_scale,
-                                    image_info->subresource_layouts.GetSubresourceLayout(VK_IMAGE_ASPECT_COLOR_BIT, 0, layer),
-                                    VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
+    for (uint32_t layer = 0; layer < image_info->layer_count; ++layer)
+    {
+        screenshot_handler_->WriteImage(
+            image_info->layer_count > 1 ? filename_prefix + "_layer_" + std::to_string(layer) : filename_prefix,
+            device_info,
+            GetInjectedDeviceCalls(device_info->handle),
+            memory_properties,
+            device_info->allocator.get(),
+            image_info->handle,
+            image_info->format,
+            image_info->extent.width,
+            image_info->extent.height,
+            layer,
+            screenshot_scale,
+            image_info->subresource_layouts.GetSubresourceLayout(VK_IMAGE_ASPECT_COLOR_BIT, 0, layer),
+            VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
+    }
 }
 
 bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
@@ -2811,7 +2814,7 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
                     filename_prefix += "_attachment_" + std::to_string(j);
                 }
 
-                WriteFrameBoundaryImage(image_info, filename_prefix, 0);
+                WriteFrameBoundaryImage(image_info, filename_prefix);
             }
         }
     }
@@ -2845,7 +2848,7 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDevic
 
             const format::HandleId handle_id  = frame_boundary->pImages.GetPointer()[i];
             const VulkanImageInfo* image_info = GetObjectInfoTable().GetVkImageInfo(handle_id);
-            WriteFrameBoundaryImage(image_info, filename_prefix, 0);
+            WriteFrameBoundaryImage(image_info, filename_prefix);
         }
     }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2774,6 +2774,28 @@ void VulkanReplayConsumerBase::WriteFrameBoundaryImage(const VulkanImageInfo* im
     }
 }
 
+void VulkanReplayConsumerBase::PresentFrameBoundaryImage(const VulkanImageInfo* image_info)
+{
+    const auto* device_info = object_info_table_->GetVkDeviceInfo(image_info->parent_id);
+    GFXRECON_ASSERT(device_info != nullptr);
+
+    const auto* physical_device_info = object_info_table_->GetVkPhysicalDeviceInfo(device_info->parent_id);
+    GFXRECON_ASSERT(physical_device_info != nullptr);
+
+    auto* instance_info = object_info_table_->GetVkInstanceInfo(physical_device_info->parent_id);
+    GFXRECON_ASSERT(instance_info != nullptr);
+
+    const auto* instance_table = GetInstanceTable(instance_info->handle);
+    swapchain_->PresentImageAdHoc(device_info,
+                                  nullptr,
+                                  image_info,
+                                  instance_info,
+                                  instance_table,
+                                  GetInjectedDeviceCalls(device_info->handle),
+                                  application_.get(),
+                                  options_.screenshot_scale);
+}
+
 bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
     const VulkanCommandBufferInfo* command_buffer_info)
 {
@@ -2783,42 +2805,77 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
         return false;
     }
 
-    if (screenshot_handler_->IsScreenshotFrame())
+    const bool             override_requested  = !options_.present_override_image_name.empty();
+    const VulkanImageInfo* override_image_info = present_override_image_id_ != format::kNullHandleId
+                                                     ? object_info_table_->GetVkImageInfo(present_override_image_id_)
+                                                     : nullptr;
+
+    if (options_.present_frame_boundary)
     {
-        for (size_t i = 0; i < command_buffer_info->frame_buffer_ids.size(); ++i)
+        if (override_image_info != nullptr)
         {
-            auto* framebuffer_info = object_info_table_->GetVkFramebufferInfo(command_buffer_info->frame_buffer_ids[i]);
-
-            for (size_t j = 0; j < framebuffer_info->attachment_image_view_ids.size(); ++j)
-            {
-                auto image_view_id   = framebuffer_info->attachment_image_view_ids[j];
-                auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
-                auto image_info      = object_info_table_->GetVkImageInfo(image_view_info->image_id);
-
-                // Only screenshot images that are color attachments.
-                if (!graphics::ImageHasUsage(image_info->usage, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT))
-                {
-                    continue;
-                }
-
-                std::string filename_prefix =
-                    screenshot_file_prefix_ + "_frame_" + std::to_string(screenshot_handler_->GetCurrentFrame());
-
-                if (!command_buffer_info->frame_buffer_ids.empty())
-                {
-                    filename_prefix += "_renderpass_" + std::to_string(i);
-                }
-
-                if (!framebuffer_info->attachment_image_view_ids.empty())
-                {
-                    filename_prefix += "_attachment_" + std::to_string(j);
-                }
-
-                WriteFrameBoundaryImage(image_info, filename_prefix);
-            }
+            PresentFrameBoundaryImage(override_image_info);
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING_ONCE(
+                "--present-frame-boundary: the frame boundary declares no image; provide --present-override "
+                "<debug-name>");
         }
     }
-    screenshot_handler_->EndFrame();
+
+    if (screenshot_handler_ != nullptr)
+    {
+        if (screenshot_handler_->IsScreenshotFrame())
+        {
+            if (override_requested)
+            {
+                if (override_image_info != nullptr)
+                {
+                    const std::string filename_prefix =
+                        screenshot_file_prefix_ + "_frame_" + std::to_string(screenshot_handler_->GetCurrentFrame());
+                    WriteFrameBoundaryImage(override_image_info, filename_prefix);
+                }
+            }
+            else
+            {
+                for (size_t i = 0; i < command_buffer_info->frame_buffer_ids.size(); ++i)
+                {
+                    auto* framebuffer_info =
+                        object_info_table_->GetVkFramebufferInfo(command_buffer_info->frame_buffer_ids[i]);
+
+                    for (size_t j = 0; j < framebuffer_info->attachment_image_view_ids.size(); ++j)
+                    {
+                        auto image_view_id   = framebuffer_info->attachment_image_view_ids[j];
+                        auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
+                        auto image_info      = object_info_table_->GetVkImageInfo(image_view_info->image_id);
+
+                        // Only screenshot images that are color attachments.
+                        if (!graphics::ImageHasUsage(image_info->usage, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT))
+                        {
+                            continue;
+                        }
+
+                        std::string filename_prefix = screenshot_file_prefix_ + "_frame_" +
+                                                      std::to_string(screenshot_handler_->GetCurrentFrame());
+
+                        if (!command_buffer_info->frame_buffer_ids.empty())
+                        {
+                            filename_prefix += "_renderpass_" + std::to_string(i);
+                        }
+
+                        if (!framebuffer_info->attachment_image_view_ids.empty())
+                        {
+                            filename_prefix += "_attachment_" + std::to_string(j);
+                        }
+
+                        WriteFrameBoundaryImage(image_info, filename_prefix);
+                    }
+                }
+            }
+        }
+        screenshot_handler_->EndFrame();
+    }
     return true;
 }
 
@@ -2834,25 +2891,62 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDevic
         return false;
     }
 
-    if (screenshot_handler_->IsScreenshotFrame())
+    const bool             override_requested  = !options_.present_override_image_name.empty();
+    const VulkanImageInfo* override_image_info = present_override_image_id_ != format::kNullHandleId
+                                                     ? object_info_table_->GetVkImageInfo(present_override_image_id_)
+                                                     : nullptr;
+    const VulkanImageInfo* declared_image_info = nullptr;
+    if (frame_boundary->pImages.GetLength() > 0)
     {
-        for (uint32_t i = 0; i < frame_boundary->pImages.GetLength(); ++i)
+        declared_image_info = GetObjectInfoTable().GetVkImageInfo(frame_boundary->pImages.GetPointer()[0]);
+        GFXRECON_ASSERT(declared_image_info != nullptr);
+    }
+
+    if (options_.present_frame_boundary)
+    {
+        const VulkanImageInfo* presentation_image = override_requested ? override_image_info : declared_image_info;
+        if (presentation_image != nullptr)
         {
-            std::string filename_prefix =
-                screenshot_file_prefix_ + "_frame_" + std::to_string(screenshot_handler_->GetCurrentFrame());
-
-            if (frame_boundary->pImages.GetLength() > 1)
-            {
-                filename_prefix += "_image_" + std::to_string(i);
-            }
-
-            const format::HandleId handle_id  = frame_boundary->pImages.GetPointer()[i];
-            const VulkanImageInfo* image_info = GetObjectInfoTable().GetVkImageInfo(handle_id);
-            WriteFrameBoundaryImage(image_info, filename_prefix);
+            PresentFrameBoundaryImage(presentation_image);
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING_ONCE(
+                "--present-frame-boundary: the frame boundary declares no image; provide --present-override "
+                "<debug-name>");
         }
     }
 
-    screenshot_handler_->EndFrame();
+    if (screenshot_handler_ != nullptr)
+    {
+        if (screenshot_handler_->IsScreenshotFrame())
+        {
+            const std::string filename_prefix =
+                screenshot_file_prefix_ + "_frame_" + std::to_string(screenshot_handler_->GetCurrentFrame());
+
+            if (override_requested)
+            {
+                if (override_image_info != nullptr)
+                {
+                    WriteFrameBoundaryImage(override_image_info, filename_prefix);
+                }
+            }
+            else
+            {
+                for (uint32_t i = 0; i < frame_boundary->pImages.GetLength(); ++i)
+                {
+                    const VulkanImageInfo* image_info =
+                        GetObjectInfoTable().GetVkImageInfo(frame_boundary->pImages.GetPointer()[i]);
+                    GFXRECON_ASSERT(image_info != nullptr);
+                    WriteFrameBoundaryImage(image_info,
+                                            frame_boundary->pImages.GetLength() > 1
+                                                ? filename_prefix + "_image_" + std::to_string(i)
+                                                : filename_prefix);
+                }
+            }
+        }
+        screenshot_handler_->EndFrame();
+    }
 
     return true;
 }
@@ -5083,7 +5177,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
         }
     }
 
-    if (screenshot_handler_ != nullptr)
+    if (screenshot_handler_ != nullptr || options_.present_frame_boundary)
     {
         for (uint32_t i = 0; i < submitCount; ++i)
         {
@@ -5376,7 +5470,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
     }
 
     // Check whether any of the submitted command buffers are frame boundaries.
-    if (screenshot_handler_ != nullptr)
+    if (screenshot_handler_ != nullptr || options_.present_frame_boundary)
     {
         for (uint32_t i = 0; i < submitCount; ++i)
         {
@@ -5394,16 +5488,6 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
                 {
                     auto command_buffer_info =
                         GetObjectInfoTable().GetVkCommandBufferInfo(command_buffer_infos[j].commandBuffer);
-
-                    // Apply any layouts from submitted command lists.
-                    for (auto image_layout : command_buffer_info->image_layout_barriers)
-                    {
-                        auto image_info = GetObjectInfoTable().GetVkImageInfo(image_layout.first);
-                        if (image_info != nullptr)
-                        {
-                            image_info->current_layout = image_layout.second;
-                        }
-                    }
 
                     if (CheckCommandBufferInfoForFrameBoundary(command_buffer_info))
                     {

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5394,6 +5394,17 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
                 {
                     auto command_buffer_info =
                         GetObjectInfoTable().GetVkCommandBufferInfo(command_buffer_infos[j].commandBuffer);
+
+                    // Apply any layouts from submitted command lists.
+                    for (auto image_layout : command_buffer_info->image_layout_barriers)
+                    {
+                        auto image_info = GetObjectInfoTable().GetVkImageInfo(image_layout.first);
+                        if (image_info != nullptr)
+                        {
+                            image_info->current_layout = image_layout.second;
+                        }
+                    }
+
                     if (CheckCommandBufferInfoForFrameBoundary(command_buffer_info))
                     {
                         break;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2729,110 +2729,106 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
     }
 }
 
-bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
-    const VulkanCommandBufferInfo* command_buffer_info)
+void VulkanReplayConsumerBase::WriteFrameBoundaryImage(const VulkanImageInfo* image_info,
+                                                       const std::string&     filename_prefix,
+                                                       uint32_t               layer)
 {
-    GFXRECON_ASSERT(command_buffer_info != nullptr);
-    if (command_buffer_info->is_frame_boundary)
-    {
-        if (screenshot_handler_->IsScreenshotFrame())
-        {
-            VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(command_buffer_info->parent_id);
+    GFXRECON_ASSERT(image_info != nullptr);
 
-            VkPhysicalDeviceMemoryProperties memory_properties;
-            {
-                util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-                auto                             instance_table = GetInstanceTable(device_info->parent);
-                GFXRECON_ASSERT(instance_table != nullptr);
-
-                // TODO: This should be stored in the VulkanDeviceInfo structure to avoid the need for frequent
-                // queries.
-                instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
-            }
-
-            for (size_t i = 0; i < command_buffer_info->frame_buffer_ids.size(); ++i)
-            {
-                auto framebuffer_info =
-                    object_info_table_->GetVkFramebufferInfo(command_buffer_info->frame_buffer_ids[i]);
-
-                for (size_t j = 0; j < framebuffer_info->attachment_image_view_ids.size(); ++j)
-                {
-                    auto image_view_id   = framebuffer_info->attachment_image_view_ids[j];
-                    auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
-                    auto image_info      = object_info_table_->GetVkImageInfo(image_view_info->image_id);
-
-                    // Only screenshot images that are color attachments.
-                    if (!graphics::ImageHasUsage(image_info->usage, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT))
-                    {
-                        continue;
-                    }
-
-                    std::string filename_prefix = screenshot_file_prefix_;
-                    filename_prefix += "_frame_";
-                    filename_prefix += std::to_string(screenshot_handler_->GetCurrentFrame());
-
-                    if (command_buffer_info->frame_buffer_ids.size() > 0)
-                    {
-                        filename_prefix += "_renderpass_";
-                        filename_prefix += std::to_string(i);
-                    }
-
-                    if (framebuffer_info->attachment_image_view_ids.size() > 0)
-                    {
-                        filename_prefix += "_attachment_";
-                        filename_prefix += std::to_string(j);
-                    }
-
-                    // NOTE: optional scale takes precedence over explicit screenshot width/height
-                    auto screenshot_scale = options_.screenshot_scale;
-                    if (!screenshot_scale && options_.screenshot_width > 0 && options_.screenshot_height > 0)
-                    {
-                        screenshot_scale = { static_cast<float>(options_.screenshot_width) /
-                                                 static_cast<float>(image_info->extent.width),
-                                             static_cast<float>(options_.screenshot_height) /
-                                                 static_cast<float>(image_info->extent.height) };
-                    }
-
-                    screenshot_handler_->WriteImage(
-                        filename_prefix,
-                        device_info,
-                        GetInjectedDeviceCalls(device_info->handle),
-                        memory_properties,
-                        device_info->allocator.get(),
-                        image_info->handle,
-                        image_info->format,
-                        image_info->extent.width,
-                        image_info->extent.height,
-                        0,
-                        screenshot_scale,
-                        image_info->subresource_layouts.GetSubresourceLayout(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0),
-                        VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
-                }
-            }
-        }
-        screenshot_handler_->EndFrame();
-        return true;
-    }
-    return false;
-}
-
-bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDeviceInfo* device_info,
-                                                               const PNextNode*        pnext)
-{
-    const auto* frame_boundary = GetPNextMetaStruct<Decoded_VkFrameBoundaryEXT>(pnext);
-    if (frame_boundary == nullptr ||
-        ((frame_boundary->decoded_value->flags & VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT) == 0))
-    {
-        return false;
-    }
+    auto* device_info = object_info_table_->GetVkDeviceInfo(image_info->parent_id);
+    GFXRECON_ASSERT(device_info != nullptr);
 
     VkPhysicalDeviceMemoryProperties memory_properties;
     {
         util::MarkInjectedCommandsHelper mark_injected_commands_helper;
         auto                             instance_table = GetInstanceTable(device_info->parent);
         GFXRECON_ASSERT(instance_table != nullptr);
-
         instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+    }
+
+    // NOTE: optional scale takes precedence over explicit screenshot width/height
+    auto screenshot_scale = options_.screenshot_scale;
+    if (!screenshot_scale && options_.screenshot_width > 0 && options_.screenshot_height > 0)
+    {
+        screenshot_scale = {
+            static_cast<float>(options_.screenshot_width) / static_cast<float>(image_info->extent.width),
+            static_cast<float>(options_.screenshot_height) / static_cast<float>(image_info->extent.height)
+        };
+    }
+
+    screenshot_handler_->WriteImage(filename_prefix,
+                                    device_info,
+                                    GetInjectedDeviceCalls(device_info->handle),
+                                    memory_properties,
+                                    device_info->allocator.get(),
+                                    image_info->handle,
+                                    image_info->format,
+                                    image_info->extent.width,
+                                    image_info->extent.height,
+                                    layer,
+                                    screenshot_scale,
+                                    image_info->subresource_layouts.GetSubresourceLayout(VK_IMAGE_ASPECT_COLOR_BIT, 0, layer),
+                                    VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
+}
+
+bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
+    const VulkanCommandBufferInfo* command_buffer_info)
+{
+    GFXRECON_ASSERT(command_buffer_info != nullptr);
+    if (!command_buffer_info->is_frame_boundary)
+    {
+        return false;
+    }
+
+    if (screenshot_handler_->IsScreenshotFrame())
+    {
+        for (size_t i = 0; i < command_buffer_info->frame_buffer_ids.size(); ++i)
+        {
+            auto* framebuffer_info = object_info_table_->GetVkFramebufferInfo(command_buffer_info->frame_buffer_ids[i]);
+
+            for (size_t j = 0; j < framebuffer_info->attachment_image_view_ids.size(); ++j)
+            {
+                auto image_view_id   = framebuffer_info->attachment_image_view_ids[j];
+                auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
+                auto image_info      = object_info_table_->GetVkImageInfo(image_view_info->image_id);
+
+                // Only screenshot images that are color attachments.
+                if (!graphics::ImageHasUsage(image_info->usage, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT))
+                {
+                    continue;
+                }
+
+                std::string filename_prefix =
+                    screenshot_file_prefix_ + "_frame_" + std::to_string(screenshot_handler_->GetCurrentFrame());
+
+                if (!command_buffer_info->frame_buffer_ids.empty())
+                {
+                    filename_prefix += "_renderpass_" + std::to_string(i);
+                }
+
+                if (!framebuffer_info->attachment_image_view_ids.empty())
+                {
+                    filename_prefix += "_attachment_" + std::to_string(j);
+                }
+
+                WriteFrameBoundaryImage(image_info, filename_prefix, 0);
+            }
+        }
+    }
+    screenshot_handler_->EndFrame();
+    return true;
+}
+
+bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDeviceInfo* device_info,
+                                                               const PNextNode*        pnext)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(device_info);
+
+    const auto* frame_boundary = GetPNextMetaStruct<Decoded_VkFrameBoundaryEXT>(pnext);
+    if (frame_boundary == nullptr ||
+        ((frame_boundary->decoded_value->flags & VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT) == 0))
+    {
+        return false;
     }
 
     if (screenshot_handler_->IsScreenshotFrame())
@@ -2847,32 +2843,9 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDevic
                 filename_prefix += "_image_" + std::to_string(i);
             }
 
-            const format::HandleId handleId   = frame_boundary->pImages.GetPointer()[i];
-            const VulkanImageInfo* image_info = GetObjectInfoTable().GetVkImageInfo(handleId);
-
-            // NOTE: optional scale takes precedence over explicit screenshot width/height
-            auto screenshot_scale = options_.screenshot_scale;
-            if (!screenshot_scale && options_.screenshot_width > 0 && options_.screenshot_height > 0)
-            {
-                screenshot_scale = {
-                    static_cast<float>(options_.screenshot_width) / static_cast<float>(image_info->extent.width),
-                    static_cast<float>(options_.screenshot_height) / static_cast<float>(image_info->extent.height)
-                };
-            }
-
-            screenshot_handler_->WriteImage(
-                filename_prefix,
-                device_info,
-                GetInjectedDeviceCalls(device_info->handle),
-                memory_properties,
-                device_info->allocator.get(),
-                image_info->handle,
-                image_info->format,
-                image_info->extent.width,
-                image_info->extent.height,
-                0,
-                screenshot_scale,
-                image_info->subresource_layouts.GetSubresourceLayout(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0));
+            const format::HandleId handle_id  = frame_boundary->pImages.GetPointer()[i];
+            const VulkanImageInfo* image_info = GetObjectInfoTable().GetVkImageInfo(handle_id);
+            WriteFrameBoundaryImage(image_info, filename_prefix, 0);
         }
     }
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -2060,7 +2060,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     bool CheckCommandBufferInfoForFrameBoundary(const VulkanCommandBufferInfo* command_buffer_info);
     bool CheckPNextChainForFrameBoundary(const VulkanDeviceInfo* device_info, const PNextNode* pnext);
-    void WriteFrameBoundaryImage(const VulkanImageInfo* image_info, const std::string& filename_prefix, uint32_t layer);
+    void WriteFrameBoundaryImage(const VulkanImageInfo* image_info, const std::string& filename_prefix);
 
     void UpdateDescriptorSetInfoWithTemplate(VulkanDescriptorSetInfo*                  desc_set_info,
                                              const VulkanDescriptorUpdateTemplateInfo* template_info,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -2061,6 +2061,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     bool CheckCommandBufferInfoForFrameBoundary(const VulkanCommandBufferInfo* command_buffer_info);
     bool CheckPNextChainForFrameBoundary(const VulkanDeviceInfo* device_info, const PNextNode* pnext);
     void WriteFrameBoundaryImage(const VulkanImageInfo* image_info, const std::string& filename_prefix);
+    void PresentFrameBoundaryImage(const VulkanImageInfo* image_info);
 
     void UpdateDescriptorSetInfoWithTemplate(VulkanDescriptorSetInfo*                  desc_set_info,
                                              const VulkanDescriptorUpdateTemplateInfo* template_info,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -2060,6 +2060,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     bool CheckCommandBufferInfoForFrameBoundary(const VulkanCommandBufferInfo* command_buffer_info);
     bool CheckPNextChainForFrameBoundary(const VulkanDeviceInfo* device_info, const PNextNode* pnext);
+    void WriteFrameBoundaryImage(const VulkanImageInfo* image_info, const std::string& filename_prefix, uint32_t layer);
 
     void UpdateDescriptorSetInfoWithTemplate(VulkanDescriptorSetInfo*                  desc_set_info,
                                              const VulkanDescriptorUpdateTemplateInfo* template_info,

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -184,6 +184,7 @@ struct VulkanReplayOptions : public ReplayOptions
     SkipGetFenceStatus                  skip_get_fence_status{ SkipGetFenceStatus::NoSkip };
     std::vector<util::UintRange>        skip_get_fence_ranges;
     bool                                wait_before_present{ false };
+    bool                                present_frame_boundary{ false };
     VkFlags                             debug_message_severity{ VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
                                     VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT };
 

--- a/tools/replay/replay_vulkan_feature.cpp
+++ b/tools/replay/replay_vulkan_feature.cpp
@@ -86,6 +86,7 @@ const char kShaderReplaceArgument[]            = "--replace-shaders";
 const char kSwapchainOption[]                  = "--swapchain";
 const char kPresentModeOption[]                = "--present-mode";
 const char kPresentOverrideImageArgument[]     = "--present-override";
+const char kPresentFrameBoundaryArgument[]     = "--present-frame-boundary";
 const char kEnableUseCapturedSwapchainIndices[] =
     "--use-captured-swapchain-indices"; // The same: util::SwapchainOption::kCaptured
 const char kVirtualSwapchainSkipBlitShortOption[] = "--vssb";
@@ -349,6 +350,11 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
         replay_options.offscreen_swapchain_frame_boundary = true;
     }
 
+    if (arg_parser.IsOptionSet(kPresentFrameBoundaryArgument))
+    {
+        replay_options.present_frame_boundary = true;
+    }
+
     if (arg_parser.IsOptionSet(kVirtualSwapchainSkipBlitLongOption) ||
         arg_parser.IsOptionSet(kVirtualSwapchainSkipBlitShortOption))
     {
@@ -601,6 +607,14 @@ std::vector<util::FeatureOptionDesc> ReplayVulkanFeature::GetOptionDescs() const
                  "named one." },
                true,
                kPresentOverrideImageArgument },
+             { "",
+               { "Live-present an image whenever replay encounters VkFrameBoundaryEXT or a",
+                 "recognized command-buffer frame marker. An image selected with",
+                 "--present-override takes precedence; otherwise replay uses the first image",
+                 "declared by VkFrameBoundaryEXT. This requires the virtual swapchain. A",
+                 "multi-layer image is tiled into one window." },
+               false,
+               kPresentFrameBoundaryArgument },
              { "",
                { "Skip the blit to the real swapchain to increase replay performance." },
                false,


### PR DESCRIPTION
With certain VR games I ran into the issue of them only having frame boundaries, but not any presentation. So even `--present-override` did nothing since there is no presentation. Another issue I ran into is VR images having 2 layers, both of which are needed to be either screenshotted or presented.

This PR:
- Adds `--present-frame-boundary` to present frame-boundary images;
- Screenshots now dump all layers;