### PR TITLE
Add includes that libc++ 23 no longer provides transitively

### DIFF
--- a/external/catch2/catch.hpp
+++ b/external/catch2/catch.hpp
@@ -918,6 +918,7 @@ constexpr auto operator "" _catch_sr( char const* rawChars, std::size_t size ) n
 // start catch_meta.hpp
 
 
+#include <new>
 #include <type_traits>
 
 namespace Catch {

--- a/framework/decode/vulkan_submit_job.cpp
+++ b/framework/decode/vulkan_submit_job.cpp
@@ -25,6 +25,8 @@
 #include "graphics/vulkan_struct_get_pnext.h"
 #include "generated/generated_vulkan_enum_to_string.h"
 
+#include <algorithm>
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 

--- a/framework/util/platform.h
+++ b/framework/util/platform.h
@@ -29,6 +29,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <cwchar>


### PR DESCRIPTION
Homebrew LLVM 23 ships a libc++ where `<string>` and friends stop pulling in `<cstdlib>`, `<new>` and `<algorithm>`.

Three files relied on that and failed to compile. Include what each file uses so the tree builds on any conforming libc++.

Tested on Apple M4 Pro macOS 26.6.2.