### PR TITLE
Miscellaneous replay settings fixes

### DIFF
--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -56,7 +56,6 @@ struct ReplayOptions
     bool                         sync_queue_submissions{ false };
     bool                         enable_debug_device_lost{ false };
     bool                         create_dummy_allocations{ false };
-    bool                         omit_null_hardware_buffers{ false };
     bool                         quit_after_measurement_frame_range{ false };
     bool                         quit_after_frame{ false };
     bool                         flush_measurement_frame_range{ false };

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -271,6 +271,9 @@ struct VulkanReplayOptions : public ReplayOptions
 
     void MaybeWaitBeforeFirstSubmit() const;
     void MaybeWaitBeforeFrame() const;
+
+    // Prevent querying properties of AHardwareBuffer that couldn't be re-created at replay time.
+    bool omit_null_hardware_buffers{ false };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -32,10 +32,9 @@
 
 const char kOptions[] =
     "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--remove-unsupported,--validate,"
-    "--debug-device-lost,--create-dummy-allocations,--screenshot-all,--onhb|--omit-null-hardware-buffers,"
-    "--qamr|--quit-after-measurement-range,--fmr|--flush-measurement-range,--flush-inside-measurement-range,"
-    "--pbi-all,--preload-measurement-range,--log-timestamps,--async-processing,"
-    "--dump-resources-before-draw,--dump-resources-modifiable-state-only";
+    "--debug-device-lost,--create-dummy-allocations,--screenshot-all,--qamr|--quit-after-measurement-range,"
+    "--fmr|--flush-measurement-range,--flush-inside-measurement-range,--pbi-all,--preload-measurement-range,"
+    "--log-timestamps,--async-processing,--dump-resources-before-draw,--dump-resources-modifiable-state-only";
 
 const char kArguments[] =
     "--log-level,--log-file,--cpu-mask,--gpu,--pause-frame,--wsi,--screenshots,--screenshot-interval,"
@@ -107,7 +106,6 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-scale <scale>] [--screenshot-interval <N>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--wsi <platform>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--remove-unsupported] [--validate]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--onhb | --omit-null-hardware-buffers]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--mfr|--measurement-frame-range <start-frame>-<end-frame>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--measurement-file <file>] [--quit-after-measurement-range]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--flush-measurement-range]");

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -146,13 +146,13 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --log-level <level>\tSpecify lowest level message to log. Options are:");
     GFXRECON_WRITE_CONSOLE("          \t\tfatal, error, warning, info, and debug. Default is info.");
     GFXRECON_WRITE_CONSOLE("  --log-timestamps\tOutput a timestamp in front of each log message.");
-    GFXRECON_WRITE_CONSOLE("  --log-file <file>\tWrite log messages to a file at the specified path.")
+    GFXRECON_WRITE_CONSOLE("  --log-file <file>\tWrite log messages to a file at the specified path.");
     GFXRECON_WRITE_CONSOLE("          \t\tDefault is: Empty string (file logging disabled).");
 #if defined(_WIN32)
     GFXRECON_WRITE_CONSOLE("  --log-debugview\tLog messages with OutputDebugStringA.");
 #endif
     GFXRECON_WRITE_CONSOLE(
-        "  --debug-messenger-level <level>\tSpecify lowest debug messenger severity level. Options are:")
+        "  --debug-messenger-level <level>\tSpecify lowest debug messenger severity level. Options are:");
     GFXRECON_WRITE_CONSOLE("          \t\terror, warning, info, and debug. Default is warning.");
     GFXRECON_WRITE_CONSOLE("  --pause-frame <N>\tPause after replaying frame number N.");
     GFXRECON_WRITE_CONSOLE("  --paused\t\tPause after replaying the first frame (same");
@@ -224,8 +224,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE(
         "  --pbis <index1,index2>\t\tPrint block information between block index1 and block index2.");
 #if defined(_WIN32)
-    GFXRECON_WRITE_CONSOLE("")
-    GFXRECON_WRITE_CONSOLE("Windows only:")
+    GFXRECON_WRITE_CONSOLE("");
+    GFXRECON_WRITE_CONSOLE("Windows only:");
     GFXRECON_WRITE_CONSOLE("  --dump-resources <submit-index,command-index,drawcall-index>");
     GFXRECON_WRITE_CONSOLE("          \t\tDump resources for a specific drawcall.");
     GFXRECON_WRITE_CONSOLE(

--- a/tools/replay/replay_vulkan_feature.cpp
+++ b/tools/replay/replay_vulkan_feature.cpp
@@ -112,6 +112,8 @@ const char kReplayEventPluginPath[]                 = "--replay-event-plugin-pat
 const char kReplayEventPluginParams[]               = "--replay-event-plugin-params";
 const char kIsolateRenderPasses[]                   = "--isolate-render-passes";
 const char kSerializeComputeAndTransfer[]           = "--serialize-compute-and-transfer";
+const char kOmitNullHardwareBuffersShortOption[]    = "--onhb";
+const char kOmitNullHardwareBuffersLongOption[]     = "--omit-null-hardware-buffers";
 
 const char kMemoryTranslationNone[]    = "none";
 const char kMemoryTranslationRemap[]   = "remap";
@@ -501,6 +503,8 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
 
     replay_options.screenshot_apply_prerotation = arg_parser.IsOptionSet(kScreenshotApplyPrerotationArgument);
 
+    replay_options.omit_null_hardware_buffers = arg_parser.IsOptionSet(kOmitNullHardwareBuffersLongOption);
+
     return replay_options;
 }
 
@@ -714,6 +718,11 @@ std::vector<util::FeatureOptionDesc> ReplayVulkanFeature::GetOptionDescs() const
                  "debug, info, warning, and error. The default is warning." },
                true,
                kDebugMessageSeverityArgument },
+             { "",
+               { "Skip calls to `vkGetAndroidHardwareBufferPropertiesANDROID` when the provided Android",
+                 "AHardwareBuffer is NULL at replay time (for example when it could not be recreated)." },
+               false,
+               AliasNames(kOmitNullHardwareBuffersShortOption, kOmitNullHardwareBuffersLongOption) },
              // This entry has no description, so it stays out of the usage text.
              { "", {}, false, kSerializeComputeAndTransfer } };
 }

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -66,8 +66,6 @@ const char kRemoveUnsupportedOption[]            = "--remove-unsupported";
 const char kValidateOption[]                     = "--validate";
 const char kDebugDeviceLostOption[]              = "--debug-device-lost";
 const char kCreateDummyAllocationsOption[]       = "--create-dummy-allocations";
-const char kOmitNullHardwareBuffersLongOption[]  = "--omit-null-hardware-buffers";
-const char kOmitNullHardwareBuffersShortOption[] = "--onhb";
 const char kScreenshotAllOption[]                = "--screenshot-all";
 const char kScreenshotRangeArgument[]            = "--screenshots";
 const char kScreenshotIntervalArgument[]         = "--screenshot-interval";
@@ -823,12 +821,6 @@ static void GetReplayOptions(gfxrecon::decode::ReplayOptions&      options,
     if (arg_parser.IsOptionSet(kRemoveUnsupportedOption))
     {
         options.remove_unsupported_features = true;
-    }
-
-    if (arg_parser.IsOptionSet(kOmitNullHardwareBuffersLongOption) ||
-        arg_parser.IsOptionSet(kOmitNullHardwareBuffersShortOption))
-    {
-        options.omit_null_hardware_buffers = true;
     }
 
     if (arg_parser.IsOptionSet(kQuitAfterMeasurementRangeOption))


### PR DESCRIPTION
This PR contains 2 unrelated commits:

### Add some forgotten semicolons
It does not change the behavior of GFXReconstruct, but fix some review tools.

### Move `--onhb` option to Vulkan-only settings
This option is only implemented for Vulkan and, as far as I know, only makes sense for Vulkan (I don't see why you could import Android buffers on DirectX).

This commit also adds a description for the option, which was missing.