### PR TITLE
Record AHBs whose properties query reports a zero allocationSize

### DIFF
--- a/framework/encode/vulkan_capture_common.cpp
+++ b/framework/encode/vulkan_capture_common.cpp
@@ -305,8 +305,9 @@ void CommonProcessHardwareBuffer(format::ThreadId                      thread_id
         if (vk_result == VK_SUCCESS)
             vk_result = device_table->GetAndroidHardwareBufferPropertiesANDROID(device, hardware_buffer, &properties);
 
-        const size_t ahb_size = properties.allocationSize;
-        GFXRECON_ASSERT(ahb_size > 0);
+        // properties.allocationSize may legitimately be zero for a GPU-only AHB (see
+        // VulkanCaptureManager::ProcessHardwareBuffer).  It is passed to vkAllocateMemory unchanged below, which is
+        // what an AHB import requires, so no assumption is made about its value here.
 
         VkExternalFormatANDROID external_format = {};
         external_format.sType                   = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID;

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2168,8 +2168,11 @@ void VulkanCaptureManager::ProcessHardwareBuffer(format::ThreadId thread_id,
 
     if (vk_result == VK_SUCCESS)
     {
+        // VK_SUCCESS with allocationSize == 0 is a valid result.  Some implementations (e.g. the Android emulator's
+        // gralloc) report zero for AHardwareBuffers created without CPU usage flags even though the buffer is fully
+        // usable by the GPU.  The AHB creation must still be recorded so that replay can recreate the buffer; the
+        // size is only needed to snapshot the contents of CPU-readable buffers.
         const size_t ahb_size = properties.allocationSize;
-        assert(ahb_size);
 
         CommonProcessHardwareBuffer(thread_id, device_wrapper, memory_id, hardware_buffer, ahb_size, this, nullptr);
     }


### PR DESCRIPTION
`vkGetAndroidHardwareBufferPropertiesANDROID` can return `VK_SUCCESS` with `allocationSize == 0`.   `gralloc` (in the emulator only?) does this for AHardwareBuffers created without CPU usage flags (the window buffers used by the platform UI toolkit are one example).  The capture layer treated that as undefined: `VulkanCaptureManager::ProcessHardwareBuffer` asserted on the size, and the GPU-only branch of `CommonProcessHardwareBuffer `asserted on it again after re-querying it.  In debug builds this aborts the captured process on launch.

The AHB is still a valid backing store for the application's `VkImage`, so the `kCreateHardwareBufferCommand `metadata block must be written or replay cannot recreate the buffer.  The size itself is only used to snapshot the contents of CPU-readable buffers, and for the GPU-only path it is passed through unchanged to `vkAllocateMemory`, which is what an AHB import requires anyway.

Changes:
- framework/encode/vulkan_capture_manager.cpp: remove assert(ahb_size) in `ProcessHardwareBuffer `and document why zero is a valid value.
- framework/encode/vulkan_capture_common.cpp: remove the now-unused ahb_size local and GFXRECON_ASSERT(ahb_size > 0) in the GPU-only branch of `CommonProcessHardwareBuffer`.

Replay is unaffected.

Supersedes #3231, which skipped `CommonProcessHardwareBuffer `for a zero size and therefore omitted the AHB from the capture file.

Testing: the affected code is compiled only for VK_USE_PLATFORM_ANDROID_KHR, so this change needs to be verified by capturing an application on the Android emulator with default gralloc with a debug build of the layer, confirming capture no longer aborts and that the resulting file replays.