### PR TITLE
Ingore validation cache extension

### DIFF
--- a/framework/graphics/vulkan_feature_util.cpp
+++ b/framework/graphics/vulkan_feature_util.cpp
@@ -46,6 +46,7 @@ std::set<std::string> kIgnorableExtensions = {
     VK_EXT_TOOLING_INFO_EXTENSION_NAME,   VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
     "VK_ANDROID_frame_boundary",          "VK_EXT_frame_boundary",
     VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME,
+    VK_EXT_VALIDATION_CACHE_EXTENSION_NAME,
 };
 
 VkResult GetInstanceLayers(PFN_vkEnumerateInstanceLayerProperties instance_layer_proc,

--- a/framework/graphics/vulkan_feature_util.cpp
+++ b/framework/graphics/vulkan_feature_util.cpp
@@ -43,9 +43,12 @@ GFXRECON_BEGIN_NAMESPACE(feature_util)
 // enable the extension with no support present on the replay device (usually because the layer is
 // no longer there)
 std::set<std::string> kIgnorableExtensions = {
-    VK_EXT_TOOLING_INFO_EXTENSION_NAME,   VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
-    "VK_ANDROID_frame_boundary",          "VK_EXT_frame_boundary",
-    VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME,
+    VK_EXT_TOOLING_INFO_EXTENSION_NAME,
+    VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
+    "VK_ANDROID_frame_boundary",
+    "VK_EXT_frame_boundary",
+    VK_EXT_LAYER_SETTINGS_EXTENSION_NAME,
+    VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME,
     VK_EXT_VALIDATION_CACHE_EXTENSION_NAME,
 };
 


### PR DESCRIPTION
When capturing with the vulkan validation layer enabled, gfxreplay already handles not to find the validation layer on replay. However a replay may still fail if the validation layer did use the VK_EXT_validation_cache extension.