### PR TITLE
Fix for crash on Android Emulator

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2165,10 +2165,8 @@ void VulkanCaptureManager::ProcessHardwareBuffer(format::ThreadId thread_id,
     }
     else
     {
-        GFXRECON_LOG_ERROR("GetAndroidHardwareBufferPropertiesANDROID returned %s with allocationSize %" PRIu64
-                           ": hardware buffer data will be omitted from the capture file",
-                           util::ToString(vk_result).c_str(),
-                           static_cast<uint64_t>(properties.allocationSize));
+        GFXRECON_LOG_ERROR("GetAndroidHardwareBufferPropertiesANDROID failed: hardware buffer data will be omitted "
+                           "from the capture file");
     }
 #else
     GFXRECON_UNREFERENCED_PARAMETER(thread_id);

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2158,6 +2158,9 @@ void VulkanCaptureManager::ProcessHardwareBuffer(format::ThreadId thread_id,
     VkResult vk_result =
         device_table->GetAndroidHardwareBufferPropertiesANDROID(device_unwrapped, hardware_buffer, &properties);
 
+    // There was originally an assert on properties.allocationSize inside the if(). It was causing a crash
+    // when trying to trace on the Android emulator in some circumstances. The failure is a nomral operating error
+    // not a cause for a crash in debug mode.
     if (vk_result == VK_SUCCESS && properties.allocationSize > 0)
     {
         const size_t ahb_size = properties.allocationSize;

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2158,17 +2158,17 @@ void VulkanCaptureManager::ProcessHardwareBuffer(format::ThreadId thread_id,
     VkResult vk_result =
         device_table->GetAndroidHardwareBufferPropertiesANDROID(device_unwrapped, hardware_buffer, &properties);
 
-    if (vk_result == VK_SUCCESS)
+    if (vk_result == VK_SUCCESS && properties.allocationSize > 0)
     {
         const size_t ahb_size = properties.allocationSize;
-        assert(ahb_size);
-
         CommonProcessHardwareBuffer(thread_id, device_wrapper, memory_id, hardware_buffer, ahb_size, this, nullptr);
     }
     else
     {
-        GFXRECON_LOG_ERROR("GetAndroidHardwareBufferPropertiesANDROID failed: hardware buffer data will be omitted "
-                           "from the capture file");
+        GFXRECON_LOG_ERROR("GetAndroidHardwareBufferPropertiesANDROID returned %s with allocationSize %" PRIu64
+                           ": hardware buffer data will be omitted from the capture file",
+                           util::ToString(vk_result).c_str(),
+                           static_cast<uint64_t>(properties.allocationSize));
     }
 #else
     GFXRECON_UNREFERENCED_PARAMETER(thread_id);


### PR DESCRIPTION
Games on the Android emulator on macOS that use the JAVA UI instead of their own embedded GUI framework are crashing on launch when I attempt to capture them. This change vastly improves the number of games I'm able to capture (tested in use already).

Why: The emulator's Vulkan driver returns VK_SUCCESS from vkGetAndroidHardwareBufferPropertiesANDROID with allocationSize == 0 for HWUI's window AHardwareBuffers, and ProcessHardwareBuffer() turned that into a fatal assert(ahb_size), aborting the captured process. This change treats a zero allocation size the same as a failed properties query — log an error and omit that buffer's data from the capture — so capture continues instead of killing the app. It also protects release builds, which compile the assert out and would have passed size 0 into CommonProcessHardwareBuffer().