### PR TITLE
vulkan: Fix crash during async pipeline compilation and handle destruction

### DIFF
--- a/framework/decode/common_handle_mapping_util.h
+++ b/framework/decode/common_handle_mapping_util.h
@@ -83,15 +83,6 @@ static typename T::HandleType* MapHandleArray(HandlePointerDecoder<typename T::H
                 if (info != nullptr)
                 {
                     handles[i] = info->handle;
-
-                    if constexpr (has_handle_future_v<T>)
-                    {
-                        if (info->handle == VK_NULL_HANDLE && info->future.valid())
-                        {
-                            const auto& [result, async_handles] = info->future.get();
-                            handles[i]                          = async_handles[info->future_handle_index];
-                        }
-                    }
                 }
                 else
                 {

--- a/framework/decode/vulkan_object_info_table_base.h
+++ b/framework/decode/vulkan_object_info_table_base.h
@@ -27,6 +27,7 @@
 #include "decode/vulkan_object_info.h"
 #include "format/format.h"
 #include "util/defines.h"
+#include "util/logging.h"
 
 #include "vulkan/vulkan.h"
 
@@ -62,8 +63,21 @@ static inline void sync_handle(T* object)
     static_assert(has_handle_future_v<T>);
     if (object != nullptr && object->handle == VK_NULL_HANDLE && object->future.valid())
     {
-        const auto& [result, async_handles] = object->future.get();
-        object->handle                      = async_handles[object->future_handle_index];
+        try
+        {
+            const auto& [result, async_handles] = object->future.get();
+            GFXRECON_ASSERT(object->future_handle_index < async_handles.size());
+            object->handle = async_handles[object->future_handle_index];
+        }
+        catch (const std::exception& e)
+        {
+            // Catch std::exception to prevent worker-thread exceptions from escaping silently
+            // or causing undefined behavior during subsequent replay.
+            GFXRECON_LOG_FATAL("Future error while synchronizing handle: %s", e.what());
+        }
+
+        // Release shared state and prevent redundant future.get() synchronization on subsequent lookups.
+        object->future = {};
     }
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -8555,13 +8555,12 @@ VkResult VulkanReplayConsumerBase::OverrideSetDebugUtilsObjectNameEXT(
         size_t               info_size   = graphics::vulkan_struct_deep_copy(info, 1, nullptr);
         std::vector<uint8_t> info_copy(info_size);
         graphics::vulkan_struct_deep_copy(info, 1, info_copy.data());
-        auto& async_handle_asset         = async_tracked_handles_[pipeline_id];
-        async_handle_asset.post_build_fn = [this,
-                                            device = device_info->handle,
-                                            pipeline_id,
-                                            func,
-                                            info_copy = std::move(info_copy),
-                                            original_result]() mutable {
+        async_tracked_handles_[pipeline_id].post_build_fn = [this,
+                                                             device = device_info->handle,
+                                                             pipeline_id,
+                                                             func,
+                                                             info_copy = std::move(info_copy),
+                                                             original_result]() mutable {
             auto* info = reinterpret_cast<VkDebugUtilsObjectNameInfoEXT*>(info_copy.data());
 
             // correct referenced handle in info. this would sync, but task is already done
@@ -13596,70 +13595,69 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShadersEXT(
     return replay_result;
 }
 
+void VulkanReplayConsumerBase::DestroyAssociatedPipelineCache(const VulkanDeviceInfo* device_info, VkPipeline pipeline)
+{
+    if (pipeline == VK_NULL_HANDLE)
+    {
+        return;
+    }
+
+    auto itCorresp = pipeline_cache_correspondances_.find(pipeline);
+    if (itCorresp != pipeline_cache_correspondances_.end())
+    {
+        format::HandleId id = itCorresp->second;
+        pipeline_cache_correspondances_.erase(itCorresp);
+
+        // For batched pipeline creations or shared pipeline caches, multiple pipelines
+        // reference the same pipeline cache ID. Do not destroy the driver cache until the last pipeline is destroyed.
+        bool sameIdFound = false;
+        for (const auto& elt : pipeline_cache_correspondances_)
+        {
+            if (elt.second == id)
+            {
+                sameIdFound = true;
+                break;
+            }
+        }
+
+        // If this is the only remaining pipeline bound to the pipeline cache, save and destroy the pipeline cache
+        if (!sameIdFound)
+        {
+            auto itTracked = tracked_pipeline_caches_.find(id);
+            GFXRECON_ASSERT(itTracked != tracked_pipeline_caches_.end());
+            GFXRECON_ASSERT(itTracked->second.device_info != nullptr);
+            GFXRECON_ASSERT(itTracked->second.vk_cache != VK_NULL_HANDLE);
+
+            if (save_pipeline_caches_to_file)
+            {
+                SavePipelineCache(id, itTracked->second);
+            }
+            auto device_table = GetInjectedDeviceCalls(device_info->handle);
+            auto injected     = device_table.Open();
+            injected->DestroyPipelineCache(itTracked->second.device_info->handle, itTracked->second.vk_cache, nullptr);
+            tracked_pipeline_caches_.erase(itTracked);
+        }
+    }
+}
+
 void VulkanReplayConsumerBase::OverrideDestroyPipeline(
     PFN_vkDestroyPipeline                                      func,
     const VulkanDeviceInfo*                                    device_info,
     const VulkanPipelineInfo*                                  pipeline_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    GFXRECON_ASSERT(device_info != nullptr);
-    VkDevice                     in_device     = device_info->handle;
-    VkPipeline                   in_pipeline   = VK_NULL_HANDLE;
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
+    DestroyTrackedHandle(func, device_info, pipeline_info, pAllocator, [this, device_info](VkPipeline p) {
+        DestroyAssociatedPipelineCache(device_info, p);
+    });
+}
 
-    if (pipeline_info != nullptr)
-    {
-        in_pipeline =
-            MapHandle<VulkanPipelineInfo>(pipeline_info->capture_id, &VulkanObjectInfoTable::GetVkPipelineInfo);
-
-        if (IsUsedByAsyncTask(pipeline_info->capture_id))
-        {
-            // schedule deletion
-            DestroyAsyncHandle(pipeline_info->capture_id, [func, in_device, in_pipeline, in_pAllocator]() {
-                func(in_device, in_pipeline, in_pAllocator);
-            });
-            return;
-        }
-
-        // Check if the pipeline has been created with a specially created pipeline cache
-        auto itCorresp = pipeline_cache_correspondances_.find(pipeline_info->handle);
-        if (itCorresp != pipeline_cache_correspondances_.end())
-        {
-            format::HandleId id = itCorresp->second;
-            pipeline_cache_correspondances_.erase(itCorresp);
-
-            // Find if other pipelines have been created with the same pipeline cache
-            bool sameIdFound = false;
-            for (const auto& elt : pipeline_cache_correspondances_)
-            {
-                if (elt.second == id)
-                {
-                    sameIdFound = true;
-                    break;
-                }
-            }
-
-            // If this is the only remaining pipeline bound to the pipeline cache, save and destroy the pipeline cache
-            if (!sameIdFound)
-            {
-                auto itTracked = tracked_pipeline_caches_.find(id);
-                GFXRECON_ASSERT(itTracked != tracked_pipeline_caches_.end());
-                GFXRECON_ASSERT(itTracked->second.device_info != nullptr);
-                GFXRECON_ASSERT(itTracked->second.vk_cache != VK_NULL_HANDLE);
-
-                if (save_pipeline_caches_to_file)
-                {
-                    SavePipelineCache(id, itTracked->second);
-                }
-                auto device_table = GetInjectedDeviceCalls(device_info->handle);
-                auto injected     = device_table.Open();
-                injected->DestroyPipelineCache(
-                    itTracked->second.device_info->handle, itTracked->second.vk_cache, nullptr);
-                tracked_pipeline_caches_.erase(itTracked);
-            }
-        }
-    }
-    func(in_device, in_pipeline, in_pAllocator);
+void VulkanReplayConsumerBase::OverrideDestroyPipelineLayout(
+    PFN_vkDestroyPipelineLayout                                func,
+    const VulkanDeviceInfo*                                    device_info,
+    VulkanPipelineLayoutInfo*                                  pipeline_layout_info,
+    const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+{
+    DestroyTrackedHandle(func, device_info, pipeline_layout_info, pAllocator);
 }
 
 void VulkanReplayConsumerBase::OverrideDestroyRenderPass(
@@ -13668,24 +13666,7 @@ void VulkanReplayConsumerBase::OverrideDestroyRenderPass(
     VulkanRenderPassInfo*                                      renderpass_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice                     in_device     = device_info->handle;
-    VkRenderPass                 in_renderpass = VK_NULL_HANDLE;
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
-
-    if (renderpass_info != nullptr)
-    {
-        in_renderpass = renderpass_info->handle;
-
-        if (IsUsedByAsyncTask(renderpass_info->capture_id))
-        {
-            // schedule deletion
-            DestroyAsyncHandle(renderpass_info->capture_id, [func, in_device, in_renderpass, in_pAllocator]() {
-                func(in_device, in_renderpass, in_pAllocator);
-            });
-            return;
-        }
-    }
-    func(in_device, in_renderpass, in_pAllocator);
+    DestroyTrackedHandle(func, device_info, renderpass_info, pAllocator);
 }
 
 void VulkanReplayConsumerBase::OverrideDestroyShaderModule(
@@ -13694,24 +13675,7 @@ void VulkanReplayConsumerBase::OverrideDestroyShaderModule(
     VulkanShaderModuleInfo*                                    shader_module_info,
     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice                     in_device        = device_info->handle;
-    VkShaderModule               in_shader_module = VK_NULL_HANDLE;
-    const VkAllocationCallbacks* in_pAllocator    = GetAllocationCallbacks(pAllocator);
-
-    if (shader_module_info != nullptr)
-    {
-        in_shader_module = shader_module_info->handle;
-
-        if (IsUsedByAsyncTask(shader_module_info->capture_id))
-        {
-            // schedule deletion
-            DestroyAsyncHandle(shader_module_info->capture_id, [func, in_device, in_shader_module, in_pAllocator]() {
-                func(in_device, in_shader_module, in_pAllocator);
-            });
-            return;
-        }
-    }
-    func(in_device, in_shader_module, in_pAllocator);
+    DestroyTrackedHandle(func, device_info, shader_module_info, pAllocator);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideGetPastPresentationTimingGOOGLE(
@@ -13873,7 +13837,7 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
             MapHandle<VulkanPipelineInfo>(parent_id, &VulkanObjectInfoTable::GetVkPipelineInfo);
         };
     }
-    TrackAsyncHandles(handle_deps, sync_fn);
+    uint64_t async_task_id = TrackAsyncHandles(handle_deps, sync_fn);
 
     // define pipeline-creation task, assert object-lifetimes by copying/moving into closure
     auto task = [this,
@@ -13885,6 +13849,7 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
                  call_info,
                  in_pAllocator,
                  createInfoCount,
+                 async_task_id,
                  create_info_data = std::move(create_info_data),
                  handle_deps      = std::move(handle_deps),
                  pipeline_ids     = std::move(pipeline_ids)]() mutable -> handle_create_result_t<VkPipeline> {
@@ -13909,16 +13874,18 @@ std::function<decode::handle_create_result_t<VkPipeline>()> VulkanReplayConsumer
                                 pipeline_cache,
                                 cache_pipeline_id,
                                 replay_result,
-                                pipeline_handles = out_pipelines.data(),
-                                num_pipelines    = out_pipelines.size(),
-                                handle_deps      = std::move(handle_deps)] {
+                                pipeline_handles = out_pipelines,
+                                async_task_id,
+                                handle_deps = std::move(handle_deps)]() mutable {
             // asynchronous operation is done. clear tracked handles, call deferred deletes
-            ClearAsyncHandles(handle_deps);
+            ClearAsyncHandles(async_task_id, handle_deps);
 
             // if a pipeline cache was created, track it to know when to destroy it/save it to file
             if (cache_pipeline_id != format::kNullHandleId && replay_result == VK_SUCCESS)
             {
-                TrackNewPipelineCache(device_info, cache_pipeline_id, pipeline_cache, pipeline_handles, num_pipelines);
+                // Copy pipeline_handles: the result vector is freed once every info in the batch has synced its future.
+                TrackNewPipelineCache(
+                    device_info, cache_pipeline_id, pipeline_cache, pipeline_handles.data(), pipeline_handles.size());
             }
         });
         return { replay_result, std::move(out_pipelines) };
@@ -13997,7 +13964,7 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
             MapHandle<VulkanPipelineInfo>(parent_id, &VulkanObjectInfoTable::GetVkPipelineInfo);
         };
     }
-    TrackAsyncHandles(handle_deps, sync_fn);
+    uint64_t async_task_id = TrackAsyncHandles(handle_deps, sync_fn);
 
     // define pipeline-creation task, assert object-lifetimes by copying/moving into closure
     auto task = [this,
@@ -14009,6 +13976,7 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
                  call_info,
                  in_pAllocator,
                  createInfoCount,
+                 async_task_id,
                  create_info_data = std::move(create_info_data),
                  handle_deps      = std::move(handle_deps),
                  pipeline_ids     = std::move(pipeline_ids)]() mutable -> handle_create_result_t<VkPipeline> {
@@ -14026,16 +13994,18 @@ std::function<handle_create_result_t<VkPipeline>()> VulkanReplayConsumerBase::As
                                 pipeline_cache,
                                 cache_pipeline_id,
                                 replay_result,
-                                pipeline_handles = out_pipelines.data(),
-                                num_pipelines    = out_pipelines.size(),
-                                handle_deps      = std::move(handle_deps)] {
+                                pipeline_handles = out_pipelines,
+                                async_task_id,
+                                handle_deps = std::move(handle_deps)]() mutable {
             // asynchronous operation is done. clear tracked handles, call deferred deletes
-            ClearAsyncHandles(handle_deps);
+            ClearAsyncHandles(async_task_id, handle_deps);
 
             // if a pipeline cache was created, track it to know when to destroy it/save it to file
             if (cache_pipeline_id != format::kNullHandleId && replay_result == VK_SUCCESS)
             {
-                TrackNewPipelineCache(device_info, cache_pipeline_id, pipeline_cache, pipeline_handles, num_pipelines);
+                // Copy pipeline_handles: the result vector is freed once every info in the batch has synced its future.
+                TrackNewPipelineCache(
+                    device_info, cache_pipeline_id, pipeline_cache, pipeline_handles.data(), pipeline_handles.size());
             }
         });
         return { replay_result, std::move(out_pipelines) };
@@ -14074,7 +14044,7 @@ VulkanReplayConsumerBase::AsyncCreateShadersEXT(PFN_vkCreateShadersEXT          
             MapHandle<VulkanShaderEXTInfo>(parent_id, &VulkanObjectInfoTable::GetVkShaderEXTInfo);
         };
     }
-    TrackAsyncHandles(handle_deps, sync_fn);
+    uint64_t async_task_id = TrackAsyncHandles(handle_deps, sync_fn);
 
     // assemble array of info-structs
     std::vector<VulkanShaderEXTInfo*> shader_ext_infos(pShaders->GetLength());
@@ -14094,6 +14064,7 @@ VulkanReplayConsumerBase::AsyncCreateShadersEXT(PFN_vkCreateShadersEXT          
                  in_pAllocator,
                  use_address_replacement,
                  createInfoCount,
+                 async_task_id,
                  create_info_data = std::move(create_info_data),
                  handle_deps      = std::move(handle_deps),
                  shaders          = std::move(shaders),
@@ -14126,39 +14097,63 @@ VulkanReplayConsumerBase::AsyncCreateShadersEXT(PFN_vkCreateShadersEXT          
         }
 
         // schedule dependency-clear on main-thread
-        MainThreadQueue().post([this, handle_deps = std::move(handle_deps)] { ClearAsyncHandles(handle_deps); });
+        MainThreadQueue().post([this, async_task_id, handle_deps = std::move(handle_deps)] {
+            ClearAsyncHandles(async_task_id, handle_deps);
+        });
         return { replay_result, std::move(out_shaders) };
     };
     return task;
 }
 
-void VulkanReplayConsumerBase::TrackAsyncHandles(const std::unordered_set<format::HandleId>& async_handles,
-                                                 const std::function<void()>&                sync_fn)
+bool VulkanReplayConsumerBase::IsUsedByAsyncTask(format::HandleId handle) const
 {
-    for (const auto& handle : async_handles)
-    {
-        // check to avoid overwriting existing handle-destructors
-        if (async_tracked_handles_.count(handle) == 0)
-        {
-            async_tracked_handles_[handle] = { sync_fn, {} };
-        }
-    }
+    auto it = async_tracked_handles_.find(handle);
+    return it != async_tracked_handles_.end() && !it->second.async_task_ids.empty();
 }
 
-void VulkanReplayConsumerBase::ClearAsyncHandles(const std::unordered_set<format::HandleId>& async_handles)
+uint64_t VulkanReplayConsumerBase::TrackAsyncHandles(const std::unordered_set<format::HandleId>& async_handles,
+                                                     const std::function<void()>&                sync_fn)
 {
+    uint64_t async_task_id = next_async_task_id_++;
+    if (sync_fn)
+    {
+        async_task_sync_fns_[async_task_id] = sync_fn;
+    }
+
     for (const auto& handle : async_handles)
     {
+        if (handle != format::kNullHandleId)
+        {
+            async_tracked_handles_[handle].async_task_ids.insert(async_task_id);
+        }
+    }
+    return async_task_id;
+}
+
+void VulkanReplayConsumerBase::ClearAsyncHandles(uint64_t                                    async_task_id,
+                                                 const std::unordered_set<format::HandleId>& async_handles)
+{
+    async_task_sync_fns_.erase(async_task_id);
+
+    for (const auto& handle : async_handles)
+    {
+        if (handle == format::kNullHandleId)
+        {
+            continue;
+        }
+
         auto it = async_tracked_handles_.find(handle);
         if (it != async_tracked_handles_.end())
         {
-            const auto& [tracked_handle, handle_asset] = *it;
-
-            if (handle_asset.post_build_fn)
+            it->second.async_task_ids.erase(async_task_id);
+            if (it->second.async_task_ids.empty())
             {
-                handle_asset.post_build_fn();
+                if (it->second.post_build_fn)
+                {
+                    it->second.post_build_fn();
+                }
+                async_tracked_handles_.erase(it);
             }
-            async_tracked_handles_.erase(it);
         }
     }
 }
@@ -14169,29 +14164,69 @@ void VulkanReplayConsumerBase::DestroyAsyncHandle(format::HandleId handle, std::
 
     if (it != async_tracked_handles_.end())
     {
-        async_tracked_handle_asset_t& handle_asset = it->second;
-
-        if constexpr (async_defer_deletion_)
+        // Snapshot the set of active async task IDs referencing this handle
+        auto task_ids = it->second.async_task_ids;
+        for (uint64_t tid : task_ids)
         {
-            handle_asset.post_build_fn = std::move(destroy_fn);
+            auto sync_it = async_task_sync_fns_.find(tid);
+            if (sync_it != async_task_sync_fns_.end() && sync_it->second)
+            {
+                sync_it->second();
+            }
         }
-        else
+
+        // Synchronizing tasks above signals completion, but post-creation tasks (TrackNewPipelineCache,
+        // ClearAsyncHandles) were dispatched to MainThreadQueue(). Draining the queue guarantees that
+        // pipeline-to-cache correspondences are registered before destroy_fn() executes.
+        main_thread_queue_.poll();
+
+        // Every synced task has drained and erased its IDs by now.
+        GFXRECON_ASSERT(async_tracked_handles_.find(handle) == async_tracked_handles_.end());
+
+        if (destroy_fn)
         {
-            if (handle_asset.sync_fn)
-            {
-                handle_asset.sync_fn();
-            }
-            if (handle_asset.post_build_fn)
-            {
-                handle_asset.post_build_fn();
-            }
-            if (destroy_fn)
-            {
-                destroy_fn();
-            }
-            async_tracked_handles_.erase(it);
+            destroy_fn();
         }
     }
+}
+
+template <typename InfoType, typename DestroyFunc, typename PreDestroyHook>
+void VulkanReplayConsumerBase::DestroyTrackedHandle(
+    DestroyFunc                                                func,
+    const VulkanDeviceInfo*                                    device_info,
+    const InfoType*                                            object_info,
+    const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+    PreDestroyHook                                             pre_destroy_hook)
+{
+    GFXRECON_ASSERT(device_info != nullptr);
+    VkDevice                      in_device     = device_info->handle;
+    typename InfoType::HandleType in_handle     = VK_NULL_HANDLE;
+    const VkAllocationCallbacks*  in_pAllocator = GetAllocationCallbacks(pAllocator);
+
+    if (object_info != nullptr)
+    {
+        in_handle = object_info->handle;
+
+        if (IsUsedByAsyncTask(object_info->capture_id))
+        {
+            auto capture_id = object_info->capture_id;
+            DestroyAsyncHandle(capture_id, [func, in_device, in_handle, in_pAllocator, pre_destroy_hook]() {
+                if constexpr (!std::is_same_v<PreDestroyHook, std::nullptr_t>)
+                {
+                    pre_destroy_hook(in_handle);
+                }
+                func(in_device, in_handle, in_pAllocator);
+            });
+            return;
+        }
+
+        if constexpr (!std::is_same_v<PreDestroyHook, std::nullptr_t>)
+        {
+            pre_destroy_hook(in_handle);
+        }
+    }
+
+    func(in_device, in_handle, in_pAllocator);
 }
 
 void VulkanReplayConsumerBase::SetCurrentBlockIndex(uint64_t block_index)

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -453,18 +453,19 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     }
 
     //! track arbitrary handles that are currently used by asynchronous operations
-    void TrackAsyncHandles(const std::unordered_set<format::HandleId>& async_handles,
-                           const std::function<void()>&                sync_fn);
+    uint64_t TrackAsyncHandles(const std::unordered_set<format::HandleId>& async_handles,
+                               const std::function<void()>&                sync_fn);
 
-    //! clear handles that are currently used by asynchronous operations,
-    //! invoke stored deletion-functions
-    void ClearAsyncHandles(const std::unordered_set<format::HandleId>& async_handles);
+    //! Clear handle references for the given async task, and invoke deferred post-build
+    //! callbacks once all referencing tasks have finished.
+    void ClearAsyncHandles(uint64_t async_task_id, const std::unordered_set<format::HandleId>& async_handles);
 
     //! schedules deletion of already tracked handles
+    //! synchronizes all active async tasks referencing the handle and invokes the destroy function
     void DestroyAsyncHandle(format::HandleId handle, std::function<void()> destroy_fn);
 
     //! return true if this handle is currently being tracked (was passed to 'TrackAsyncHandles' earlier)
-    bool IsUsedByAsyncTask(uint64_t handle) const { return async_tracked_handles_.count(handle) > 0; }
+    bool IsUsedByAsyncTask(format::HandleId handle) const;
 
     //! returns true if asynchronous operations should be used at all
     bool UseAsyncOperations() { return options_.num_pipeline_creation_jobs != 0; }
@@ -1656,6 +1657,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                  const VulkanPipelineInfo*                                  pipeline_info,
                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
+    void OverrideDestroyPipelineLayout(PFN_vkDestroyPipelineLayout                                func,
+                                       const VulkanDeviceInfo*                                    device_info,
+                                       VulkanPipelineLayoutInfo*                                  pipeline_layout_info,
+                                       const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
+
     void OverrideDestroyRenderPass(PFN_vkDestroyRenderPass                                    func,
                                    const VulkanDeviceInfo*                                    device_info,
                                    VulkanRenderPassInfo*                                      renderpass_info,
@@ -2189,6 +2195,33 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     template <typename CreateInfo>
     static void RemoveFailOnCompileRequiredFlags(CreateInfo* create_infos, uint32_t create_info_count);
 
+    /**
+     * @brief   DestroyTrackedHandle handles synchronous or deferred destruction of Vulkan handles
+     *          (e.g., VkPipeline, VkPipelineLayout, VkRenderPass, VkShaderModule) tracked across replay.
+     *
+     * If the handle is referenced by active asynchronous tasks (e.g. concurrent pipeline compilation),
+     * destruction is deferred via DestroyAsyncHandle until all referencing tasks complete. Otherwise,
+     * it is destroyed immediately.
+     *
+     * An optional PreDestroyHook can be provided to execute cleanup (such as destroying associated pipeline caches)
+     * immediately before driver destruction.
+     *
+     * @tparam  InfoType            Object info wrapper struct (e.g., VulkanPipelineInfo)
+     * @tparam  DestroyFunc         Vulkan API destroy function pointer type
+     * @tparam  PreDestroyHook      Optional callable invoked with the resolved handle prior to driver destruction
+     * @param   func                Vulkan API destroy function (e.g., vkDestroyPipeline)
+     * @param   device_info         VulkanDeviceInfo struct for the owning logical device
+     * @param   object_info         Object info struct containing the handle and capture ID
+     * @param   pAllocator          Optional Vulkan allocation callbacks
+     * @param   pre_destroy_hook    Optional callback invoked before calling func
+     */
+    template <typename InfoType, typename DestroyFunc, typename PreDestroyHook = std::nullptr_t>
+    void DestroyTrackedHandle(DestroyFunc                                                func,
+                              const VulkanDeviceInfo*                                    device_info,
+                              const InfoType*                                            object_info,
+                              const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                              PreDestroyHook                                             pre_destroy_hook = nullptr);
+
   private:
     util::platform::LibraryHandle                                            loader_handle_;
     PFN_vkGetInstanceProcAddr                                                get_instance_proc_addr_;
@@ -2220,20 +2253,26 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     util::ThreadPool main_thread_queue_;
     util::ThreadPool background_queue_;
 
-    //! async_tracked_handle_asset_t groups assets used by tracked async-dependencies
-    struct async_tracked_handle_asset_t
-    {
-        //! function to synchronize (blocking wait) with parent asynchronous-task
-        std::function<void()> sync_fn;
+    //! Asynchronous task and handle tracking:
+    //! Multiple background compilation tasks can concurrently reference shared handles
+    //! (e.g. VkPipelineLayout, VkRenderPass, VkShaderModule). Handles track the set of
+    //! active async task IDs referencing them to maintain reference counts and allow
+    //! synchronizing all referencing tasks prior to handle destruction.
+    uint64_t                                            next_async_task_id_{ 1 };
+    std::unordered_map<uint64_t, std::function<void()>> async_task_sync_fns_;
 
-        //! function used to defer deletion of a tracked async-dependency
+    //! Tracks active asynchronous tasks and deferred operations for a Vulkan handle
+    struct AsyncTrackedHandle
+    {
+        //! Active async task IDs referencing this handle
+        std::unordered_set<uint64_t> async_task_ids;
+
+        //! Deferred action invoked on the main thread after all referencing async tasks complete
         std::function<void()> post_build_fn;
     };
-    //! stores handles used/referenced by currently running async tasks
-    std::unordered_map<format::HandleId, async_tracked_handle_asset_t> async_tracked_handles_;
 
-    //! decide whether to sync/wait or defer deletion of handles used by currently running async tasks
-    static constexpr bool async_defer_deletion_ = false;
+    //! Maps a tracked handle ID to its active referencing async tasks and optional post-build callback.
+    std::unordered_map<format::HandleId, AsyncTrackedHandle> async_tracked_handles_;
 
     // Imported semaphores are semaphores that are used to track external memory.
     // During replay, the external memory is not present (we have no Fds or handles to valid
@@ -2308,6 +2347,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                           VkPipelineCache         pipelineCache,
                                           VkPipeline*             pipelines,
                                           size_t                  pipelineCount);
+    void            DestroyAssociatedPipelineCache(const VulkanDeviceInfo* device_info, VkPipeline pipeline);
 
     const bool save_pipeline_caches_to_file;
     const bool load_pipeline_caches_from_file;

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -1230,11 +1230,10 @@ void VulkanReplayConsumer::Process_vkDestroyPipelineLayout(
     const ApiCallInfo&                          call_info,
     args::DestroyPipelineLayout&                args)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(args.device, &CommonObjectInfoTable::GetVkDeviceInfo);
-    VkPipelineLayout in_pipelineLayout = MapHandle<VulkanPipelineLayoutInfo>(args.pipelineLayout, &CommonObjectInfoTable::GetVkPipelineLayoutInfo);
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(&args.pAllocator);
+    auto in_device = GetObjectInfoTable().GetVkDeviceInfo(args.device);
+    auto in_pipelineLayout = GetObjectInfoTable().GetVkPipelineLayoutInfo(args.pipelineLayout);
 
-    GetDeviceTable(in_device)->DestroyPipelineLayout(in_device, in_pipelineLayout, in_pAllocator);
+    OverrideDestroyPipelineLayout(GetDeviceTable(in_device->handle)->DestroyPipelineLayout, in_device, in_pipelineLayout, &args.pAllocator);
     RemoveHandle(args.pipelineLayout, &CommonObjectInfoTable::RemoveVkPipelineLayoutInfo);
 }
 

--- a/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
@@ -156,6 +156,7 @@
     "vkCreateComputePipelines": "OverrideCreateComputePipelines",
     "vkDestroyShaderModule": "OverrideDestroyShaderModule",
     "vkDestroyPipeline": "OverrideDestroyPipeline",
+    "vkDestroyPipelineLayout": "OverrideDestroyPipelineLayout",
     "vkDestroyRenderPass": "OverrideDestroyRenderPass",
     "vkCreateVideoSessionKHR": "OverrideCreateVideoSessionKHR",
     "vkDestroyVideoSessionKHR": "OverrideDestroyVideoSessionKHR",


### PR DESCRIPTION
When replaying traces with parallel pipeline creation enabled (`--pipeline-creation-jobs` / `--pcj`), background worker threads compile pipelines asynchronously. Several edge cases in async handle tracking, handle destruction, and pipeline cache lifecycle caused driver crashes and race conditions.

### Key issues and fixes:

1. **Reference-counted handle tracking across concurrent tasks:**
   Multiple async pipeline creation tasks frequently share common dependencies (`VkPipelineLayout`, `VkRenderPass`, `VkShaderModule`). Previously, dependencies were tracked globally without task reference counting. When the first task finished, it cleared the handle, allowing premature destruction and use-after-free in subsequent tasks still compiling on background threads (e.g. `SIGSEGV` in `SPIR_Parser::parse`).
   - **Fix**: Track dependencies by async task ID sets and deferred callbacks in `struct AsyncTrackedHandle` (`async_tracked_handles_`) and per-task sync callbacks in `async_task_sync_fns_`. A handle is only cleared when all referencing tasks have finished. In `DestroyAsyncHandle`, all referencing tasks are synchronized before destroying the handle.

2. **Handle destruction lifecycle and consolidation:**
   Consolidate handle destruction across `VkPipeline`, `VkPipelineLayout`, `VkRenderPass`, and `VkShaderModule` via `DestroyTrackedHandle`. Defer destruction when handles are tracked by active async tasks via `DestroyAsyncHandle`.

3. **Intercept `VkPipelineLayout` destruction:**
   During async pipeline compilation, the main thread previously destroyed `VkPipelineLayout` handles immediately via `vkDestroyPipelineLayout` because GFXReconstruct lacked an override, crashing background compilation threads accessing the layout.
   - **Fix**: Add `OverrideDestroyPipelineLayout` to `replay_overrides.json` and defer layout destruction via `DestroyTrackedHandle` until referencing async tasks complete.

4. **Shared pipeline cache lifecycle and dispatch ordering:**
   In batched creations or shared caches, multiple pipelines reference the same pipeline cache ID. `OverrideDestroyPipeline` previously destroyed the cache on the first pipeline destruction, leading to assertion failures (`tracked_pipeline_caches_`) or missed cache saves. Additionally, capturing `out_pipelines.data()` by raw pointer into the `MainThreadQueue` completion callback caused dangling pointers because the result vector in the future's shared state is freed once all handles in the batch have synced their futures (`object->future = {}`).
   - **Fix**: Extract `DestroyAssociatedPipelineCache` and track remaining correspondences (`sameIdFound`) so `vkDestroyPipelineCache` and `SavePipelineCache` execute only after the last pipeline is destroyed. Capture `pipeline_handles` by value into completion closures. In `DestroyAsyncHandle`, drain `main_thread_queue_.poll()` after worker synchronization so cache registrations dispatch before destruction, and assert all referencing tasks have erased their IDs.

5. **Exception handling and future synchronization invariants:**
   In `sync_handle`, unhandled worker thread exceptions could escape during handle synchronization.
   - **Fix**: Enforce the `object->future_handle_index < async_handles.size()` invariant via `GFXRECON_ASSERT`, catch `const std::exception&` with `GFXRECON_LOG_FATAL` to fail fast with diagnostic information, and clear `object->future = {}` upon resolution to release the future's shared state and prevent redundant synchronization.