### PR TITLE
Replay pre-frame blocks before the first FrameBegin

### DIFF
--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -203,6 +203,8 @@ void Application::Run()
 
     file_processor_->InitializeFrameProcessing(params_);
 
+    bool pre_frame_processed = false;
+
     while (running_)
     {
         ProcessEvents(paused_);
@@ -210,6 +212,17 @@ void Application::Run()
         // Only process the next frame if a quit event was not processed or not paused.
         if (running_ && !paused_)
         {
+            if (!pre_frame_processed)
+            {
+                // Explicitly process the pre-frame phase before advancing to the next frame.
+                if (!file_processor_->ProcessPreFrame())
+                {
+                    running_ = false;
+                    break;
+                }
+                pre_frame_processed = true;
+            }
+
             // Add one to match "trim frame range semantic"
             uint64_t frame_number = file_processor_->GetCurrentFrameNumber() + 1;
 

--- a/framework/decode/block_processor.cpp
+++ b/framework/decode/block_processor.cpp
@@ -109,6 +109,39 @@ bool BlockProcessor::IsFileValid() const
     return false;
 }
 
+bool BlockProcessor::NextBlockIsFrame() const
+{
+    if (file_stack_.empty())
+    {
+        return false;
+    }
+
+    // Within the state setup, next block might be any type, but that does not mean they belong to a frame.
+    if (in_state_setup_)
+    {
+        return false;
+    }
+
+    // Outside of state setup, a meta data, annotation, or state marker block type,
+    // means that the next block is not part of a frame.
+    format::BlockHeader header{};
+    const size_t        peeked = GetCurrentFile().active_file->PeekBytes(&header, sizeof(header));
+    if (peeked < sizeof(header))
+    {
+        return false;
+    }
+
+    switch (format::RemoveCompressedBlockBit(header.type))
+    {
+        case format::kMetaDataBlock:
+        case format::kAnnotation:
+        case format::kStateMarkerBlock:
+            return false;
+        default:
+            return true;
+    }
+}
+
 file_processor::ProcessBlocksResult BlockProcessor::MakeResult(file_processor::ProcessBlockState state) const
 {
     return file_processor::ProcessBlocksResult(
@@ -123,6 +156,13 @@ file_processor::ProcessBlockState BlockProcessor::ProcessBlock(Policy& policy, B
     if (!policy.ContinueBlockProcessing(block_index_))
     {
         return file_processor::ProcessBlockState::kEndProcessing;
+    }
+
+    // The pre-frame phase ends before the first block that belongs to frame 0.
+    if (pre_frame_boundary_pending_ && NextBlockIsFrame())
+    {
+        pre_frame_boundary_pending_ = false;
+        return file_processor::ProcessBlockState::kPreFrameBoundary;
     }
 
     BlockParser& block_parser = *block_parser_.get();
@@ -385,9 +425,15 @@ bool BlockProcessor::ProcessExecuteBlocksFromFile(const ExecuteBlocksFromFileArg
     return success;
 }
 
+void BlockProcessor::ProcessStateBeginMarkerFrameState(const StateBeginMarkerArgs& state_begin)
+{
+    in_state_setup_ = true;
+}
+
 void BlockProcessor::ProcessStateEndMarkerFrameState(const StateEndMarkerArgs& state_end)
 {
-    first_frame_ = state_end.frame_number;
+    in_state_setup_ = false;
+    first_frame_    = state_end.frame_number;
 }
 
 void BlockProcessor::ProcessAnnotation(const AnnotationArgs& annotation)
@@ -549,7 +595,13 @@ bool BlockProcessor::AtEof() const
 
 BlockProcessor::ActiveFileContext& BlockProcessor::GetCurrentFile()
 {
-    GFXRECON_ASSERT(file_stack_.size());
+    GFXRECON_ASSERT(file_stack_.size() > 0);
+    return file_stack_.back();
+}
+
+const BlockProcessor::ActiveFileContext& BlockProcessor::GetCurrentFile() const
+{
+    GFXRECON_ASSERT(file_stack_.size() > 0);
     return file_stack_.back();
 }
 

--- a/framework/decode/block_processor.h
+++ b/framework/decode/block_processor.h
@@ -135,6 +135,7 @@ class BlockProcessor
     bool ProcessFrameDelimiter(format::ApiCallId call_id);
     bool ProcessFrameDelimiter(const FrameEndMarkerArgs& end_frame);
     bool ProcessExecuteBlocksFromFile(const ExecuteBlocksFromFileArgs& execute_blocks_info);
+    void ProcessStateBeginMarkerFrameState(const StateBeginMarkerArgs& state_begin);
     void ProcessStateEndMarkerFrameState(const StateEndMarkerArgs& state_end);
     void ProcessAnnotation(const AnnotationArgs& annotation);
     void HandleBlockReadError(BlockIOError error_code, const char* error_message);
@@ -150,6 +151,14 @@ class BlockProcessor
     bool HasPendingBlocksToSkip() const noexcept { return !pending_blocks_to_skip_.empty(); }
 
   private:
+    /// This is true until the first block that belongs to frame 0 is encountered.
+    /// Meta-data, annotation, and state marker blocks are considered pre-frame.
+    bool pre_frame_boundary_pending_{ true };
+
+    /// This is true once the block processor encounters a state begin marker block,
+    /// and remains true until the a state end marker block is encountered.
+    bool in_state_setup_{ false };
+
     // Frame/block/error tracking -- written exclusively by the active loading path.
     uint64_t     frame_number_{ file_processor::kFirstFrame };
     BlockIOError error_state_{ kErrorInvalidFileDescriptor };
@@ -220,9 +229,15 @@ class BlockProcessor
 
     bool               AtEof() const;
     ActiveFileContext& GetCurrentFile();
+    const ActiveFileContext& GetCurrentFile() const;
 
     static bool IsFrameDelimiter(format::BlockType block_type, format::MarkerType marker_type);
     bool        IsFrameDelimiter(format::ApiCallId call_id) const;
+
+    /// Peeks the next block header on the active file.
+    /// Returns true if the next block belongs to a frame (i.e., not pre-frame).
+    /// Leading meta and annotation blocks and state markers are pre-frame.
+    bool NextBlockIsFrame() const;
 };
 
 // Explicit instantiation declarations -- definitions live in block_processor.cpp.

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -141,6 +141,13 @@ bool FileProcessor::Initialize(const std::string& filename)
     return success;
 }
 
+bool FileProcessor::ProcessPreFrame()
+{
+    const bool success = ProcessNextFrame();
+    GFXRECON_ASSERT(dispatch_frame_number_ == kFirstFrame);
+    return success;
+}
+
 bool FileProcessor::ProcessNextFrame()
 {
     GFXRECON_ASSERT(frame_processing_initialized_);

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -113,6 +113,10 @@ class FileProcessor
     // skipped blocks, not merely that the process thread has read and omitted them.
     bool IsSkippingFinished() const { return dispatch_skipping_finished_; }
 
+    /// Replays the pre-frame blocks and returns before the first block of frame 0.
+    /// Call once, before the first ProcessNextFrame().
+    bool ProcessPreFrame();
+
     // Returns true if there are more frames to process, false if all frames have been processed or an error has
     // occurred.  Use GetErrorState() to determine error condition.
     virtual bool ProcessNextFrame();

--- a/framework/decode/file_processor_types.h
+++ b/framework/decode/file_processor_types.h
@@ -59,11 +59,12 @@ enum class ProcessBlockState : int32_t
     // Negative values indicate terminal states. Do not call ProcessBlocks again after receiving these.
     //
     // Returned when ProcessBlocks ...
-    kFrameBoundary = 1,  // encountered a frame boundary
-    kContinue      = 0,  // never returned by ProcessBlocks. Denotes placeholder/noop ProcessBlocksResult.
-    kEndProcessing = -1, // completed processing (block limit reached or decoder complete)
-    kError         = -2, // encountered an error
-    kEndOfFile     = -3, // clean EOF on the root capture file
+    kPreFrameBoundary = 2,  // finished processing pre-frame blocks
+    kFrameBoundary    = 1,  // encountered a frame boundary
+    kContinue         = 0,  // never returned by ProcessBlocks. Denotes placeholder/noop ProcessBlocksResult.
+    kEndProcessing    = -1, // completed processing (block limit reached or decoder complete)
+    kError            = -2, // encountered an error
+    kEndOfFile        = -3, // clean EOF on the root capture file
 };
 
 // Returns true if processing should continue (non-negative state values are non-terminal).

--- a/framework/decode/file_processor_visitors.h
+++ b/framework/decode/file_processor_visitors.h
@@ -227,6 +227,13 @@ class ProcessVisitor
         success            = block_processor_.ProcessExecuteBlocksFromFile(*execute_blocks);
     }
 
+    void operator()(const StateBeginMarkerArgs* state_setup)
+    {
+        is_frame_delimiter = false;
+        success            = true;
+        block_processor_.ProcessStateBeginMarkerFrameState(*state_setup);
+    }
+
     void operator()(const StateEndMarkerArgs* state_end)
     {
         is_frame_delimiter = false;

--- a/framework/plugin/replay_event_sink.cpp
+++ b/framework/plugin/replay_event_sink.cpp
@@ -58,7 +58,11 @@ GfxrReplayEventHeader ReplayEventSink::CreateEventHeader(GfxrReplayEventType typ
 
 uint64_t ReplayEventSink::QueueSubmitBegin(format::HandleId queue_id)
 {
-    GFXRECON_ASSERT(frame_active_);
+    // Submits outside a frame belong to state setup. Plugins do not see them.
+    if (!frame_active_)
+    {
+        return GFXR_REPLAY_INVALID_SUBMIT_INDEX;
+    }
 
     GfxrReplayQueueSubmitBeginEvent event = {};
     event.header                          = CreateEventHeader(GFXR_REPLAY_EVENT_QUEUE_SUBMIT_BEGIN);
@@ -82,6 +86,11 @@ void ReplayEventSink::QueueSubmitEnd(uint64_t                              submi
                                      int32_t                               result,
                                      GfxrReplayQueueSubmitCompletionSource completion_source)
 {
+    if (submit_index == GFXR_REPLAY_INVALID_SUBMIT_INDEX)
+    {
+        return;
+    }
+
     GFXRECON_ASSERT(frame_active_);
 
     GfxrReplayQueueSubmitEndEvent event = {};

--- a/framework/plugin/test/main.cpp
+++ b/framework/plugin/test/main.cpp
@@ -33,6 +33,8 @@ class TestReplayEventSink : public gfxrecon::plugin::ReplayEventSink
     GfxrReplayEventHeader         last_event_header     = {};
     GfxrReplayQueueSubmitEndEvent last_submit_end_event = {};
     GfxrReplayFrameEndEvent       last_frame_end_event  = {};
+    uint32_t                      submit_begin_count    = 0;
+    uint32_t                      submit_end_count      = 0;
 
   protected:
     void EmitQueueSubmitBegin(const GfxrReplayQueueSubmitBeginEvent& event) override
@@ -41,6 +43,7 @@ class TestReplayEventSink : public gfxrecon::plugin::ReplayEventSink
         REQUIRE(event.header.type == GFXR_REPLAY_EVENT_QUEUE_SUBMIT_BEGIN);
         REQUIRE(event.header.struct_size == sizeof(GfxrReplayQueueSubmitBeginEvent));
         last_event_header = event.header;
+        ++submit_begin_count;
     }
 
     void EmitQueueSubmitEnd(const GfxrReplayQueueSubmitEndEvent& event) override
@@ -50,6 +53,7 @@ class TestReplayEventSink : public gfxrecon::plugin::ReplayEventSink
         REQUIRE(event.header.struct_size == sizeof(GfxrReplayQueueSubmitEndEvent));
         last_event_header     = event.header;
         last_submit_end_event = event;
+        ++submit_end_count;
     }
 
     void EmitFrameBegin(const GfxrReplayFrameBeginEvent& event) override
@@ -370,4 +374,25 @@ TEST_CASE("ReplayEventPluginLoader - read load", "[plugin]")
     plugin->QueueSubmitBegin(0);
     plugin->QueueSubmitEnd(0, 0, VK_SUCCESS, GFXR_REPLAY_QUEUE_SUBMIT_COMPLETION_SOURCE_SUBMIT_RETURN);
     plugin->FrameEnd();
+}
+
+TEST_CASE("ReplayEventSink - submits outside a frame are not emitted", "[plugin]")
+{
+    TestReplayEventSink event_sink;
+    REQUIRE_FALSE(event_sink.IsFrameActive());
+
+    uint64_t setup_submit = event_sink.QueueSubmitBegin(0);
+    REQUIRE(setup_submit == GFXR_REPLAY_INVALID_SUBMIT_INDEX);
+    event_sink.QueueSubmitEnd(setup_submit, 0, VK_SUCCESS, GFXR_REPLAY_QUEUE_SUBMIT_COMPLETION_SOURCE_SUBMIT_RETURN);
+    REQUIRE(event_sink.submit_begin_count == 0);
+    REQUIRE(event_sink.submit_end_count == 0);
+
+    event_sink.FrameBegin(0);
+    uint64_t first_submit = event_sink.QueueSubmitBegin(0);
+    REQUIRE(first_submit == 0);
+    event_sink.QueueSubmitEnd(first_submit, 0, VK_SUCCESS, GFXR_REPLAY_QUEUE_SUBMIT_COMPLETION_SOURCE_SUBMIT_RETURN);
+    event_sink.FrameEnd();
+    REQUIRE(event_sink.submit_begin_count == 1);
+    REQUIRE(event_sink.last_frame_end_event.first_submit_index == 0);
+    REQUIRE(event_sink.last_frame_end_event.last_submit_index == 0);
 }

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -350,6 +350,10 @@ int main(int argc, const char** argv)
 
             file_processor.InitializeFrameProcessing();
 
+            // Pre-frame blocks go to the initial stream. Each loop iteration then completes one frame,
+            // which the detection check, frame range, and file-per-frame logic below rely on.
+            success = success && file_processor.ProcessPreFrame();
+
             while (success)
             {
                 success = file_processor.ProcessNextFrame();


### PR DESCRIPTION
`BlockProcessor::ProcessBlocks()` returns `kPreFrameBoundary` once, before the first block that belongs to frame 0. It peeks the next block header and treats leading meta, annotation, and state marker blocks, and every block inside a state block, as pre-frame. `FileProcessor::ProcessPreFrame()` replays up to that boundary, and `Application::Run()` calls it once before the frame loop.

A trimmed capture's state setup now runs before FrameBegin 0, so its queue submits emit no plugin events and the first frame interval holds only frame work.

Full captures replay the same blocks in the same order, only the two leading meta blocks move ahead of FrameBegin 0.