### PR TITLE
Json output for screenshots

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -143,6 +143,9 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/screenshot_handler.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/screenshot_handler_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/screenshot_handler_base.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/screenshot_json.h
+                    ${CMAKE_CURRENT_LIST_DIR}/screenshot_json.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/screenshot_result.h
                     ${CMAKE_CURRENT_LIST_DIR}/string_array_decoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/string_decoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/struct_pointer_decoder.h
@@ -468,6 +471,7 @@ target_link_libraries(gfxrecon_decode
                         gfxrecon_graphics
                         gfxrecon_format
                         gfxrecon_util
+                        project_version
                         $<$<BOOL:${ANDROID}>:gfxrecon_replay_event_plugin_loader>
                         vulkan_registry
                         vulkan_memory_allocator

--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -20,17 +20,21 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
+#include "decode/decoder_util.h"
 #include "decode/screenshot_handler.h"
+#include "decode/vulkan_temporary_objects.h"
+#include "decode/window.h"
 #include "util/image_writer.h"
 #include "util/logging.h"
 #include "util/platform.h"
 #include "graphics/vulkan_resources_util.h"
-#include "decode/decoder_util.h"
 #include "generated/generated_vulkan_enum_to_string.h"
+#include "generated/generated_vulkan_struct_decoders.h"
 
 #include <limits>
 #include <algorithm>
 #include <memory>
+#include <vulkan/vulkan_core.h>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -41,49 +45,80 @@ static constexpr uint32_t kDefaultQueueIndex       = 0;
 static constexpr size_t kUnormIndex = 0;
 static constexpr size_t kSrgbIndex  = 1;
 
-inline void WriteImageFile(
-    const std::string& filename, util::ScreenshotFormat file_format, uint32_t width, uint32_t height, void* data)
+static bool WriteImageFile(const std::string&     filename_prefix,
+                           util::ScreenshotFormat file_format,
+                           uint32_t               width,
+                           uint32_t               height,
+                           const void*            data,
+                           ScreenshotWriteResult& result)
 {
+    std::string filename;
+    bool        written = false;
+
     switch (file_format)
     {
         default:
             GFXRECON_LOG_ERROR("Screenshot format invalid!  Expected BMP or PNG, falling back to BMP.");
+            result.messages.push_back({ screenshot_reason::kFormatFallback,
+                                        "Screenshot format invalid!  Expected BMP or PNG, falling back to BMP." });
             // Intentional fall-through
         case util::ScreenshotFormat::kBmp:
-            if (!util::imagewriter::WriteBmpImage(filename + ".bmp", width, height, data))
+            filename = filename_prefix + ".bmp";
+            written  = util::imagewriter::WriteBmpImage(filename, width, height, data);
+            if (!written)
             {
                 GFXRECON_LOG_ERROR("Screenshot could not be created: failed to write BMP file %s", filename.c_str());
             }
             break;
 #ifdef GFXRECON_ENABLE_PNG_SCREENSHOT
         case util::ScreenshotFormat::kPng:
-            if (!util::imagewriter::WritePngImage(filename + ".png", width, height, data))
+            filename = filename_prefix + ".png";
+            written  = util::imagewriter::WritePngImage(filename, width, height, data);
+            if (!written)
             {
                 GFXRECON_LOG_ERROR("Screenshot could not be created: failed to write PNG file %s", filename.c_str());
             }
             break;
 #endif // GFXRECON_ENABLE_PNG_SCREENSHOT
     }
+
+    if (written)
+    {
+        result.status = ScreenshotStatus::kWritten;
+        result.file   = filename;
+        result.width  = width;
+        result.height = height;
+    }
+    else
+    {
+        result.status      = ScreenshotStatus::kFailed;
+        result.reason_code = screenshot_reason::kFileWriteFailed;
+        result.message     = "Screenshot could not be created: failed to write file " + filename;
+        result.file.clear();
+    }
+
+    return written;
 }
 
-void ScreenshotHandler::WriteImage(const std::string&                         filename_prefix,
-                                   const VulkanDeviceInfo*                    device_info,
-                                   const graphics::VulkanInjectedDeviceCalls& injected_calls,
-                                   const VkPhysicalDeviceMemoryProperties&    memory_properties,
-                                   VulkanResourceAllocator*                   allocator,
-                                   VkImage                                    image,
-                                   VkFormat                                   format,
-                                   uint32_t                                   width,
-                                   uint32_t                                   height,
-                                   uint32_t                                   layer,
-                                   const std::optional<std::array<float, 2>>& copy_scale,
-                                   VkImageLayout                              image_layout,
-                                   VkSurfaceTransformFlagBitsKHR              pre_transform)
+ScreenshotWriteResult ScreenshotHandler::WriteImage(const std::string&                         filename_prefix,
+                                                    const VulkanDeviceInfo*                    device_info,
+                                                    const graphics::VulkanInjectedDeviceCalls& injected_calls,
+                                                    const VkPhysicalDeviceMemoryProperties&    memory_properties,
+                                                    VulkanResourceAllocator*                   allocator,
+                                                    VkImage                                    image,
+                                                    VkFormat                                   format,
+                                                    uint32_t                                   width,
+                                                    uint32_t                                   height,
+                                                    uint32_t                                   layer,
+                                                    const std::optional<std::array<float, 2>>& copy_scale,
+                                                    VkImageLayout                              image_layout,
+                                                    VkSurfaceTransformFlagBitsKHR              pre_transform)
 {
     if (!injected_calls.IsValid() || allocator == nullptr)
     {
         GFXRECON_LOG_ERROR("Screenshot could not be created: missing device table or allocator");
-        return;
+        return ScreenshotWriteResult::Failed(screenshot_reason::kMissingDeviceTable,
+                                             "Screenshot could not be created: missing device table or allocator");
     }
 
     // The screenshot copy below is made by replay and is not in the capture file.
@@ -96,7 +131,9 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
                              filename_prefix.c_str(),
                              width,
                              height);
-        return;
+        return ScreenshotWriteResult::Skipped(screenshot_reason::kZeroSizeImage,
+                                              "Cannot create screenshot for 0 size image (width=" +
+                                                  std::to_string(width) + ", height=" + std::to_string(height) + ")");
     }
 
     // derive output-size and orientation from provided scale
@@ -114,6 +151,19 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
         flip_y      = copy_scale.value()[1] < 0.f;
     }
 
+    if (copy_width == 0 || copy_height == 0)
+    {
+        GFXRECON_LOG_WARNING("Screenshot scaling reduced dimensions to zero (width=%" PRIu32 ", height=%" PRIu32 ").",
+                             copy_width,
+                             copy_height);
+
+        return ScreenshotWriteResult::Skipped(
+            screenshot_reason::kZeroSizeImage,
+            "Screenshot scaling reduced dimensions to zero (width=" + std::to_string(copy_width) +
+                ", height=" + std::to_string(copy_height) + ")");
+    }
+
+    ScreenshotWriteResult write_result;
     VkResult result = VK_SUCCESS;
     auto     device = device_info->handle;
     // TODO: Improved queue selection; ensure queue supports transfer operations.
@@ -141,387 +191,404 @@ void ScreenshotHandler::WriteImage(const std::string&                         fi
         }
         else
         {
-            GFXRECON_LOG_ERROR("Screenshot could not be created: failed to create a command pool")
+            GFXRECON_LOG_ERROR("Screenshot could not be created: failed to create a command pool");
+            return ScreenshotWriteResult::Failed(screenshot_reason::kCommandPoolCreateFailed,
+                                                 "Screenshot could not be created: failed to create a command pool",
+                                                 result);
         }
     }
+
+    auto& copy_resource = copy_resource_entry->second;
+    auto  copy_format   = GetConversionFormat(format);
+
+    // Get a queue.
+    VkQueue queue = GetDeviceQueue(injected.GetTable(), device_info, kDefaultQueueFamilyIndex, kDefaultQueueIndex);
+    if (queue == VK_NULL_HANDLE)
+    {
+        return ScreenshotWriteResult::Failed(screenshot_reason::kCommandBufferAllocateFailed,
+                                             "Screenshot could not be created: failed detect a suitable queue",
+                                             result);
+    }
+
+    // Get a buffer size.
+    VkDeviceSize buffer_size     = copy_resource.buffer_size;
+    bool         create_resource = false;
+
+    // If the copy resource is not initialized, or the image properties have changed, recompute the copy size.
+    if (buffer_size == 0 || copy_resource.width != copy_width || copy_resource.height != copy_height ||
+        copy_resource.format != copy_format || copy_resource.flip_x != flip_x || copy_resource.flip_y != flip_y)
+    {
+        buffer_size     = GetCopyBufferSize(device, injected, copy_format, copy_width, copy_height);
+        create_resource = true;
+    }
+
+    if (create_resource)
+    {
+        if (buffer_size == 0)
+        {
+            // GetCopyBufferSize failed to determine a valid size.
+            return ScreenshotWriteResult::Failed(screenshot_reason::kUnsupportedFormat,
+                                                 "Screenshot could not be created: failed to determine transfer "
+                                                 "buffer size for format " +
+                                                     util::ToString(copy_format));
+        }
+
+        // Need to create/recreate resource.
+        DestroyCopyResource(device, &copy_resource);
+
+        result = CreateCopyResource(device,
+                                    injected,
+                                    memory_properties,
+                                    buffer_size,
+                                    format,
+                                    copy_format,
+                                    width,
+                                    height,
+                                    copy_width,
+                                    copy_height,
+                                    flip_x,
+                                    flip_y,
+                                    &copy_resource);
+    }
+
+    if (result != VK_SUCCESS)
+    {
+        GFXRECON_LOG_ERROR("Screenshot could not be created: failed to create a transfer resource");
+        return ScreenshotWriteResult::Failed(screenshot_reason::kTransferResourceCreateFailed,
+                                             "Screenshot could not be created: failed to create a transfer resource",
+                                             result);
+    }
+
+    // Get a command buffer.
+    VkCommandBuffer command_buffer = VK_NULL_HANDLE;
+
+    VkCommandBufferAllocateInfo allocate_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
+    allocate_info.pNext                       = nullptr;
+    allocate_info.commandPool                 = copy_resource.command_pool;
+    allocate_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    allocate_info.commandBufferCount          = 1;
+
+    result = injected->AllocateCommandBuffers(device, &allocate_info, &command_buffer);
+    if (result == VK_SUCCESS)
+    {
+        VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
+        begin_info.pNext                    = nullptr;
+        begin_info.flags                    = 0;
+        begin_info.pInheritanceInfo         = nullptr;
+
+        result = injected.BeginCommandBuffer(command_buffer, &begin_info, __func__);
+    }
+
+    if (result != VK_SUCCESS)
+    {
+        GFXRECON_LOG_ERROR("Screenshot could not be created: failed to allocate or begin a command buffer");
+        if (command_buffer != VK_NULL_HANDLE)
+        {
+            injected->FreeCommandBuffers(device, copy_resource.command_pool, 1, &command_buffer);
+        }
+
+        return ScreenshotWriteResult::Failed(
+            screenshot_reason::kCommandBufferAllocateFailed,
+            "Screenshot could not be created: failed to allocate or begin a command buffer",
+            result);
+    }
+
+    auto image_aspect_mask = graphics::GetFormatAspects(format);
+
+    // Transition source image from image_layout to the TRANSFER_SRC layout.
+    VkImageMemoryBarrier src_image_barrier            = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+    src_image_barrier.pNext                           = nullptr;
+    src_image_barrier.srcAccessMask                   = 0;
+    src_image_barrier.dstAccessMask                   = VK_ACCESS_TRANSFER_READ_BIT;
+    src_image_barrier.oldLayout                       = image_layout;
+    src_image_barrier.newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    src_image_barrier.srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+    src_image_barrier.dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+    src_image_barrier.image                           = image;
+    src_image_barrier.subresourceRange.aspectMask     = image_aspect_mask;
+    src_image_barrier.subresourceRange.baseArrayLayer = layer;
+    src_image_barrier.subresourceRange.layerCount     = 1;
+    src_image_barrier.subresourceRange.baseMipLevel   = 0;
+    src_image_barrier.subresourceRange.levelCount     = 1;
+
+    injected->CmdPipelineBarrier(command_buffer,
+                                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                 0,
+                                 0,
+                                 nullptr,
+                                 0,
+                                 nullptr,
+                                 1,
+                                 &src_image_barrier);
+
+    // The 'copy_image' is the image to be used with the image to buffer copy.
+    VkImage copy_image             = image;
+    auto    copy_image_aspect_mask = graphics::GetFormatAspects(copy_format);
+
+    if (copy_resource.convert_image != VK_NULL_HANDLE)
+    {
+        // Need to perform a blit to covert the Vulkan image format to the image file format.
+        copy_image = copy_resource.convert_image;
+
+        // Transition blit target to the TRANSFER_DST layout.
+        VkImageMemoryBarrier convert_image_barrier            = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+        convert_image_barrier.pNext                           = nullptr;
+        convert_image_barrier.srcAccessMask                   = 0;
+        convert_image_barrier.dstAccessMask                   = VK_ACCESS_TRANSFER_WRITE_BIT;
+        convert_image_barrier.oldLayout                       = VK_IMAGE_LAYOUT_UNDEFINED;
+        convert_image_barrier.newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        convert_image_barrier.srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+        convert_image_barrier.dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+        convert_image_barrier.image                           = copy_image;
+        convert_image_barrier.subresourceRange.aspectMask     = copy_image_aspect_mask;
+        convert_image_barrier.subresourceRange.baseArrayLayer = 0;
+        convert_image_barrier.subresourceRange.layerCount     = 1;
+        convert_image_barrier.subresourceRange.baseMipLevel   = 0;
+        convert_image_barrier.subresourceRange.levelCount     = 1;
+
+        injected->CmdPipelineBarrier(command_buffer,
+                                     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     0,
+                                     0,
+                                     nullptr,
+                                     0,
+                                     nullptr,
+                                     1,
+                                     &convert_image_barrier);
+
+        VkImageBlit blit_region;
+        blit_region.srcSubresource.aspectMask     = image_aspect_mask;
+        blit_region.srcSubresource.mipLevel       = 0;
+        blit_region.srcSubresource.baseArrayLayer = layer;
+        blit_region.srcSubresource.layerCount     = 1;
+        blit_region.srcOffsets[0].x               = 0;
+        blit_region.srcOffsets[0].y               = 0;
+        blit_region.srcOffsets[0].z               = 0;
+        blit_region.srcOffsets[1].x               = width;
+        blit_region.srcOffsets[1].y               = height;
+        blit_region.srcOffsets[1].z               = 1;
+        blit_region.dstSubresource.aspectMask     = copy_image_aspect_mask;
+        blit_region.dstSubresource.mipLevel       = 0;
+        blit_region.dstSubresource.baseArrayLayer = 0;
+        blit_region.dstSubresource.layerCount     = 1;
+        blit_region.dstOffsets[0].x               = flip_x ? copy_width : 0;
+        blit_region.dstOffsets[0].y               = flip_y ? copy_height : 0;
+        blit_region.dstOffsets[0].z               = 0;
+        blit_region.dstOffsets[1].x               = flip_x ? 0 : copy_width;
+        blit_region.dstOffsets[1].y               = flip_y ? 0 : copy_height;
+        blit_region.dstOffsets[1].z               = 1;
+
+        injected->CmdBlitImage(command_buffer,
+                               image,
+                               VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               copy_image,
+                               VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                               1,
+                               &blit_region,
+                               VK_FILTER_NEAREST);
+
+        // Transition blit target from the TRANSFER_DST layout to TRANSFER_SRC layout for the image to
+        // buffer copy.
+        convert_image_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        convert_image_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        convert_image_barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        convert_image_barrier.newLayout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+
+        injected->CmdPipelineBarrier(command_buffer,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     0,
+                                     0,
+                                     nullptr,
+                                     0,
+                                     nullptr,
+                                     1,
+                                     &convert_image_barrier);
+    }
+
+    VkBufferImageCopy copy_region;
+    copy_region.bufferOffset                    = 0;
+    copy_region.bufferRowLength                 = 0;
+    copy_region.bufferImageHeight               = 0;
+    copy_region.imageSubresource.aspectMask     = copy_image_aspect_mask;
+    copy_region.imageSubresource.mipLevel       = 0;
+    copy_region.imageSubresource.baseArrayLayer = 0;
+    copy_region.imageSubresource.layerCount     = 1;
+    copy_region.imageOffset                     = { 0, 0, 0 };
+    copy_region.imageExtent                     = { copy_width, copy_height, 1 };
+
+    injected->CmdCopyImageToBuffer(
+        command_buffer, copy_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, copy_resource.buffer, 1, &copy_region);
+
+    // Transition source image back to image_layout after the screenshot.
+    src_image_barrier.srcAccessMask       = VK_ACCESS_TRANSFER_READ_BIT;
+    src_image_barrier.dstAccessMask       = 0;
+    src_image_barrier.oldLayout           = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    src_image_barrier.newLayout           = image_layout;
+    src_image_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    src_image_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+
+    injected->CmdPipelineBarrier(command_buffer,
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                 VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                 0,
+                                 0,
+                                 nullptr,
+                                 0,
+                                 nullptr,
+                                 1,
+                                 &src_image_barrier);
+
+    // Make sure any pending work is finished, as we are not waiting on any semaphores from previous
+    // submissions.
+    result = injected->DeviceWaitIdle(device);
+    if (result != VK_SUCCESS)
+    {
+        GFXRECON_LOG_ERROR("ScreenshotHandler: DeviceWaitIdle failed with %s", util::ToString(result).c_str());
+        injected->FreeCommandBuffers(device, copy_resource.command_pool, 1, &command_buffer);
+        return ScreenshotWriteResult::Failed(screenshot_reason::kDeviceWaitIdleFailed,
+                                             "ScreenshotHandler: DeviceWaitIdle failed with " + util::ToString(result),
+                                             result);
+    }
+
+    result = injected->EndCommandBuffer(command_buffer);
 
     if (result == VK_SUCCESS)
     {
-        auto&   copy_resource = copy_resource_entry->second;
-        auto    copy_format   = GetConversionFormat(format);
-        VkQueue queue         = VK_NULL_HANDLE;
+        VkSubmitInfo submit_info         = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
+        submit_info.waitSemaphoreCount   = 0;
+        submit_info.pWaitSemaphores      = nullptr;
+        submit_info.pWaitDstStageMask    = nullptr;
+        submit_info.commandBufferCount   = 1;
+        submit_info.pCommandBuffers      = &command_buffer;
+        submit_info.signalSemaphoreCount = 0;
+        submit_info.pSignalSemaphores    = nullptr;
 
-        // Get a queue.
-        queue = GetDeviceQueue(injected.GetTable(), device_info, kDefaultQueueFamilyIndex, kDefaultQueueIndex);
+        result = injected->QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
+    }
 
-        // Get a buffer size.
-        VkDeviceSize buffer_size     = copy_resource.buffer_size;
-        bool         create_resource = false;
+    if (result != VK_SUCCESS)
+    {
+        injected->FreeCommandBuffers(device, copy_resource.command_pool, 1, &command_buffer);
+        const char* path = (copy_resource.convert_image != VK_NULL_HANDLE ? "(blit path) " : "");
+        GFXRECON_LOG_ERROR(
+            "ScreenshotHandler: Queue submission %sfailed with %s", path, util::ToString(result).c_str());
+        return ScreenshotWriteResult::Failed(screenshot_reason::kQueueSubmitFailed,
+                                             std::string("ScreenshotHandler: Queue submission ") + path +
+                                                 "failed with " + util::ToString(result),
+                                             result);
+    }
 
-        // If the copy resource is not initialized, or the image properties have changed, recompute the copy size.
-        if (buffer_size == 0 || copy_resource.width != copy_width || copy_resource.height != copy_height ||
-            copy_resource.format != copy_format || copy_resource.flip_x != flip_x || copy_resource.flip_y != flip_y)
+    result = injected->QueueWaitIdle(queue);
+    if (result != VK_SUCCESS)
+    {
+        injected->FreeCommandBuffers(device, copy_resource.command_pool, 1, &command_buffer);
+
+        GFXRECON_LOG_ERROR("ScreenshotHandler: Queue wait failed with %s", util::ToString(result).c_str());
+        const char* path = (copy_resource.convert_image != VK_NULL_HANDLE ? "(blit path) " : "");
+        return ScreenshotWriteResult::Failed(screenshot_reason::kQueueSubmitFailed,
+                                             std::string("ScreenshotHandler: QueueWaitIdle ") + path + "failed with " +
+                                                 util::ToString(result),
+                                             result);
+    }
+
+    injected->FreeCommandBuffers(device, copy_resource.command_pool, 1, &command_buffer);
+
+    void* data = nullptr;
+    result     = allocator->MapResourceMemoryDirect(copy_resource.buffer_size, 0, &data, copy_resource.buffer_data);
+    if (result != VK_SUCCESS)
+    {
+        GFXRECON_LOG_ERROR("Screenshot could not be created: failed to map resource memory");
+        return ScreenshotWriteResult::Failed(screenshot_reason::kMemoryMapFailed,
+                                             "Screenshot could not be created: failed to map resource memory",
+                                             result);
+    }
+
+    if ((copy_resource.memory_property_flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) !=
+        VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)
+    {
+        VkMappedMemoryRange invalidate_range = { VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE };
+        invalidate_range.pNext               = nullptr;
+        invalidate_range.memory              = copy_resource.buffer_memory;
+        invalidate_range.offset              = 0;
+        invalidate_range.size                = copy_resource.buffer_size;
+
+        allocator->InvalidateMappedMemoryRangesDirect(1, &invalidate_range, &copy_resource.buffer_memory_data);
+    }
+
+    void*  write_data  = data;
+    size_t pixel_count = static_cast<size_t>(copy_width) * copy_height;
+
+    uint32_t final_width  = copy_width;
+    uint32_t final_height = copy_height;
+
+    util::imagewriter::ImageRotation rotation = util::imagewriter::ImageRotation::DEG_0;
+    if (pre_transform == VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR ||
+        pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR)
+    {
+        rotation = util::imagewriter::ImageRotation::DEG_90;
+    }
+    else if (pre_transform == VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR ||
+             pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR)
+    {
+        rotation = util::imagewriter::ImageRotation::DEG_180;
+    }
+    else if (pre_transform == VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR ||
+             pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR)
+    {
+        rotation = util::imagewriter::ImageRotation::DEG_270;
+    }
+
+    bool is_mirrored = (pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR ||
+                        pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR ||
+                        pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR ||
+                        pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR);
+
+    if (rotation != util::imagewriter::ImageRotation::DEG_0 || is_mirrored)
+    {
+        // Note: We safely assume a 32-bit pixel format (4 bytes) because GetConversionFormat()
+        // strictly enforces VK_FORMAT_B8G8R8A8_UNORM or VK_FORMAT_B8G8R8A8_SRGB.
+        GFXRECON_ASSERT(copy_format == VK_FORMAT_B8G8R8A8_UNORM || copy_format == VK_FORMAT_B8G8R8A8_SRGB);
+
+        try
         {
-            buffer_size     = GetCopyBufferSize(device, injected, copy_format, copy_width, copy_height);
-            create_resource = true;
-        }
-
-        if (create_resource)
-        {
-            // Need to create/recreate resource.
-            DestroyCopyResource(device, &copy_resource);
-
-            result = CreateCopyResource(device,
-                                        injected,
-                                        memory_properties,
-                                        buffer_size,
-                                        format,
-                                        copy_format,
-                                        width,
-                                        height,
-                                        copy_width,
-                                        copy_height,
-                                        flip_x,
-                                        flip_y,
-                                        &copy_resource);
-        }
-        else if (buffer_size == 0)
-        {
-            // GetCopyBufferSize failed to determine a valid size.
-            result = VK_ERROR_INITIALIZATION_FAILED;
-        }
-
-        if (result == VK_SUCCESS)
-        {
-            // Get a command buffer.
-            VkCommandBuffer command_buffer = VK_NULL_HANDLE;
-
-            VkCommandBufferAllocateInfo allocate_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
-            allocate_info.pNext                       = nullptr;
-            allocate_info.commandPool                 = copy_resource.command_pool;
-            allocate_info.level                       = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-            allocate_info.commandBufferCount          = 1;
-
-            result = injected->AllocateCommandBuffers(device, &allocate_info, &command_buffer);
-            if (result == VK_SUCCESS)
+            if (rotated_pixels_buffer_.size() < pixel_count)
             {
-                VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-                begin_info.pNext                    = nullptr;
-                begin_info.flags                    = 0;
-                begin_info.pInheritanceInfo         = nullptr;
-
-                result = injected.BeginCommandBuffer(command_buffer, &begin_info, __func__);
+                rotated_pixels_buffer_.resize(pixel_count);
             }
 
-            if (result == VK_SUCCESS)
-            {
-                auto image_aspect_mask = graphics::GetFormatAspects(format);
+            const uint32_t* src_pixels = reinterpret_cast<const uint32_t*>(data);
+            uint32_t*       dst_pixels = rotated_pixels_buffer_.data();
+            write_data                 = rotated_pixels_buffer_.data();
 
-                // Transition source image from image_layout to the TRANSFER_SRC layout.
-                VkImageMemoryBarrier src_image_barrier            = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
-                src_image_barrier.pNext                           = nullptr;
-                src_image_barrier.srcAccessMask                   = 0;
-                src_image_barrier.dstAccessMask                   = VK_ACCESS_TRANSFER_READ_BIT;
-                src_image_barrier.oldLayout                       = image_layout;
-                src_image_barrier.newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-                src_image_barrier.srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
-                src_image_barrier.dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
-                src_image_barrier.image                           = image;
-                src_image_barrier.subresourceRange.aspectMask     = image_aspect_mask;
-                src_image_barrier.subresourceRange.baseArrayLayer = layer;
-                src_image_barrier.subresourceRange.layerCount     = 1;
-                src_image_barrier.subresourceRange.baseMipLevel   = 0;
-                src_image_barrier.subresourceRange.levelCount     = 1;
+            final_width  = (rotation == util::imagewriter::ImageRotation::DEG_90 ||
+                           rotation == util::imagewriter::ImageRotation::DEG_270)
+                               ? copy_height
+                               : copy_width;
+            final_height = (rotation == util::imagewriter::ImageRotation::DEG_90 ||
+                            rotation == util::imagewriter::ImageRotation::DEG_270)
+                               ? copy_width
+                               : copy_height;
 
-                injected->CmdPipelineBarrier(command_buffer,
-                                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                             0,
-                                             0,
-                                             nullptr,
-                                             0,
-                                             nullptr,
-                                             1,
-                                             &src_image_barrier);
-
-                // The 'copy_image' is the image to be used with the image to buffer copy.
-                VkImage copy_image             = image;
-                auto    copy_image_aspect_mask = graphics::GetFormatAspects(copy_format);
-
-                if (copy_resource.convert_image != VK_NULL_HANDLE)
-                {
-                    // Need to perform a blit to covert the Vulkan image format to the image file format.
-                    copy_image = copy_resource.convert_image;
-
-                    // Transition blit target to the TRANSFER_DST layout.
-                    VkImageMemoryBarrier convert_image_barrier            = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
-                    convert_image_barrier.pNext                           = nullptr;
-                    convert_image_barrier.srcAccessMask                   = 0;
-                    convert_image_barrier.dstAccessMask                   = VK_ACCESS_TRANSFER_WRITE_BIT;
-                    convert_image_barrier.oldLayout                       = VK_IMAGE_LAYOUT_UNDEFINED;
-                    convert_image_barrier.newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-                    convert_image_barrier.srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
-                    convert_image_barrier.dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
-                    convert_image_barrier.image                           = copy_image;
-                    convert_image_barrier.subresourceRange.aspectMask     = copy_image_aspect_mask;
-                    convert_image_barrier.subresourceRange.baseArrayLayer = 0;
-                    convert_image_barrier.subresourceRange.layerCount     = 1;
-                    convert_image_barrier.subresourceRange.baseMipLevel   = 0;
-                    convert_image_barrier.subresourceRange.levelCount     = 1;
-
-                    injected->CmdPipelineBarrier(command_buffer,
-                                                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 0,
-                                                 nullptr,
-                                                 1,
-                                                 &convert_image_barrier);
-
-                    VkImageBlit blit_region;
-                    blit_region.srcSubresource.aspectMask     = image_aspect_mask;
-                    blit_region.srcSubresource.mipLevel       = 0;
-                    blit_region.srcSubresource.baseArrayLayer = layer;
-                    blit_region.srcSubresource.layerCount     = 1;
-                    blit_region.srcOffsets[0].x               = 0;
-                    blit_region.srcOffsets[0].y               = 0;
-                    blit_region.srcOffsets[0].z               = 0;
-                    blit_region.srcOffsets[1].x               = width;
-                    blit_region.srcOffsets[1].y               = height;
-                    blit_region.srcOffsets[1].z               = 1;
-                    blit_region.dstSubresource.aspectMask     = copy_image_aspect_mask;
-                    blit_region.dstSubresource.mipLevel       = 0;
-                    blit_region.dstSubresource.baseArrayLayer = 0;
-                    blit_region.dstSubresource.layerCount     = 1;
-                    blit_region.dstOffsets[0].x               = flip_x ? copy_width : 0;
-                    blit_region.dstOffsets[0].y               = flip_y ? copy_height : 0;
-                    blit_region.dstOffsets[0].z               = 0;
-                    blit_region.dstOffsets[1].x               = flip_x ? 0 : copy_width;
-                    blit_region.dstOffsets[1].y               = flip_y ? 0 : copy_height;
-                    blit_region.dstOffsets[1].z               = 1;
-
-                    injected->CmdBlitImage(command_buffer,
-                                           image,
-                                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                           copy_image,
-                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                           1,
-                                           &blit_region,
-                                           VK_FILTER_NEAREST);
-
-                    // Transition blit target from the TRANSFER_DST layout to TRANSFER_SRC layout for the image to
-                    // buffer copy.
-                    convert_image_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-                    convert_image_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-                    convert_image_barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-                    convert_image_barrier.newLayout     = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-
-                    injected->CmdPipelineBarrier(command_buffer,
-                                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 0,
-                                                 nullptr,
-                                                 1,
-                                                 &convert_image_barrier);
-                }
-
-                VkBufferImageCopy copy_region;
-                copy_region.bufferOffset                    = 0;
-                copy_region.bufferRowLength                 = 0;
-                copy_region.bufferImageHeight               = 0;
-                copy_region.imageSubresource.aspectMask     = copy_image_aspect_mask;
-                copy_region.imageSubresource.mipLevel       = 0;
-                copy_region.imageSubresource.baseArrayLayer = 0;
-                copy_region.imageSubresource.layerCount     = 1;
-                copy_region.imageOffset                     = { 0, 0, 0 };
-                copy_region.imageExtent                     = { copy_width, copy_height, 1 };
-
-                injected->CmdCopyImageToBuffer(command_buffer,
-                                               copy_image,
-                                               VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                               copy_resource.buffer,
-                                               1,
-                                               &copy_region);
-
-                // Transition source image back to image_layout after the screenshot.
-                src_image_barrier.srcAccessMask       = VK_ACCESS_TRANSFER_READ_BIT;
-                src_image_barrier.dstAccessMask       = 0;
-                src_image_barrier.oldLayout           = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-                src_image_barrier.newLayout           = image_layout;
-                src_image_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-                src_image_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-
-                injected->CmdPipelineBarrier(command_buffer,
-                                             VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                             0,
-                                             0,
-                                             nullptr,
-                                             0,
-                                             nullptr,
-                                             1,
-                                             &src_image_barrier);
-
-                injected->EndCommandBuffer(command_buffer);
-
-                // Make sure any pending work is finished, as we are not waiting on any semaphores from previous
-                // submissions.
-                result = injected->DeviceWaitIdle(device);
-                if (result != VK_SUCCESS)
-                {
-                    GFXRECON_LOG_ERROR("ScreenshotHandler: DeviceWaitIdle failed with %s",
-                                       util::ToString(result).c_str());
-                }
-
-                if (result == VK_SUCCESS)
-                {
-                    VkSubmitInfo submit_info         = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
-                    submit_info.waitSemaphoreCount   = 0;
-                    submit_info.pWaitSemaphores      = nullptr;
-                    submit_info.pWaitDstStageMask    = nullptr;
-                    submit_info.commandBufferCount   = 1;
-                    submit_info.pCommandBuffers      = &command_buffer;
-                    submit_info.signalSemaphoreCount = 0;
-                    submit_info.pSignalSemaphores    = nullptr;
-
-                    result = injected->QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
-                    if (result != VK_SUCCESS)
-                    {
-                        GFXRECON_LOG_ERROR("ScreenshotHandler: Queue submission %sfailed with %s",
-                                           (copy_resource.convert_image != VK_NULL_HANDLE ? "(blit path) " : ""),
-                                           util::ToString(result).c_str());
-                    }
-                }
-
-                if (result == VK_SUCCESS)
-                {
-                    result = injected->QueueWaitIdle(queue);
-                    if (result != VK_SUCCESS)
-                    {
-                        GFXRECON_LOG_ERROR("ScreenshotHandler: Queue wait failed with %s",
-                                           util::ToString(result).c_str());
-                    }
-                }
-
-                if (result == VK_SUCCESS)
-                {
-                    void* data = nullptr;
-                    result     = allocator->MapResourceMemoryDirect(
-                        copy_resource.buffer_size, 0, &data, copy_resource.buffer_data);
-
-                    if (result == VK_SUCCESS)
-                    {
-                        if ((copy_resource.memory_property_flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) !=
-                            VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)
-                        {
-                            VkMappedMemoryRange invalidate_range = { VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE };
-                            invalidate_range.pNext               = nullptr;
-                            invalidate_range.memory              = copy_resource.buffer_memory;
-                            invalidate_range.offset              = 0;
-                            invalidate_range.size                = copy_resource.buffer_size;
-
-                            allocator->InvalidateMappedMemoryRangesDirect(
-                                1, &invalidate_range, &copy_resource.buffer_memory_data);
-                        }
-
-                        void*  write_data  = data;
-                        size_t pixel_count = static_cast<size_t>(copy_width) * copy_height;
-
-                        uint32_t final_width  = copy_width;
-                        uint32_t final_height = copy_height;
-
-                        util::imagewriter::ImageRotation rotation = util::imagewriter::ImageRotation::DEG_0;
-                        if (pre_transform == VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR ||
-                            pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR)
-                        {
-                            rotation = util::imagewriter::ImageRotation::DEG_90;
-                        }
-                        else if (pre_transform == VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR ||
-                                 pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR)
-                        {
-                            rotation = util::imagewriter::ImageRotation::DEG_180;
-                        }
-                        else if (pre_transform == VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR ||
-                                 pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR)
-                        {
-                            rotation = util::imagewriter::ImageRotation::DEG_270;
-                        }
-
-                        bool is_mirrored =
-                            (pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR ||
-                             pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR ||
-                             pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR ||
-                             pre_transform == VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR);
-
-                        if (rotation != util::imagewriter::ImageRotation::DEG_0 || is_mirrored)
-                        {
-                            // Note: We safely assume a 32-bit pixel format (4 bytes) because GetConversionFormat()
-                            // strictly enforces VK_FORMAT_B8G8R8A8_UNORM or VK_FORMAT_B8G8R8A8_SRGB.
-                            GFXRECON_ASSERT(copy_format == VK_FORMAT_B8G8R8A8_UNORM ||
-                                            copy_format == VK_FORMAT_B8G8R8A8_SRGB);
-
-                            try
-                            {
-                                if (rotated_pixels_buffer_.size() < pixel_count)
-                                {
-                                    rotated_pixels_buffer_.resize(pixel_count);
-                                }
-
-                                const uint32_t* src_pixels = reinterpret_cast<const uint32_t*>(data);
-                                uint32_t*       dst_pixels = rotated_pixels_buffer_.data();
-                                write_data                 = rotated_pixels_buffer_.data();
-
-                                final_width  = (rotation == util::imagewriter::ImageRotation::DEG_90 ||
-                                               rotation == util::imagewriter::ImageRotation::DEG_270)
-                                                   ? copy_height
-                                                   : copy_width;
-                                final_height = (rotation == util::imagewriter::ImageRotation::DEG_90 ||
-                                                rotation == util::imagewriter::ImageRotation::DEG_270)
-                                                   ? copy_width
-                                                   : copy_height;
-
-                                util::imagewriter::RotateAndMirrorPixels(rotation,
-                                                                         is_mirrored,
-                                                                         src_pixels,
-                                                                         dst_pixels,
-                                                                         copy_width,
-                                                                         copy_height,
-                                                                         final_width,
-                                                                         final_height);
-                            }
-                            catch (const std::bad_alloc&)
-                            {
-                                GFXRECON_LOG_ERROR("Screenshot could not be rotated: failed to allocate memory");
-                            }
-                        }
-
-                        WriteImageFile(filename_prefix, screenshot_format_, final_width, final_height, write_data);
-
-                        allocator->UnmapResourceMemoryDirect(copy_resource.buffer_data);
-                    }
-                    else
-                    {
-                        GFXRECON_LOG_ERROR("Screenshot could not be created: failed to map resource memory");
-                    }
-                }
-                else
-                {
-                    GFXRECON_LOG_ERROR("Screenshot could not be created: failed to execute image transfer");
-                }
-
-                injected->FreeCommandBuffers(device, copy_resource.command_pool, 1, &command_buffer);
-            }
+            util::imagewriter::RotateAndMirrorPixels(
+                rotation, is_mirrored, src_pixels, dst_pixels, copy_width, copy_height, final_width, final_height);
         }
-        else
+        catch (const std::bad_alloc&)
         {
-            GFXRECON_LOG_ERROR("Screenshot could not be created: failed to create a transfer resource");
+            // The unrotated image is still written.
+            GFXRECON_LOG_ERROR("Screenshot could not be rotated: failed to allocate memory");
+            write_result.messages.push_back({ screenshot_reason::kRotationAllocFailed,
+                                              "Screenshot could not be rotated: failed to allocate memory" });
         }
     }
+
+    WriteImageFile(filename_prefix, screenshot_format_, final_width, final_height, write_data, write_result);
+
+    allocator->UnmapResourceMemoryDirect(copy_resource.buffer_data);
+
+    return write_result;
 }
 
 void ScreenshotHandler::DestroyDeviceResources(VkDevice                                   device,
@@ -542,6 +609,262 @@ void ScreenshotHandler::DestroyDeviceResources(VkDevice                         
 
         copy_resources_.erase(entry);
     }
+}
+
+ScreenshotHandler::~ScreenshotHandler()
+{
+    if (json_ != nullptr)
+    {
+        // The frame counter starts at 1, so the number of frames seen is one less than the current frame.
+        json_->Close(current_frame_number_ - 1);
+    }
+}
+
+void ScreenshotHandler::OpenResultJson(const VulkanReplayOptions& options, const std::string& filename)
+{
+    json_ = std::make_unique<ScreenshotJson>(options);
+    if (!json_->Open(filename))
+    {
+        GFXRECON_LOG_WARNING("Screenshot results will not be recorded: could not open %s", filename.c_str());
+        json_.reset();
+    }
+}
+
+void ScreenshotHandler::BeginFrame(const char*             boundary_type,
+                                   const char*             call_name,
+                                   const VulkanQueueInfo*  queue_info,
+                                   std::optional<VkResult> capture_result,
+                                   uint64_t                block_index)
+{
+    if ((json_ == nullptr) || !IsScreenshotFrame())
+    {
+        return;
+    }
+
+    std::optional<format::HandleId> queue_id;
+    if (queue_info != nullptr)
+    {
+        queue_id = queue_info->capture_id;
+    }
+
+    json_->BeginFrame(current_frame_number_, block_index, boundary_type, call_name, queue_id, capture_result);
+}
+
+void ScreenshotHandler::SetBoundarySwapchain(uint32_t swapchain_count)
+{
+    if (ScreenshotJson* json = GetOpenJsonFrame())
+    {
+        json->SetBoundarySwapchain(swapchain_count);
+    }
+}
+
+void ScreenshotHandler::SetBoundaryCommandBuffer(format::HandleId command_buffer_id)
+{
+    if (ScreenshotJson* json = GetOpenJsonFrame())
+    {
+        json->SetBoundaryCommandBuffer(command_buffer_id);
+    }
+}
+
+void ScreenshotHandler::SetBoundaryFrameBoundaryEXT(const Decoded_VkFrameBoundaryEXT* frame_boundary)
+{
+    ScreenshotJson* json = GetOpenJsonFrame();
+    if ((json == nullptr) || (frame_boundary == nullptr) || (frame_boundary->decoded_value == nullptr))
+    {
+        return;
+    }
+
+    json->SetBoundaryFrameBoundaryEXT(
+        *frame_boundary->decoded_value, frame_boundary->pImages.GetPointer(), frame_boundary->pImages.GetLength());
+}
+
+void ScreenshotHandler::SetBoundaryFrameBoundaryANDROID(const VulkanSemaphoreInfo* semaphore_info)
+{
+    if (ScreenshotJson* json = GetOpenJsonFrame())
+    {
+        std::optional<format::HandleId> semaphore_id;
+        if (semaphore_info != nullptr)
+        {
+            semaphore_id = semaphore_info->capture_id;
+        }
+        json->SetBoundaryFrameBoundaryANDROID(semaphore_id);
+    }
+}
+
+void ScreenshotHandler::SkipFrame(const char* code, const std::string& message, bool is_error)
+{
+    if (is_error)
+    {
+        GFXRECON_LOG_ERROR("Frame %u: no screenshot written (%s): %s", current_frame_number_, code, message.c_str());
+    }
+    else
+    {
+        GFXRECON_LOG_WARNING("Frame %u: no screenshot written (%s): %s", current_frame_number_, code, message.c_str());
+    }
+
+    if (ScreenshotJson* json = GetOpenJsonFrame())
+    {
+        json->SetFrameReason(code, message, is_error);
+    }
+}
+
+void ScreenshotHandler::AddOutput(const char*           source_kind,
+                                  format::HandleId      image_id,
+                                  uint32_t              layer,
+                                  std::optional<size_t> image_index)
+{
+    if (ScreenshotJson* json = GetOpenJsonFrame())
+    {
+        json->AddOutput(source_kind, image_id, layer);
+        if (image_index)
+        {
+            json->SetOutputImageIndex(image_index.value());
+        }
+    }
+}
+
+void ScreenshotHandler::AddFramebufferAttachmentOutput(format::HandleId image_id,
+                                                       format::HandleId framebuffer_id,
+                                                       size_t           render_pass_index,
+                                                       size_t           attachment_index,
+                                                       format::HandleId image_view_id)
+{
+    if (ScreenshotJson* json = GetOpenJsonFrame())
+    {
+        json->AddOutput("framebufferAttachment", image_id, 0);
+        json->SetOutputFramebufferAttachment(framebuffer_id, render_pass_index, attachment_index, image_view_id);
+    }
+}
+
+void ScreenshotHandler::AddSwapchainOutput(const char*                     source_kind,
+                                           format::HandleId                image_id,
+                                           uint32_t                        layer,
+                                           const Decoded_VkPresentInfoKHR* meta_info,
+                                           uint32_t                        swapchain_index,
+                                           format::HandleId                swapchain_id,
+                                           uint32_t                        image_index,
+                                           const VulkanSwapchainKHRInfo*   swapchain_info,
+                                           const VulkanSurfaceKHRInfo*     surface_info)
+{
+    ScreenshotJson* json = GetOpenJsonFrame();
+    if (json == nullptr)
+    {
+        return;
+    }
+
+    json->AddOutput(source_kind, image_id, layer);
+    json->SetOutputSwapchain(swapchain_id, swapchain_index, image_index);
+
+    if (swapchain_info != nullptr)
+    {
+        std::optional<std::string> surface_extension;
+        std::optional<VkExtent2D>  window_size;
+
+        if ((surface_info != nullptr) && (surface_info->window != nullptr))
+        {
+            surface_extension = surface_info->window->GetWsiExtension();
+            window_size       = surface_info->window->GetSize();
+        }
+
+        json->SetOutputPresentInfo(meta_info,
+                                   swapchain_index,
+                                   swapchain_info->surface_id,
+                                   surface_extension,
+                                   window_size,
+                                   { swapchain_info->width, swapchain_info->height });
+    }
+}
+
+ScreenshotWriteResult ScreenshotHandler::WriteOutput(const std::string&                         filename_prefix,
+                                                     const VulkanDeviceInfo*                    device_info,
+                                                     const graphics::VulkanInjectedDeviceCalls& injected_calls,
+                                                     const VkPhysicalDeviceMemoryProperties&    memory_properties,
+                                                     VkImage                                    image,
+                                                     VkFormat                                   format,
+                                                     uint32_t                                   width,
+                                                     uint32_t                                   height,
+                                                     uint32_t                                   layer,
+                                                     VkImageLayout                              image_layout,
+                                                     VkSurfaceTransformFlagBitsKHR              pre_transform)
+{
+    GFXRECON_ASSERT(device_info != nullptr);
+
+    ScreenshotJson* json = GetOpenJsonFrame();
+    if (json != nullptr)
+    {
+        json->SetOutputImage(format, width, height, pre_transform);
+    }
+
+    // NOTE: optional scale takes precedence over explicit screenshot width/height
+    auto screenshot_scale = scale_;
+    if (!screenshot_scale && width_ > 0 && height_ > 0 && width > 0 && height > 0)
+    {
+        screenshot_scale = { static_cast<float>(width_) / static_cast<float>(width),
+                             static_cast<float>(height_) / static_cast<float>(height) };
+    }
+
+    ScreenshotWriteResult result = WriteImage(filename_prefix,
+                                              device_info,
+                                              injected_calls,
+                                              memory_properties,
+                                              device_info->allocator.get(),
+                                              image,
+                                              format,
+                                              width,
+                                              height,
+                                              layer,
+                                              screenshot_scale,
+                                              image_layout,
+                                              pre_transform);
+
+    if (json != nullptr)
+    {
+        json->SetOutputResult(result);
+    }
+
+    return result;
+}
+
+void ScreenshotHandler::SkipOutput(const char* code, const std::string& message, bool is_error)
+{
+    if (is_error)
+    {
+        GFXRECON_LOG_ERROR(
+            "Screenshot for frame %u could not be created (%s): %s", current_frame_number_, code, message.c_str());
+    }
+    else
+    {
+        GFXRECON_LOG_WARNING("Screenshot for frame %u skipped (%s): %s", current_frame_number_, code, message.c_str());
+    }
+
+    if (ScreenshotJson* json = GetOpenJsonFrame())
+    {
+        json->SetOutputSkipped(code, message, is_error);
+    }
+}
+
+void ScreenshotHandler::EndFrame(std::optional<VkResult> replay_result)
+{
+    ScreenshotJson* json = GetOpenJsonFrame();
+    if (json != nullptr)
+    {
+        if (replay_result)
+        {
+            json->SetReplayResult(replay_result.value());
+
+            if (replay_result.value() < 0)
+            {
+                json->AddFrameMessage(
+                    screenshot_reason::kReplayCallFailed,
+                    "The call that ended the frame failed in replay; the screenshot content may not be valid",
+                    replay_result);
+            }
+        }
+
+        json->EndFrame();
+    }
+
+    ScreenshotHandlerBase::EndFrame();
 }
 
 bool ScreenshotHandler::IsSrgbFormat(VkFormat image_format) const
@@ -814,6 +1137,11 @@ void ScreenshotHandler::DestroyCopyResource(VkDevice device, CopyResource* copy_
             copy_resource->convert_image_memory      = VK_NULL_HANDLE;
             copy_resource->convert_image_memory_data = 0;
         }
+
+        copy_resource->buffer_size = 0;
+        copy_resource->width       = 0;
+        copy_resource->height      = 0;
+        copy_resource->format      = VK_FORMAT_UNDEFINED;
     }
 }
 

--- a/framework/decode/screenshot_handler.h
+++ b/framework/decode/screenshot_handler.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
-** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2019-2026 LunarG, Inc.
+**
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
 ** to deal in the Software without restriction, including without limitation
@@ -24,6 +24,8 @@
 #define GFXRECON_DECODE_SCREENSHOT_HANDLER_H
 
 #include "decode/screenshot_handler_base.h"
+#include "decode/screenshot_json.h"
+#include "decode/screenshot_result.h"
 #include "decode/vulkan_object_info.h"
 #include "decode/vulkan_replay_options.h"
 #include "decode/vulkan_resource_allocator.h"
@@ -33,8 +35,9 @@
 
 #include "vulkan/vulkan.h"
 
-#include <atomic>
-#include <mutex>
+#include <array>
+#include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -42,36 +45,96 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+struct Decoded_VkFrameBoundaryEXT;
+
 class ScreenshotHandler : public ScreenshotHandlerBase
 {
   public:
-    ScreenshotHandler(util::ScreenshotFormat              screenshot_format,
-                      const std::vector<ScreenshotRange>& screenshot_ranges,
-                      uint32_t                            screenshot_interval) :
-        ScreenshotHandlerBase(screenshot_format, screenshot_ranges, screenshot_interval)
-    {}
+    explicit ScreenshotHandler(const VulkanReplayOptions& options, const std::string& json_filename) :
+        ScreenshotHandlerBase(options.screenshot_format, options.screenshot_ranges, options.screenshot_interval),
+        scale_(options.screenshot_scale), width_(options.screenshot_width), height_(options.screenshot_height)
+    {
+        OpenResultJson(options, json_filename);
+    }
 
-    ScreenshotHandler(util::ScreenshotFormat         screenshot_format,
-                      std::vector<ScreenshotRange>&& screenshot_ranges,
-                      uint32_t                       screenshot_interval) :
-        ScreenshotHandlerBase(screenshot_format, screenshot_ranges, screenshot_interval)
-    {}
+    ~ScreenshotHandler();
 
-    void WriteImage(const std::string&                         filename_prefix,
-                    const VulkanDeviceInfo*                    device_info,
-                    const graphics::VulkanInjectedDeviceCalls& injected_calls,
-                    const VkPhysicalDeviceMemoryProperties&    memory_properties,
-                    VulkanResourceAllocator*                   allocator,
-                    VkImage                                    image,
-                    VkFormat                                   format,
-                    uint32_t                                   width,
-                    uint32_t                                   height,
-                    uint32_t                                   layer,
-                    const std::optional<std::array<float, 2>>& copy_scale,
-                    VkImageLayout                              image_layout,
-                    VkSurfaceTransformFlagBitsKHR              pre_transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
+    // Copies one image layer to a file. The returned result says whether the file was written and, if not, why.
+    ScreenshotWriteResult
+    WriteImage(const std::string&                         filename_prefix,
+               const VulkanDeviceInfo*                    device_info,
+               const graphics::VulkanInjectedDeviceCalls& injected_calls,
+               const VkPhysicalDeviceMemoryProperties&    memory_properties,
+               VulkanResourceAllocator*                   allocator,
+               VkImage                                    image,
+               VkFormat                                   format,
+               uint32_t                                   width,
+               uint32_t                                   height,
+               uint32_t                                   layer,
+               const std::optional<std::array<float, 2>>& copy_scale,
+               VkImageLayout                              image_layout,
+               VkSurfaceTransformFlagBitsKHR              pre_transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
 
     void DestroyDeviceResources(VkDevice device, const graphics::VulkanInjectedDeviceCalls& injected_calls);
+
+    // Creates a new frame entry in the output json
+    void BeginFrame(const char*             boundary_type,
+                    const char*             call_name,
+                    const VulkanQueueInfo*  queue_info,
+                    std::optional<VkResult> capture_result,
+                    uint64_t                block_index);
+
+    // Records that the whole frame produced no outputs, with a log line and a reason code. Mirrors SkipOutput.
+    void SkipFrame(const char* code, const std::string& message, bool is_error);
+
+    void EndFrame(std::optional<VkResult> replay_result);
+
+    // Boundary details of the open frame.
+    void SetBoundarySwapchain(uint32_t swapchain_count);
+    void SetBoundaryCommandBuffer(format::HandleId command_buffer_id);
+    void SetBoundaryFrameBoundaryEXT(const Decoded_VkFrameBoundaryEXT* frame_boundary);
+    void SetBoundaryFrameBoundaryANDROID(const VulkanSemaphoreInfo* semaphore_info);
+
+    // Adds an output entry to the open frame, if any, and makes it the current output. image_index records the
+    // position of the image in the boundary's image list when there is one.
+    void AddOutput(const char*           source_kind,
+                   format::HandleId      image_id,
+                   uint32_t              layer,
+                   std::optional<size_t> image_index = std::nullopt);
+
+    // Adds an output entry for one color attachment of a framebuffer rendered by a frame boundary command buffer.
+    void AddFramebufferAttachmentOutput(format::HandleId image_id,
+                                        format::HandleId framebuffer_id,
+                                        size_t           render_pass_index,
+                                        size_t           attachment_index,
+                                        format::HandleId image_view_id);
+
+    // Adds an output entry for one swapchain of a present and records the swapchain slot.
+    void AddSwapchainOutput(const char*                     source_kind,
+                            format::HandleId                image_id,
+                            uint32_t                        layer,
+                            const Decoded_VkPresentInfoKHR* meta_info,
+                            uint32_t                        swapchain_index,
+                            format::HandleId                swapchain_id,
+                            uint32_t                        image_index,
+                            const VulkanSwapchainKHRInfo*   swapchain_info,
+                            const VulkanSurfaceKHRInfo*     surface_info);
+
+    // Writes the current output: applies the configured scale or size, copies the image and records the outcome.
+    ScreenshotWriteResult WriteOutput(const std::string&                         filename_prefix,
+                                      const VulkanDeviceInfo*                    device_info,
+                                      const graphics::VulkanInjectedDeviceCalls& injected_calls,
+                                      const VkPhysicalDeviceMemoryProperties&    memory_properties,
+                                      VkImage                                    image,
+                                      VkFormat                                   format,
+                                      uint32_t                                   width,
+                                      uint32_t                                   height,
+                                      uint32_t                                   layer,
+                                      VkImageLayout                              image_layout,
+                                      VkSurfaceTransformFlagBitsKHR              pre_transform);
+
+    // Records that the current output was not written, with a log line and a reason code.
+    void SkipOutput(const char* code, const std::string& message, bool is_error);
 
   private:
     struct CopyResource
@@ -126,8 +189,21 @@ class ScreenshotHandler : public ScreenshotHandlerBase
 
     void DestroyCopyResource(VkDevice device, CopyResource* copy_resource) const;
 
+    // Initializes the output json file.
+    void OpenResultJson(const VulkanReplayOptions& options, const std::string& filename);
+
+    // The output JSON with an entry open for the current frame, or null when the frame is not being recorded.
+    ScreenshotJson* GetOpenJsonFrame() { return ((json_ != nullptr) && json_->HasOpenFrame()) ? json_.get() : nullptr; }
+
   private:
     CommandPools copy_resources_;
+
+    // Optional scale and size applied to every output. The scale takes precedence over the size.
+    std::optional<std::array<float, 2>> scale_;
+    uint32_t                            width_{ 0 };
+    uint32_t                            height_{ 0 };
+
+    std::unique_ptr<ScreenshotJson> json_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/screenshot_handler_base.h
+++ b/framework/decode/screenshot_handler_base.h
@@ -46,6 +46,8 @@ class ScreenshotHandlerBase
                           std::vector<ScreenshotRange>&& screenshot_ranges,
                           uint32_t                       screenshot_interval);
 
+    virtual ~ScreenshotHandlerBase() = default;
+
     uint32_t GetCurrentFrame() const { return current_frame_number_; }
 
     void EndFrame();

--- a/framework/decode/screenshot_json.cpp
+++ b/framework/decode/screenshot_json.cpp
@@ -1,0 +1,670 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "decode/screenshot_json.h"
+
+#include "decode/vulkan_pnext_node.h"
+#include "generated/generated_vulkan_enum_to_string.h"
+#include "generated/generated_vulkan_struct_decoders.h"
+#include PROJECT_VERSION_HEADER_FILE
+#include "util/logging.h"
+#include "util/platform.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+ScreenshotJson::ScreenshotJson(const VulkanReplayOptions& options)
+{
+    header_["schemaVersion"]   = kSchemaVersion;
+    header_["gfxreconVersion"] = GetProjectVersionString();
+    header_["vulkanVersion"]   = std::to_string(VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE)) + "." +
+                               std::to_string(VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE)) + "." +
+                               std::to_string(VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
+    header_["api"]         = "vulkan";
+    header_["captureFile"] = options.capture_filename;
+
+    auto& json_options = header_["options"];
+
+    auto& ranges = json_options["ranges"];
+    ranges       = nlohmann::ordered_json::array();
+    for (const auto& range : options.screenshot_ranges)
+    {
+        nlohmann::ordered_json json_range;
+        json_range["first"] = range.first;
+        json_range["last"]  = range.last;
+        ranges.push_back(json_range);
+    }
+
+    json_options["interval"] = options.screenshot_interval;
+    json_options["format"]   = (options.screenshot_format == util::ScreenshotFormat::kPng) ? util::kScreenshotFormatPng
+                                                                                           : util::kScreenshotFormatBmp;
+    json_options["dir"]      = options.screenshot_dir;
+    json_options["prefix"]   = options.screenshot_file_prefix.empty() ? std::string(kDefaultScreenshotFilePrefix)
+                                                                      : options.screenshot_file_prefix;
+
+    if (options.screenshot_scale)
+    {
+        json_options["scale"] = { options.screenshot_scale.value()[0], options.screenshot_scale.value()[1] };
+    }
+    else
+    {
+        json_options["scale"] = nullptr;
+    }
+
+    if (options.screenshot_width > 0 && options.screenshot_height > 0)
+    {
+        json_options["size"]["width"]  = options.screenshot_width;
+        json_options["size"]["height"] = options.screenshot_height;
+    }
+    else
+    {
+        json_options["size"] = nullptr;
+    }
+
+    json_options["applyPrerotation"]           = options.screenshot_apply_prerotation;
+    json_options["ignoreFrameBoundaryAndroid"] = options.screenshot_ignore_frameBoundaryAndroid;
+}
+
+ScreenshotJson::~ScreenshotJson()
+{
+    if (file_ != nullptr)
+    {
+        // Close without a summary: the owner did not get to a clean shutdown.
+        util::platform::FileWrite("\n]", 2, file_);
+        util::platform::FileClose(file_);
+        file_ = nullptr;
+    }
+}
+
+bool ScreenshotJson::Open(const std::string& filename)
+{
+    GFXRECON_ASSERT(file_ == nullptr);
+
+    int ret = util::platform::FileOpen(&file_, filename.c_str(), "w");
+    if (ret || file_ == nullptr)
+    {
+        file_ = nullptr;
+#if defined(_WIN32)
+        GFXRECON_LOG_ERROR("Could not open screenshot result json file %s", filename.c_str());
+#else
+        GFXRECON_LOG_ERROR("Could not open screenshot result json file %s (%s)", filename.c_str(), strerror(ret));
+#endif
+        return false;
+    }
+
+    first_block_ = true;
+
+    util::platform::FileWrite("[\n", 2, file_);
+
+    nlohmann::ordered_json header_block;
+    header_block["header"] = header_;
+    WriteBlock(header_block);
+
+    return true;
+}
+
+void ScreenshotJson::Close(uint32_t frames_seen)
+{
+    if (file_ == nullptr)
+    {
+        return;
+    }
+
+    if (frame_open_)
+    {
+        EndFrame();
+    }
+
+    nlohmann::ordered_json summary_block;
+    auto&                  summary = summary_block["summary"];
+    summary["framesSeen"]          = frames_seen;
+    summary["framesRequested"]     = frames_requested_;
+    summary["framesWritten"]       = frames_written_;
+    summary["framesPartial"]       = frames_partial_;
+    summary["framesSkipped"]       = frames_skipped_;
+    summary["framesFailed"]        = frames_failed_;
+    summary["filesWritten"]        = files_written_;
+    WriteBlock(summary_block);
+
+    util::platform::FileWrite("\n]", 2, file_);
+    util::platform::FileClose(file_);
+    file_ = nullptr;
+}
+
+void ScreenshotJson::BeginFrame(uint32_t                        frame,
+                                uint64_t                        block_index,
+                                const char*                     boundary_type,
+                                const char*                     call,
+                                std::optional<format::HandleId> queue_id,
+                                std::optional<VkResult>         capture_result)
+{
+    GFXRECON_ASSERT(!frame_open_);
+
+    if (frame_open_)
+    {
+        EndFrame();
+    }
+
+    frame_.clear();
+    frame_open_            = true;
+    frame_reason_is_error_ = false;
+    current_output_status_.reset();
+    outputs_written_ = 0;
+    outputs_skipped_ = 0;
+    outputs_failed_  = 0;
+
+    frame_["frame"]      = frame;
+    frame_["blockIndex"] = block_index;
+
+    auto& boundary   = frame_["boundary"];
+    boundary["type"] = boundary_type;
+    boundary["call"] = call;
+    if (queue_id)
+    {
+        boundary["queueId"] = queue_id.value();
+    }
+    else
+    {
+        boundary["queueId"] = nullptr;
+    }
+    if (capture_result)
+    {
+        boundary["captureResult"] = util::ToString(capture_result.value());
+    }
+    else
+    {
+        boundary["captureResult"] = nullptr;
+    }
+    boundary["replayResult"] = nullptr;
+
+    frame_["status"]   = ScreenshotFrameStatusToString(ScreenshotFrameStatus::kSkipped);
+    frame_["outputs"]  = nlohmann::ordered_json::array();
+    frame_["messages"] = nlohmann::ordered_json::array();
+}
+
+void ScreenshotJson::SetReplayResult(VkResult replay_result)
+{
+    GFXRECON_ASSERT(frame_open_);
+    frame_["boundary"]["replayResult"] = util::ToString(replay_result);
+}
+
+void ScreenshotJson::SetBoundarySwapchain(uint32_t swapchain_count)
+{
+    GFXRECON_ASSERT(frame_open_);
+    frame_["boundary"]["swapchainCount"] = swapchain_count;
+}
+
+void ScreenshotJson::SetBoundaryCommandBuffer(format::HandleId command_buffer_id)
+{
+    GFXRECON_ASSERT(frame_open_);
+    frame_["boundary"]["commandBufferId"] = command_buffer_id;
+}
+
+void ScreenshotJson::SetBoundaryFrameBoundaryEXT(const VkFrameBoundaryEXT& info,
+                                                 const format::HandleId*   image_ids,
+                                                 size_t                    image_count)
+{
+    GFXRECON_ASSERT(frame_open_);
+
+    auto& boundary_json = frame_["boundary"]["frameBoundaryEXT"];
+    boundary_json["flags"] =
+        util::ToString<VkFrameBoundaryFlagBitsEXT>(static_cast<VkFlags>(info.flags), util::kToString_Default, 0, 4);
+    boundary_json["frameID"]    = info.frameID;
+    boundary_json["imageCount"] = info.imageCount;
+
+    auto& images = boundary_json["images"];
+    images       = nlohmann::ordered_json::array();
+    for (size_t i = 0; (i < image_count) && (image_ids != nullptr); ++i)
+    {
+        images.push_back(image_ids[i]);
+    }
+
+    boundary_json["bufferCount"] = info.bufferCount;
+    boundary_json["tagName"]     = info.tagName;
+    boundary_json["tagSize"]     = info.tagSize;
+}
+
+void ScreenshotJson::SetBoundaryFrameBoundaryANDROID(std::optional<format::HandleId> semaphore_id)
+{
+    GFXRECON_ASSERT(frame_open_);
+    if (semaphore_id)
+    {
+        frame_["boundary"]["semaphoreId"] = semaphore_id.value();
+    }
+    else
+    {
+        frame_["boundary"]["semaphoreId"] = nullptr;
+    }
+}
+
+void ScreenshotJson::SetFrameReason(const std::string& code, const std::string& message, bool is_error)
+{
+    GFXRECON_ASSERT(frame_open_);
+    InsertReason(frame_, code, message, std::nullopt);
+    frame_reason_is_error_ = is_error;
+}
+
+void ScreenshotJson::AddFrameMessage(const std::string&      code,
+                                     const std::string&      message,
+                                     std::optional<VkResult> vk_result)
+{
+    GFXRECON_ASSERT(frame_open_);
+    nlohmann::ordered_json entry;
+    entry["code"]    = code;
+    entry["message"] = message;
+    if (vk_result)
+    {
+        entry["vkResult"] = util::ToString(vk_result.value());
+    }
+    frame_["messages"].push_back(entry);
+}
+
+void ScreenshotJson::EndFrame()
+{
+    if (!frame_open_)
+    {
+        return;
+    }
+
+    CommitCurrentOutputStatus();
+
+    const ScreenshotFrameStatus status =
+        ComputeFrameStatus(outputs_written_, outputs_skipped_, outputs_failed_, frame_reason_is_error_);
+    frame_["status"] = ScreenshotFrameStatusToString(status);
+
+    if ((outputs_written_ + outputs_skipped_ + outputs_failed_) == 0 && frame_.find("reason") == frame_.end())
+    {
+        InsertReason(frame_, screenshot_reason::kNoOutputs, "The frame boundary produced no outputs", std::nullopt);
+    }
+
+    // Move status and reason next to the boundary block so that the entry reads top-down: what ended the frame, how
+    // it went, then the outputs.
+    nlohmann::ordered_json ordered;
+    for (const char* key : { "frame", "blockIndex", "boundary", "status", "reason" })
+    {
+        const auto it = frame_.find(key);
+        if (it != frame_.end())
+        {
+            ordered[key] = *it;
+        }
+    }
+    for (auto it = frame_.begin(); it != frame_.end(); ++it)
+    {
+        if (ordered.find(it.key()) == ordered.end())
+        {
+            ordered[it.key()] = it.value();
+        }
+    }
+
+    ++frames_requested_;
+    files_written_ += outputs_written_;
+    switch (status)
+    {
+        case ScreenshotFrameStatus::kWritten:
+            ++frames_written_;
+            break;
+        case ScreenshotFrameStatus::kPartial:
+            ++frames_partial_;
+            break;
+        case ScreenshotFrameStatus::kSkipped:
+            ++frames_skipped_;
+            break;
+        case ScreenshotFrameStatus::kFailed:
+            ++frames_failed_;
+            break;
+    }
+
+    WriteBlock(ordered);
+
+    frame_.clear();
+    frame_open_ = false;
+}
+
+void ScreenshotJson::AddOutput(const char* source_kind, format::HandleId image_id, uint32_t layer)
+{
+    GFXRECON_ASSERT(frame_open_);
+
+    CommitCurrentOutputStatus();
+
+    auto& outputs = frame_["outputs"];
+    outputs.push_back(nlohmann::ordered_json::object());
+
+    auto& source   = outputs.back()["source"];
+    source["kind"] = source_kind;
+    if (image_id != format::kNullHandleId)
+    {
+        source["imageId"] = image_id;
+    }
+    else
+    {
+        source["imageId"] = nullptr;
+    }
+    source["layer"] = layer;
+}
+
+nlohmann::ordered_json& ScreenshotJson::CurrentOutput()
+{
+    GFXRECON_ASSERT(frame_open_);
+    auto& outputs = frame_["outputs"];
+    GFXRECON_ASSERT(!outputs.empty());
+    return outputs.back();
+}
+
+void ScreenshotJson::SetOutputSwapchain(format::HandleId swapchain_id, uint32_t swapchain_index, uint32_t image_index)
+{
+    auto& source             = CurrentOutput()["source"];
+    source["swapchainId"]    = swapchain_id;
+    source["swapchainIndex"] = swapchain_index;
+    source["imageIndex"]     = image_index;
+}
+
+void ScreenshotJson::SetOutputImageIndex(size_t image_index)
+{
+    CurrentOutput()["source"]["imageIndex"] = image_index;
+}
+
+void ScreenshotJson::SetOutputFramebufferAttachment(format::HandleId framebuffer_id,
+                                                    size_t           render_pass_index,
+                                                    size_t           attachment_index,
+                                                    format::HandleId image_view_id)
+{
+    auto& source              = CurrentOutput()["source"];
+    source["framebufferId"]   = framebuffer_id;
+    source["renderPassIndex"] = render_pass_index;
+    source["attachmentIndex"] = attachment_index;
+    source["imageViewId"]     = image_view_id;
+}
+
+void ScreenshotJson::SetOutputImage(VkFormat                      format,
+                                    uint32_t                      width,
+                                    uint32_t                      height,
+                                    VkSurfaceTransformFlagBitsKHR pre_transform)
+{
+    auto& source           = CurrentOutput()["source"];
+    source["format"]       = util::ToString(format);
+    source["extent"]       = { width, height };
+    source["preTransform"] = util::ToString(pre_transform);
+}
+
+void ScreenshotJson::SetOutputPresentInfo(const Decoded_VkPresentInfoKHR*   meta_info,
+                                          uint32_t                          swapchain_index,
+                                          format::HandleId                  surface_id,
+                                          const std::optional<std::string>& surface_extension,
+                                          const std::optional<VkExtent2D>&  window_size,
+                                          const VkExtent2D&                 swapchain_extent)
+{
+    GFXRECON_ASSERT((meta_info != nullptr) && (meta_info->decoded_value != nullptr));
+
+    const uint32_t   i     = swapchain_index;
+    const PNextNode* pnext = meta_info->pNext;
+
+    auto& present = CurrentOutput()["present"];
+
+    present["surfaceId"] = surface_id;
+
+    if (surface_extension)
+    {
+        present["surfaceExtension"] = surface_extension.value();
+    }
+    else
+    {
+        present["surfaceExtension"] = nullptr;
+    }
+
+    if (window_size)
+    {
+        present["replayWindowSize"] = { window_size->width, window_size->height };
+    }
+    else
+    {
+        present["replayWindowSize"] = nullptr;
+    }
+
+    present["swapchainExtent"] = { swapchain_extent.width, swapchain_extent.height };
+
+    // VkSwapchainPresentModeInfoKHR (also covers the EXT alias).
+    present["presentMode"] = nullptr;
+    if (const auto* mode_info = GetPNextMetaStruct<Decoded_VkSwapchainPresentModeInfoKHR>(pnext);
+        (mode_info != nullptr) && (mode_info->decoded_value != nullptr) &&
+        (mode_info->decoded_value->pPresentModes != nullptr) && (i < mode_info->pPresentModes.GetLength()))
+    {
+        present["presentMode"] = util::ToString(mode_info->pPresentModes.GetPointer()[i]);
+    }
+
+    // VkPresentRegionsKHR: damage rectangles for incremental present.
+    present["regions"] = nullptr;
+    if (const auto* regions_info = GetPNextMetaStruct<Decoded_VkPresentRegionsKHR>(pnext);
+        (regions_info != nullptr) && (regions_info->decoded_value != nullptr) &&
+        (regions_info->decoded_value->pRegions != nullptr) && (i < regions_info->pRegions->GetLength()))
+    {
+        const VkPresentRegionKHR& region  = regions_info->pRegions->GetPointer()[i];
+        auto&                     regions = present["regions"];
+        regions                           = nlohmann::ordered_json::array();
+        if (region.pRectangles != nullptr)
+        {
+            for (uint32_t r = 0; r < region.rectangleCount; ++r)
+            {
+                const VkRectLayerKHR&  rect = region.pRectangles[r];
+                nlohmann::ordered_json rect_json;
+                rect_json["offset"] = { rect.offset.x, rect.offset.y };
+                rect_json["extent"] = { rect.extent.width, rect.extent.height };
+                rect_json["layer"]  = rect.layer;
+                regions.push_back(rect_json);
+            }
+        }
+    }
+
+    // VkDisplayPresentInfoKHR: the only present struct that carries real placement rectangles.
+    present["displayPresentInfo"] = nullptr;
+    if (const auto* display_info = GetPNextMetaStruct<Decoded_VkDisplayPresentInfoKHR>(pnext);
+        (display_info != nullptr) && (display_info->decoded_value != nullptr))
+    {
+        const VkDisplayPresentInfoKHR& info    = *display_info->decoded_value;
+        auto&                          display = present["displayPresentInfo"];
+        display["srcRect"]["offset"]           = { info.srcRect.offset.x, info.srcRect.offset.y };
+        display["srcRect"]["extent"]           = { info.srcRect.extent.width, info.srcRect.extent.height };
+        display["dstRect"]["offset"]           = { info.dstRect.offset.x, info.dstRect.offset.y };
+        display["dstRect"]["extent"]           = { info.dstRect.extent.width, info.dstRect.extent.height };
+        display["persistent"]                  = (info.persistent != VK_FALSE);
+    }
+
+    // VkDeviceGroupPresentInfoKHR
+    present["deviceMask"]             = nullptr;
+    present["deviceGroupPresentMode"] = nullptr;
+    if (const auto* group_info = GetPNextMetaStruct<Decoded_VkDeviceGroupPresentInfoKHR>(pnext);
+        (group_info != nullptr) && (group_info->decoded_value != nullptr))
+    {
+        if ((group_info->decoded_value->pDeviceMasks != nullptr) && (i < group_info->pDeviceMasks.GetLength()))
+        {
+            present["deviceMask"] = group_info->pDeviceMasks.GetPointer()[i];
+        }
+        present["deviceGroupPresentMode"] = util::ToString(group_info->decoded_value->mode);
+    }
+
+    // VkPresentIdKHR / VkPresentId2KHR
+    present["presentId"] = nullptr;
+    if (const auto* id_info = GetPNextMetaStruct<Decoded_VkPresentIdKHR>(pnext);
+        (id_info != nullptr) && (id_info->decoded_value != nullptr) &&
+        (id_info->decoded_value->pPresentIds != nullptr) && (i < id_info->pPresentIds.GetLength()))
+    {
+        present["presentId"] = id_info->pPresentIds.GetPointer()[i];
+    }
+    else if (const auto* id2_info = GetPNextMetaStruct<Decoded_VkPresentId2KHR>(pnext);
+             (id2_info != nullptr) && (id2_info->decoded_value != nullptr) &&
+             (id2_info->decoded_value->pPresentIds != nullptr) && (i < id2_info->pPresentIds.GetLength()))
+    {
+        present["presentId"] = id2_info->pPresentIds.GetPointer()[i];
+    }
+
+    // VkPresentTimesInfoGOOGLE
+    present["presentTime"] = nullptr;
+    if (const auto* times_info = GetPNextMetaStruct<Decoded_VkPresentTimesInfoGOOGLE>(pnext);
+        (times_info != nullptr) && (times_info->decoded_value != nullptr) &&
+        (times_info->decoded_value->pTimes != nullptr) && (i < times_info->pTimes->GetLength()))
+    {
+        const VkPresentTimeGOOGLE& time              = times_info->pTimes->GetPointer()[i];
+        present["presentTime"]["presentID"]          = time.presentID;
+        present["presentTime"]["desiredPresentTime"] = time.desiredPresentTime;
+    }
+
+    // VkSwapchainPresentFenceInfoKHR (also covers the EXT alias).
+    present["presentFenceId"] = nullptr;
+    if (const auto* fence_info = GetPNextMetaStruct<Decoded_VkSwapchainPresentFenceInfoKHR>(pnext);
+        (fence_info != nullptr) && (i < fence_info->pFences.GetLength()))
+    {
+        present["presentFenceId"] = fence_info->pFences.GetPointer()[i];
+    }
+}
+
+void ScreenshotJson::SetOutputResult(const ScreenshotWriteResult& result)
+{
+    auto& entry = CurrentOutput();
+
+    if (result.status == ScreenshotStatus::kWritten)
+    {
+        entry["file"] = result.file;
+    }
+    else
+    {
+        entry["file"] = nullptr;
+    }
+
+    SetCurrentOutputStatus(result.status);
+
+    if (result.status != ScreenshotStatus::kWritten)
+    {
+        InsertReason(entry,
+                     result.reason_code,
+                     result.message,
+                     (result.vk_result != VK_SUCCESS) ? std::optional<VkResult>(result.vk_result) : std::nullopt);
+    }
+    else
+    {
+        auto& written     = entry["written"];
+        written["width"]  = result.width;
+        written["height"] = result.height;
+    }
+
+    if (!result.messages.empty())
+    {
+        auto& messages = entry["messages"];
+        messages       = nlohmann::ordered_json::array();
+        for (const auto& message : result.messages)
+        {
+            nlohmann::ordered_json json_message;
+            json_message["code"]    = message.code;
+            json_message["message"] = message.message;
+            messages.push_back(json_message);
+        }
+    }
+}
+
+void ScreenshotJson::SetOutputSkipped(const std::string&      code,
+                                      const std::string&      message,
+                                      bool                    is_error,
+                                      std::optional<VkResult> vk_result)
+{
+    auto& entry   = CurrentOutput();
+    entry["file"] = nullptr;
+    SetCurrentOutputStatus(is_error ? ScreenshotStatus::kFailed : ScreenshotStatus::kSkipped);
+    InsertReason(entry, code, message, vk_result);
+}
+
+void ScreenshotJson::SetCurrentOutputStatus(ScreenshotStatus status)
+{
+    CurrentOutput()["status"] = ScreenshotStatusToString(status);
+    current_output_status_    = status;
+}
+
+void ScreenshotJson::CommitCurrentOutputStatus()
+{
+    if (frame_["outputs"].empty())
+    {
+        return;
+    }
+
+    switch (current_output_status_.value_or(ScreenshotStatus::kFailed))
+    {
+        case ScreenshotStatus::kWritten:
+            ++outputs_written_;
+            break;
+        case ScreenshotStatus::kSkipped:
+            ++outputs_skipped_;
+            break;
+        case ScreenshotStatus::kFailed:
+            ++outputs_failed_;
+            break;
+    }
+
+    current_output_status_.reset();
+}
+
+ScreenshotFrameStatus
+ScreenshotJson::ComputeFrameStatus(uint32_t written, uint32_t skipped, uint32_t failed, bool reason_is_error)
+{
+    const uint32_t total = written + skipped + failed;
+    if (total == 0)
+    {
+        return reason_is_error ? ScreenshotFrameStatus::kFailed : ScreenshotFrameStatus::kSkipped;
+    }
+    if (written == total)
+    {
+        return ScreenshotFrameStatus::kWritten;
+    }
+    if (written > 0)
+    {
+        return ScreenshotFrameStatus::kPartial;
+    }
+    return (failed > 0) ? ScreenshotFrameStatus::kFailed : ScreenshotFrameStatus::kSkipped;
+}
+
+void ScreenshotJson::InsertReason(nlohmann::ordered_json& entry,
+                                  const std::string&      code,
+                                  const std::string&      message,
+                                  std::optional<VkResult> vk_result)
+{
+    auto& reason      = entry["reason"];
+    reason["code"]    = code;
+    reason["message"] = message;
+    if (vk_result)
+    {
+        reason["vkResult"] = util::ToString(vk_result.value());
+    }
+}
+
+void ScreenshotJson::WriteBlock(const nlohmann::ordered_json& block)
+{
+    GFXRECON_ASSERT(file_ != nullptr);
+
+    if (!first_block_)
+    {
+        util::platform::FileWrite(",\n", 2, file_);
+    }
+    first_block_ = false;
+
+    const std::string text = block.dump(util::kJsonIndentWidth);
+    util::platform::FileWrite(text.c_str(), text.size(), file_);
+    util::platform::FileFlush(file_);
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/screenshot_json.h
+++ b/framework/decode/screenshot_json.h
@@ -1,0 +1,160 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_SCREENSHOT_JSON_H
+#define GFXRECON_DECODE_SCREENSHOT_JSON_H
+
+#include "decode/screenshot_result.h"
+#include "decode/vulkan_replay_options.h"
+#include "format/format.h"
+#include "util/defines.h"
+#include "util/json_util.h"
+
+#include "vulkan/vulkan.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <optional>
+#include <string>
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+struct Decoded_VkPresentInfoKHR;
+
+class ScreenshotJson
+{
+  public:
+    static constexpr uint32_t kSchemaVersion = 1;
+
+    explicit ScreenshotJson(const VulkanReplayOptions& options);
+    ~ScreenshotJson();
+
+    bool Open(const std::string& filename);
+    void Close(uint32_t frames_seen);
+    bool HasOpenFrame() const { return frame_open_; }
+
+    void BeginFrame(uint32_t                        frame,
+                    uint64_t                        block_index,
+                    const char*                     boundary_type,
+                    const char*                     call,
+                    std::optional<format::HandleId> queue_id,
+                    std::optional<VkResult>         capture_result);
+
+    void EndFrame();
+
+    void SetReplayResult(VkResult replay_result);
+
+    void SetBoundarySwapchain(uint32_t swapchain_count);
+    void SetBoundaryCommandBuffer(format::HandleId command_buffer_id);
+    void
+    SetBoundaryFrameBoundaryEXT(const VkFrameBoundaryEXT& info, const format::HandleId* image_ids, size_t image_count);
+    void SetBoundaryFrameBoundaryANDROID(std::optional<format::HandleId> semaphore_id);
+
+    // Records why the frame produced no outputs at all.
+    void SetFrameReason(const std::string& code, const std::string& message, bool is_error);
+
+    // Appends a non-blocking message to the open frame.
+    void AddFrameMessage(const std::string& code, const std::string& message, std::optional<VkResult> vk_result);
+
+    // Appends an output entry to the open frame and makes it the current output
+    void AddOutput(const char* source_kind, format::HandleId image_id, uint32_t layer);
+
+    // Source details of the current output. Each applies to one source kind.
+    void SetOutputSwapchain(format::HandleId swapchain_id, uint32_t swapchain_index, uint32_t image_index);
+    void SetOutputImageIndex(size_t image_index);
+    void SetOutputFramebufferAttachment(format::HandleId framebuffer_id,
+                                        size_t           render_pass_index,
+                                        size_t           attachment_index,
+                                        format::HandleId image_view_id);
+
+    void SetOutputImage(VkFormat format, uint32_t width, uint32_t height, VkSurfaceTransformFlagBitsKHR pre_transform);
+
+    // Everything from VkPresentInfoKHR and its pNext chain that applies to the swapchain at swapchain_index, plus
+    // what replay knows about the surface. surface_extension and window_size are absent when replay has no window.
+    void SetOutputPresentInfo(const Decoded_VkPresentInfoKHR*   meta_info,
+                              uint32_t                          swapchain_index,
+                              format::HandleId                  surface_id,
+                              const std::optional<std::string>& surface_extension,
+                              const std::optional<VkExtent2D>&  window_size,
+                              const VkExtent2D&                 swapchain_extent);
+
+    // Outcome of the current output: either the result of a write attempt, or a skip decided before any write.
+    void SetOutputResult(const ScreenshotWriteResult& result);
+    void SetOutputSkipped(const std::string&      code,
+                          const std::string&      message,
+                          bool                    is_error,
+                          std::optional<VkResult> vk_result = std::nullopt);
+
+  private:
+    // The output most recently added to the open frame.
+    nlohmann::ordered_json& CurrentOutput();
+
+    // Records the status of the current output in the JSON and remembers it for the frame counters.
+    void SetCurrentOutputStatus(ScreenshotStatus status);
+
+    // Adds the status of the current output, if any, to the frame counters.
+    void CommitCurrentOutputStatus();
+
+    static void InsertReason(nlohmann::ordered_json& entry,
+                             const std::string&      code,
+                             const std::string&      message,
+                             std::optional<VkResult> vk_result);
+
+    void WriteBlock(const nlohmann::ordered_json& block);
+
+    // Computes the status of a frame from the number of its outputs in each status. reason_is_error classifies a
+    // frame without any outputs
+    static ScreenshotFrameStatus
+    ComputeFrameStatus(uint32_t written, uint32_t skipped, uint32_t failed, bool reason_is_error);
+
+  private:
+    FILE*                  file_{ nullptr };
+    bool                   first_block_{ true };
+    bool                   frame_open_{ false };
+    bool                   frame_reason_is_error_{ false };
+    nlohmann::ordered_json header_;
+    nlohmann::ordered_json frame_;
+
+    // Status of the output most recently added to the open frame, counted when the next output is added or the frame
+    // ends. An output that never receives a status counts as failed.
+    std::optional<ScreenshotStatus> current_output_status_;
+
+    // Outputs of the open frame by status.
+    uint32_t outputs_written_{ 0 };
+    uint32_t outputs_skipped_{ 0 };
+    uint32_t outputs_failed_{ 0 };
+
+    uint32_t frames_requested_{ 0 };
+    uint32_t frames_written_{ 0 };
+    uint32_t frames_partial_{ 0 };
+    uint32_t frames_skipped_{ 0 };
+    uint32_t frames_failed_{ 0 };
+    uint32_t files_written_{ 0 };
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_SCREENSHOT_JSON_H

--- a/framework/decode/screenshot_result.h
+++ b/framework/decode/screenshot_result.h
@@ -1,0 +1,158 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_SCREENSHOT_RESULT_H
+#define GFXRECON_DECODE_SCREENSHOT_RESULT_H
+
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+// Outcome of one screenshot output (a single image file).
+enum class ScreenshotStatus
+{
+    kWritten,
+    kSkipped,
+    kFailed
+};
+
+// Outcome of a whole screenshot frame, derived from the statuses of its outputs.
+enum class ScreenshotFrameStatus
+{
+    kWritten,
+    kPartial,
+    kSkipped,
+    kFailed
+};
+
+// Reason codes shared by the frame-level reason and the per-output reason of the screenshot result JSON.
+namespace screenshot_reason
+{
+// Non-error reasons
+constexpr char kFrameBoundaryNoImages[]       = "FRAME_BOUNDARY_NO_IMAGES";
+constexpr char kFrameBoundaryAndroidNoImage[] = "FRAME_BOUNDARY_ANDROID_NO_IMAGE";
+constexpr char kNotColorAttachment[]          = "NOT_COLOR_ATTACHMENT";
+constexpr char kNoFramebuffers[]              = "NO_FRAMEBUFFERS";
+constexpr char kSwapchainNoImages[]           = "SWAPCHAIN_NO_IMAGES";
+constexpr char kZeroSizeImage[]               = "ZERO_SIZE_IMAGE";
+constexpr char kNoOutputs[]                   = "NO_OUTPUTS";
+
+// Errors
+constexpr char kImageIndexOutOfRange[]         = "IMAGE_INDEX_OUT_OF_RANGE";
+constexpr char kUnknownImage[]                 = "UNKNOWN_IMAGE";
+constexpr char kUnknownSwapchain[]             = "UNKNOWN_SWAPCHAIN";
+constexpr char kUnsupportedFormat[]            = "UNSUPPORTED_FORMAT";
+constexpr char kDeviceWaitIdleFailed[]         = "DEVICE_WAIT_IDLE_FAILED";
+constexpr char kQueueSubmitFailed[]            = "QUEUE_SUBMIT_FAILED";
+constexpr char kMemoryMapFailed[]              = "MEMORY_MAP_FAILED";
+constexpr char kFileWriteFailed[]              = "FILE_WRITE_FAILED";
+constexpr char kReplayCallFailed[]             = "REPLAY_CALL_FAILED";
+constexpr char kMissingDeviceTable[]           = "MISSING_DEVICE_TABLE";
+constexpr char kCommandPoolCreateFailed[]      = "COMMAND_POOL_CREATE_FAILED";
+constexpr char kCommandBufferAllocateFailed[]  = "COMMAND_BUFFER_ALLOCATE_FAILED";
+constexpr char kTransferResourceCreateFailed[] = "TRANSFER_RESOURCE_CREATE_FAILED";
+
+// Non-blocking messages. The output is still written.
+constexpr char kFormatFallback[]      = "FORMAT_FALLBACK";
+constexpr char kRotationAllocFailed[] = "ROTATION_ALLOC_FAILED";
+} // namespace screenshot_reason
+
+struct ScreenshotMessage
+{
+    std::string code;
+    std::string message;
+};
+
+// Result of a single screenshot write. Every early return of ScreenshotHandler::WriteImage maps to one reason code.
+struct ScreenshotWriteResult
+{
+    ScreenshotStatus status{ ScreenshotStatus::kFailed };
+    std::string      reason_code; // One of the screenshot_reason constants. Empty when the file was written.
+    std::string      message;     // The text that went to the log.
+    VkResult         vk_result{ VK_SUCCESS }; // Set when a Vulkan call produced the failure.
+    std::string      file;                    // Path of the file that was written. Empty otherwise.
+    uint32_t         width{ 0 };              // Dimensions of the written image.
+    uint32_t         height{ 0 };
+    std::vector<ScreenshotMessage> messages; // Non-blocking warnings raised while writing.
+
+    static ScreenshotWriteResult
+    Failed(const std::string& code, const std::string& message, VkResult vk_result = VK_SUCCESS)
+    {
+        ScreenshotWriteResult result;
+        result.status      = ScreenshotStatus::kFailed;
+        result.reason_code = code;
+        result.message     = message;
+        result.vk_result   = vk_result;
+        return result;
+    }
+
+    static ScreenshotWriteResult Skipped(const std::string& code, const std::string& message)
+    {
+        ScreenshotWriteResult result;
+        result.status      = ScreenshotStatus::kSkipped;
+        result.reason_code = code;
+        result.message     = message;
+        return result;
+    }
+};
+
+inline const char* ScreenshotStatusToString(ScreenshotStatus status)
+{
+    switch (status)
+    {
+        case ScreenshotStatus::kWritten:
+            return "written";
+        case ScreenshotStatus::kSkipped:
+            return "skipped";
+        case ScreenshotStatus::kFailed:
+        default:
+            return "failed";
+    }
+}
+
+inline const char* ScreenshotFrameStatusToString(ScreenshotFrameStatus status)
+{
+    switch (status)
+    {
+        case ScreenshotFrameStatus::kWritten:
+            return "written";
+        case ScreenshotFrameStatus::kPartial:
+            return "partial";
+        case ScreenshotFrameStatus::kSkipped:
+            return "skipped";
+        case ScreenshotFrameStatus::kFailed:
+        default:
+            return "failed";
+    }
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_SCREENSHOT_RESULT_H

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2621,25 +2621,38 @@ void VulkanReplayConsumerBase::InitializeScreenshotHandler()
         screenshot_file_prefix_ = util::filepath::Join(options_.screenshot_dir, screenshot_file_prefix_);
     }
 
-    screenshot_handler_ = std::make_unique<ScreenshotHandler>(
-        options_.screenshot_format, options_.screenshot_ranges, options_.screenshot_interval);
+    const std::string screenshots_json_filename = screenshot_file_prefix_ + ".json";
+    screenshot_handler_ = std::make_unique<ScreenshotHandler>(options_, screenshots_json_filename);
 }
 
-void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* meta_info) const
+void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* meta_info,
+                                                const VulkanQueueInfo*          queue_info,
+                                                VkResult                        original_result)
 {
+    GFXRECON_ASSERT(screenshot_handler_ != nullptr);
+
     if (meta_info != nullptr && meta_info->decoded_value != nullptr && !meta_info->pSwapchains.IsNull())
     {
+        screenshot_handler_->BeginFrame(
+            "vkQueuePresentKHR", "vkQueuePresentKHR", queue_info, original_result, block_index_);
+
         auto present_info  = meta_info->decoded_value;
         auto swapchain_ids = meta_info->pSwapchains.GetPointer();
+
+        screenshot_handler_->SetBoundarySwapchain(present_info->swapchainCount);
 
         for (uint32_t i = 0; i < present_info->swapchainCount; ++i)
         {
             auto swapchain_info = object_info_table_->GetVkSwapchainKHRInfo(swapchain_ids[i]);
+            auto surface_info   = (swapchain_info != nullptr)
+                                      ? object_info_table_->GetVkSurfaceKHRInfo(swapchain_info->surface_id)
+                                      : nullptr;
+
             if (swapchain_info != nullptr && swapchain_info->device_info != nullptr &&
                 swapchain_info->images.size() > 0)
             {
-                auto     device_info = swapchain_info->device_info;
                 uint32_t image_index = present_info->pImageIndices[i];
+                auto     device_info = swapchain_info->device_info;
 
                 auto instance_table = GetInstanceTable(device_info->parent);
                 assert(instance_table != nullptr);
@@ -2660,12 +2673,39 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
                 filename_prefix += "_frame_";
                 filename_prefix += std::to_string(screenshot_handler_->GetCurrentFrame());
 
-                VkFormat      image_format = swapchain_info->format;
-                VkImageLayout image_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-                VkImage       image        = swapchain_info->images[image_index];
-                uint32_t      image_width  = swapchain_info->width;
-                uint32_t      image_height = swapchain_info->height;
-                uint32_t      num_layers   = 1;
+                const char*      source_kind  = "swapchainImage";
+                format::HandleId image_id     = format::kNullHandleId;
+                VkFormat         image_format = swapchain_info->format;
+                VkImageLayout    image_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+                VkImage          image        = VK_NULL_HANDLE;
+                uint32_t         image_width  = swapchain_info->width;
+                uint32_t         image_height = swapchain_info->height;
+                uint32_t         num_layers   = 1;
+
+                if (image_index < swapchain_info->images.size())
+                {
+                    image = swapchain_info->images[image_index];
+                }
+                else
+                {
+                    screenshot_handler_->AddSwapchainOutput(source_kind,
+                                                            image_id,
+                                                            0,
+                                                            meta_info,
+                                                            i,
+                                                            swapchain_ids[i],
+                                                            image_index,
+                                                            swapchain_info,
+                                                            surface_info);
+
+                    screenshot_handler_->SkipOutput(
+                        screenshot_reason::kImageIndexOutOfRange,
+                        "Present image index " + std::to_string(image_index) + " exceeds the " +
+                            std::to_string(swapchain_info->images.size()) + " replay images of swapchain " +
+                            std::to_string(swapchain_ids[i]),
+                        true);
+                    continue;
+                }
 
                 // apply swapchain-image override, if any
                 const VulkanImageInfo* override_img_info = nullptr;
@@ -2676,65 +2716,137 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
 
                     if (override_img_info != nullptr)
                     {
+                        source_kind  = "presentOverrideImage";
+                        image_id     = present_override_image_id_;
                         image_format = override_img_info->format;
                         image        = override_img_info->handle;
                         image_width  = override_img_info->extent.width;
                         image_height = override_img_info->extent.height;
                         num_layers   = override_img_info->layer_count;
                     }
-                }
-
-                // NOTE: optional scale takes precedence over explicit screenshot width/height
-                auto screenshot_scale = options_.screenshot_scale;
-                if (!screenshot_scale && options_.screenshot_width > 0 && options_.screenshot_height > 0)
-                {
-                    screenshot_scale = {
-                        static_cast<float>(options_.screenshot_width) / static_cast<float>(image_width),
-                        static_cast<float>(options_.screenshot_height) / static_cast<float>(image_height)
-                    };
-                }
-
-                for (uint32_t layer = 0; layer < num_layers; ++layer)
-                {
-                    // WriteImage barriers only the layer it copies, so it has to transition from that layer's layout.
-                    VkImageLayout layer_layout = image_layout;
-                    if (override_img_info != nullptr)
+                    else
                     {
-                        const VkImageLayout tracked_layout =
-                            override_img_info->subresource_layouts.GetSubresourceLayout(
-                                VK_IMAGE_ASPECT_COLOR_BIT, 0, layer);
-                        layer_layout = (tracked_layout != VK_IMAGE_LAYOUT_UNDEFINED)
-                                           ? tracked_layout
-                                           : VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL;
-                    }
+                        screenshot_handler_->AddSwapchainOutput(source_kind,
+                                                                image_id,
+                                                                0,
+                                                                meta_info,
+                                                                i,
+                                                                swapchain_ids[i],
+                                                                image_index,
+                                                                swapchain_info,
+                                                                surface_info);
 
-                    screenshot_handler_->WriteImage(
-                        num_layers > 1 ? filename_prefix + "_layer_" + std::to_string(layer) : filename_prefix,
-                        device_info,
-                        GetInjectedDeviceCalls(device_info->handle),
-                        memory_properties,
-                        device_info->allocator.get(),
-                        image,
-                        image_format,
-                        image_width,
-                        image_height,
-                        layer,
-                        screenshot_scale,
-                        layer_layout,
-                        options_.screenshot_apply_prerotation ? swapchain_info->pre_transform
-                                                              : VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
+                        screenshot_handler_->SkipOutput(screenshot_reason::kUnknownImage,
+                                                        "Present override image " +
+                                                            std::to_string(present_override_image_id_) +
+                                                            " is not known to replay",
+                                                        true);
+                    }
                 }
+
+                if (image != VK_NULL_HANDLE)
+                {
+                    const VkSurfaceTransformFlagBitsKHR pre_transform = options_.screenshot_apply_prerotation
+                                                                            ? swapchain_info->pre_transform
+                                                                            : VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+
+                    for (uint32_t layer = 0; layer < num_layers; ++layer)
+                    {
+                        screenshot_handler_->AddSwapchainOutput(source_kind,
+                                                                image_id,
+                                                                layer,
+                                                                meta_info,
+                                                                i,
+                                                                swapchain_ids[i],
+                                                                image_index,
+                                                                swapchain_info,
+                                                                surface_info);
+
+                        // WriteImage barriers only the layer it copies, so it has to transition from that layer's
+                        // layout.
+                        VkImageLayout layer_layout = image_layout;
+                        if (override_img_info != nullptr)
+                        {
+                            const VkImageLayout tracked_layout =
+                                override_img_info->subresource_layouts.GetSubresourceLayout(
+                                    VK_IMAGE_ASPECT_COLOR_BIT, 0, layer);
+                            layer_layout = (tracked_layout != VK_IMAGE_LAYOUT_UNDEFINED)
+                                               ? tracked_layout
+                                               : VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL;
+                        }
+
+                        screenshot_handler_->WriteOutput(
+                            num_layers > 1 ? filename_prefix + "_layer_" + std::to_string(layer) : filename_prefix,
+                            device_info,
+                            GetInjectedDeviceCalls(device_info->handle),
+                            memory_properties,
+                            image,
+                            image_format,
+                            image_width,
+                            image_height,
+                            layer,
+                            layer_layout,
+                            pre_transform);
+                    }
+                }
+            }
+            else if (swapchain_info == nullptr)
+            {
+                screenshot_handler_->AddSwapchainOutput("swapchainImage",
+                                                        format::kNullHandleId,
+                                                        0,
+                                                        meta_info,
+                                                        i,
+                                                        swapchain_ids[i],
+                                                        0,
+                                                        swapchain_info,
+                                                        surface_info);
+
+                screenshot_handler_->SkipOutput(screenshot_reason::kUnknownSwapchain,
+                                                "Swapchain " + std::to_string(swapchain_ids[i]) +
+                                                    " is not known to replay",
+                                                true);
+            }
+            else
+            {
+                screenshot_handler_->AddSwapchainOutput("swapchainImage",
+                                                        format::kNullHandleId,
+                                                        0,
+                                                        meta_info,
+                                                        i,
+                                                        swapchain_ids[i],
+                                                        0,
+                                                        swapchain_info,
+                                                        surface_info);
+
+                screenshot_handler_->SkipOutput(screenshot_reason::kSwapchainNoImages,
+                                                "Swapchain " + std::to_string(swapchain_ids[i]) +
+                                                    " has no replay images (surface filtered out by "
+                                                    "--surface-index, or an offscreen swapchain that never "
+                                                    "acquired an image)",
+                                                false);
             }
         }
     }
 }
 
 bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
-    const VulkanCommandBufferInfo* command_buffer_info)
+    const VulkanCommandBufferInfo* command_buffer_info,
+    const char*                    call_name,
+    const VulkanQueueInfo*         queue_info,
+    VkResult                       original_result,
+    VkResult                       replay_result)
 {
     GFXRECON_ASSERT(command_buffer_info != nullptr);
+    GFXRECON_ASSERT(screenshot_handler_ != nullptr);
+
     if (command_buffer_info->is_frame_boundary)
     {
+        screenshot_handler_->BeginFrame(
+            "commandBufferFrameBoundary", call_name, queue_info, original_result, block_index_);
+
+        screenshot_handler_->SetBoundaryCommandBuffer(command_buffer_info->capture_id);
+
         if (screenshot_handler_->IsScreenshotFrame())
         {
             VulkanDeviceInfo* device_info = object_info_table_->GetVkDeviceInfo(command_buffer_info->parent_id);
@@ -2750,6 +2862,13 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
                 instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
             }
 
+            if (command_buffer_info->frame_buffer_ids.empty())
+            {
+                screenshot_handler_->SkipFrame(screenshot_reason::kNoFramebuffers,
+                                               "The frame boundary command buffer rendered to no framebuffer",
+                                               false);
+            }
+
             for (size_t i = 0; i < command_buffer_info->frame_buffer_ids.size(); ++i)
             {
                 auto framebuffer_info =
@@ -2761,9 +2880,17 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
                     auto image_view_info = object_info_table_->GetVkImageViewInfo(image_view_id);
                     auto image_info      = object_info_table_->GetVkImageInfo(image_view_info->image_id);
 
+                    screenshot_handler_->AddFramebufferAttachmentOutput(
+                        image_info->capture_id, command_buffer_info->frame_buffer_ids[i], i, j, image_view_id);
+
                     // Only screenshot images that are color attachments.
                     if (!graphics::ImageHasUsage(image_info->usage, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT))
                     {
+                        screenshot_handler_->SkipOutput(screenshot_reason::kNotColorAttachment,
+                                                        "Attachment " + std::to_string(j) + " of framebuffer " +
+                                                            std::to_string(command_buffer_info->frame_buffer_ids[i]) +
+                                                            " is not a color attachment",
+                                                        false);
                         continue;
                     }
 
@@ -2783,100 +2910,109 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(
                         filename_prefix += std::to_string(j);
                     }
 
-                    // NOTE: optional scale takes precedence over explicit screenshot width/height
-                    auto screenshot_scale = options_.screenshot_scale;
-                    if (!screenshot_scale && options_.screenshot_width > 0 && options_.screenshot_height > 0)
-                    {
-                        screenshot_scale = { static_cast<float>(options_.screenshot_width) /
-                                                 static_cast<float>(image_info->extent.width),
-                                             static_cast<float>(options_.screenshot_height) /
-                                                 static_cast<float>(image_info->extent.height) };
-                    }
-
-                    screenshot_handler_->WriteImage(
+                    screenshot_handler_->WriteOutput(
                         filename_prefix,
                         device_info,
                         GetInjectedDeviceCalls(device_info->handle),
                         memory_properties,
-                        device_info->allocator.get(),
                         image_info->handle,
                         image_info->format,
                         image_info->extent.width,
                         image_info->extent.height,
                         0,
-                        screenshot_scale,
                         image_info->subresource_layouts.GetSubresourceLayout(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0),
                         VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
                 }
             }
         }
-        screenshot_handler_->EndFrame();
+        screenshot_handler_->EndFrame(replay_result);
         return true;
     }
     return false;
 }
 
 bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const VulkanDeviceInfo* device_info,
-                                                               const PNextNode*        pnext)
+                                                               const PNextNode*        pnext,
+                                                               const char*             call_name,
+                                                               const VulkanQueueInfo*  queue_info,
+                                                               VkResult                original_result,
+                                                               VkResult                replay_result)
 {
+    GFXRECON_ASSERT(screenshot_handler_ != nullptr);
+
     const auto* frame_boundary = GetPNextMetaStruct<Decoded_VkFrameBoundaryEXT>(pnext);
-    if (frame_boundary == nullptr ||
+    if (frame_boundary == nullptr || frame_boundary->decoded_value == nullptr ||
         ((frame_boundary->decoded_value->flags & VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT) == 0))
     {
         return false;
     }
 
-    VkPhysicalDeviceMemoryProperties memory_properties;
-    {
-        util::MarkInjectedCommandsHelper mark_injected_commands_helper;
-        auto                             instance_table = GetInstanceTable(device_info->parent);
-        GFXRECON_ASSERT(instance_table != nullptr);
+    screenshot_handler_->BeginFrame("VkFrameBoundaryEXT", call_name, queue_info, original_result, block_index_);
 
-        instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
-    }
+    const size_t image_count = frame_boundary->pImages.GetLength();
+
+    screenshot_handler_->SetBoundaryFrameBoundaryEXT(frame_boundary);
 
     if (screenshot_handler_->IsScreenshotFrame())
     {
-        for (uint32_t i = 0; i < frame_boundary->pImages.GetLength(); ++i)
+        VkPhysicalDeviceMemoryProperties memory_properties;
+        {
+            util::MarkInjectedCommandsHelper mark_injected_commands_helper;
+            auto                             instance_table = GetInstanceTable(device_info->parent);
+            GFXRECON_ASSERT(instance_table != nullptr);
+
+            instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+        }
+
+        if (image_count == 0)
+        {
+            // A frame boundary without images is valid, and common for offscreen rendering. There is nothing replay
+            // could screenshot, so say so instead of silently skipping the frame.
+            screenshot_handler_->SkipFrame(screenshot_reason::kFrameBoundaryNoImages,
+                                           std::string("VkFrameBoundaryEXT on ") + call_name +
+                                               " lists no images; nothing to screenshot",
+                                           false);
+        }
+
+        for (size_t i = 0; i < image_count; ++i)
         {
             std::string filename_prefix =
                 screenshot_file_prefix_ + "_frame_" + std::to_string(screenshot_handler_->GetCurrentFrame());
 
-            if (frame_boundary->pImages.GetLength() > 1)
+            if (image_count > 1)
             {
                 filename_prefix += "_image_" + std::to_string(i);
             }
 
-            const format::HandleId handleId   = frame_boundary->pImages.GetPointer()[i];
-            const VulkanImageInfo* image_info = GetObjectInfoTable().GetVkImageInfo(handleId);
+            const format::HandleId image_id   = frame_boundary->pImages.GetPointer()[i];
+            const VulkanImageInfo* image_info = GetObjectInfoTable().GetVkImageInfo(image_id);
+            screenshot_handler_->AddOutput("frameBoundaryImage", image_id, 0, i);
 
-            // NOTE: optional scale takes precedence over explicit screenshot width/height
-            auto screenshot_scale = options_.screenshot_scale;
-            if (!screenshot_scale && options_.screenshot_width > 0 && options_.screenshot_height > 0)
+            if (image_info == nullptr)
             {
-                screenshot_scale = {
-                    static_cast<float>(options_.screenshot_width) / static_cast<float>(image_info->extent.width),
-                    static_cast<float>(options_.screenshot_height) / static_cast<float>(image_info->extent.height)
-                };
+                screenshot_handler_->SkipOutput(screenshot_reason::kUnknownImage,
+                                                "VkFrameBoundaryEXT image " + std::to_string(image_id) +
+                                                    " is not known to replay",
+                                                true);
+                continue;
             }
 
-            screenshot_handler_->WriteImage(
+            screenshot_handler_->WriteOutput(
                 filename_prefix,
                 device_info,
                 GetInjectedDeviceCalls(device_info->handle),
                 memory_properties,
-                device_info->allocator.get(),
                 image_info->handle,
                 image_info->format,
                 image_info->extent.width,
                 image_info->extent.height,
                 0,
-                screenshot_scale,
-                image_info->subresource_layouts.GetSubresourceLayout(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0));
+                image_info->subresource_layouts.GetSubresourceLayout(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0),
+                VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
         }
     }
 
-    screenshot_handler_->EndFrame();
+    screenshot_handler_->EndFrame(replay_result);
 
     return true;
 }
@@ -5056,7 +5192,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
 
     if (options_.dumping_resources && resource_dumper_->MustDumpQueueSubmitIndex(index))
     {
-        resource_dumper_->QueueSubmit(
+        result = resource_dumper_->QueueSubmit(
             current_submits_span, GetInjectedDeviceCalls(queue_info->handle), queue_info, fence, index);
     }
     else
@@ -5114,7 +5250,11 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
             if (submit_info_data != nullptr)
             {
                 if (CheckPNextChainForFrameBoundary(object_info_table_->GetVkDeviceInfo(queue_info->parent_id),
-                                                    submit_info_data[i].pNext))
+                                                    submit_info_data[i].pNext,
+                                                    "vkQueueSubmit",
+                                                    queue_info,
+                                                    original_result,
+                                                    result))
                 {
                     break;
                 }
@@ -5125,7 +5265,9 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit        
                 {
                     auto command_buffer_info = GetObjectInfoTable().GetVkCommandBufferInfo(command_buffer_ids[j]);
 
-                    if (CheckCommandBufferInfoForFrameBoundary(command_buffer_info))
+                    // Check whether any of the submitted command lists buffers are frame boundaries.
+                    if (CheckCommandBufferInfoForFrameBoundary(
+                            command_buffer_info, "vkQueueSubmit", queue_info, original_result, result))
                     {
                         break;
                     }
@@ -5342,7 +5484,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
 
     if (options_.dumping_resources && resource_dumper_->MustDumpQueueSubmitIndex(index))
     {
-        resource_dumper_->QueueSubmit2(
+        result = resource_dumper_->QueueSubmit2(
             current_submits_span, GetInjectedDeviceCalls(queue_info->handle), queue_info, fence, index);
     }
     else
@@ -5407,7 +5549,11 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
             if (submit_info_data != nullptr)
             {
                 if (CheckPNextChainForFrameBoundary(object_info_table_->GetVkDeviceInfo(queue_info->parent_id),
-                                                    submit_info_data[i].pNext))
+                                                    submit_info_data[i].pNext,
+                                                    "vkQueueSubmit2",
+                                                    queue_info,
+                                                    original_result,
+                                                    result))
                 {
                     break;
                 }
@@ -5418,7 +5564,8 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2      
                 {
                     auto command_buffer_info =
                         GetObjectInfoTable().GetVkCommandBufferInfo(command_buffer_infos[j].commandBuffer);
-                    if (CheckCommandBufferInfoForFrameBoundary(command_buffer_info))
+                    if (CheckCommandBufferInfoForFrameBoundary(
+                            command_buffer_info, "vkQueueSubmit2", queue_info, original_result, result))
                     {
                         break;
                     }
@@ -9553,7 +9700,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
         auto meta_info = pPresentInfo->GetMetaStructPointer();
         assert((meta_info != nullptr) && !meta_info->pSwapchains.IsNull());
 
-        WriteScreenshots(meta_info);
+        WriteScreenshots(meta_info, queue_info, original_result);
     }
 
     // If rendering is restricted to a specific surface, need to check for dummy swapchains at present.
@@ -9909,7 +10056,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
 
     if (screenshot_handler_ != nullptr)
     {
-        screenshot_handler_->EndFrame();
+        screenshot_handler_->EndFrame(result);
     }
 
     return result;
@@ -12147,43 +12294,48 @@ void VulkanReplayConsumerBase::OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryA
 
     if (screenshot_handler_ != nullptr && !options_.screenshot_ignore_frameBoundaryAndroid)
     {
-        if (screenshot_handler_->IsScreenshotFrame() && image_info != nullptr)
+        screenshot_handler_->BeginFrame(
+            "vkFrameBoundaryANDROID", "vkFrameBoundaryANDROID", nullptr, std::nullopt, block_index_);
+
+        screenshot_handler_->SetBoundaryFrameBoundaryANDROID(semaphore_info);
+
+        if (screenshot_handler_->IsScreenshotFrame())
         {
-            const std::string filename_prefix =
-                screenshot_file_prefix_ + "_frame_" + std::to_string(screenshot_handler_->GetCurrentFrame());
-
-            auto instance_table = GetInstanceTable(device_info->parent);
-            GFXRECON_ASSERT(instance_table != nullptr);
-
-            VkPhysicalDeviceMemoryProperties memory_properties;
-            instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
-
-            // NOTE: optional scale takes precedence over explicit screenshot width/height
-            auto screenshot_scale = options_.screenshot_scale;
-            if (!screenshot_scale && options_.screenshot_width > 0 && options_.screenshot_height > 0)
+            if (image_info != nullptr)
             {
-                screenshot_scale = {
-                    static_cast<float>(options_.screenshot_width) / static_cast<float>(image_info->extent.width),
-                    static_cast<float>(options_.screenshot_height) / static_cast<float>(image_info->extent.height)
-                };
-            }
+                const std::string filename_prefix =
+                    screenshot_file_prefix_ + "_frame_" + std::to_string(screenshot_handler_->GetCurrentFrame());
 
-            screenshot_handler_->WriteImage(
-                filename_prefix,
-                device_info,
-                GetInjectedDeviceCalls(device_info->handle),
-                memory_properties,
-                device_info->allocator.get(),
-                image_info->handle,
-                image_info->format,
-                image_info->extent.width,
-                image_info->extent.height,
-                0,
-                screenshot_scale,
-                image_info->subresource_layouts.GetSubresourceLayout(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0));
+                auto instance_table = GetInstanceTable(device_info->parent);
+                GFXRECON_ASSERT(instance_table != nullptr);
+
+                VkPhysicalDeviceMemoryProperties memory_properties;
+                instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+
+                screenshot_handler_->AddOutput("frameBoundaryImage", image_info->capture_id, 0);
+
+                screenshot_handler_->WriteOutput(
+                    filename_prefix,
+                    device_info,
+                    GetInjectedDeviceCalls(device_info->handle),
+                    memory_properties,
+                    image_info->handle,
+                    image_info->format,
+                    image_info->extent.width,
+                    image_info->extent.height,
+                    0,
+                    image_info->subresource_layouts.GetSubresourceLayout(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0),
+                    VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
+            }
+            else
+            {
+                screenshot_handler_->SkipFrame(screenshot_reason::kFrameBoundaryAndroidNoImage,
+                                               "vkFrameBoundaryANDROID was called without an image",
+                                               false);
+            }
         }
 
-        screenshot_handler_->EndFrame();
+        screenshot_handler_->EndFrame(std::nullopt);
     }
 
     bool presented_ad_hoc = false;

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -2046,7 +2046,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void InitializeScreenshotHandler();
 
-    void WriteScreenshots(const Decoded_VkPresentInfoKHR* meta_info) const;
+    void WriteScreenshots(const Decoded_VkPresentInfoKHR* meta_info,
+                          const VulkanQueueInfo*          queue_info,
+                          VkResult                        original_result);
 
     /**
      * @brief   Applies the layouts tracked while recording a command buffer to the images they refer to.
@@ -2058,8 +2060,17 @@ class VulkanReplayConsumerBase : public VulkanConsumer
      */
     void PropagateImageLayouts(const VulkanCommandBufferInfo* command_buffer_info);
 
-    bool CheckCommandBufferInfoForFrameBoundary(const VulkanCommandBufferInfo* command_buffer_info);
-    bool CheckPNextChainForFrameBoundary(const VulkanDeviceInfo* device_info, const PNextNode* pnext);
+    bool CheckCommandBufferInfoForFrameBoundary(const VulkanCommandBufferInfo* command_buffer_info,
+                                                const char*                    call_name,
+                                                const VulkanQueueInfo*         queue_info,
+                                                VkResult                       original_result,
+                                                VkResult                       replay_result);
+    bool CheckPNextChainForFrameBoundary(const VulkanDeviceInfo* device_info,
+                                         const PNextNode*        pnext,
+                                         const char*             call_name,
+                                         const VulkanQueueInfo*  queue_info,
+                                         VkResult                original_result,
+                                         VkResult                replay_result);
 
     void UpdateDescriptorSetInfoWithTemplate(VulkanDescriptorSetInfo*                  desc_set_info,
                                              const VulkanDescriptorUpdateTemplateInfo* template_info,

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -178,7 +178,7 @@ struct VulkanReplayOptions : public ReplayOptions
     int32_t                             override_gpu_group_index{ -1 };
     int32_t                             surface_index{ -1 };
     CreateResourceAllocator             create_resource_allocator;
-    uint32_t                            screenshot_width, screenshot_height;
+    uint32_t                            screenshot_width{ 0 }, screenshot_height{ 0 };
     std::optional<std::array<float, 2>> screenshot_scale;
     std::string                         replace_shader_dir;
     SkipGetFenceStatus                  skip_get_fence_status{ SkipGetFenceStatus::NoSkip };


### PR DESCRIPTION
A json file now provides additional information related to dumped screenshots

An example of the json schema for `QueuePresent`:
```Json
{
  "header": {
    "schemaVersion": 1,
    "gfxreconVersion": "1.0.5-dev (json_for_screenshots:ab7d5a7) Debug",
    "vulkanVersion": "1.4.361",
    "api": "vulkan",
    "captureFile": "../../madmax_20230908T130125.gfxr",
    "options": {
      "ranges": [
        {
          "first": 22900,
          "last": 23000
        }
      ],
      "interval": 1,
      "format": "bmp",
      "dir": "json",
      "prefix": "screenshot",
      "scale": [
        0.5,
        0.5
      ],
      "size": null,
      "applyPrerotation": false,
      "ignoreFrameBoundaryAndroid": false
    }
  }
},
{
  "frame": 22900,
  "blockIndex": 420364,
  "boundary": {
    "type": "vkQueuePresentKHR",
    "call": "vkQueuePresentKHR",
    "queueId": 25,
    "captureResult": "VK_SUCCESS",
    "replayResult": "VK_SUCCESS",
    "swapchainCount": 1
  },
  "status": "written",
  "outputs": [
    {
      "source": {
        "kind": "swapchainImage",
        "imageId": null,
        "layer": 0,
        "swapchainId": 1690,
        "swapchainIndex": 0,
        "imageIndex": 1,
        "format": "VK_FORMAT_B8G8R8A8_SRGB",
        "extent": [
          1024,
          768
        ],
        "preTransform": "VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR"
      },
      "present": {
        "surfaceId": 1687,
        "surfaceExtension": "VK_KHR_xcb_surface",
        "replayWindowSize": [
          1024,
          768
        ],
        "swapchainExtent": [
          1024,
          768
        ],
        "presentMode": null,
        "regions": null,
        "displayPresentInfo": null,
        "deviceMask": null,
        "deviceGroupPresentMode": null,
        "presentId": null,
        "presentTime": null,
        "presentFenceId": null
      },
      "file": "json/screenshot_frame_22900.bmp",
      "status": "written",
      "written": {
        "width": 512,
        "height": 384
      }
    }
  ],
  "messages": []
}
```

Another example for `vkFrameBoundaryANDROID`
```Json
{
  "header": {
    "schemaVersion": 1,
    "gfxreconVersion": "1.0.5-dev (json_for_screenshots:2e30762) Debug",
    "vulkanVersion": "1.4.361",
    "api": "vulkan",
    "captureFile": "/storage/emulated/0/Download/easy.sudoku.puzzle.solver.free_manual_000009f4ce92bdd3.gfxr",
    "options": {
      "ranges": [
        {
          "first": 1,
          "last": 4294967295
        }
      ],
      "interval": 1,
      "format": "bmp",
      "dir": "/storage/emulated/0/Download/dumps1",
      "prefix": "screenshot",
      "scale": null,
      "size": null,
      "applyPrerotation": false,
      "ignoreFrameBoundaryAndroid": false
    }
  }
},
{
  "frame": 1,
  "blockIndex": 1149,
  "boundary": {
    "type": "vkFrameBoundaryANDROID",
    "call": "vkFrameBoundaryANDROID",
    "queueId": null,
    "captureResult": null,
    "replayResult": null,
    "semaphoreId": 410
  },
  "status": "written",
  "outputs": [
    {
      "source": {
        "kind": "frameBoundaryImage",
        "imageId": 161,
        "layer": 0,
        "format": "VK_FORMAT_R8G8B8A8_UNORM",
        "extent": [
          1440,
          3120
        ],
        "preTransform": "VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR"
      },
      "file": "/storage/emulated/0/Download/dumps1/screenshot_frame_1.bmp",
      "status": "written",
      "written": {
        "width": 1440,
        "height": 3120
      }
    }
  ],
  "messages": []
},
```