### PR TITLE
replay: Fix hole discovered in testing for features

### DIFF
--- a/tools/replay/replay_feature.h
+++ b/tools/replay/replay_feature.h
@@ -36,6 +36,7 @@ struct android_app;
 #include "graphics/frame_loop_info.h"
 #include "util/argument_parser.h"
 #include "util/feature_base.h"
+#include "util/logging.h"
 
 #include <memory>
 #include <stdexcept>
@@ -131,14 +132,29 @@ class ReplayFeature : public ReplayFeatureBase
     {
         file_processor_ = file_processor;
         application_    = application;
+
+        // Make the decoder here, and not in RegisterConsumerAndDecoder(). A feature can use the
+        // decoder between these two calls. The D3D12 two-pass tracking pass is one example. A
+        // decoder that is made late is a null pointer for all such code.
+        decoder_ = std::make_unique<DecoderT>();
     }
 
     void FinalizeConsumer() {}
 
-    void RegisterConsumerAndDecoder(graphics::FpsInfo*        fps_info,
-                                    std::unique_ptr<DecoderT> decoder = std::make_unique<DecoderT>())
+    // Adds the consumer to the decoder, then adds the decoder to the file processor.
+    // InitConsumer() already made a decoder of the default type. Supply decoder only to
+    // replace that decoder with a different type, as the Vulkan feature does for the
+    // isolate_render_passes option.
+    void RegisterConsumerAndDecoder(graphics::FpsInfo* fps_info, std::unique_ptr<DecoderT> decoder = nullptr)
     {
-        decoder_ = std::move(decoder);
+        if (decoder != nullptr)
+        {
+            decoder_ = std::move(decoder);
+        }
+
+        // InitConsumer() must run first. A feature that does not call it has no decoder.
+        GFXRECON_ASSERT(decoder_ != nullptr);
+
         replay_consumer_->SetFpsInfo(fps_info);
         decoder_->AddConsumer(replay_consumer_.get());
         file_processor_->AddDecoder(decoder_.get());


### PR DESCRIPTION
There were scenarios where the decoder could be null in the current design.  Fix that hole.