### PR TITLE
generators: take static array lengths from the registry len attribute

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -11,6 +11,7 @@ if (${RUN_TESTS})
     target_sources(gfxrecon_framework_test PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
             $<$<BOOL:${GFXRECON_ENABLE_VULKAN}>:${CMAKE_CURRENT_LIST_DIR}/test/test_arm_data_graph_structs.cpp>
+            $<$<BOOL:${GFXRECON_ENABLE_VULKAN}>:${CMAKE_CURRENT_LIST_DIR}/test/test_static_array_len.cpp>
             ${CMAKE_CURRENT_LIST_DIR}/../tools/platform_debug_helper.cpp)
     target_link_libraries(gfxrecon_framework_test PRIVATE gfxrecon_encode gfxrecon_decode)
     if (MSVC)

--- a/framework/decode/handle_pointer_decoder.h
+++ b/framework/decode/handle_pointer_decoder.h
@@ -83,6 +83,9 @@ class HandlePointerDecoder
         }
     }
 
+    // See PointerDecoderBase::SetExpectedLength().
+    void SetExpectedLength(size_t len) { decoder_.SetExpectedLength(len); }
+
     void SetHandleLength(size_t len)
     {
         handle_data_len_ = len;
@@ -99,7 +102,17 @@ class HandlePointerDecoder
 
     const T* GetHandlePointer() const { return handle_data_; }
 
-    size_t Decode(const uint8_t* buffer, size_t buffer_size) { return decoder_.DecodeHandleId(buffer, buffer_size); }
+    size_t Decode(const uint8_t* buffer, size_t buffer_size)
+    {
+        size_t bytes_read = decoder_.DecodeHandleId(buffer, buffer_size);
+
+        if (is_memory_external_ && !decoder_.IsNull())
+        {
+            decoder_.CheckExpectedLength("Handle pointer", capacity_);
+        }
+
+        return bytes_read;
+    }
 
     // The value returned is only guaranteed to be valid if the current consumer has called SetConsumerData.
     void* GetConsumerData(size_t index) const

--- a/framework/decode/pointer_decoder.h
+++ b/framework/decode/pointer_decoder.h
@@ -215,6 +215,8 @@ class PointerDecoder : public PointerDecoderBase
         {
             size_t len = GetLength();
 
+            CheckExpectedLength("Pointer", capacity_);
+
             if (len <= capacity_)
             {
                 ValueDecoder::DecodeArrayFrom<SrcT>(buffer, buffer_size, data_, len);

--- a/framework/decode/pointer_decoder_base.h
+++ b/framework/decode/pointer_decoder_base.h
@@ -27,6 +27,10 @@
 #include "decode/value_decoder.h"
 #include "format/format.h"
 #include "util/defines.h"
+#include "util/logging.h"
+
+#include <cinttypes>
+#include <optional>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -77,6 +81,12 @@ class PointerDecoderBase
     // sub-range (e.g. a single element) for one call, and are responsible for restoring the
     // original value afterward if the array's backing storage is reused.
     void SetLength(size_t len) { len_ = len; }
+
+    // For a fixed-extent array whose registry 'len' names a sibling count member (e.g.
+    // VkPhysicalDeviceMemoryProperties::memoryTypes with memoryTypeCount), records the count decoded from the
+    // enclosing struct so the decoded array length can be checked against it.  Captures written before the count
+    // was honored hold the full capacity, which is also accepted; see CheckExpectedLength().
+    void SetExpectedLength(size_t len) { expected_len_ = len; }
 
     static bool PeekAttributesAndType(const uint8_t* buffer,
                                       size_t         buffer_size,
@@ -161,10 +171,34 @@ class PointerDecoderBase
         return bytes_read;
     }
 
+  public:
+    // Reports a decoded array length for a fixed-extent array that matches neither the count member recorded with
+    // SetExpectedLength() nor the array capacity.  Neither value is trusted over the other: the count comes from the
+    // capture stream as well, and older captures legitimately hold the full capacity regardless of the count.
+    // A length above the capacity is left to the owning decoder's truncation warning.
+    // Public so that decoders composed of a PointerDecoder (HandlePointerDecoder) can apply it to their member.
+    void CheckExpectedLength(const char* decoder_name, size_t capacity) const
+    {
+        if (expected_len_ && (len_ != *expected_len_) && (len_ < capacity))
+        {
+            GFXRECON_LOG_WARNING(
+                "%s decoder received an array of %" PRIuPTR
+                " elements for a fixed-extent array, which matches neither the associated count (%" PRIuPTR
+                ") nor the array capacity (%" PRIuPTR ")",
+                decoder_name,
+                len_,
+                *expected_len_,
+                capacity);
+        }
+    }
+
   private:
     size_t   len_;
     uint64_t address_;
     uint32_t attrib_;
+
+    // Count member associated with a fixed-extent array; see SetExpectedLength().
+    std::optional<size_t> expected_len_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/struct_pointer_decoder.h
+++ b/framework/decode/struct_pointer_decoder.h
@@ -157,6 +157,8 @@ class StructPointerDecoder : public PointerDecoderBase
                 assert(struct_memory_ != nullptr);
                 assert(len <= capacity_);
 
+                CheckExpectedLength("Struct pointer", capacity_);
+
                 if ((struct_memory_ == nullptr) || (len > capacity_))
                 {
                     GFXRECON_LOG_WARNING("Struct pointer decoder's external memory capacity (%" PRIuPTR

--- a/framework/encode/parameter_encoder.h
+++ b/framework/encode/parameter_encoder.h
@@ -38,9 +38,11 @@
 #include "format/format.h"
 #include "format/platform_types.h"
 #include "util/defines.h"
+#include "util/logging.h"
 #include "util/output_stream.h"
 #include "util/platform.h"
 
+#include <cinttypes>
 #include <cstring>
 #include <cwchar>
 #include <memory>
@@ -55,6 +57,25 @@ class ParameterEncoder
     ParameterEncoder(util::OutputStream* stream) : output_stream_(stream) {}
 
     ~ParameterEncoder() {}
+
+    // Bound the element count of a fixed-extent array whose registry 'len' names a sibling count member, e.g.
+    // VkPhysicalDeviceMemoryProperties::memoryTypes[VK_MAX_MEMORY_TYPES] with len="memoryTypeCount". The count is
+    // produced by the driver or application; a value above the array's capacity would read past the end of the
+    // source array, so it is clamped to the capacity and reported.
+    static size_t ClampStaticArrayLength(size_t length, size_t capacity, const char* name)
+    {
+        if (length > capacity)
+        {
+            GFXRECON_LOG_WARNING("Element count (%" PRIuPTR ") for %s exceeds the array capacity (%" PRIuPTR
+                                 "); only the first %" PRIuPTR " elements will be encoded",
+                                 length,
+                                 name,
+                                 capacity,
+                                 capacity);
+            return capacity;
+        }
+        return length;
+    }
 
     // clang-format off
 

--- a/framework/generated/dx12_generators/dx12_base_generator.py
+++ b/framework/generated/dx12_generators/dx12_base_generator.py
@@ -1265,19 +1265,6 @@ class Dx12BaseGenerator():
             return True
         return False
 
-    def get_static_array_len(self, name, params, capacity):
-        """Determine the length value of a static array (get_array_len() returns the total capacity, not the actual length)."""
-        # The XML registry does not provide a direct method for determining if a parameter provides the length
-        # of a static array, but the parameter naming follows a pattern of array name = 'values' and length
-        # name = 'value_count'.  We will search the parameter list for a length parameter using this pattern.
-        length_name = name[:-1] + 'Count'
-        for param in params:
-            if length_name == noneStr(param.find('name').text):
-                return length_name
-
-        # Not all static arrays have an associated length parameter. These will use capacity as length.
-        return capacity
-
     def is_struct_black_listed(self, typename):
         """Determines if a struct with the specified typename is blacklisted."""
         if typename in self.STRUCT_BLACKLIST:

--- a/framework/generated/generated_vulkan_cpp_structs.cpp
+++ b/framework/generated/generated_vulkan_cpp_structs.cpp
@@ -33,6 +33,8 @@
 #include "generated/generated_vulkan_cpp_consumer_extension.h"
 #include "generated/generated_vulkan_enum_to_string.h"
 
+#include <algorithm>
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
@@ -8412,7 +8414,8 @@ std::string GenerateStruct_VkQueueFamilyGlobalPriorityProperties(std::ostream &o
     struct_body << "\t" << "VkStructureType(" << structInfo->sType << ")" << "," << std::endl;
     struct_body << "\t\t\t" << pnext_name << "," << std::endl;
     struct_body << "\t\t\t" << structInfo->priorityCount << "," << std::endl;
-    struct_body << "\t\t\t" << VulkanCppConsumerBase::BuildValue(reinterpret_cast<const VkQueueGlobalPriority*>(&structInfo->priorities[0]), VK_MAX_GLOBAL_PRIORITY_SIZE) << ",";
+    const uint32_t priorities_count = std::min<uint32_t>(structInfo->priorityCount, VK_MAX_GLOBAL_PRIORITY_SIZE);
+    struct_body << "\t\t\t" << VulkanCppConsumerBase::BuildValue(reinterpret_cast<const VkQueueGlobalPriority*>(&structInfo->priorities[0]), priorities_count) << ",";
     std::string variable_name = consumer.AddStruct(struct_body, "queueFamilyGlobalPriorityProperties");
     out << "\t\t" << "VkQueueFamilyGlobalPriorityProperties " << variable_name << " {" << std::endl;
     out << "\t\t" << struct_body.str() << std::endl;
@@ -22284,7 +22287,8 @@ std::string GenerateStruct_VkShaderModuleIdentifierEXT(std::ostream &out, const 
     struct_body << "\t" << "VkStructureType(" << structInfo->sType << ")" << "," << std::endl;
     struct_body << "\t\t\t" << pnext_name << "," << std::endl;
     struct_body << "\t\t\t" << structInfo->identifierSize << "," << std::endl;
-    struct_body << "\t\t\t" << VulkanCppConsumerBase::BuildValue(reinterpret_cast<const uint8_t*>(&structInfo->identifier[0]), VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT) << ",";
+    const uint32_t identifier_count = std::min<uint32_t>(structInfo->identifierSize, VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT);
+    struct_body << "\t\t\t" << VulkanCppConsumerBase::BuildValue(reinterpret_cast<const uint8_t*>(&structInfo->identifier[0]), identifier_count) << ",";
     std::string variable_name = consumer.AddStruct(struct_body, "shaderModuleIdentifierEXT");
     out << "\t\t" << "VkShaderModuleIdentifierEXT " << variable_name << " {" << std::endl;
     out << "\t\t" << struct_body.str() << std::endl;

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -2207,10 +2207,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryTypeCount));
     wrapper->memoryTypes = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkMemoryType>>();
     wrapper->memoryTypes->SetExternalMemory(value->memoryTypes, VK_MAX_MEMORY_TYPES);
+    wrapper->memoryTypes->SetExpectedLength(value->memoryTypeCount);
     bytes_read += wrapper->memoryTypes->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryHeapCount));
     wrapper->memoryHeaps = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkMemoryHeap>>();
     wrapper->memoryHeaps->SetExternalMemory(value->memoryHeaps, VK_MAX_MEMORY_HEAPS);
+    wrapper->memoryHeaps->SetExpectedLength(value->memoryHeapCount);
     bytes_read += wrapper->memoryHeaps->Decode((buffer + bytes_read), (buffer_size - bytes_read));
 
     return bytes_read;
@@ -4161,6 +4163,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->physicalDeviceCount));
     wrapper->physicalDevices.SetExternalMemory(value->physicalDevices, VK_MAX_DEVICE_GROUP_SIZE);
+    wrapper->physicalDevices.SetExpectedLength(value->physicalDeviceCount);
     bytes_read += wrapper->physicalDevices.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->subsetAllocation));
 
@@ -7406,6 +7409,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueFa
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->priorityCount));
     wrapper->priorities.SetExternalMemory(value->priorities, VK_MAX_GLOBAL_PRIORITY_SIZE);
+    wrapper->priorities.SetExpectedLength(value->priorityCount);
     bytes_read += wrapper->priorities.DecodeEnum((buffer + bytes_read), (buffer_size - bytes_read));
 
     return bytes_read;
@@ -21072,6 +21076,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShaderM
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->identifierSize));
     wrapper->identifier.SetExternalMemory(value->identifier, VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT);
+    wrapper->identifier.SetExpectedLength(value->identifierSize);
     bytes_read += wrapper->identifier.DecodeUInt8((buffer + bytes_read), (buffer_size - bytes_read));
 
     return bytes_read;

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -1092,9 +1092,11 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceLimits& value
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryProperties& value)
 {
     encoder->EncodeUInt32Value(value.memoryTypeCount);
-    EncodeStructArray(encoder, value.memoryTypes, value.memoryTypeCount);
+    const size_t memoryTypes_count = ParameterEncoder::ClampStaticArrayLength(value.memoryTypeCount, VK_MAX_MEMORY_TYPES, "VkPhysicalDeviceMemoryProperties::memoryTypes");
+    EncodeStructArray(encoder, value.memoryTypes, memoryTypes_count);
     encoder->EncodeUInt32Value(value.memoryHeapCount);
-    EncodeStructArray(encoder, value.memoryHeaps, value.memoryHeapCount);
+    const size_t memoryHeaps_count = ParameterEncoder::ClampStaticArrayLength(value.memoryHeapCount, VK_MAX_MEMORY_HEAPS, "VkPhysicalDeviceMemoryProperties::memoryHeaps");
+    EncodeStructArray(encoder, value.memoryHeaps, memoryHeaps_count);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseProperties& value)
@@ -2076,7 +2078,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceGroupProperti
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.physicalDeviceCount);
-    encoder->EncodeVulkanHandleArray<vulkan_wrappers::PhysicalDeviceWrapper>(value.physicalDevices, value.physicalDeviceCount);
+    const size_t physicalDevices_count = ParameterEncoder::ClampStaticArrayLength(value.physicalDeviceCount, VK_MAX_DEVICE_GROUP_SIZE, "VkPhysicalDeviceGroupProperties::physicalDevices");
+    encoder->EncodeVulkanHandleArray<vulkan_wrappers::PhysicalDeviceWrapper>(value.physicalDevices, physicalDevices_count);
     encoder->EncodeUInt32Value(value.subsetAllocation);
 }
 
@@ -3805,7 +3808,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkQueueFamilyGlobalPriorityPr
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.priorityCount);
-    encoder->EncodeEnumArray(value.priorities, VK_MAX_GLOBAL_PRIORITY_SIZE);
+    const size_t priorities_count = ParameterEncoder::ClampStaticArrayLength(value.priorityCount, VK_MAX_GLOBAL_PRIORITY_SIZE, "VkQueueFamilyGlobalPriorityProperties::priorities");
+    encoder->EncodeEnumArray(value.priorities, priorities_count);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceIndexTypeUint8Features& value)
@@ -10535,7 +10539,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkShaderModuleIdentifierEXT& 
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStructIfValid(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.identifierSize);
-    encoder->EncodeUInt8Array(value.identifier, VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT);
+    const size_t identifier_count = ParameterEncoder::ClampStaticArrayLength(value.identifierSize, VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT, "VkShaderModuleIdentifierEXT::identifier");
+    encoder->EncodeUInt8Array(value.identifier, identifier_count);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceOpticalFlowFeaturesNV& value)

--- a/framework/generated/khronos_generators/khronos_api_call_encoders_generator.py
+++ b/framework/generated/khronos_generators/khronos_api_call_encoders_generator.py
@@ -76,6 +76,9 @@ class KhronosApiCallEncodersGenerator():
         indent += ' ' * self.INDENT_SIZE
 
         for value in values:
+            preamble = self.make_counted_static_array_preamble(name, value)
+            if preamble:
+                body += indent + '{}\n'.format(preamble)
             method_call = self.make_encoder_method_call(
                 name, value, values, '', omit_output_param
             )

--- a/framework/generated/khronos_generators/khronos_base_generator.py
+++ b/framework/generated/khronos_generators/khronos_base_generator.py
@@ -1120,38 +1120,17 @@ class KhronosBaseGenerator(OutputGenerator):
                     # strings.  We strip the null-terminated substring from the 'len' field and only return the parameter specifying the string count.
                     result = len.split(',')[0]
             else:
-                paramname = param.find('name')
-                # If there is an enum inside "[...]", return the enum
-                if (paramname.tail is not None) and ('[' in paramname.tail):
-                    result = None
-                    paramenumsizes = param.findall('enum')
-                    for paramenumsize in paramenumsizes:
-                        # If there is more than one we'll pick the last one. But current vk.xml file doesn't have an instance with more than one.
-                        result = paramenumsize.text
-                else:
-                    result = len
+                # A static array (a bracketed extent after the name) may also carry a 'len' attribute naming
+                # the sibling that holds the number of meaningful elements, e.g.
+                #   <member len="memoryTypeCount">VkMemoryType memoryTypes[VK_MAX_MEMORY_TYPES]
+                # In that case the registry's 'len' is the array length; the bracketed capacity is
+                # reported separately by the caller (see array_capacity).
+                result = len
             if result:
                 result = str(result).replace('::', '->')
-        else:
-            # Check for a static array
-            paramname = param.find('name')
-            if (paramname.tail is not None) and ('[' in paramname.tail):
-                paramenumsizes = param.findall('enum')
-                if paramenumsizes:
-                    first = True
-                    for paramenumsize in paramenumsizes:
-                        if first:
-                            first = False
-                            result = paramenumsize.text
-                        else:
-                            result +=', '
-                            result += paramenumsize.text
-                else:
-                    paramsizes = paramname.tail[1:-1].split('][')
-                    sizetokens = []
-                    for paramsize in paramsizes:
-                        sizetokens.append(paramsize)
-                    result = ', '.join(sizetokens)
+        elif self.is_static_array(param):
+            # A static array with no 'len': every element is meaningful, so the length is the capacity.
+            result = self.get_static_array_capacity(param)
         return result
 
     def is_static_array(self, param):
@@ -1161,18 +1140,16 @@ class KhronosBaseGenerator(OutputGenerator):
             return True
         return False
 
-    def get_static_array_len(self, name, params, capacity):
-        """Determine the length value of a static array (get_array_len() returns the total capacity, not the actual length)."""
-        # The XML registry does not provide a direct method for determining if a parameter provides the length
-        # of a static array, but the parameter naming follows a pattern of array name = 'values' and length
-        # name = 'value_count'.  We will search the parameter list for a length parameter using this pattern.
-        length_name = name[:-1] + 'Count'
-        for param in params:
-            if length_name == noneStr(param.find('name').text):
-                return length_name
-
-        # Not all static arrays have an associated length parameter. These will use capacity as length.
-        return capacity
+    def get_static_array_capacity(self, param):
+        """Retrieve the bracketed capacity of a static array, ignoring any 'len' attribute."""
+        result = None
+        paramname = param.find('name')
+        paramenumsizes = param.findall('enum')
+        if paramenumsizes:
+            result = ', '.join(paramenumsize.text for paramenumsize in paramenumsizes)
+        else:
+            result = ', '.join(paramname.tail[1:-1].split(']['))
+        return result
 
     def needs_length_cast_to_size_t(self, type):
         api_data = self.get_api_data()
@@ -1771,13 +1748,12 @@ class KhronosBaseGenerator(OutputGenerator):
             else:
                 array_length = self.get_array_len(param)
 
-            # Get array length for HandlesInfo structs e.g. VkPipelineBinaryHandlesInfoKHR
+            # For a static array, array_length is the registry 'len' (the number of meaningful elements,
+            # e.g. memoryTypeCount) when the registry states one and the bracketed capacity otherwise, while
+            # array_capacity is always the bracketed capacity (e.g. VK_MAX_MEMORY_TYPES).
             array_capacity = None
             if self.is_static_array(param):
-                array_capacity = array_length
-                array_length = self.get_static_array_len(
-                    name, params, array_capacity
-                )
+                array_capacity = self.get_static_array_capacity(param)
 
             array_dimension = 0
             if array_length:
@@ -2350,6 +2326,18 @@ class KhronosBaseGenerator(OutputGenerator):
                     return values
         return None
 
+    def is_counted_static_array(self, value):
+        """Check for a static array whose registry 'len' names a sibling count member (e.g. memoryTypes[VK_MAX_MEMORY_TYPES] with len="memoryTypeCount")."""
+        return bool(value.array_capacity) and (value.array_length_value is not None)
+
+    def is_decoded_before(self, struct_name, first, second):
+        """Check that struct member 'first' is declared, and so decoded, before member 'second'."""
+        members = self.all_struct_members.get(struct_name)
+        if not members:
+            return False
+        names = [member.name for member in members]
+        return (first.name in names) and (second.name in names) and (names.index(first.name) < names.index(second.name))
+
     def make_array_length_expression(self, value, prefix=''):
         """Generate an expression for the length of a given array value."""
         length_expr = value.array_length
@@ -2372,6 +2360,24 @@ class KhronosBaseGenerator(OutputGenerator):
                 length_value.name, prefix + length_value.name
             )
         return length_expr
+
+    def make_counted_static_array_length_var(self, value):
+        """Name of the local holding the clamped element count of a counted static array."""
+        return '{}_count'.format(value.name)
+
+    def make_counted_static_array_preamble(self, name, value, prefix=''):
+        """Generate the declaration of the clamped element count for a counted static array, or None otherwise.
+
+        The count is runtime data; the clamp keeps it from indexing past the fixed-extent array it describes.
+        Callers emit this line ahead of the encoder call produced by make_encoder_method_call().
+        """
+        if not self.is_counted_static_array(value):
+            return None
+        return 'const size_t {} = ParameterEncoder::ClampStaticArrayLength({}, {}, "{}::{}");'.format(
+            self.make_counted_static_array_length_var(value),
+            self.make_array_length_expression(value, prefix),
+            value.array_capacity, name, value.name
+        )
 
     def make_array2d_length_expression(self, value, values, prefix=''):
         length_exprs = value.array_length.split(',')
@@ -2471,7 +2477,11 @@ class KhronosBaseGenerator(OutputGenerator):
                 args.append(self.make_array_length_expression(value, prefix))
             else:
                 method_call += 'Array'
-                args.append(self.make_array_length_expression(value, prefix))
+                if self.is_counted_static_array(value):
+                    # Declared by make_counted_static_array_preamble(), which callers emit first.
+                    args.append(self.make_counted_static_array_length_var(value))
+                else:
+                    args.append(self.make_array_length_expression(value, prefix))
         elif is_struct:
             if value.is_pointer:
                 method_call += 'Ptr'

--- a/framework/generated/khronos_generators/khronos_struct_decoders_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_decoders_body_generator.py
@@ -158,6 +158,12 @@ class KhronosStructDecodersBodyGenerator():
                             name=value.name,
                             arraylen=value.array_capacity
                         )
+                        if self.is_counted_static_array(value) and self.is_decoded_before(name, value.array_length_value, value):
+                            # The registry names a sibling count member (e.g. memoryTypeCount for memoryTypes) that
+                            # has already been decoded; let the pointer decoder check the array length against it.
+                            main_body += '    wrapper->{}{}SetExpectedLength(value->{});\n'.format(
+                                value.name, access_op, value.array_length_value.name
+                            )
 
                     if is_struct or is_string or is_handle_like:
                         main_body += '    bytes_read += wrapper->{}{}Decode({});\n'.format(

--- a/framework/generated/khronos_generators/khronos_struct_encoders_body_generator.py
+++ b/framework/generated/khronos_generators/khronos_struct_encoders_body_generator.py
@@ -131,6 +131,9 @@ class KhronosStructEncodersBodyGenerator():
                         api_data.extended_struct_func_prefix, prefix + value.name
                     )
             else:
+                preamble = self.make_counted_static_array_preamble(name, value, prefix)
+                if preamble:
+                    body += '    {}\n'.format(preamble)
                 method_call = self.make_encoder_method_call(
                     name, value, values, prefix
                 )

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_struct_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_cpp_struct_generator.py
@@ -107,6 +107,7 @@ class VulkanCppStructGeneratorOptions(VulkanBaseGeneratorOptions):
                 'generated/generated_vulkan_cpp_consumer_extension.h',
                 'generated/generated_vulkan_enum_to_string.h',
             ))
+            self.begin_end_file_data.system_headers.append('algorithm')
             self.begin_end_file_data.common_api_headers = []
 
         self.begin_end_file_data.namespaces.extend(('gfxrecon', 'decode'))
@@ -579,6 +580,14 @@ class VulkanCppStructGenerator(VulkanBaseGenerator):
 
                         local_header.append(arrayName + arrayProcess)
                         local_body.append(makeOutStructSet(arrayVarName, locals(), isFirstArg, isLastArg, indent))
+                elif arg.array_capacity and not handleObjectType:
+                    # Counted static array of basic or enum values. Must precede the enum branch: a fixed-extent member
+                    # needs an inline brace list, not the separately named array that branch emits. Handle arrays are
+                    # excluded; they need handle-to-variable mapping. The count comes from the capture, so clamp it.
+                    count_var = f'{arg.name}_count'
+                    struct_param = f'reinterpret_cast<const {arg.base_type}*>(&{struct_prefix}{arg.name}[0])'
+                    local_body.append(makeGen(f'const uint32_t {count_var} = std::min<uint32_t>({lengths[0]}, {arg.array_capacity});', locals(), indent))
+                    local_body.append(makeOutStructSet(f'VulkanCppConsumerBase::BuildValue({struct_param}, {count_var})', locals(), isFirstArg, isLastArg, indent))
                 elif self.is_enum(arg.base_type) or self.is_flags(arg.base_type):
                     arrayVarName = makeSnakeCaseName(arg.name + "Array")
                     valuesVarName = makeSnakeCaseName(arg.name + "Values")

--- a/framework/test/test_static_array_len.cpp
+++ b/framework/test/test_static_array_len.cpp
@@ -1,0 +1,258 @@
+/*
+** Copyright (c) 2026 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+/// @file Encode/decode round trips for fixed-extent ("static") array members whose registry 'len' names a
+/// sibling count member, e.g. VkQueueFamilyGlobalPriorityProperties::priorities[VK_MAX_GLOBAL_PRIORITY_SIZE]
+/// with len="priorityCount".  The encoder writes 'count' elements; the decoder must accept that, the full
+/// capacity written by older captures, and any other in-range length, while staying in sync with the stream.
+
+#include <catch2/catch.hpp>
+
+#include "decode/decode_allocator.h"
+#include "decode/value_decoder.h"
+#include "encode/parameter_buffer.h"
+#include "encode/parameter_encoder.h"
+#include "generated/generated_vulkan_struct_decoders.h"
+#include "generated/generated_vulkan_struct_encoders.h"
+#include "util/logging.h"
+
+#include "vulkan/vulkan.h"
+
+#include <memory>
+
+namespace
+{
+using namespace gfxrecon;
+
+constexpr uint32_t kSentinel = 0xDEADBEEF;
+
+VkQueueFamilyGlobalPriorityProperties MakePriorityProperties(uint32_t count)
+{
+    VkQueueFamilyGlobalPriorityProperties props{};
+    props.sType         = VK_STRUCTURE_TYPE_QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES;
+    props.priorityCount = count;
+
+    const VkQueueGlobalPriority values[] = { VK_QUEUE_GLOBAL_PRIORITY_LOW,
+                                             VK_QUEUE_GLOBAL_PRIORITY_MEDIUM,
+                                             VK_QUEUE_GLOBAL_PRIORITY_HIGH,
+                                             VK_QUEUE_GLOBAL_PRIORITY_REALTIME };
+    for (uint32_t i = 0; i < VK_MAX_GLOBAL_PRIORITY_SIZE; ++i)
+    {
+        props.priorities[i] = values[i % 4];
+    }
+    return props;
+}
+
+// Writes the struct the way the generated encoders did before the registry 'len' was honored: the count member
+// followed by 'array_length' elements of the fixed-extent array.
+void EncodeWithArrayLength(encode::ParameterEncoder*                    encoder,
+                           const VkQueueFamilyGlobalPriorityProperties& props,
+                           size_t                                       array_length)
+{
+    encoder->EncodeEnumValue(props.sType);
+    encode::EncodePNextStruct(encoder, props.pNext);
+    encoder->EncodeUInt32Value(props.priorityCount);
+    encoder->EncodeEnumArray(props.priorities, array_length);
+}
+
+struct DecodeResult
+{
+    VkQueueFamilyGlobalPriorityProperties value{};
+    size_t                                array_length{ 0 };
+};
+
+// Decodes the struct followed by the sentinel, verifying the decoder consumed exactly the struct's bytes.
+DecodeResult DecodeAndCheckSync(const encode::ParameterBuffer& buffer)
+{
+    DecodeResult result;
+
+    decode::DecodeAllocator::Begin();
+
+    decode::Decoded_VkQueueFamilyGlobalPriorityProperties wrapper;
+    wrapper.decoded_value = &result.value;
+
+    const uint8_t* data       = buffer.GetData();
+    size_t         size       = buffer.GetDataSize();
+    size_t         bytes_read = decode::DecodeStruct(data, size, &wrapper);
+    result.array_length       = wrapper.priorities.GetLength();
+
+    uint32_t sentinel = 0;
+    bytes_read += decode::ValueDecoder::DecodeUInt32Value(data + bytes_read, size - bytes_read, &sentinel);
+    REQUIRE(bytes_read == size);
+    REQUIRE(sentinel == kSentinel);
+
+    decode::DecodeAllocator::End();
+    return result;
+}
+} // namespace
+
+TEST_CASE("Counted static array encodes the counted elements, not the capacity", "[enc/dec]")
+{
+    util::Log::Init(util::LoggingSeverity::kError);
+    auto buffer  = std::make_unique<encode::ParameterBuffer>();
+    auto encoder = std::make_unique<encode::ParameterEncoder>(buffer.get());
+
+    const uint32_t count = 3;
+    const auto     props = MakePriorityProperties(count);
+
+    encode::EncodeStruct(encoder.get(), props);
+    encoder->EncodeUInt32Value(kSentinel);
+
+    const auto decoded = DecodeAndCheckSync(*buffer);
+    REQUIRE(decoded.array_length == count);
+    REQUIRE(decoded.value.priorityCount == count);
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        REQUIRE(decoded.value.priorities[i] == props.priorities[i]);
+    }
+    // Elements past the count are never written by the decoder.
+    for (uint32_t i = count; i < VK_MAX_GLOBAL_PRIORITY_SIZE; ++i)
+    {
+        REQUIRE(decoded.value.priorities[i] == 0);
+    }
+}
+
+TEST_CASE("Counted static array holding the full capacity (older captures) still decodes", "[enc/dec]")
+{
+    util::Log::Init(util::LoggingSeverity::kError);
+    auto buffer  = std::make_unique<encode::ParameterBuffer>();
+    auto encoder = std::make_unique<encode::ParameterEncoder>(buffer.get());
+
+    const uint32_t count = 3;
+    const auto     props = MakePriorityProperties(count);
+
+    EncodeWithArrayLength(encoder.get(), props, VK_MAX_GLOBAL_PRIORITY_SIZE);
+    encoder->EncodeUInt32Value(kSentinel);
+
+    const auto decoded = DecodeAndCheckSync(*buffer);
+    REQUIRE(decoded.array_length == VK_MAX_GLOBAL_PRIORITY_SIZE);
+    REQUIRE(decoded.value.priorityCount == count);
+    for (uint32_t i = 0; i < VK_MAX_GLOBAL_PRIORITY_SIZE; ++i)
+    {
+        REQUIRE(decoded.value.priorities[i] == props.priorities[i]);
+    }
+}
+
+TEST_CASE("Counted static array with a length matching neither count nor capacity stays in sync", "[enc/dec]")
+{
+    // The decoder reports this case (see PointerDecoderBase::CheckExpectedLength); the block must still decode.
+    util::Log::Init(util::LoggingSeverity::kFatal);
+    auto buffer  = std::make_unique<encode::ParameterBuffer>();
+    auto encoder = std::make_unique<encode::ParameterEncoder>(buffer.get());
+
+    const uint32_t count         = 3;
+    const size_t   stream_length = 5;
+    const auto     props         = MakePriorityProperties(count);
+
+    EncodeWithArrayLength(encoder.get(), props, stream_length);
+    encoder->EncodeUInt32Value(kSentinel);
+
+    const auto decoded = DecodeAndCheckSync(*buffer);
+    REQUIRE(decoded.array_length == stream_length);
+    for (size_t i = 0; i < stream_length; ++i)
+    {
+        REQUIRE(decoded.value.priorities[i] == props.priorities[i]);
+    }
+}
+
+TEST_CASE("Counted static array longer than the capacity is truncated but stays in sync", "[enc/dec]")
+{
+    util::Log::Init(util::LoggingSeverity::kFatal);
+    auto buffer  = std::make_unique<encode::ParameterBuffer>();
+    auto encoder = std::make_unique<encode::ParameterEncoder>(buffer.get());
+
+    // Build a source array larger than the struct member so the over-long stream can be produced.
+    VkQueueGlobalPriority oversized[VK_MAX_GLOBAL_PRIORITY_SIZE + 4];
+    for (auto& priority : oversized)
+    {
+        priority = VK_QUEUE_GLOBAL_PRIORITY_HIGH;
+    }
+    auto props = MakePriorityProperties(VK_MAX_GLOBAL_PRIORITY_SIZE + 4);
+
+    encoder->EncodeEnumValue(props.sType);
+    encode::EncodePNextStruct(encoder.get(), props.pNext);
+    encoder->EncodeUInt32Value(props.priorityCount);
+    encoder->EncodeEnumArray(oversized, VK_MAX_GLOBAL_PRIORITY_SIZE + 4);
+    encoder->EncodeUInt32Value(kSentinel);
+
+    const auto decoded = DecodeAndCheckSync(*buffer);
+    REQUIRE(decoded.array_length == VK_MAX_GLOBAL_PRIORITY_SIZE + 4);
+    for (uint32_t i = 0; i < VK_MAX_GLOBAL_PRIORITY_SIZE; ++i)
+    {
+        REQUIRE(decoded.value.priorities[i] == VK_QUEUE_GLOBAL_PRIORITY_HIGH);
+    }
+}
+
+TEST_CASE("ClampStaticArrayLength bounds the count by the capacity", "[encode]")
+{
+    util::Log::Init(util::LoggingSeverity::kFatal);
+    REQUIRE(encode::ParameterEncoder::ClampStaticArrayLength(0, 16, "test") == 0);
+    REQUIRE(encode::ParameterEncoder::ClampStaticArrayLength(3, 16, "test") == 3);
+    REQUIRE(encode::ParameterEncoder::ClampStaticArrayLength(16, 16, "test") == 16);
+    REQUIRE(encode::ParameterEncoder::ClampStaticArrayLength(17, 16, "test") == 16);
+}
+
+TEST_CASE("Counted static struct array encodes the counted elements", "[enc/dec]")
+{
+    util::Log::Init(util::LoggingSeverity::kError);
+    auto buffer  = std::make_unique<encode::ParameterBuffer>();
+    auto encoder = std::make_unique<encode::ParameterEncoder>(buffer.get());
+
+    VkPhysicalDeviceMemoryProperties props{};
+    props.memoryTypeCount = 2;
+    props.memoryTypes[0]  = { VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0 };
+    props.memoryTypes[1]  = { VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, 1 };
+    props.memoryHeapCount = 1;
+    props.memoryHeaps[0]  = { 1024, VK_MEMORY_HEAP_DEVICE_LOCAL_BIT };
+
+    encode::EncodeStruct(encoder.get(), props);
+    encoder->EncodeUInt32Value(kSentinel);
+
+    decode::DecodeAllocator::Begin();
+
+    VkPhysicalDeviceMemoryProperties                 decoded{};
+    decode::Decoded_VkPhysicalDeviceMemoryProperties wrapper;
+    wrapper.decoded_value = &decoded;
+
+    const uint8_t* data       = buffer->GetData();
+    size_t         size       = buffer->GetDataSize();
+    size_t         bytes_read = decode::DecodeStruct(data, size, &wrapper);
+
+    uint32_t sentinel = 0;
+    bytes_read += decode::ValueDecoder::DecodeUInt32Value(data + bytes_read, size - bytes_read, &sentinel);
+    REQUIRE(bytes_read == size);
+    REQUIRE(sentinel == kSentinel);
+
+    REQUIRE(wrapper.memoryTypes->GetLength() == props.memoryTypeCount);
+    REQUIRE(wrapper.memoryHeaps->GetLength() == props.memoryHeapCount);
+    REQUIRE(decoded.memoryTypeCount == props.memoryTypeCount);
+    REQUIRE(decoded.memoryHeapCount == props.memoryHeapCount);
+    for (uint32_t i = 0; i < props.memoryTypeCount; ++i)
+    {
+        REQUIRE(decoded.memoryTypes[i].propertyFlags == props.memoryTypes[i].propertyFlags);
+        REQUIRE(decoded.memoryTypes[i].heapIndex == props.memoryTypes[i].heapIndex);
+    }
+    REQUIRE(decoded.memoryHeaps[0].size == props.memoryHeaps[0].size);
+    REQUIRE(decoded.memoryHeaps[0].flags == props.memoryHeaps[0].flags);
+
+    decode::DecodeAllocator::End();
+}


### PR DESCRIPTION
Replace the '<name>Count' sibling heuristic with the registry len. Heuristic was incomplete, and no longer needed.
Future captures of VkQueueFamilyGlobalPriorityProperties::priorities and VkShaderModuleIdentifierEXT::identifier will encode only up to length. 

Decoder compatibility is maintained.

Encoder clamps the count to capacity; decoder warns on a length matching neither count nor capacity.